### PR TITLE
lxd: Add support for forced deletion of projects

### DIFF
--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -337,6 +337,7 @@ type InstanceServer interface {
 	UpdateProject(name string, project api.ProjectPut, ETag string) (err error)
 	RenameProject(name string, project api.ProjectPost) (op Operation, err error)
 	DeleteProject(name string) (err error)
+	DeleteProjectForce(name string) (err error)
 
 	// Storage pool functions ("storage" API extension)
 	GetStoragePoolNames() (names []string, err error)

--- a/client/lxd_projects.go
+++ b/client/lxd_projects.go
@@ -145,3 +145,18 @@ func (r *ProtocolLXD) DeleteProject(name string) error {
 
 	return nil
 }
+
+// DeleteProjectForce deletes a project and everything inside of it.
+func (r *ProtocolLXD) DeleteProjectForce(name string) error {
+	if !r.HasExtension("projects_force_delete") {
+		return fmt.Errorf("The server is missing the required \"projects_force_delete\" API extension")
+	}
+
+	// Send the request.
+	_, _, err := r.query("DELETE", fmt.Sprintf("/projects/%s?force=1", url.PathEscape(name)), nil, "")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2535,3 +2535,8 @@ Adds a new {config:option}`device-unix-hotplug-device-conf:ownership.inherit` co
 ## `unix_device_hotplug_subsystem_device_option`
 
 Adds a new {config:option}`device-unix-hotplug-device-conf:subsystem` configuration option for `unix-hotplug` devices. This adds support for detecting `unix-hotplug` devices by subsystem, and can be used in conjunction with {config:option}`device-unix-hotplug-device-conf:productid` and {config:option}`device-unix-hotplug-device-conf:vendorid`.
+
+## `projects_force_delete`
+
+This extends `DELETE /1.0/projects` to allow `?force=true` which will
+delete everything inside of the project along with the project itself.

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -14567,6 +14567,11 @@ paths:
         delete:
             description: Removes the project.
             operationId: project_delete
+            parameters:
+                - description: Delete project and related artifacts
+                  in: query
+                  name: force
+                  type: boolean
             produces:
                 - application/json
             responses:

--- a/lxc/project.go
+++ b/lxc/project.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"errors"
 	"fmt"
 	"io"
@@ -181,6 +182,8 @@ func (c *cmdProjectCreate) run(cmd *cobra.Command, args []string) error {
 type cmdProjectDelete struct {
 	global  *cmdGlobal
 	project *cmdProject
+
+	flagForce bool
 }
 
 func (c *cmdProjectDelete) command() *cobra.Command {
@@ -191,6 +194,7 @@ func (c *cmdProjectDelete) command() *cobra.Command {
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Delete projects`))
 
+	cmd.Flags().BoolVarP(&c.flagForce, "force", "f", false, i18n.G("Force delete the project and everything it contains."))
 	cmd.RunE = c.run
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
@@ -202,6 +206,16 @@ func (c *cmdProjectDelete) command() *cobra.Command {
 	}
 
 	return cmd
+}
+
+func (c *cmdProjectDelete) promptConfirmation(name string) bool {
+	reader := bufio.NewReader(os.Stdin)
+
+	fmt.Printf(i18n.G("Remove %s and everything it contains (instances, images, volumes, networks, ...) (yes/no): "), name)
+	input, _ := reader.ReadString('\n')
+	input = strings.TrimSuffix(input, "\n")
+
+	return slices.Contains([]string{i18n.G("yes")}, strings.ToLower(input))
 }
 
 func (c *cmdProjectDelete) run(cmd *cobra.Command, args []string) error {
@@ -228,10 +242,22 @@ func (c *cmdProjectDelete) run(cmd *cobra.Command, args []string) error {
 		return errors.New(i18n.G("Missing project name"))
 	}
 
-	// Delete the project
-	err = resource.server.DeleteProject(resource.name)
-	if err != nil {
-		return err
+	// Delete the project, server is unable to find the project here.
+	if c.flagForce {
+		if !c.promptConfirmation(resource.name) {
+			fmt.Println(i18n.G("Project deletion aborted"))
+			return nil
+		}
+
+		err := resource.server.DeleteProjectForce(resource.name)
+		if err != nil {
+			return err
+		}
+	} else {
+		err = resource.server.DeleteProject(resource.name)
+		if err != nil {
+			return err
+		}
 	}
 
 	if !c.global.flagQuiet {

--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -954,62 +954,18 @@ func projectStateGet(d *Daemon, r *http.Request) response.Response {
 
 // Check if a project is empty.
 func projectIsEmpty(ctx context.Context, project *cluster.Project, tx *db.ClusterTx) (bool, error) {
-	instances, err := cluster.GetInstances(ctx, tx.Tx(), cluster.InstanceFilter{Project: &project.Name})
+	usedBy, err := projectUsedBy(ctx, tx, project)
 	if err != nil {
 		return false, err
 	}
 
-	if len(instances) > 0 {
-		return false, nil
-	}
-
-	images, err := cluster.GetImages(ctx, tx.Tx(), cluster.ImageFilter{Project: &project.Name})
-	if err != nil {
-		return false, err
-	}
-
-	if len(images) > 0 {
-		return false, nil
-	}
-
-	profiles, err := cluster.GetProfiles(ctx, tx.Tx(), cluster.ProfileFilter{Project: &project.Name})
-	if err != nil {
-		return false, err
-	}
-
-	if len(profiles) > 0 {
-		// Consider the project empty if it is only used by the default profile.
-		if len(profiles) == 1 && profiles[0].Name == "default" {
-			return true, nil
+	defaultProfile := api.NewURL().Path(version.APIVersion, "profiles", api.ProjectDefaultName).Project(project.Name).String()
+	for _, entry := range usedBy {
+		// Ignore the default profile.
+		if entry == defaultProfile {
+			continue
 		}
 
-		return false, nil
-	}
-
-	volumes, err := tx.GetStorageVolumeURIs(ctx, project.Name)
-	if err != nil {
-		return false, err
-	}
-
-	if len(volumes) > 0 {
-		return false, nil
-	}
-
-	networks, err := tx.GetNetworkURIs(ctx, project.ID, project.Name)
-	if err != nil {
-		return false, err
-	}
-
-	if len(networks) > 0 {
-		return false, nil
-	}
-
-	acls, err := tx.GetNetworkACLURIs(ctx, project.ID, project.Name)
-	if err != nil {
-		return false, err
-	}
-
-	if len(acls) > 0 {
 		return false, nil
 	}
 

--- a/po/ar.po
+++ b/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-08 16:23-0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:282
+#: lxc/project.go:308
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -871,7 +871,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:162
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1198,7 +1198,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:103
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1212,7 +1212,7 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/project.go:390 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
 #: lxc/storage_volume.go:1188
 #, c-format
@@ -1482,7 +1482,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:95 lxc/project.go:96
 msgid "Create projects"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
-#: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:756 lxc/project.go:600 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
@@ -1633,7 +1633,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:193 lxc/project.go:194
 msgid "Delete projects"
 msgstr ""
 
@@ -1733,10 +1733,10 @@ msgstr ""
 #: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
 #: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
 #: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
-#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:32 lxc/project.go:96
+#: lxc/project.go:194 lxc/project.go:288 lxc/project.go:424 lxc/project.go:498
+#: lxc/project.go:618 lxc/project.go:683 lxc/project.go:771 lxc/project.go:815
+#: lxc/project.go:876 lxc/project.go:943 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -2000,7 +2000,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:287 lxc/project.go:288
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2080,7 +2080,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/project.go:746 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
 #, c-format
 msgid "Error setting properties: %v"
@@ -2094,7 +2094,7 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
+#: lxc/profile.go:981 lxc/project.go:740 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
 #: lxc/storage_volume.go:2199
 #, c-format
@@ -2377,6 +2377,10 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
+#: lxc/project.go:197
+msgid "Force delete the project and everything it contains."
+msgstr ""
+
 #: lxc/cluster.go:1301
 msgid "Force evacuation without user confirmation"
 msgstr ""
@@ -2436,8 +2440,8 @@ msgstr ""
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:500
+#: lxc/project.go:945 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2503,7 +2507,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:942 lxc/project.go:943
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2551,7 +2555,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:428
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2615,7 +2619,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:423 lxc/project.go:424
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2709,7 +2713,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:594
 msgid "IMAGES"
 msgstr ""
 
@@ -3047,7 +3051,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1020
 msgid "LIMIT"
 msgstr ""
 
@@ -3349,7 +3353,7 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:497 lxc/project.go:498
 msgid "List projects"
 msgstr ""
 
@@ -3654,7 +3658,7 @@ msgstr ""
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -3908,9 +3912,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:404 lxc/project.go:149 lxc/project.go:242 lxc/project.go:344
+#: lxc/project.go:461 lxc/project.go:650 lxc/project.go:719 lxc/project.go:847
+#: lxc/project.go:976
 msgid "Missing project name"
 msgstr ""
 
@@ -4034,7 +4038,7 @@ msgstr ""
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:593
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
@@ -4048,11 +4052,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:599
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:598
 msgid "NETWORKS"
 msgstr ""
 
@@ -4064,9 +4068,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:551
+#: lxc/project.go:556 lxc/project.go:561 lxc/project.go:566 lxc/project.go:571
+#: lxc/project.go:576 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4362,7 +4366,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:595
 msgid "PROFILES"
 msgstr ""
 
@@ -4440,7 +4444,7 @@ msgstr ""
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/project.go:391 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
 #: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4532,19 +4536,23 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:175
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:264
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:665
 #, c-format
 msgid "Project %s renamed to %s"
+msgstr ""
+
+#: lxc/project.go:248
+msgid "Project deletion aborted"
 msgstr ""
 
 #: lxc/remote.go:107
@@ -4689,7 +4697,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:1019
 msgid "RESOURCE"
 msgstr ""
 
@@ -4741,7 +4749,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:910 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4786,6 +4794,13 @@ msgstr ""
 #: lxc/delete.go:48
 #, c-format
 msgid "Remove %s (yes/no): "
+msgstr ""
+
+#: lxc/project.go:214
+#, c-format
+msgid ""
+"Remove %s and everything it contains (instances, images, volumes, "
+"networks, ...) (yes/no): "
 msgstr ""
 
 #: lxc/cluster_group.go:522
@@ -4909,7 +4924,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:617 lxc/project.go:618
 msgid "Rename projects"
 msgstr ""
 
@@ -5066,7 +5081,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:597
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5074,7 +5089,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:596
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5262,11 +5277,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:682
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:683
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5378,7 +5393,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:690
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5523,7 +5538,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:814 lxc/project.go:815
 msgid "Show project options"
 msgstr ""
 
@@ -5769,7 +5784,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:875 lxc/project.go:876
 msgid "Switch the current project"
 msgstr ""
 
@@ -5948,7 +5963,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:448
+#: lxc/project.go:474
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6155,7 +6170,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:991
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6167,12 +6182,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:1021 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:601
 #: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
@@ -6299,7 +6314,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:770 lxc/project.go:771
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6351,7 +6366,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:775
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6512,9 +6527,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:553
+#: lxc/project.go:558 lxc/project.go:563 lxc/project.go:568 lxc/project.go:573
+#: lxc/project.go:578 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6550,7 +6565,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:495
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -7100,20 +7115,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:94 lxc/project.go:191 lxc/project.go:286 lxc/project.go:813
+#: lxc/project.go:874 lxc/project.go:941
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:422 lxc/project.go:769
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:681
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:615
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7181,7 +7196,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:583 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7541,7 +7556,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:98
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7549,7 +7564,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:290
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7719,6 +7734,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1206 lxc/project.go:218
 msgid "yes"
 msgstr ""

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-08 16:23-0800\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -391,7 +391,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:282
+#: lxc/project.go:308
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:162
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1201,7 +1201,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:103
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1215,7 +1215,7 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/project.go:390 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
 #: lxc/storage_volume.go:1188
 #, c-format
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:95 lxc/project.go:96
 msgid "Create projects"
 msgstr ""
 
@@ -1530,7 +1530,7 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
-#: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:756 lxc/project.go:600 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
@@ -1636,7 +1636,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:193 lxc/project.go:194
 msgid "Delete projects"
 msgstr ""
 
@@ -1736,10 +1736,10 @@ msgstr ""
 #: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
 #: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
 #: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
-#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:32 lxc/project.go:96
+#: lxc/project.go:194 lxc/project.go:288 lxc/project.go:424 lxc/project.go:498
+#: lxc/project.go:618 lxc/project.go:683 lxc/project.go:771 lxc/project.go:815
+#: lxc/project.go:876 lxc/project.go:943 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -2003,7 +2003,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:287 lxc/project.go:288
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2083,7 +2083,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/project.go:746 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
 #, c-format
 msgid "Error setting properties: %v"
@@ -2097,7 +2097,7 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
+#: lxc/profile.go:981 lxc/project.go:740 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
 #: lxc/storage_volume.go:2199
 #, c-format
@@ -2380,6 +2380,10 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
+#: lxc/project.go:197
+msgid "Force delete the project and everything it contains."
+msgstr ""
+
 #: lxc/cluster.go:1301
 msgid "Force evacuation without user confirmation"
 msgstr ""
@@ -2439,8 +2443,8 @@ msgstr ""
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:500
+#: lxc/project.go:945 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2506,7 +2510,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:942 lxc/project.go:943
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2554,7 +2558,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:428
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2618,7 +2622,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:423 lxc/project.go:424
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2712,7 +2716,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:594
 msgid "IMAGES"
 msgstr ""
 
@@ -3050,7 +3054,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1020
 msgid "LIMIT"
 msgstr ""
 
@@ -3352,7 +3356,7 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:497 lxc/project.go:498
 msgid "List projects"
 msgstr ""
 
@@ -3657,7 +3661,7 @@ msgstr ""
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -3911,9 +3915,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:404 lxc/project.go:149 lxc/project.go:242 lxc/project.go:344
+#: lxc/project.go:461 lxc/project.go:650 lxc/project.go:719 lxc/project.go:847
+#: lxc/project.go:976
 msgid "Missing project name"
 msgstr ""
 
@@ -4037,7 +4041,7 @@ msgstr ""
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:593
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
@@ -4051,11 +4055,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:599
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:598
 msgid "NETWORKS"
 msgstr ""
 
@@ -4067,9 +4071,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:551
+#: lxc/project.go:556 lxc/project.go:561 lxc/project.go:566 lxc/project.go:571
+#: lxc/project.go:576 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4365,7 +4369,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:595
 msgid "PROFILES"
 msgstr ""
 
@@ -4443,7 +4447,7 @@ msgstr ""
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/project.go:391 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
 #: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4535,19 +4539,23 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:175
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:264
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:665
 #, c-format
 msgid "Project %s renamed to %s"
+msgstr ""
+
+#: lxc/project.go:248
+msgid "Project deletion aborted"
 msgstr ""
 
 #: lxc/remote.go:107
@@ -4692,7 +4700,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:1019
 msgid "RESOURCE"
 msgstr ""
 
@@ -4744,7 +4752,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:910 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4789,6 +4797,13 @@ msgstr ""
 #: lxc/delete.go:48
 #, c-format
 msgid "Remove %s (yes/no): "
+msgstr ""
+
+#: lxc/project.go:214
+#, c-format
+msgid ""
+"Remove %s and everything it contains (instances, images, volumes, "
+"networks, ...) (yes/no): "
 msgstr ""
 
 #: lxc/cluster_group.go:522
@@ -4912,7 +4927,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:617 lxc/project.go:618
 msgid "Rename projects"
 msgstr ""
 
@@ -5069,7 +5084,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:597
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5077,7 +5092,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:596
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5265,11 +5280,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:682
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:683
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5381,7 +5396,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:690
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5526,7 +5541,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:814 lxc/project.go:815
 msgid "Show project options"
 msgstr ""
 
@@ -5772,7 +5787,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:875 lxc/project.go:876
 msgid "Switch the current project"
 msgstr ""
 
@@ -5951,7 +5966,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:448
+#: lxc/project.go:474
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6158,7 +6173,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:991
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6170,12 +6185,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:1021 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:601
 #: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
@@ -6302,7 +6317,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:770 lxc/project.go:771
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6354,7 +6369,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:775
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6515,9 +6530,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:553
+#: lxc/project.go:558 lxc/project.go:563 lxc/project.go:568 lxc/project.go:573
+#: lxc/project.go:578 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6553,7 +6568,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:495
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -7103,20 +7118,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:94 lxc/project.go:191 lxc/project.go:286 lxc/project.go:813
+#: lxc/project.go:874 lxc/project.go:941
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:422 lxc/project.go:769
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:681
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:615
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7184,7 +7199,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:583 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7544,7 +7559,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:98
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7552,7 +7567,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:290
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7722,6 +7737,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1206 lxc/project.go:218
 msgid "yes"
 msgstr ""

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-08 16:23-0800\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -391,7 +391,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:282
+#: lxc/project.go:308
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:162
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1201,7 +1201,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:103
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1215,7 +1215,7 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/project.go:390 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
 #: lxc/storage_volume.go:1188
 #, c-format
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:95 lxc/project.go:96
 msgid "Create projects"
 msgstr ""
 
@@ -1530,7 +1530,7 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
-#: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:756 lxc/project.go:600 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
@@ -1636,7 +1636,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:193 lxc/project.go:194
 msgid "Delete projects"
 msgstr ""
 
@@ -1736,10 +1736,10 @@ msgstr ""
 #: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
 #: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
 #: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
-#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:32 lxc/project.go:96
+#: lxc/project.go:194 lxc/project.go:288 lxc/project.go:424 lxc/project.go:498
+#: lxc/project.go:618 lxc/project.go:683 lxc/project.go:771 lxc/project.go:815
+#: lxc/project.go:876 lxc/project.go:943 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -2003,7 +2003,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:287 lxc/project.go:288
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2083,7 +2083,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/project.go:746 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
 #, c-format
 msgid "Error setting properties: %v"
@@ -2097,7 +2097,7 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
+#: lxc/profile.go:981 lxc/project.go:740 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
 #: lxc/storage_volume.go:2199
 #, c-format
@@ -2380,6 +2380,10 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
+#: lxc/project.go:197
+msgid "Force delete the project and everything it contains."
+msgstr ""
+
 #: lxc/cluster.go:1301
 msgid "Force evacuation without user confirmation"
 msgstr ""
@@ -2439,8 +2443,8 @@ msgstr ""
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:500
+#: lxc/project.go:945 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2506,7 +2510,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:942 lxc/project.go:943
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2554,7 +2558,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:428
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2618,7 +2622,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:423 lxc/project.go:424
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2712,7 +2716,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:594
 msgid "IMAGES"
 msgstr ""
 
@@ -3050,7 +3054,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1020
 msgid "LIMIT"
 msgstr ""
 
@@ -3352,7 +3356,7 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:497 lxc/project.go:498
 msgid "List projects"
 msgstr ""
 
@@ -3657,7 +3661,7 @@ msgstr ""
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -3911,9 +3915,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:404 lxc/project.go:149 lxc/project.go:242 lxc/project.go:344
+#: lxc/project.go:461 lxc/project.go:650 lxc/project.go:719 lxc/project.go:847
+#: lxc/project.go:976
 msgid "Missing project name"
 msgstr ""
 
@@ -4037,7 +4041,7 @@ msgstr ""
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:593
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
@@ -4051,11 +4055,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:599
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:598
 msgid "NETWORKS"
 msgstr ""
 
@@ -4067,9 +4071,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:551
+#: lxc/project.go:556 lxc/project.go:561 lxc/project.go:566 lxc/project.go:571
+#: lxc/project.go:576 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4365,7 +4369,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:595
 msgid "PROFILES"
 msgstr ""
 
@@ -4443,7 +4447,7 @@ msgstr ""
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/project.go:391 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
 #: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4535,19 +4539,23 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:175
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:264
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:665
 #, c-format
 msgid "Project %s renamed to %s"
+msgstr ""
+
+#: lxc/project.go:248
+msgid "Project deletion aborted"
 msgstr ""
 
 #: lxc/remote.go:107
@@ -4692,7 +4700,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:1019
 msgid "RESOURCE"
 msgstr ""
 
@@ -4744,7 +4752,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:910 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4789,6 +4797,13 @@ msgstr ""
 #: lxc/delete.go:48
 #, c-format
 msgid "Remove %s (yes/no): "
+msgstr ""
+
+#: lxc/project.go:214
+#, c-format
+msgid ""
+"Remove %s and everything it contains (instances, images, volumes, "
+"networks, ...) (yes/no): "
 msgstr ""
 
 #: lxc/cluster_group.go:522
@@ -4912,7 +4927,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:617 lxc/project.go:618
 msgid "Rename projects"
 msgstr ""
 
@@ -5069,7 +5084,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:597
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5077,7 +5092,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:596
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5265,11 +5280,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:682
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:683
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5381,7 +5396,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:690
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5526,7 +5541,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:814 lxc/project.go:815
 msgid "Show project options"
 msgstr ""
 
@@ -5772,7 +5787,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:875 lxc/project.go:876
 msgid "Switch the current project"
 msgstr ""
 
@@ -5951,7 +5966,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:448
+#: lxc/project.go:474
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6158,7 +6173,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:991
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6170,12 +6185,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:1021 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:601
 #: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
@@ -6302,7 +6317,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:770 lxc/project.go:771
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6354,7 +6369,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:775
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6515,9 +6530,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:553
+#: lxc/project.go:558 lxc/project.go:563 lxc/project.go:568 lxc/project.go:573
+#: lxc/project.go:578 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6553,7 +6568,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:495
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -7103,20 +7118,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:94 lxc/project.go:191 lxc/project.go:286 lxc/project.go:813
+#: lxc/project.go:874 lxc/project.go:941
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:422 lxc/project.go:769
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:681
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:615
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7184,7 +7199,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:583 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7544,7 +7559,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:98
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7552,7 +7567,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:290
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7722,6 +7737,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1206 lxc/project.go:218
 msgid "yes"
 msgstr ""

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-08 16:23-0800\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -391,7 +391,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:282
+#: lxc/project.go:308
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:162
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1201,7 +1201,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:103
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1215,7 +1215,7 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/project.go:390 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
 #: lxc/storage_volume.go:1188
 #, c-format
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:95 lxc/project.go:96
 msgid "Create projects"
 msgstr ""
 
@@ -1530,7 +1530,7 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
-#: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:756 lxc/project.go:600 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
@@ -1636,7 +1636,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:193 lxc/project.go:194
 msgid "Delete projects"
 msgstr ""
 
@@ -1736,10 +1736,10 @@ msgstr ""
 #: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
 #: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
 #: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
-#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:32 lxc/project.go:96
+#: lxc/project.go:194 lxc/project.go:288 lxc/project.go:424 lxc/project.go:498
+#: lxc/project.go:618 lxc/project.go:683 lxc/project.go:771 lxc/project.go:815
+#: lxc/project.go:876 lxc/project.go:943 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -2003,7 +2003,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:287 lxc/project.go:288
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2083,7 +2083,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/project.go:746 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
 #, c-format
 msgid "Error setting properties: %v"
@@ -2097,7 +2097,7 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
+#: lxc/profile.go:981 lxc/project.go:740 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
 #: lxc/storage_volume.go:2199
 #, c-format
@@ -2380,6 +2380,10 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
+#: lxc/project.go:197
+msgid "Force delete the project and everything it contains."
+msgstr ""
+
 #: lxc/cluster.go:1301
 msgid "Force evacuation without user confirmation"
 msgstr ""
@@ -2439,8 +2443,8 @@ msgstr ""
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:500
+#: lxc/project.go:945 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2506,7 +2510,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:942 lxc/project.go:943
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2554,7 +2558,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:428
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2618,7 +2622,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:423 lxc/project.go:424
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2712,7 +2716,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:594
 msgid "IMAGES"
 msgstr ""
 
@@ -3050,7 +3054,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1020
 msgid "LIMIT"
 msgstr ""
 
@@ -3352,7 +3356,7 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:497 lxc/project.go:498
 msgid "List projects"
 msgstr ""
 
@@ -3657,7 +3661,7 @@ msgstr ""
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -3911,9 +3915,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:404 lxc/project.go:149 lxc/project.go:242 lxc/project.go:344
+#: lxc/project.go:461 lxc/project.go:650 lxc/project.go:719 lxc/project.go:847
+#: lxc/project.go:976
 msgid "Missing project name"
 msgstr ""
 
@@ -4037,7 +4041,7 @@ msgstr ""
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:593
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
@@ -4051,11 +4055,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:599
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:598
 msgid "NETWORKS"
 msgstr ""
 
@@ -4067,9 +4071,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:551
+#: lxc/project.go:556 lxc/project.go:561 lxc/project.go:566 lxc/project.go:571
+#: lxc/project.go:576 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4365,7 +4369,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:595
 msgid "PROFILES"
 msgstr ""
 
@@ -4443,7 +4447,7 @@ msgstr ""
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/project.go:391 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
 #: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4535,19 +4539,23 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:175
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:264
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:665
 #, c-format
 msgid "Project %s renamed to %s"
+msgstr ""
+
+#: lxc/project.go:248
+msgid "Project deletion aborted"
 msgstr ""
 
 #: lxc/remote.go:107
@@ -4692,7 +4700,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:1019
 msgid "RESOURCE"
 msgstr ""
 
@@ -4744,7 +4752,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:910 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4789,6 +4797,13 @@ msgstr ""
 #: lxc/delete.go:48
 #, c-format
 msgid "Remove %s (yes/no): "
+msgstr ""
+
+#: lxc/project.go:214
+#, c-format
+msgid ""
+"Remove %s and everything it contains (instances, images, volumes, "
+"networks, ...) (yes/no): "
 msgstr ""
 
 #: lxc/cluster_group.go:522
@@ -4912,7 +4927,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:617 lxc/project.go:618
 msgid "Rename projects"
 msgstr ""
 
@@ -5069,7 +5084,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:597
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5077,7 +5092,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:596
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5265,11 +5280,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:682
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:683
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5381,7 +5396,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:690
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5526,7 +5541,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:814 lxc/project.go:815
 msgid "Show project options"
 msgstr ""
 
@@ -5772,7 +5787,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:875 lxc/project.go:876
 msgid "Switch the current project"
 msgstr ""
 
@@ -5951,7 +5966,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:448
+#: lxc/project.go:474
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6158,7 +6173,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:991
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6170,12 +6185,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:1021 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:601
 #: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
@@ -6302,7 +6317,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:770 lxc/project.go:771
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6354,7 +6369,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:775
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6515,9 +6530,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:553
+#: lxc/project.go:558 lxc/project.go:563 lxc/project.go:568 lxc/project.go:573
+#: lxc/project.go:578 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6553,7 +6568,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:495
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -7103,20 +7118,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:94 lxc/project.go:191 lxc/project.go:286 lxc/project.go:813
+#: lxc/project.go:874 lxc/project.go:941
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:422 lxc/project.go:769
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:681
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:615
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7184,7 +7199,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:583 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7544,7 +7559,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:98
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7552,7 +7567,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:290
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7722,6 +7737,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1206 lxc/project.go:218
 msgid "yes"
 msgstr ""

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-08 16:23-0800\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -391,7 +391,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:282
+#: lxc/project.go:308
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:162
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1201,7 +1201,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:103
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1215,7 +1215,7 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/project.go:390 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
 #: lxc/storage_volume.go:1188
 #, c-format
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:95 lxc/project.go:96
 msgid "Create projects"
 msgstr ""
 
@@ -1530,7 +1530,7 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
-#: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:756 lxc/project.go:600 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
@@ -1636,7 +1636,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:193 lxc/project.go:194
 msgid "Delete projects"
 msgstr ""
 
@@ -1736,10 +1736,10 @@ msgstr ""
 #: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
 #: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
 #: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
-#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:32 lxc/project.go:96
+#: lxc/project.go:194 lxc/project.go:288 lxc/project.go:424 lxc/project.go:498
+#: lxc/project.go:618 lxc/project.go:683 lxc/project.go:771 lxc/project.go:815
+#: lxc/project.go:876 lxc/project.go:943 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -2003,7 +2003,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:287 lxc/project.go:288
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2083,7 +2083,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/project.go:746 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
 #, c-format
 msgid "Error setting properties: %v"
@@ -2097,7 +2097,7 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
+#: lxc/profile.go:981 lxc/project.go:740 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
 #: lxc/storage_volume.go:2199
 #, c-format
@@ -2380,6 +2380,10 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
+#: lxc/project.go:197
+msgid "Force delete the project and everything it contains."
+msgstr ""
+
 #: lxc/cluster.go:1301
 msgid "Force evacuation without user confirmation"
 msgstr ""
@@ -2439,8 +2443,8 @@ msgstr ""
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:500
+#: lxc/project.go:945 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2506,7 +2510,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:942 lxc/project.go:943
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2554,7 +2558,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:428
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2618,7 +2622,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:423 lxc/project.go:424
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2712,7 +2716,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:594
 msgid "IMAGES"
 msgstr ""
 
@@ -3050,7 +3054,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1020
 msgid "LIMIT"
 msgstr ""
 
@@ -3352,7 +3356,7 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:497 lxc/project.go:498
 msgid "List projects"
 msgstr ""
 
@@ -3657,7 +3661,7 @@ msgstr ""
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -3911,9 +3915,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:404 lxc/project.go:149 lxc/project.go:242 lxc/project.go:344
+#: lxc/project.go:461 lxc/project.go:650 lxc/project.go:719 lxc/project.go:847
+#: lxc/project.go:976
 msgid "Missing project name"
 msgstr ""
 
@@ -4037,7 +4041,7 @@ msgstr ""
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:593
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
@@ -4051,11 +4055,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:599
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:598
 msgid "NETWORKS"
 msgstr ""
 
@@ -4067,9 +4071,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:551
+#: lxc/project.go:556 lxc/project.go:561 lxc/project.go:566 lxc/project.go:571
+#: lxc/project.go:576 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4365,7 +4369,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:595
 msgid "PROFILES"
 msgstr ""
 
@@ -4443,7 +4447,7 @@ msgstr ""
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/project.go:391 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
 #: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4535,19 +4539,23 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:175
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:264
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:665
 #, c-format
 msgid "Project %s renamed to %s"
+msgstr ""
+
+#: lxc/project.go:248
+msgid "Project deletion aborted"
 msgstr ""
 
 #: lxc/remote.go:107
@@ -4692,7 +4700,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:1019
 msgid "RESOURCE"
 msgstr ""
 
@@ -4744,7 +4752,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:910 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4789,6 +4797,13 @@ msgstr ""
 #: lxc/delete.go:48
 #, c-format
 msgid "Remove %s (yes/no): "
+msgstr ""
+
+#: lxc/project.go:214
+#, c-format
+msgid ""
+"Remove %s and everything it contains (instances, images, volumes, "
+"networks, ...) (yes/no): "
 msgstr ""
 
 #: lxc/cluster_group.go:522
@@ -4912,7 +4927,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:617 lxc/project.go:618
 msgid "Rename projects"
 msgstr ""
 
@@ -5069,7 +5084,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:597
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5077,7 +5092,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:596
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5265,11 +5280,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:682
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:683
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5381,7 +5396,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:690
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5526,7 +5541,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:814 lxc/project.go:815
 msgid "Show project options"
 msgstr ""
 
@@ -5772,7 +5787,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:875 lxc/project.go:876
 msgid "Switch the current project"
 msgstr ""
 
@@ -5951,7 +5966,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:448
+#: lxc/project.go:474
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6158,7 +6173,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:991
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6170,12 +6185,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:1021 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:601
 #: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
@@ -6302,7 +6317,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:770 lxc/project.go:771
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6354,7 +6369,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:775
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6515,9 +6530,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:553
+#: lxc/project.go:558 lxc/project.go:563 lxc/project.go:568 lxc/project.go:573
+#: lxc/project.go:578 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6553,7 +6568,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:495
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -7103,20 +7118,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:94 lxc/project.go:191 lxc/project.go:286 lxc/project.go:813
+#: lxc/project.go:874 lxc/project.go:941
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:422 lxc/project.go:769
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:681
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:615
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7184,7 +7199,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:583 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7544,7 +7559,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:98
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7552,7 +7567,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:290
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7722,6 +7737,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1206 lxc/project.go:218
 msgid "yes"
 msgstr ""

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-08 16:23-0800\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -620,7 +620,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: lxc/project.go:282
+#: lxc/project.go:308
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -1159,7 +1159,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:162
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Alternatives config Verzeichnis."
@@ -1504,7 +1504,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/project.go:102
+#: lxc/project.go:103
 #, fuzzy
 msgid "Config key/value to apply to the new project"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -1520,7 +1520,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/project.go:390 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
 #: lxc/storage_volume.go:1188
 #, fuzzy, c-format
@@ -1814,7 +1814,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:95 lxc/project.go:96
 #, fuzzy
 msgid "Create projects"
 msgstr "Fehlerhafte Profil URL %s"
@@ -1863,7 +1863,7 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
-#: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:756 lxc/project.go:600 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
@@ -1977,7 +1977,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:193 lxc/project.go:194
 #, fuzzy
 msgid "Delete projects"
 msgstr "Fehlerhafte Profil URL %s"
@@ -2080,10 +2080,10 @@ msgstr ""
 #: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
 #: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
 #: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
-#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:32 lxc/project.go:96
+#: lxc/project.go:194 lxc/project.go:288 lxc/project.go:424 lxc/project.go:498
+#: lxc/project.go:618 lxc/project.go:683 lxc/project.go:771 lxc/project.go:815
+#: lxc/project.go:876 lxc/project.go:943 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -2377,7 +2377,7 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:287 lxc/project.go:288
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2460,7 +2460,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/project.go:746 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
@@ -2474,7 +2474,7 @@ msgstr "Fehler beim hinzufügen des Alias %s\n"
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
+#: lxc/profile.go:981 lxc/project.go:740 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
 #: lxc/storage_volume.go:2199
 #, c-format
@@ -2773,6 +2773,10 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
+#: lxc/project.go:197
+msgid "Force delete the project and everything it contains."
+msgstr ""
+
 #: lxc/cluster.go:1301
 msgid "Force evacuation without user confirmation"
 msgstr ""
@@ -2833,8 +2837,8 @@ msgstr ""
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:500
+#: lxc/project.go:945 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2902,7 +2906,7 @@ msgstr "Generiere Nutzerzertifikat. Dies kann wenige Minuten dauern...\n"
 msgid "Get UEFI variables for instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:942 lxc/project.go:943
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2955,7 +2959,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:428
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -3031,7 +3035,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:423 lxc/project.go:424
 #, fuzzy
 msgid "Get values for project configuration keys"
 msgstr "Profil %s erstellt\n"
@@ -3128,7 +3132,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:594
 msgid "IMAGES"
 msgstr ""
 
@@ -3481,7 +3485,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1020
 msgid "LIMIT"
 msgstr ""
 
@@ -3811,7 +3815,7 @@ msgstr "Aliasse:\n"
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:497 lxc/project.go:498
 msgid "List projects"
 msgstr ""
 
@@ -4152,7 +4156,7 @@ msgstr "Fehlerhafte Profil URL %s"
 msgid "Manage profiles"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 #, fuzzy
 msgid "Manage projects"
 msgstr "Fehlerhafte Profil URL %s"
@@ -4433,9 +4437,9 @@ msgstr "Profilname kann nicht geändert werden"
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:404 lxc/project.go:149 lxc/project.go:242 lxc/project.go:344
+#: lxc/project.go:461 lxc/project.go:650 lxc/project.go:719 lxc/project.go:847
+#: lxc/project.go:976
 #, fuzzy
 msgid "Missing project name"
 msgstr "Profilname kann nicht geändert werden"
@@ -4569,7 +4573,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:593
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
@@ -4583,11 +4587,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:599
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:598
 msgid "NETWORKS"
 msgstr ""
 
@@ -4599,9 +4603,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:551
+#: lxc/project.go:556 lxc/project.go:561 lxc/project.go:566 lxc/project.go:571
+#: lxc/project.go:576 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4904,7 +4908,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:595
 msgid "PROFILES"
 msgstr ""
 
@@ -4986,7 +4990,7 @@ msgstr ""
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/project.go:391 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
 #: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -5083,20 +5087,25 @@ msgstr "Profil %s erstellt\n"
 msgid "Profiles: "
 msgstr "Profil %s erstellt\n"
 
-#: lxc/project.go:174
+#: lxc/project.go:175
 #, fuzzy, c-format
 msgid "Project %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/project.go:238
+#: lxc/project.go:264
 #, fuzzy, c-format
 msgid "Project %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/project.go:639
+#: lxc/project.go:665
 #, fuzzy, c-format
 msgid "Project %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
+
+#: lxc/project.go:248
+#, fuzzy
+msgid "Project deletion aborted"
+msgstr "Profil %s gelöscht\n"
 
 #: lxc/remote.go:107
 msgid "Project to use for the remote"
@@ -5244,7 +5253,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:1019
 msgid "RESOURCE"
 msgstr ""
 
@@ -5299,7 +5308,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr "entfernte Instanz %s existiert bereits"
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:910 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
@@ -5344,6 +5353,13 @@ msgstr ""
 #: lxc/delete.go:48
 #, c-format
 msgid "Remove %s (yes/no): "
+msgstr ""
+
+#: lxc/project.go:214
+#, c-format
+msgid ""
+"Remove %s and everything it contains (instances, images, volumes, "
+"networks, ...) (yes/no): "
 msgstr ""
 
 #: lxc/cluster_group.go:522
@@ -5486,7 +5502,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:617 lxc/project.go:618
 #, fuzzy
 msgid "Rename projects"
 msgstr "Fehlerhafte Profil URL %s"
@@ -5654,7 +5670,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:597
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5662,7 +5678,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:596
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5862,12 +5878,12 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:682
 #, fuzzy
 msgid "Set project configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/project.go:657
+#: lxc/project.go:683
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5990,7 +6006,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:690
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -6154,7 +6170,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:814 lxc/project.go:815
 msgid "Show project options"
 msgstr ""
 
@@ -6416,7 +6432,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:875 lxc/project.go:876
 msgid "Switch the current project"
 msgstr ""
 
@@ -6601,7 +6617,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/project.go:448
+#: lxc/project.go:474
 #, fuzzy, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -6815,7 +6831,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:991
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6827,12 +6843,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:1021 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:601
 #: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
@@ -6974,7 +6990,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:770 lxc/project.go:771
 #, fuzzy
 msgid "Unset project configuration keys"
 msgstr "Profil %s erstellt\n"
@@ -7035,7 +7051,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:775
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -7210,9 +7226,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:553
+#: lxc/project.go:558 lxc/project.go:563 lxc/project.go:568 lxc/project.go:573
+#: lxc/project.go:578 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -7260,7 +7276,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:495
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 #, fuzzy
 msgid "[<remote>:]"
@@ -8342,8 +8358,8 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:94 lxc/project.go:191 lxc/project.go:286 lxc/project.go:813
+#: lxc/project.go:874 lxc/project.go:941
 #, fuzzy
 msgid "[<remote>:]<project>"
 msgstr ""
@@ -8351,7 +8367,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:422 lxc/project.go:769
 #, fuzzy
 msgid "[<remote>:]<project> <key>"
 msgstr ""
@@ -8359,7 +8375,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/project.go:655
+#: lxc/project.go:681
 #, fuzzy
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
@@ -8367,7 +8383,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/project.go:589
+#: lxc/project.go:615
 #, fuzzy
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
@@ -8509,7 +8525,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:583 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -8873,7 +8889,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:98
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -8881,7 +8897,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:290
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -9051,7 +9067,7 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1206 lxc/project.go:218
 msgid "yes"
 msgstr ""
 

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-08 16:23-0800\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -391,7 +391,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:282
+#: lxc/project.go:308
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -877,7 +877,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:162
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1205,7 +1205,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:103
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1219,7 +1219,7 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/project.go:390 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
 #: lxc/storage_volume.go:1188
 #, c-format
@@ -1492,7 +1492,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:95 lxc/project.go:96
 msgid "Create projects"
 msgstr ""
 
@@ -1537,7 +1537,7 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
-#: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:756 lxc/project.go:600 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
@@ -1647,7 +1647,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:193 lxc/project.go:194
 msgid "Delete projects"
 msgstr ""
 
@@ -1748,10 +1748,10 @@ msgstr ""
 #: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
 #: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
 #: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
-#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:32 lxc/project.go:96
+#: lxc/project.go:194 lxc/project.go:288 lxc/project.go:424 lxc/project.go:498
+#: lxc/project.go:618 lxc/project.go:683 lxc/project.go:771 lxc/project.go:815
+#: lxc/project.go:876 lxc/project.go:943 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -2024,7 +2024,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:287 lxc/project.go:288
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2105,7 +2105,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/project.go:746 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
 #, c-format
 msgid "Error setting properties: %v"
@@ -2119,7 +2119,7 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
+#: lxc/profile.go:981 lxc/project.go:740 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
 #: lxc/storage_volume.go:2199
 #, c-format
@@ -2402,6 +2402,10 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
+#: lxc/project.go:197
+msgid "Force delete the project and everything it contains."
+msgstr ""
+
 #: lxc/cluster.go:1301
 msgid "Force evacuation without user confirmation"
 msgstr ""
@@ -2461,8 +2465,8 @@ msgstr ""
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:500
+#: lxc/project.go:945 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2528,7 +2532,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:942 lxc/project.go:943
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2581,7 +2585,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:428
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2652,7 +2656,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:423 lxc/project.go:424
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2747,7 +2751,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:594
 msgid "IMAGES"
 msgstr ""
 
@@ -3085,7 +3089,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1020
 msgid "LIMIT"
 msgstr ""
 
@@ -3389,7 +3393,7 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:497 lxc/project.go:498
 msgid "List projects"
 msgstr ""
 
@@ -3704,7 +3708,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -3972,9 +3976,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:404 lxc/project.go:149 lxc/project.go:242 lxc/project.go:344
+#: lxc/project.go:461 lxc/project.go:650 lxc/project.go:719 lxc/project.go:847
+#: lxc/project.go:976
 msgid "Missing project name"
 msgstr ""
 
@@ -4099,7 +4103,7 @@ msgstr ""
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:593
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
@@ -4113,11 +4117,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:599
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:598
 msgid "NETWORKS"
 msgstr ""
 
@@ -4129,9 +4133,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:551
+#: lxc/project.go:556 lxc/project.go:561 lxc/project.go:566 lxc/project.go:571
+#: lxc/project.go:576 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4429,7 +4433,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:595
 msgid "PROFILES"
 msgstr ""
 
@@ -4508,7 +4512,7 @@ msgstr ""
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/project.go:391 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
 #: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4600,19 +4604,23 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:175
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:264
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:665
 #, c-format
 msgid "Project %s renamed to %s"
+msgstr ""
+
+#: lxc/project.go:248
+msgid "Project deletion aborted"
 msgstr ""
 
 #: lxc/remote.go:107
@@ -4757,7 +4765,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:1019
 msgid "RESOURCE"
 msgstr ""
 
@@ -4809,7 +4817,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:910 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4854,6 +4862,13 @@ msgstr ""
 #: lxc/delete.go:48
 #, c-format
 msgid "Remove %s (yes/no): "
+msgstr ""
+
+#: lxc/project.go:214
+#, c-format
+msgid ""
+"Remove %s and everything it contains (instances, images, volumes, "
+"networks, ...) (yes/no): "
 msgstr ""
 
 #: lxc/cluster_group.go:522
@@ -4982,7 +4997,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:617 lxc/project.go:618
 msgid "Rename projects"
 msgstr ""
 
@@ -5140,7 +5155,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:597
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5148,7 +5163,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:596
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5342,11 +5357,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:682
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:683
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5464,7 +5479,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:690
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5618,7 +5633,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:814 lxc/project.go:815
 msgid "Show project options"
 msgstr ""
 
@@ -5867,7 +5882,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:875 lxc/project.go:876
 msgid "Switch the current project"
 msgstr ""
 
@@ -6046,7 +6061,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/project.go:448
+#: lxc/project.go:474
 #, fuzzy, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "  Χρήση δικτύου:"
@@ -6254,7 +6269,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:991
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6266,12 +6281,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:1021 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:601
 #: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
@@ -6407,7 +6422,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:770 lxc/project.go:771
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6466,7 +6481,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:775
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6628,9 +6643,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:553
+#: lxc/project.go:558 lxc/project.go:563 lxc/project.go:568 lxc/project.go:573
+#: lxc/project.go:578 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6666,7 +6681,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:495
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -7216,20 +7231,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:94 lxc/project.go:191 lxc/project.go:286 lxc/project.go:813
+#: lxc/project.go:874 lxc/project.go:941
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:422 lxc/project.go:769
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:681
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:615
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7297,7 +7312,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:583 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7657,7 +7672,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:98
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7665,7 +7680,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:290
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7835,7 +7850,7 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1206 lxc/project.go:218
 msgid "yes"
 msgstr ""
 

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-08 16:23-0800\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -391,7 +391,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:282
+#: lxc/project.go:308
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:162
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1201,7 +1201,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:103
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1215,7 +1215,7 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/project.go:390 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
 #: lxc/storage_volume.go:1188
 #, c-format
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:95 lxc/project.go:96
 msgid "Create projects"
 msgstr ""
 
@@ -1530,7 +1530,7 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
-#: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:756 lxc/project.go:600 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
@@ -1636,7 +1636,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:193 lxc/project.go:194
 msgid "Delete projects"
 msgstr ""
 
@@ -1736,10 +1736,10 @@ msgstr ""
 #: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
 #: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
 #: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
-#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:32 lxc/project.go:96
+#: lxc/project.go:194 lxc/project.go:288 lxc/project.go:424 lxc/project.go:498
+#: lxc/project.go:618 lxc/project.go:683 lxc/project.go:771 lxc/project.go:815
+#: lxc/project.go:876 lxc/project.go:943 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -2003,7 +2003,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:287 lxc/project.go:288
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2083,7 +2083,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/project.go:746 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
 #, c-format
 msgid "Error setting properties: %v"
@@ -2097,7 +2097,7 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
+#: lxc/profile.go:981 lxc/project.go:740 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
 #: lxc/storage_volume.go:2199
 #, c-format
@@ -2380,6 +2380,10 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
+#: lxc/project.go:197
+msgid "Force delete the project and everything it contains."
+msgstr ""
+
 #: lxc/cluster.go:1301
 msgid "Force evacuation without user confirmation"
 msgstr ""
@@ -2439,8 +2443,8 @@ msgstr ""
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:500
+#: lxc/project.go:945 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2506,7 +2510,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:942 lxc/project.go:943
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2554,7 +2558,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:428
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2618,7 +2622,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:423 lxc/project.go:424
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2712,7 +2716,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:594
 msgid "IMAGES"
 msgstr ""
 
@@ -3050,7 +3054,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1020
 msgid "LIMIT"
 msgstr ""
 
@@ -3352,7 +3356,7 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:497 lxc/project.go:498
 msgid "List projects"
 msgstr ""
 
@@ -3657,7 +3661,7 @@ msgstr ""
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -3911,9 +3915,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:404 lxc/project.go:149 lxc/project.go:242 lxc/project.go:344
+#: lxc/project.go:461 lxc/project.go:650 lxc/project.go:719 lxc/project.go:847
+#: lxc/project.go:976
 msgid "Missing project name"
 msgstr ""
 
@@ -4037,7 +4041,7 @@ msgstr ""
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:593
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
@@ -4051,11 +4055,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:599
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:598
 msgid "NETWORKS"
 msgstr ""
 
@@ -4067,9 +4071,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:551
+#: lxc/project.go:556 lxc/project.go:561 lxc/project.go:566 lxc/project.go:571
+#: lxc/project.go:576 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4365,7 +4369,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:595
 msgid "PROFILES"
 msgstr ""
 
@@ -4443,7 +4447,7 @@ msgstr ""
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/project.go:391 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
 #: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4535,19 +4539,23 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:175
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:264
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:665
 #, c-format
 msgid "Project %s renamed to %s"
+msgstr ""
+
+#: lxc/project.go:248
+msgid "Project deletion aborted"
 msgstr ""
 
 #: lxc/remote.go:107
@@ -4692,7 +4700,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:1019
 msgid "RESOURCE"
 msgstr ""
 
@@ -4744,7 +4752,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:910 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4789,6 +4797,13 @@ msgstr ""
 #: lxc/delete.go:48
 #, c-format
 msgid "Remove %s (yes/no): "
+msgstr ""
+
+#: lxc/project.go:214
+#, c-format
+msgid ""
+"Remove %s and everything it contains (instances, images, volumes, "
+"networks, ...) (yes/no): "
 msgstr ""
 
 #: lxc/cluster_group.go:522
@@ -4912,7 +4927,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:617 lxc/project.go:618
 msgid "Rename projects"
 msgstr ""
 
@@ -5069,7 +5084,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:597
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5077,7 +5092,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:596
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5265,11 +5280,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:682
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:683
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5381,7 +5396,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:690
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5526,7 +5541,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:814 lxc/project.go:815
 msgid "Show project options"
 msgstr ""
 
@@ -5772,7 +5787,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:875 lxc/project.go:876
 msgid "Switch the current project"
 msgstr ""
 
@@ -5951,7 +5966,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:448
+#: lxc/project.go:474
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6158,7 +6173,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:991
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6170,12 +6185,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:1021 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:601
 #: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
@@ -6302,7 +6317,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:770 lxc/project.go:771
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6354,7 +6369,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:775
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6515,9 +6530,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:553
+#: lxc/project.go:558 lxc/project.go:563 lxc/project.go:568 lxc/project.go:573
+#: lxc/project.go:578 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6553,7 +6568,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:495
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -7103,20 +7118,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:94 lxc/project.go:191 lxc/project.go:286 lxc/project.go:813
+#: lxc/project.go:874 lxc/project.go:941
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:422 lxc/project.go:769
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:681
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:615
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7184,7 +7199,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:583 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7544,7 +7559,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:98
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7552,7 +7567,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:290
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7722,6 +7737,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1206 lxc/project.go:218
 msgid "yes"
 msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-08 16:23-0800\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -613,7 +613,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/project.go:282
+#: lxc/project.go:308
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -1123,7 +1123,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:162
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Nombre del contenedor es: %s"
@@ -1458,7 +1458,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: lxc/project.go:102
+#: lxc/project.go:103
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1473,7 +1473,7 @@ msgstr "Perfil para aplicar al nuevo contenedor"
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/project.go:390 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
 #: lxc/storage_volume.go:1188
 #, c-format
@@ -1754,7 +1754,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:95 lxc/project.go:96
 msgid "Create projects"
 msgstr ""
 
@@ -1800,7 +1800,7 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
-#: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:756 lxc/project.go:600 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
@@ -1911,7 +1911,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:193 lxc/project.go:194
 msgid "Delete projects"
 msgstr ""
 
@@ -2012,10 +2012,10 @@ msgstr ""
 #: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
 #: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
 #: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
-#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:32 lxc/project.go:96
+#: lxc/project.go:194 lxc/project.go:288 lxc/project.go:424 lxc/project.go:498
+#: lxc/project.go:618 lxc/project.go:683 lxc/project.go:771 lxc/project.go:815
+#: lxc/project.go:876 lxc/project.go:943 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -2289,7 +2289,7 @@ msgstr "Perfil %s creado"
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:287 lxc/project.go:288
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2370,7 +2370,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/project.go:746 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
@@ -2384,7 +2384,7 @@ msgstr "Error actualizando el archivo de plantilla: %s"
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
+#: lxc/profile.go:981 lxc/project.go:740 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
 #: lxc/storage_volume.go:2199
 #, c-format
@@ -2671,6 +2671,10 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
+#: lxc/project.go:197
+msgid "Force delete the project and everything it contains."
+msgstr ""
+
 #: lxc/cluster.go:1301
 msgid "Force evacuation without user confirmation"
 msgstr ""
@@ -2731,8 +2735,8 @@ msgstr ""
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:500
+#: lxc/project.go:945 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2799,7 +2803,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr "Aliases:"
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:942 lxc/project.go:943
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2852,7 +2856,7 @@ msgstr "Perfil %s creado"
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:428
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2923,7 +2927,7 @@ msgstr "Perfil %s creado"
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:423 lxc/project.go:424
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -3019,7 +3023,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:594
 msgid "IMAGES"
 msgstr ""
 
@@ -3365,7 +3369,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1020
 msgid "LIMIT"
 msgstr ""
 
@@ -3679,7 +3683,7 @@ msgstr "Aliases:"
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:497 lxc/project.go:498
 msgid "List projects"
 msgstr ""
 
@@ -3997,7 +4001,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -4271,9 +4275,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:404 lxc/project.go:149 lxc/project.go:242 lxc/project.go:344
+#: lxc/project.go:461 lxc/project.go:650 lxc/project.go:719 lxc/project.go:847
+#: lxc/project.go:976
 #, fuzzy
 msgid "Missing project name"
 msgstr "Nombre del contenedor es: %s"
@@ -4402,7 +4406,7 @@ msgstr ""
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:593
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
@@ -4416,11 +4420,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:599
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:598
 msgid "NETWORKS"
 msgstr ""
 
@@ -4432,9 +4436,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:551
+#: lxc/project.go:556 lxc/project.go:561 lxc/project.go:566 lxc/project.go:571
+#: lxc/project.go:576 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4730,7 +4734,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:595
 msgid "PROFILES"
 msgstr ""
 
@@ -4809,7 +4813,7 @@ msgstr ""
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/project.go:391 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
 #: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4905,19 +4909,23 @@ msgstr ""
 msgid "Profiles: "
 msgstr "Perfil %s creado"
 
-#: lxc/project.go:174
+#: lxc/project.go:175
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:264
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:665
 #, c-format
 msgid "Project %s renamed to %s"
+msgstr ""
+
+#: lxc/project.go:248
+msgid "Project deletion aborted"
 msgstr ""
 
 #: lxc/remote.go:107
@@ -5062,7 +5070,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:1019
 msgid "RESOURCE"
 msgstr ""
 
@@ -5116,7 +5124,7 @@ msgstr "Refrescando la imagen: %s"
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:910 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -5162,6 +5170,13 @@ msgstr ""
 #: lxc/delete.go:48
 #, c-format
 msgid "Remove %s (yes/no): "
+msgstr ""
+
+#: lxc/project.go:214
+#, c-format
+msgid ""
+"Remove %s and everything it contains (instances, images, volumes, "
+"networks, ...) (yes/no): "
 msgstr ""
 
 #: lxc/cluster_group.go:522
@@ -5292,7 +5307,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:617 lxc/project.go:618
 msgid "Rename projects"
 msgstr ""
 
@@ -5455,7 +5470,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:597
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5463,7 +5478,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:596
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5658,11 +5673,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:682
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:683
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5780,7 +5795,7 @@ msgstr "Perfil %s creado"
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:690
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5935,7 +5950,7 @@ msgstr "Perfil %s creado"
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:814 lxc/project.go:815
 msgid "Show project options"
 msgstr ""
 
@@ -6185,7 +6200,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:875 lxc/project.go:876
 msgid "Switch the current project"
 msgstr ""
 
@@ -6366,7 +6381,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/project.go:448
+#: lxc/project.go:474
 #, fuzzy, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "Nombre del Miembro del Cluster"
@@ -6577,7 +6592,7 @@ msgstr "Expira: %s"
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:991
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6589,12 +6604,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:1021 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:601
 #: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
@@ -6731,7 +6746,7 @@ msgstr "Perfil %s creado"
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:770 lxc/project.go:771
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6790,7 +6805,7 @@ msgstr "Perfil %s creado"
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:775
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6953,9 +6968,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:553
+#: lxc/project.go:558 lxc/project.go:563 lxc/project.go:568 lxc/project.go:573
+#: lxc/project.go:578 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6993,7 +7008,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:495
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 #, fuzzy
 msgid "[<remote>:]"
@@ -7666,23 +7681,23 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:94 lxc/project.go:191 lxc/project.go:286 lxc/project.go:813
+#: lxc/project.go:874 lxc/project.go:941
 #, fuzzy
 msgid "[<remote>:]<project>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:422 lxc/project.go:769
 #, fuzzy
 msgid "[<remote>:]<project> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/project.go:655
+#: lxc/project.go:681
 #, fuzzy
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/project.go:589
+#: lxc/project.go:615
 #, fuzzy
 msgid "[<remote>:]<project> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7767,7 +7782,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[[<remote>:]<member>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:583 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -8127,7 +8142,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:98
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -8135,7 +8150,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:290
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -8305,7 +8320,7 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1206 lxc/project.go:218
 msgid "yes"
 msgstr ""
 

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-08 16:23-0800\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -391,7 +391,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:282
+#: lxc/project.go:308
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:162
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1201,7 +1201,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:103
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1215,7 +1215,7 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/project.go:390 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
 #: lxc/storage_volume.go:1188
 #, c-format
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:95 lxc/project.go:96
 msgid "Create projects"
 msgstr ""
 
@@ -1530,7 +1530,7 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
-#: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:756 lxc/project.go:600 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
@@ -1636,7 +1636,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:193 lxc/project.go:194
 msgid "Delete projects"
 msgstr ""
 
@@ -1736,10 +1736,10 @@ msgstr ""
 #: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
 #: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
 #: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
-#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:32 lxc/project.go:96
+#: lxc/project.go:194 lxc/project.go:288 lxc/project.go:424 lxc/project.go:498
+#: lxc/project.go:618 lxc/project.go:683 lxc/project.go:771 lxc/project.go:815
+#: lxc/project.go:876 lxc/project.go:943 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -2003,7 +2003,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:287 lxc/project.go:288
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2083,7 +2083,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/project.go:746 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
 #, c-format
 msgid "Error setting properties: %v"
@@ -2097,7 +2097,7 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
+#: lxc/profile.go:981 lxc/project.go:740 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
 #: lxc/storage_volume.go:2199
 #, c-format
@@ -2380,6 +2380,10 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
+#: lxc/project.go:197
+msgid "Force delete the project and everything it contains."
+msgstr ""
+
 #: lxc/cluster.go:1301
 msgid "Force evacuation without user confirmation"
 msgstr ""
@@ -2439,8 +2443,8 @@ msgstr ""
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:500
+#: lxc/project.go:945 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2506,7 +2510,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:942 lxc/project.go:943
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2554,7 +2558,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:428
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2618,7 +2622,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:423 lxc/project.go:424
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2712,7 +2716,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:594
 msgid "IMAGES"
 msgstr ""
 
@@ -3050,7 +3054,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1020
 msgid "LIMIT"
 msgstr ""
 
@@ -3352,7 +3356,7 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:497 lxc/project.go:498
 msgid "List projects"
 msgstr ""
 
@@ -3657,7 +3661,7 @@ msgstr ""
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -3911,9 +3915,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:404 lxc/project.go:149 lxc/project.go:242 lxc/project.go:344
+#: lxc/project.go:461 lxc/project.go:650 lxc/project.go:719 lxc/project.go:847
+#: lxc/project.go:976
 msgid "Missing project name"
 msgstr ""
 
@@ -4037,7 +4041,7 @@ msgstr ""
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:593
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
@@ -4051,11 +4055,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:599
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:598
 msgid "NETWORKS"
 msgstr ""
 
@@ -4067,9 +4071,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:551
+#: lxc/project.go:556 lxc/project.go:561 lxc/project.go:566 lxc/project.go:571
+#: lxc/project.go:576 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4365,7 +4369,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:595
 msgid "PROFILES"
 msgstr ""
 
@@ -4443,7 +4447,7 @@ msgstr ""
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/project.go:391 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
 #: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4535,19 +4539,23 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:175
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:264
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:665
 #, c-format
 msgid "Project %s renamed to %s"
+msgstr ""
+
+#: lxc/project.go:248
+msgid "Project deletion aborted"
 msgstr ""
 
 #: lxc/remote.go:107
@@ -4692,7 +4700,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:1019
 msgid "RESOURCE"
 msgstr ""
 
@@ -4744,7 +4752,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:910 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4789,6 +4797,13 @@ msgstr ""
 #: lxc/delete.go:48
 #, c-format
 msgid "Remove %s (yes/no): "
+msgstr ""
+
+#: lxc/project.go:214
+#, c-format
+msgid ""
+"Remove %s and everything it contains (instances, images, volumes, "
+"networks, ...) (yes/no): "
 msgstr ""
 
 #: lxc/cluster_group.go:522
@@ -4912,7 +4927,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:617 lxc/project.go:618
 msgid "Rename projects"
 msgstr ""
 
@@ -5069,7 +5084,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:597
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5077,7 +5092,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:596
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5265,11 +5280,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:682
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:683
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5381,7 +5396,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:690
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5526,7 +5541,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:814 lxc/project.go:815
 msgid "Show project options"
 msgstr ""
 
@@ -5772,7 +5787,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:875 lxc/project.go:876
 msgid "Switch the current project"
 msgstr ""
 
@@ -5951,7 +5966,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:448
+#: lxc/project.go:474
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6158,7 +6173,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:991
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6170,12 +6185,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:1021 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:601
 #: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
@@ -6302,7 +6317,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:770 lxc/project.go:771
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6354,7 +6369,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:775
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6515,9 +6530,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:553
+#: lxc/project.go:558 lxc/project.go:563 lxc/project.go:568 lxc/project.go:573
+#: lxc/project.go:578 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6553,7 +6568,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:495
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -7103,20 +7118,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:94 lxc/project.go:191 lxc/project.go:286 lxc/project.go:813
+#: lxc/project.go:874 lxc/project.go:941
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:422 lxc/project.go:769
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:681
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:615
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7184,7 +7199,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:583 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7544,7 +7559,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:98
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7552,7 +7567,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:290
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7722,6 +7737,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1206 lxc/project.go:218
 msgid "yes"
 msgstr ""

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-08 16:23-0800\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -391,7 +391,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:282
+#: lxc/project.go:308
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:162
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1201,7 +1201,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:103
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1215,7 +1215,7 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/project.go:390 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
 #: lxc/storage_volume.go:1188
 #, c-format
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:95 lxc/project.go:96
 msgid "Create projects"
 msgstr ""
 
@@ -1530,7 +1530,7 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
-#: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:756 lxc/project.go:600 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
@@ -1636,7 +1636,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:193 lxc/project.go:194
 msgid "Delete projects"
 msgstr ""
 
@@ -1736,10 +1736,10 @@ msgstr ""
 #: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
 #: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
 #: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
-#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:32 lxc/project.go:96
+#: lxc/project.go:194 lxc/project.go:288 lxc/project.go:424 lxc/project.go:498
+#: lxc/project.go:618 lxc/project.go:683 lxc/project.go:771 lxc/project.go:815
+#: lxc/project.go:876 lxc/project.go:943 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -2003,7 +2003,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:287 lxc/project.go:288
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2083,7 +2083,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/project.go:746 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
 #, c-format
 msgid "Error setting properties: %v"
@@ -2097,7 +2097,7 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
+#: lxc/profile.go:981 lxc/project.go:740 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
 #: lxc/storage_volume.go:2199
 #, c-format
@@ -2380,6 +2380,10 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
+#: lxc/project.go:197
+msgid "Force delete the project and everything it contains."
+msgstr ""
+
 #: lxc/cluster.go:1301
 msgid "Force evacuation without user confirmation"
 msgstr ""
@@ -2439,8 +2443,8 @@ msgstr ""
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:500
+#: lxc/project.go:945 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2506,7 +2510,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:942 lxc/project.go:943
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2554,7 +2558,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:428
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2618,7 +2622,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:423 lxc/project.go:424
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2712,7 +2716,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:594
 msgid "IMAGES"
 msgstr ""
 
@@ -3050,7 +3054,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1020
 msgid "LIMIT"
 msgstr ""
 
@@ -3352,7 +3356,7 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:497 lxc/project.go:498
 msgid "List projects"
 msgstr ""
 
@@ -3657,7 +3661,7 @@ msgstr ""
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -3911,9 +3915,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:404 lxc/project.go:149 lxc/project.go:242 lxc/project.go:344
+#: lxc/project.go:461 lxc/project.go:650 lxc/project.go:719 lxc/project.go:847
+#: lxc/project.go:976
 msgid "Missing project name"
 msgstr ""
 
@@ -4037,7 +4041,7 @@ msgstr ""
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:593
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
@@ -4051,11 +4055,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:599
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:598
 msgid "NETWORKS"
 msgstr ""
 
@@ -4067,9 +4071,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:551
+#: lxc/project.go:556 lxc/project.go:561 lxc/project.go:566 lxc/project.go:571
+#: lxc/project.go:576 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4365,7 +4369,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:595
 msgid "PROFILES"
 msgstr ""
 
@@ -4443,7 +4447,7 @@ msgstr ""
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/project.go:391 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
 #: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4535,19 +4539,23 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:175
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:264
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:665
 #, c-format
 msgid "Project %s renamed to %s"
+msgstr ""
+
+#: lxc/project.go:248
+msgid "Project deletion aborted"
 msgstr ""
 
 #: lxc/remote.go:107
@@ -4692,7 +4700,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:1019
 msgid "RESOURCE"
 msgstr ""
 
@@ -4744,7 +4752,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:910 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4789,6 +4797,13 @@ msgstr ""
 #: lxc/delete.go:48
 #, c-format
 msgid "Remove %s (yes/no): "
+msgstr ""
+
+#: lxc/project.go:214
+#, c-format
+msgid ""
+"Remove %s and everything it contains (instances, images, volumes, "
+"networks, ...) (yes/no): "
 msgstr ""
 
 #: lxc/cluster_group.go:522
@@ -4912,7 +4927,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:617 lxc/project.go:618
 msgid "Rename projects"
 msgstr ""
 
@@ -5069,7 +5084,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:597
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5077,7 +5092,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:596
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5265,11 +5280,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:682
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:683
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5381,7 +5396,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:690
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5526,7 +5541,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:814 lxc/project.go:815
 msgid "Show project options"
 msgstr ""
 
@@ -5772,7 +5787,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:875 lxc/project.go:876
 msgid "Switch the current project"
 msgstr ""
 
@@ -5951,7 +5966,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:448
+#: lxc/project.go:474
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6158,7 +6173,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:991
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6170,12 +6185,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:1021 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:601
 #: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
@@ -6302,7 +6317,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:770 lxc/project.go:771
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6354,7 +6369,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:775
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6515,9 +6530,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:553
+#: lxc/project.go:558 lxc/project.go:563 lxc/project.go:568 lxc/project.go:573
+#: lxc/project.go:578 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6553,7 +6568,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:495
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -7103,20 +7118,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:94 lxc/project.go:191 lxc/project.go:286 lxc/project.go:813
+#: lxc/project.go:874 lxc/project.go:941
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:422 lxc/project.go:769
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:681
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:615
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7184,7 +7199,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:583 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7544,7 +7559,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:98
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7552,7 +7567,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:290
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7722,6 +7737,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1206 lxc/project.go:218
 msgid "yes"
 msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-08 16:23-0800\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -618,7 +618,7 @@ msgstr ""
 "###\n"
 "### Notez que le nom est affiché mais ne peut être modifié"
 
-#: lxc/project.go:282
+#: lxc/project.go:308
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -1162,7 +1162,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:162
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Clé de configuration invalide"
@@ -1506,7 +1506,7 @@ msgstr "Définir un algorithme de compression : pour image ou aucun"
 msgid "Config key/value to apply to the new instance"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 
-#: lxc/project.go:102
+#: lxc/project.go:103
 #, fuzzy
 msgid "Config key/value to apply to the new project"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
@@ -1522,7 +1522,7 @@ msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/project.go:390 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
 #: lxc/storage_volume.go:1188
 #, c-format
@@ -1834,7 +1834,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr "Créé : %s"
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:95 lxc/project.go:96
 #, fuzzy
 msgid "Create projects"
 msgstr "Créé : %s"
@@ -1883,7 +1883,7 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
-#: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:756 lxc/project.go:600 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
@@ -2002,7 +2002,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:193 lxc/project.go:194
 #, fuzzy
 msgid "Delete projects"
 msgstr "Récupération de l'image : %s"
@@ -2106,10 +2106,10 @@ msgstr "Récupération de l'image : %s"
 #: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
 #: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
 #: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
-#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:32 lxc/project.go:96
+#: lxc/project.go:194 lxc/project.go:288 lxc/project.go:424 lxc/project.go:498
+#: lxc/project.go:618 lxc/project.go:683 lxc/project.go:771 lxc/project.go:815
+#: lxc/project.go:876 lxc/project.go:943 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -2398,7 +2398,7 @@ msgstr "Clé de configuration invalide"
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:287 lxc/project.go:288
 #, fuzzy
 msgid "Edit project configurations as YAML"
 msgstr "Clé de configuration invalide"
@@ -2482,7 +2482,7 @@ msgstr "Récupération de l'image : %s"
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/project.go:746 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
@@ -2496,7 +2496,7 @@ msgstr "Récupération de l'image : %s"
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
+#: lxc/profile.go:981 lxc/project.go:740 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
 #: lxc/storage_volume.go:2199
 #, c-format
@@ -2805,6 +2805,10 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
+#: lxc/project.go:197
+msgid "Force delete the project and everything it contains."
+msgstr ""
+
 #: lxc/cluster.go:1301
 #, fuzzy
 msgid "Force evacuation without user confirmation"
@@ -2868,8 +2872,8 @@ msgstr ""
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:500
+#: lxc/project.go:945 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2936,7 +2940,7 @@ msgstr "Génération d'un certificat client. Ceci peut prendre une minute…"
 msgid "Get UEFI variables for instance"
 msgstr "Création du conteneur"
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:942 lxc/project.go:943
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2989,7 +2993,7 @@ msgstr "Clé de configuration invalide"
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:428
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -3067,7 +3071,7 @@ msgstr "Clé de configuration invalide"
 msgid "Get values for profile configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:423 lxc/project.go:424
 #, fuzzy
 msgid "Get values for project configuration keys"
 msgstr "Clé de configuration invalide"
@@ -3166,7 +3170,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:594
 msgid "IMAGES"
 msgstr ""
 
@@ -3524,7 +3528,7 @@ msgstr "DERNIÈRE UTILISATION À"
 msgid "LAST USED AT"
 msgstr "DERNIÈRE UTILISATION À"
 
-#: lxc/project.go:994
+#: lxc/project.go:1020
 msgid "LIMIT"
 msgstr ""
 
@@ -3900,7 +3904,7 @@ msgstr "Alias :"
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:497 lxc/project.go:498
 msgid "List projects"
 msgstr ""
 
@@ -4236,7 +4240,7 @@ msgstr "Rendre l'image publique"
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 #, fuzzy
 msgid "Manage projects"
 msgstr "Rendre l'image publique"
@@ -4520,9 +4524,9 @@ msgstr "Nom de l'ensemble de stockage"
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:404 lxc/project.go:149 lxc/project.go:242 lxc/project.go:344
+#: lxc/project.go:461 lxc/project.go:650 lxc/project.go:719 lxc/project.go:847
+#: lxc/project.go:976
 #, fuzzy
 msgid "Missing project name"
 msgstr "Nom de l'ensemble de stockage"
@@ -4659,7 +4663,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:593
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
@@ -4673,11 +4677,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:599
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:598
 msgid "NETWORKS"
 msgstr ""
 
@@ -4689,9 +4693,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:551
+#: lxc/project.go:556 lxc/project.go:561 lxc/project.go:566 lxc/project.go:571
+#: lxc/project.go:576 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr "NON"
 
@@ -5006,7 +5010,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:595
 msgid "PROFILES"
 msgstr "PROFILS"
 
@@ -5089,7 +5093,7 @@ msgstr ""
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/project.go:391 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
 #: lxc/storage_volume.go:1189
 #, fuzzy
@@ -5187,20 +5191,25 @@ msgstr "Profils : %s"
 msgid "Profiles: "
 msgstr "Profils : %s"
 
-#: lxc/project.go:174
+#: lxc/project.go:175
 #, fuzzy, c-format
 msgid "Project %s created"
 msgstr "Profil %s créé"
 
-#: lxc/project.go:238
+#: lxc/project.go:264
 #, fuzzy, c-format
 msgid "Project %s deleted"
 msgstr "Profil %s supprimé"
 
-#: lxc/project.go:639
+#: lxc/project.go:665
 #, fuzzy, c-format
 msgid "Project %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
+
+#: lxc/project.go:248
+#, fuzzy
+msgid "Project deletion aborted"
+msgstr "Profil %s supprimé"
 
 #: lxc/remote.go:107
 msgid "Project to use for the remote"
@@ -5347,7 +5356,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:1019
 #, fuzzy
 msgid "RESOURCE"
 msgstr "SOURCE"
@@ -5405,7 +5414,7 @@ msgstr "Récupération de l'image : %s"
 msgid "Remote %s already exists"
 msgstr "le serveur distant %s existe déjà"
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:910 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
@@ -5452,6 +5461,13 @@ msgstr "Serveur distant : %s"
 #, c-format
 msgid "Remove %s (yes/no): "
 msgstr "Supprimer %s (oui/non) : "
+
+#: lxc/project.go:214
+#, c-format
+msgid ""
+"Remove %s and everything it contains (instances, images, volumes, "
+"networks, ...) (yes/no): "
+msgstr ""
 
 #: lxc/cluster_group.go:522
 #, fuzzy
@@ -5593,7 +5609,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:617 lxc/project.go:618
 #, fuzzy
 msgid "Rename projects"
 msgstr "Créé : %s"
@@ -5779,7 +5795,7 @@ msgstr "STATIQUE"
 msgid "STATUS"
 msgstr "ÉTAT"
 
-#: lxc/project.go:571
+#: lxc/project.go:597
 #, fuzzy
 msgid "STORAGE BUCKETS"
 msgstr "ENSEMBLE DE STOCKAGE"
@@ -5788,7 +5804,7 @@ msgstr "ENSEMBLE DE STOCKAGE"
 msgid "STORAGE POOL"
 msgstr "ENSEMBLE DE STOCKAGE"
 
-#: lxc/project.go:570
+#: lxc/project.go:596
 #, fuzzy
 msgid "STORAGE VOLUMES"
 msgstr "ENSEMBLE DE STOCKAGE"
@@ -5991,12 +6007,12 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:682
 #, fuzzy
 msgid "Set project configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/project.go:657
+#: lxc/project.go:683
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -6119,7 +6135,7 @@ msgstr "Clé de configuration invalide"
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:690
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -6287,7 +6303,7 @@ msgstr "Afficher la configuration étendue"
 msgid "Show profile configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:814 lxc/project.go:815
 #, fuzzy
 msgid "Show project options"
 msgstr "Afficher la configuration étendue"
@@ -6552,7 +6568,7 @@ msgstr "Swap (courant)"
 msgid "Swap (peak)"
 msgstr "Swap (pointe)"
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:875 lxc/project.go:876
 #, fuzzy
 msgid "Switch the current project"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -6743,7 +6759,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/project.go:448
+#: lxc/project.go:474
 #, fuzzy, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -6959,7 +6975,7 @@ msgstr "Expire : %s"
 msgid "Type: %s (ephemeral)"
 msgstr "Type : éphémère"
 
-#: lxc/project.go:965
+#: lxc/project.go:991
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6971,12 +6987,12 @@ msgstr "DATE DE PUBLICATION"
 msgid "URL"
 msgstr "URL"
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:1021 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:601
 #: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr "UTILISÉ PAR"
@@ -7120,7 +7136,7 @@ msgstr "Clé de configuration invalide"
 msgid "Unset profile configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:770 lxc/project.go:771
 #, fuzzy
 msgid "Unset project configuration keys"
 msgstr "Clé de configuration invalide"
@@ -7182,7 +7198,7 @@ msgstr "Clé de configuration invalide"
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:775
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -7355,9 +7371,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:553
+#: lxc/project.go:558 lxc/project.go:563 lxc/project.go:568 lxc/project.go:573
+#: lxc/project.go:578 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr "OUI"
 
@@ -7405,7 +7421,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:495
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 #, fuzzy
 msgid "[<remote>:]"
@@ -8586,8 +8602,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:94 lxc/project.go:191 lxc/project.go:286 lxc/project.go:813
+#: lxc/project.go:874 lxc/project.go:941
 #, fuzzy
 msgid "[<remote>:]<project>"
 msgstr ""
@@ -8595,7 +8611,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:422 lxc/project.go:769
 #, fuzzy
 msgid "[<remote>:]<project> <key>"
 msgstr ""
@@ -8603,7 +8619,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:655
+#: lxc/project.go:681
 #, fuzzy
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
@@ -8611,7 +8627,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:589
+#: lxc/project.go:615
 #, fuzzy
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
@@ -8771,7 +8787,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:583 lxc/remote.go:840
 #, fuzzy
 msgid "current"
 msgstr "Swap (courant)"
@@ -9154,7 +9170,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:98
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -9162,7 +9178,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:290
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -9333,7 +9349,7 @@ msgid "y"
 msgstr "o"
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1206 lxc/project.go:218
 msgid "yes"
 msgstr "oui"
 

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-08 16:23-0800\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -392,7 +392,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:282
+#: lxc/project.go:308
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -875,7 +875,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:162
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1202,7 +1202,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:103
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1216,7 +1216,7 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/project.go:390 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
 #: lxc/storage_volume.go:1188
 #, c-format
@@ -1486,7 +1486,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:95 lxc/project.go:96
 msgid "Create projects"
 msgstr ""
 
@@ -1531,7 +1531,7 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
-#: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:756 lxc/project.go:600 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
@@ -1637,7 +1637,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:193 lxc/project.go:194
 msgid "Delete projects"
 msgstr ""
 
@@ -1737,10 +1737,10 @@ msgstr ""
 #: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
 #: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
 #: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
-#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:32 lxc/project.go:96
+#: lxc/project.go:194 lxc/project.go:288 lxc/project.go:424 lxc/project.go:498
+#: lxc/project.go:618 lxc/project.go:683 lxc/project.go:771 lxc/project.go:815
+#: lxc/project.go:876 lxc/project.go:943 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -2004,7 +2004,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:287 lxc/project.go:288
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2084,7 +2084,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/project.go:746 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
 #, c-format
 msgid "Error setting properties: %v"
@@ -2098,7 +2098,7 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
+#: lxc/profile.go:981 lxc/project.go:740 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
 #: lxc/storage_volume.go:2199
 #, c-format
@@ -2381,6 +2381,10 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
+#: lxc/project.go:197
+msgid "Force delete the project and everything it contains."
+msgstr ""
+
 #: lxc/cluster.go:1301
 msgid "Force evacuation without user confirmation"
 msgstr ""
@@ -2440,8 +2444,8 @@ msgstr ""
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:500
+#: lxc/project.go:945 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2507,7 +2511,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:942 lxc/project.go:943
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2555,7 +2559,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:428
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2619,7 +2623,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:423 lxc/project.go:424
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2713,7 +2717,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:594
 msgid "IMAGES"
 msgstr ""
 
@@ -3051,7 +3055,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1020
 msgid "LIMIT"
 msgstr ""
 
@@ -3353,7 +3357,7 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:497 lxc/project.go:498
 msgid "List projects"
 msgstr ""
 
@@ -3658,7 +3662,7 @@ msgstr ""
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -3912,9 +3916,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:404 lxc/project.go:149 lxc/project.go:242 lxc/project.go:344
+#: lxc/project.go:461 lxc/project.go:650 lxc/project.go:719 lxc/project.go:847
+#: lxc/project.go:976
 msgid "Missing project name"
 msgstr ""
 
@@ -4038,7 +4042,7 @@ msgstr ""
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:593
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
@@ -4052,11 +4056,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:599
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:598
 msgid "NETWORKS"
 msgstr ""
 
@@ -4068,9 +4072,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:551
+#: lxc/project.go:556 lxc/project.go:561 lxc/project.go:566 lxc/project.go:571
+#: lxc/project.go:576 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4366,7 +4370,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:595
 msgid "PROFILES"
 msgstr ""
 
@@ -4444,7 +4448,7 @@ msgstr ""
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/project.go:391 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
 #: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4536,19 +4540,23 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:175
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:264
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:665
 #, c-format
 msgid "Project %s renamed to %s"
+msgstr ""
+
+#: lxc/project.go:248
+msgid "Project deletion aborted"
 msgstr ""
 
 #: lxc/remote.go:107
@@ -4693,7 +4701,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:1019
 msgid "RESOURCE"
 msgstr ""
 
@@ -4745,7 +4753,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:910 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4790,6 +4798,13 @@ msgstr ""
 #: lxc/delete.go:48
 #, c-format
 msgid "Remove %s (yes/no): "
+msgstr ""
+
+#: lxc/project.go:214
+#, c-format
+msgid ""
+"Remove %s and everything it contains (instances, images, volumes, "
+"networks, ...) (yes/no): "
 msgstr ""
 
 #: lxc/cluster_group.go:522
@@ -4913,7 +4928,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:617 lxc/project.go:618
 msgid "Rename projects"
 msgstr ""
 
@@ -5070,7 +5085,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:597
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5078,7 +5093,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:596
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5266,11 +5281,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:682
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:683
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5382,7 +5397,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:690
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5527,7 +5542,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:814 lxc/project.go:815
 msgid "Show project options"
 msgstr ""
 
@@ -5773,7 +5788,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:875 lxc/project.go:876
 msgid "Switch the current project"
 msgstr ""
 
@@ -5952,7 +5967,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:448
+#: lxc/project.go:474
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6159,7 +6174,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:991
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6171,12 +6186,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:1021 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:601
 #: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
@@ -6303,7 +6318,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:770 lxc/project.go:771
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6355,7 +6370,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:775
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6516,9 +6531,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:553
+#: lxc/project.go:558 lxc/project.go:563 lxc/project.go:568 lxc/project.go:573
+#: lxc/project.go:578 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6554,7 +6569,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:495
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -7104,20 +7119,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:94 lxc/project.go:191 lxc/project.go:286 lxc/project.go:813
+#: lxc/project.go:874 lxc/project.go:941
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:422 lxc/project.go:769
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:681
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:615
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7185,7 +7200,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:583 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7545,7 +7560,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:98
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7553,7 +7568,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:290
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7723,6 +7738,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1206 lxc/project.go:218
 msgid "yes"
 msgstr ""

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-08 16:23-0800\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -391,7 +391,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:282
+#: lxc/project.go:308
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:162
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1201,7 +1201,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:103
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1215,7 +1215,7 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/project.go:390 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
 #: lxc/storage_volume.go:1188
 #, c-format
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:95 lxc/project.go:96
 msgid "Create projects"
 msgstr ""
 
@@ -1530,7 +1530,7 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
-#: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:756 lxc/project.go:600 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
@@ -1636,7 +1636,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:193 lxc/project.go:194
 msgid "Delete projects"
 msgstr ""
 
@@ -1736,10 +1736,10 @@ msgstr ""
 #: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
 #: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
 #: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
-#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:32 lxc/project.go:96
+#: lxc/project.go:194 lxc/project.go:288 lxc/project.go:424 lxc/project.go:498
+#: lxc/project.go:618 lxc/project.go:683 lxc/project.go:771 lxc/project.go:815
+#: lxc/project.go:876 lxc/project.go:943 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -2003,7 +2003,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:287 lxc/project.go:288
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2083,7 +2083,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/project.go:746 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
 #, c-format
 msgid "Error setting properties: %v"
@@ -2097,7 +2097,7 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
+#: lxc/profile.go:981 lxc/project.go:740 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
 #: lxc/storage_volume.go:2199
 #, c-format
@@ -2380,6 +2380,10 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
+#: lxc/project.go:197
+msgid "Force delete the project and everything it contains."
+msgstr ""
+
 #: lxc/cluster.go:1301
 msgid "Force evacuation without user confirmation"
 msgstr ""
@@ -2439,8 +2443,8 @@ msgstr ""
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:500
+#: lxc/project.go:945 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2506,7 +2510,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:942 lxc/project.go:943
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2554,7 +2558,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:428
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2618,7 +2622,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:423 lxc/project.go:424
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2712,7 +2716,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:594
 msgid "IMAGES"
 msgstr ""
 
@@ -3050,7 +3054,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1020
 msgid "LIMIT"
 msgstr ""
 
@@ -3352,7 +3356,7 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:497 lxc/project.go:498
 msgid "List projects"
 msgstr ""
 
@@ -3657,7 +3661,7 @@ msgstr ""
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -3911,9 +3915,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:404 lxc/project.go:149 lxc/project.go:242 lxc/project.go:344
+#: lxc/project.go:461 lxc/project.go:650 lxc/project.go:719 lxc/project.go:847
+#: lxc/project.go:976
 msgid "Missing project name"
 msgstr ""
 
@@ -4037,7 +4041,7 @@ msgstr ""
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:593
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
@@ -4051,11 +4055,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:599
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:598
 msgid "NETWORKS"
 msgstr ""
 
@@ -4067,9 +4071,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:551
+#: lxc/project.go:556 lxc/project.go:561 lxc/project.go:566 lxc/project.go:571
+#: lxc/project.go:576 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4365,7 +4369,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:595
 msgid "PROFILES"
 msgstr ""
 
@@ -4443,7 +4447,7 @@ msgstr ""
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/project.go:391 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
 #: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4535,19 +4539,23 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:175
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:264
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:665
 #, c-format
 msgid "Project %s renamed to %s"
+msgstr ""
+
+#: lxc/project.go:248
+msgid "Project deletion aborted"
 msgstr ""
 
 #: lxc/remote.go:107
@@ -4692,7 +4700,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:1019
 msgid "RESOURCE"
 msgstr ""
 
@@ -4744,7 +4752,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:910 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4789,6 +4797,13 @@ msgstr ""
 #: lxc/delete.go:48
 #, c-format
 msgid "Remove %s (yes/no): "
+msgstr ""
+
+#: lxc/project.go:214
+#, c-format
+msgid ""
+"Remove %s and everything it contains (instances, images, volumes, "
+"networks, ...) (yes/no): "
 msgstr ""
 
 #: lxc/cluster_group.go:522
@@ -4912,7 +4927,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:617 lxc/project.go:618
 msgid "Rename projects"
 msgstr ""
 
@@ -5069,7 +5084,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:597
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5077,7 +5092,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:596
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5265,11 +5280,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:682
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:683
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5381,7 +5396,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:690
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5526,7 +5541,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:814 lxc/project.go:815
 msgid "Show project options"
 msgstr ""
 
@@ -5772,7 +5787,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:875 lxc/project.go:876
 msgid "Switch the current project"
 msgstr ""
 
@@ -5951,7 +5966,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:448
+#: lxc/project.go:474
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6158,7 +6173,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:991
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6170,12 +6185,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:1021 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:601
 #: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
@@ -6302,7 +6317,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:770 lxc/project.go:771
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6354,7 +6369,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:775
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6515,9 +6530,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:553
+#: lxc/project.go:558 lxc/project.go:563 lxc/project.go:568 lxc/project.go:573
+#: lxc/project.go:578 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6553,7 +6568,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:495
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -7103,20 +7118,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:94 lxc/project.go:191 lxc/project.go:286 lxc/project.go:813
+#: lxc/project.go:874 lxc/project.go:941
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:422 lxc/project.go:769
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:681
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:615
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7184,7 +7199,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:583 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7544,7 +7559,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:98
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7552,7 +7567,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:290
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7722,6 +7737,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1206 lxc/project.go:218
 msgid "yes"
 msgstr ""

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-08 16:23-0800\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -391,7 +391,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:282
+#: lxc/project.go:308
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:162
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1201,7 +1201,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:103
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1215,7 +1215,7 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/project.go:390 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
 #: lxc/storage_volume.go:1188
 #, c-format
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:95 lxc/project.go:96
 msgid "Create projects"
 msgstr ""
 
@@ -1530,7 +1530,7 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
-#: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:756 lxc/project.go:600 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
@@ -1636,7 +1636,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:193 lxc/project.go:194
 msgid "Delete projects"
 msgstr ""
 
@@ -1736,10 +1736,10 @@ msgstr ""
 #: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
 #: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
 #: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
-#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:32 lxc/project.go:96
+#: lxc/project.go:194 lxc/project.go:288 lxc/project.go:424 lxc/project.go:498
+#: lxc/project.go:618 lxc/project.go:683 lxc/project.go:771 lxc/project.go:815
+#: lxc/project.go:876 lxc/project.go:943 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -2003,7 +2003,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:287 lxc/project.go:288
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2083,7 +2083,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/project.go:746 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
 #, c-format
 msgid "Error setting properties: %v"
@@ -2097,7 +2097,7 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
+#: lxc/profile.go:981 lxc/project.go:740 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
 #: lxc/storage_volume.go:2199
 #, c-format
@@ -2380,6 +2380,10 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
+#: lxc/project.go:197
+msgid "Force delete the project and everything it contains."
+msgstr ""
+
 #: lxc/cluster.go:1301
 msgid "Force evacuation without user confirmation"
 msgstr ""
@@ -2439,8 +2443,8 @@ msgstr ""
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:500
+#: lxc/project.go:945 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2506,7 +2510,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:942 lxc/project.go:943
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2554,7 +2558,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:428
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2618,7 +2622,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:423 lxc/project.go:424
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2712,7 +2716,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:594
 msgid "IMAGES"
 msgstr ""
 
@@ -3050,7 +3054,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1020
 msgid "LIMIT"
 msgstr ""
 
@@ -3352,7 +3356,7 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:497 lxc/project.go:498
 msgid "List projects"
 msgstr ""
 
@@ -3657,7 +3661,7 @@ msgstr ""
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -3911,9 +3915,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:404 lxc/project.go:149 lxc/project.go:242 lxc/project.go:344
+#: lxc/project.go:461 lxc/project.go:650 lxc/project.go:719 lxc/project.go:847
+#: lxc/project.go:976
 msgid "Missing project name"
 msgstr ""
 
@@ -4037,7 +4041,7 @@ msgstr ""
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:593
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
@@ -4051,11 +4055,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:599
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:598
 msgid "NETWORKS"
 msgstr ""
 
@@ -4067,9 +4071,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:551
+#: lxc/project.go:556 lxc/project.go:561 lxc/project.go:566 lxc/project.go:571
+#: lxc/project.go:576 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4365,7 +4369,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:595
 msgid "PROFILES"
 msgstr ""
 
@@ -4443,7 +4447,7 @@ msgstr ""
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/project.go:391 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
 #: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4535,19 +4539,23 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:175
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:264
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:665
 #, c-format
 msgid "Project %s renamed to %s"
+msgstr ""
+
+#: lxc/project.go:248
+msgid "Project deletion aborted"
 msgstr ""
 
 #: lxc/remote.go:107
@@ -4692,7 +4700,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:1019
 msgid "RESOURCE"
 msgstr ""
 
@@ -4744,7 +4752,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:910 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4789,6 +4797,13 @@ msgstr ""
 #: lxc/delete.go:48
 #, c-format
 msgid "Remove %s (yes/no): "
+msgstr ""
+
+#: lxc/project.go:214
+#, c-format
+msgid ""
+"Remove %s and everything it contains (instances, images, volumes, "
+"networks, ...) (yes/no): "
 msgstr ""
 
 #: lxc/cluster_group.go:522
@@ -4912,7 +4927,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:617 lxc/project.go:618
 msgid "Rename projects"
 msgstr ""
 
@@ -5069,7 +5084,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:597
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5077,7 +5092,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:596
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5265,11 +5280,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:682
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:683
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5381,7 +5396,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:690
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5526,7 +5541,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:814 lxc/project.go:815
 msgid "Show project options"
 msgstr ""
 
@@ -5772,7 +5787,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:875 lxc/project.go:876
 msgid "Switch the current project"
 msgstr ""
 
@@ -5951,7 +5966,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:448
+#: lxc/project.go:474
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6158,7 +6173,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:991
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6170,12 +6185,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:1021 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:601
 #: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
@@ -6302,7 +6317,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:770 lxc/project.go:771
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6354,7 +6369,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:775
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6515,9 +6530,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:553
+#: lxc/project.go:558 lxc/project.go:563 lxc/project.go:568 lxc/project.go:573
+#: lxc/project.go:578 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6553,7 +6568,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:495
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -7103,20 +7118,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:94 lxc/project.go:191 lxc/project.go:286 lxc/project.go:813
+#: lxc/project.go:874 lxc/project.go:941
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:422 lxc/project.go:769
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:681
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:615
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7184,7 +7199,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:583 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7544,7 +7559,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:98
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7552,7 +7567,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:290
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7722,6 +7737,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1206 lxc/project.go:218
 msgid "yes"
 msgstr ""

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-08 16:23-0800\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -618,7 +618,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/project.go:282
+#: lxc/project.go:308
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -1125,7 +1125,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:162
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Proprietà errata: %s"
@@ -1455,7 +1455,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:103
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1469,7 +1469,7 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/project.go:390 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
 #: lxc/storage_volume.go:1188
 #, c-format
@@ -1750,7 +1750,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:95 lxc/project.go:96
 msgid "Create projects"
 msgstr ""
 
@@ -1796,7 +1796,7 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
-#: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:756 lxc/project.go:600 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
@@ -1906,7 +1906,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:193 lxc/project.go:194
 msgid "Delete projects"
 msgstr ""
 
@@ -2007,10 +2007,10 @@ msgstr ""
 #: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
 #: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
 #: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
-#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:32 lxc/project.go:96
+#: lxc/project.go:194 lxc/project.go:288 lxc/project.go:424 lxc/project.go:498
+#: lxc/project.go:618 lxc/project.go:683 lxc/project.go:771 lxc/project.go:815
+#: lxc/project.go:876 lxc/project.go:943 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -2286,7 +2286,7 @@ msgstr "Il nome del container è: %s"
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:287 lxc/project.go:288
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2367,7 +2367,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/project.go:746 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
 #, c-format
 msgid "Error setting properties: %v"
@@ -2381,7 +2381,7 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
+#: lxc/profile.go:981 lxc/project.go:740 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
 #: lxc/storage_volume.go:2199
 #, c-format
@@ -2668,6 +2668,10 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
+#: lxc/project.go:197
+msgid "Force delete the project and everything it contains."
+msgstr ""
+
 #: lxc/cluster.go:1301
 msgid "Force evacuation without user confirmation"
 msgstr ""
@@ -2728,8 +2732,8 @@ msgstr ""
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:500
+#: lxc/project.go:945 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2796,7 +2800,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr "Creazione del container in corso"
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:942 lxc/project.go:943
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2847,7 +2851,7 @@ msgstr "Il nome del container è: %s"
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:428
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2917,7 +2921,7 @@ msgstr "Il nome del container è: %s"
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:423 lxc/project.go:424
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -3013,7 +3017,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:594
 msgid "IMAGES"
 msgstr ""
 
@@ -3358,7 +3362,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1020
 msgid "LIMIT"
 msgstr ""
 
@@ -3673,7 +3677,7 @@ msgstr "Alias:"
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:497 lxc/project.go:498
 msgid "List projects"
 msgstr ""
 
@@ -3997,7 +4001,7 @@ msgstr "Creazione del container in corso"
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -4270,9 +4274,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:404 lxc/project.go:149 lxc/project.go:242 lxc/project.go:344
+#: lxc/project.go:461 lxc/project.go:650 lxc/project.go:719 lxc/project.go:847
+#: lxc/project.go:976
 #, fuzzy
 msgid "Missing project name"
 msgstr "Il nome del container è: %s"
@@ -4400,7 +4404,7 @@ msgstr ""
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:593
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
@@ -4414,11 +4418,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:599
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:598
 msgid "NETWORKS"
 msgstr ""
 
@@ -4430,9 +4434,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:551
+#: lxc/project.go:556 lxc/project.go:561 lxc/project.go:566 lxc/project.go:571
+#: lxc/project.go:576 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4730,7 +4734,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:595
 msgid "PROFILES"
 msgstr ""
 
@@ -4810,7 +4814,7 @@ msgstr ""
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/project.go:391 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
 #: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4904,19 +4908,23 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:175
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:264
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:665
 #, c-format
 msgid "Project %s renamed to %s"
+msgstr ""
+
+#: lxc/project.go:248
+msgid "Project deletion aborted"
 msgstr ""
 
 #: lxc/remote.go:107
@@ -5062,7 +5070,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:1019
 msgid "RESOURCE"
 msgstr ""
 
@@ -5116,7 +5124,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr "il remote %s esiste già"
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:910 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
@@ -5162,6 +5170,13 @@ msgstr ""
 #: lxc/delete.go:48
 #, c-format
 msgid "Remove %s (yes/no): "
+msgstr ""
+
+#: lxc/project.go:214
+#, c-format
+msgid ""
+"Remove %s and everything it contains (instances, images, volumes, "
+"networks, ...) (yes/no): "
 msgstr ""
 
 #: lxc/cluster_group.go:522
@@ -5293,7 +5308,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:617 lxc/project.go:618
 msgid "Rename projects"
 msgstr ""
 
@@ -5456,7 +5471,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:597
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5464,7 +5479,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:596
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5657,11 +5672,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:682
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:683
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5777,7 +5792,7 @@ msgstr "Il nome del container è: %s"
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:690
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5932,7 +5947,7 @@ msgstr "Il nome del container è: %s"
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:814 lxc/project.go:815
 msgid "Show project options"
 msgstr ""
 
@@ -6184,7 +6199,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:875 lxc/project.go:876
 msgid "Switch the current project"
 msgstr ""
 
@@ -6365,7 +6380,7 @@ msgstr "Il nome del container è: %s"
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: lxc/project.go:448
+#: lxc/project.go:474
 #, fuzzy, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "Il nome del container è: %s"
@@ -6575,7 +6590,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:991
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6587,12 +6602,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:1021 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:601
 #: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
@@ -6728,7 +6743,7 @@ msgstr "Il nome del container è: %s"
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:770 lxc/project.go:771
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6784,7 +6799,7 @@ msgstr "Il nome del container è: %s"
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:775
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6948,9 +6963,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:553
+#: lxc/project.go:558 lxc/project.go:563 lxc/project.go:568 lxc/project.go:573
+#: lxc/project.go:578 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6991,7 +7006,7 @@ msgstr "Creazione del container in corso"
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:495
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 #, fuzzy
 msgid "[<remote>:]"
@@ -7664,23 +7679,23 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr "Creazione del container in corso"
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:94 lxc/project.go:191 lxc/project.go:286 lxc/project.go:813
+#: lxc/project.go:874 lxc/project.go:941
 #, fuzzy
 msgid "[<remote>:]<project>"
 msgstr "Creazione del container in corso"
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:422 lxc/project.go:769
 #, fuzzy
 msgid "[<remote>:]<project> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/project.go:655
+#: lxc/project.go:681
 #, fuzzy
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/project.go:589
+#: lxc/project.go:615
 #, fuzzy
 msgid "[<remote>:]<project> <new-name>"
 msgstr "Creazione del container in corso"
@@ -7765,7 +7780,7 @@ msgstr "Creazione del container in corso"
 msgid "[[<remote>:]<member>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:583 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -8125,7 +8140,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:98
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -8133,7 +8148,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:290
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -8304,7 +8319,7 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1206 lxc/project.go:218
 msgid "yes"
 msgstr "si"
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-08 16:23-0800\n"
 "PO-Revision-Date: 2023-03-10 15:14+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -609,7 +609,7 @@ msgstr ""
 "###\n"
 "### Note that the name is shown but cannot be changed"
 
-#: lxc/project.go:282
+#: lxc/project.go:308
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -1138,7 +1138,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr "不適切なキー/値のペア: %s"
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:162
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "不適切な キー=値 のペア: %s"
@@ -1475,7 +1475,7 @@ msgstr "使用する圧縮アルゴリズムを指定します (圧縮しない�
 msgid "Config key/value to apply to the new instance"
 msgstr "新しいインスタンスに適用するキー/値の設定"
 
-#: lxc/project.go:102
+#: lxc/project.go:103
 msgid "Config key/value to apply to the new project"
 msgstr "新しいプロジェクトに適用するキー/値の設定"
 
@@ -1489,7 +1489,7 @@ msgstr "移動先のインスタンスに適用するキー/値の設定"
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/project.go:390 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
 #: lxc/storage_volume.go:1188
 #, c-format
@@ -1783,7 +1783,7 @@ msgstr "新たにネットワークを作成します"
 msgid "Create profiles"
 msgstr "プロファイルを作成します"
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:95 lxc/project.go:96
 msgid "Create projects"
 msgstr "プロジェクトを作成します"
 
@@ -1828,7 +1828,7 @@ msgstr "DEFAULT TARGET ADDRESS"
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
-#: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:756 lxc/project.go:600 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
@@ -1937,7 +1937,7 @@ msgstr "ネットワークを削除します"
 msgid "Delete profiles"
 msgstr "プロファイルを削除します"
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:193 lxc/project.go:194
 msgid "Delete projects"
 msgstr "プロジェクトを削除します"
 
@@ -2037,10 +2037,10 @@ msgstr "警告を削除します"
 #: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
 #: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
 #: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
-#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:32 lxc/project.go:96
+#: lxc/project.go:194 lxc/project.go:288 lxc/project.go:424 lxc/project.go:498
+#: lxc/project.go:618 lxc/project.go:683 lxc/project.go:771 lxc/project.go:815
+#: lxc/project.go:876 lxc/project.go:943 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -2317,7 +2317,7 @@ msgstr "ネットワークゾーンレコードをYAMLで編集します"
 msgid "Edit profile configurations as YAML"
 msgstr "プロファイル設定をYAMLで編集します"
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:287 lxc/project.go:288
 msgid "Edit project configurations as YAML"
 msgstr "プロジェクト設定をYAMLで編集します"
 
@@ -2408,7 +2408,7 @@ msgstr "イメージの取得中: %s"
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/project.go:746 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
@@ -2422,7 +2422,7 @@ msgstr "イメージのプロパティを削除します"
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
+#: lxc/profile.go:981 lxc/project.go:740 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
 #: lxc/storage_volume.go:2199
 #, c-format
@@ -2720,6 +2720,10 @@ msgstr "特定の待避アクションを強制します"
 msgid "Force creating files or directories"
 msgstr ""
 
+#: lxc/project.go:197
+msgid "Force delete the project and everything it contains."
+msgstr ""
+
 #: lxc/cluster.go:1301
 msgid "Force evacuation without user confirmation"
 msgstr "ユーザーの確認なしで強制的に待避させます"
@@ -2795,8 +2799,8 @@ msgstr ""
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:500
+#: lxc/project.go:945 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2863,7 +2867,7 @@ msgstr "クライアント証明書を生成します。1分ぐらいかかり�
 msgid "Get UEFI variables for instance"
 msgstr "インスタンスからファイルをマウントします"
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:942 lxc/project.go:943
 msgid "Get a summary of resource allocations"
 msgstr "リソース割当の状況を表示します"
 
@@ -2917,7 +2921,7 @@ msgstr "ネットワークゾーンレコードエントリを削除します"
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:428
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2984,7 +2988,7 @@ msgstr "ネットワークゾーンレコードの設定値を取得します"
 msgid "Get values for profile configuration keys"
 msgstr "プロファイルの設定値を取得します"
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:423 lxc/project.go:424
 msgid "Get values for project configuration keys"
 msgstr "プロジェクトの設定値を取得します"
 
@@ -3079,7 +3083,7 @@ msgstr "ID: %s"
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:594
 msgid "IMAGES"
 msgstr "IMAGES"
 
@@ -3439,7 +3443,7 @@ msgstr "LAST SEEN"
 msgid "LAST USED AT"
 msgstr "LAST USED AT"
 
-#: lxc/project.go:994
+#: lxc/project.go:1020
 msgid "LIMIT"
 msgstr "LIMIT"
 
@@ -3855,7 +3859,7 @@ msgstr "プロファイルを一覧表示します"
 msgid "List profiles"
 msgstr "プロファイルを一覧表示します"
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:497 lxc/project.go:498
 msgid "List projects"
 msgstr "プロジェクトを一覧表示します"
 
@@ -4211,7 +4215,7 @@ msgstr "プロファイルを管理します"
 msgid "Manage profiles"
 msgstr "プロファイルを管理します"
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr "プロジェクトを管理します"
 
@@ -4474,9 +4478,9 @@ msgstr "ストレージプール名を指定する必要があります"
 msgid "Missing profile name"
 msgstr "プロファイル名を指定する必要があります"
 
-#: lxc/profile.go:404 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:404 lxc/project.go:149 lxc/project.go:242 lxc/project.go:344
+#: lxc/project.go:461 lxc/project.go:650 lxc/project.go:719 lxc/project.go:847
+#: lxc/project.go:976
 msgid "Missing project name"
 msgstr "プロジェクト名を指定する必要があります"
 
@@ -4618,7 +4622,7 @@ msgstr "インスタンス名を指定する必要があります: "
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:593
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
@@ -4633,11 +4637,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr "NETWORKS"
 
-#: lxc/project.go:573
+#: lxc/project.go:599
 msgid "NETWORK ZONES"
 msgstr "NETWORK ZONES"
 
-#: lxc/project.go:572
+#: lxc/project.go:598
 msgid "NETWORKS"
 msgstr "NETWORKS"
 
@@ -4649,9 +4653,9 @@ msgstr "NIC:"
 msgid "NICs:"
 msgstr "NICs:"
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:551
+#: lxc/project.go:556 lxc/project.go:561 lxc/project.go:566 lxc/project.go:571
+#: lxc/project.go:576 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr "NO"
 
@@ -4952,7 +4956,7 @@ msgstr "PORTS"
 msgid "PROCESSES"
 msgstr "PROCESSES"
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:595
 msgid "PROFILES"
 msgstr "PROFILES"
 
@@ -5031,7 +5035,7 @@ msgstr "終了するには ctrl+c を押してください"
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/project.go:391 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
 #: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -5125,20 +5129,25 @@ msgstr "プロファイル:"
 msgid "Profiles: "
 msgstr "プロファイル: "
 
-#: lxc/project.go:174
+#: lxc/project.go:175
 #, c-format
 msgid "Project %s created"
 msgstr "プロジェクト %s を作成しました"
 
-#: lxc/project.go:238
+#: lxc/project.go:264
 #, c-format
 msgid "Project %s deleted"
 msgstr "プロジェクト %s を削除しました"
 
-#: lxc/project.go:639
+#: lxc/project.go:665
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr "プロジェクト名 %s を %s に変更しました"
+
+#: lxc/project.go:248
+#, fuzzy
+msgid "Project deletion aborted"
+msgstr "プロジェクト %s を削除しました"
 
 #: lxc/remote.go:107
 msgid "Project to use for the remote"
@@ -5285,7 +5294,7 @@ msgstr "query のパスは / で始める必要があります"
 msgid "Query virtual machine images"
 msgstr "仮想マシンイメージを対象にします"
 
-#: lxc/project.go:993
+#: lxc/project.go:1019
 msgid "RESOURCE"
 msgstr "RESOURCE"
 
@@ -5339,7 +5348,7 @@ msgstr "イメージの更新中: %s"
 msgid "Remote %s already exists"
 msgstr "リモート %s は既に存在します"
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:910 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -5386,6 +5395,13 @@ msgstr "リムーバブルディスク: %v"
 #, c-format
 msgid "Remove %s (yes/no): "
 msgstr "%s を消去しますか (yes/no): "
+
+#: lxc/project.go:214
+#, c-format
+msgid ""
+"Remove %s and everything it contains (instances, images, volumes, "
+"networks, ...) (yes/no): "
+msgstr ""
 
 #: lxc/cluster_group.go:522
 msgid "Remove a cluster member from a cluster group"
@@ -5513,7 +5529,7 @@ msgstr "ネットワーク名を変更します"
 msgid "Rename profiles"
 msgstr "プロファイル名を変更します"
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:617 lxc/project.go:618
 msgid "Rename projects"
 msgstr "プロジェクト名を変更します"
 
@@ -5679,7 +5695,7 @@ msgstr "STATIC"
 msgid "STATUS"
 msgstr "STATUS"
 
-#: lxc/project.go:571
+#: lxc/project.go:597
 msgid "STORAGE BUCKETS"
 msgstr "STORAGE BUCKETS"
 
@@ -5687,7 +5703,7 @@ msgstr "STORAGE BUCKETS"
 msgid "STORAGE POOL"
 msgstr "STORAGE POOL"
 
-#: lxc/project.go:570
+#: lxc/project.go:596
 msgid "STORAGE VOLUMES"
 msgstr "STORAGE VOLUMES"
 
@@ -5917,11 +5933,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 
-#: lxc/project.go:656
+#: lxc/project.go:682
 msgid "Set project configuration keys"
 msgstr "プロジェクトの設定項目を設定します"
 
-#: lxc/project.go:657
+#: lxc/project.go:683
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -6059,7 +6075,7 @@ msgstr "ネットワークゾーンレコードエントリを削除します"
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:690
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -6210,7 +6226,7 @@ msgstr "ネットワークゾーンレコードの設定を表示します"
 msgid "Show profile configurations"
 msgstr "プロファイルの設定を表示します"
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:814 lxc/project.go:815
 msgid "Show project options"
 msgstr "プロジェクトの設定を表示します"
 
@@ -6456,7 +6472,7 @@ msgstr "Swap (現在値)"
 msgid "Swap (peak)"
 msgstr "Swap (ピーク)"
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:875 lxc/project.go:876
 msgid "Switch the current project"
 msgstr "現在のプロジェクトを切り替えます"
 
@@ -6641,7 +6657,7 @@ msgstr "設定 %q はクラスタメンバー %q には存在しません"
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: lxc/project.go:448
+#: lxc/project.go:474
 #, fuzzy, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
@@ -6874,7 +6890,7 @@ msgstr "タイプ: %s"
 msgid "Type: %s (ephemeral)"
 msgstr "タイプ: %s (ephemeral)"
 
-#: lxc/project.go:965
+#: lxc/project.go:991
 msgid "UNLIMITED"
 msgstr "UNLIMITED"
 
@@ -6886,12 +6902,12 @@ msgstr "UPLOAD DATE"
 msgid "URL"
 msgstr "URL"
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:1021 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr "USAGE"
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:601
 #: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr "USED BY"
@@ -7019,7 +7035,7 @@ msgstr "ネットワークゾーンレコードの設定を削除します"
 msgid "Unset profile configuration keys"
 msgstr "プロファイルの設定を削除します"
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:770 lxc/project.go:771
 msgid "Unset project configuration keys"
 msgstr "プロジェクトの設定を削除します"
 
@@ -7077,7 +7093,7 @@ msgstr "ネットワークゾーンレコードエントリを削除します"
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:775
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -7250,9 +7266,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:553
+#: lxc/project.go:558 lxc/project.go:563 lxc/project.go:568 lxc/project.go:573
+#: lxc/project.go:578 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr "YES"
 
@@ -7291,7 +7307,7 @@ msgstr "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:495
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr "[<remote>:]"
@@ -7870,20 +7886,20 @@ msgstr "[<remote>:]<profile> <new-name>"
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr "[<remote>:]<profile> [<remote>:]<profile>"
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:94 lxc/project.go:191 lxc/project.go:286 lxc/project.go:813
+#: lxc/project.go:874 lxc/project.go:941
 msgid "[<remote>:]<project>"
 msgstr "[<remote>:]<project>"
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:422 lxc/project.go:769
 msgid "[<remote>:]<project> <key>"
 msgstr "[<remote>:]<project> <key>"
 
-#: lxc/project.go:655
+#: lxc/project.go:681
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr "[<remote>:]<project> <key>=<value>..."
 
-#: lxc/project.go:589
+#: lxc/project.go:615
 msgid "[<remote>:]<project> <new-name>"
 msgstr "[<remote>:]<project> <new-name>"
 
@@ -7954,7 +7970,7 @@ msgstr "[<remote>] <IP|FQDN|URL|token>"
 msgid "[[<remote>:]<member>]"
 msgstr "[[<remote>:]<member>]"
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:583 lxc/remote.go:840
 msgid "current"
 msgstr "現在値"
 
@@ -8482,7 +8498,7 @@ msgstr ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    profile.yaml の内容でプロファイルを更新します"
 
-#: lxc/project.go:97
+#: lxc/project.go:98
 #, fuzzy
 msgid ""
 "lxc project create p1\n"
@@ -8495,7 +8511,7 @@ msgstr ""
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
 "    config.yaml の設定を使ってインスタンスを作成します"
 
-#: lxc/project.go:264
+#: lxc/project.go:290
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -8704,7 +8720,7 @@ msgid "y"
 msgstr "y"
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1206 lxc/project.go:218
 msgid "yes"
 msgstr "yes"
 

--- a/po/ka.po
+++ b/po/ka.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-08 16:23-0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:282
+#: lxc/project.go:308
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -871,7 +871,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:162
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1198,7 +1198,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:103
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1212,7 +1212,7 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/project.go:390 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
 #: lxc/storage_volume.go:1188
 #, c-format
@@ -1482,7 +1482,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:95 lxc/project.go:96
 msgid "Create projects"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
-#: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:756 lxc/project.go:600 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
@@ -1633,7 +1633,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:193 lxc/project.go:194
 msgid "Delete projects"
 msgstr ""
 
@@ -1733,10 +1733,10 @@ msgstr ""
 #: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
 #: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
 #: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
-#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:32 lxc/project.go:96
+#: lxc/project.go:194 lxc/project.go:288 lxc/project.go:424 lxc/project.go:498
+#: lxc/project.go:618 lxc/project.go:683 lxc/project.go:771 lxc/project.go:815
+#: lxc/project.go:876 lxc/project.go:943 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -2000,7 +2000,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:287 lxc/project.go:288
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2080,7 +2080,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/project.go:746 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
 #, c-format
 msgid "Error setting properties: %v"
@@ -2094,7 +2094,7 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
+#: lxc/profile.go:981 lxc/project.go:740 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
 #: lxc/storage_volume.go:2199
 #, c-format
@@ -2377,6 +2377,10 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
+#: lxc/project.go:197
+msgid "Force delete the project and everything it contains."
+msgstr ""
+
 #: lxc/cluster.go:1301
 msgid "Force evacuation without user confirmation"
 msgstr ""
@@ -2436,8 +2440,8 @@ msgstr ""
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:500
+#: lxc/project.go:945 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2503,7 +2507,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:942 lxc/project.go:943
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2551,7 +2555,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:428
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2615,7 +2619,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:423 lxc/project.go:424
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2709,7 +2713,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:594
 msgid "IMAGES"
 msgstr ""
 
@@ -3047,7 +3051,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1020
 msgid "LIMIT"
 msgstr ""
 
@@ -3349,7 +3353,7 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:497 lxc/project.go:498
 msgid "List projects"
 msgstr ""
 
@@ -3654,7 +3658,7 @@ msgstr ""
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -3908,9 +3912,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:404 lxc/project.go:149 lxc/project.go:242 lxc/project.go:344
+#: lxc/project.go:461 lxc/project.go:650 lxc/project.go:719 lxc/project.go:847
+#: lxc/project.go:976
 msgid "Missing project name"
 msgstr ""
 
@@ -4034,7 +4038,7 @@ msgstr ""
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:593
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
@@ -4048,11 +4052,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:599
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:598
 msgid "NETWORKS"
 msgstr ""
 
@@ -4064,9 +4068,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:551
+#: lxc/project.go:556 lxc/project.go:561 lxc/project.go:566 lxc/project.go:571
+#: lxc/project.go:576 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4362,7 +4366,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:595
 msgid "PROFILES"
 msgstr ""
 
@@ -4440,7 +4444,7 @@ msgstr ""
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/project.go:391 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
 #: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4532,19 +4536,23 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:175
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:264
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:665
 #, c-format
 msgid "Project %s renamed to %s"
+msgstr ""
+
+#: lxc/project.go:248
+msgid "Project deletion aborted"
 msgstr ""
 
 #: lxc/remote.go:107
@@ -4689,7 +4697,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:1019
 msgid "RESOURCE"
 msgstr ""
 
@@ -4741,7 +4749,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:910 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4786,6 +4794,13 @@ msgstr ""
 #: lxc/delete.go:48
 #, c-format
 msgid "Remove %s (yes/no): "
+msgstr ""
+
+#: lxc/project.go:214
+#, c-format
+msgid ""
+"Remove %s and everything it contains (instances, images, volumes, "
+"networks, ...) (yes/no): "
 msgstr ""
 
 #: lxc/cluster_group.go:522
@@ -4909,7 +4924,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:617 lxc/project.go:618
 msgid "Rename projects"
 msgstr ""
 
@@ -5066,7 +5081,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:597
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5074,7 +5089,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:596
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5262,11 +5277,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:682
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:683
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5378,7 +5393,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:690
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5523,7 +5538,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:814 lxc/project.go:815
 msgid "Show project options"
 msgstr ""
 
@@ -5769,7 +5784,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:875 lxc/project.go:876
 msgid "Switch the current project"
 msgstr ""
 
@@ -5948,7 +5963,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:448
+#: lxc/project.go:474
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6155,7 +6170,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:991
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6167,12 +6182,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:1021 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:601
 #: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
@@ -6299,7 +6314,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:770 lxc/project.go:771
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6351,7 +6366,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:775
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6512,9 +6527,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:553
+#: lxc/project.go:558 lxc/project.go:563 lxc/project.go:568 lxc/project.go:573
+#: lxc/project.go:578 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6550,7 +6565,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:495
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -7100,20 +7115,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:94 lxc/project.go:191 lxc/project.go:286 lxc/project.go:813
+#: lxc/project.go:874 lxc/project.go:941
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:422 lxc/project.go:769
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:681
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:615
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7181,7 +7196,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:583 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7541,7 +7556,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:98
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7549,7 +7564,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:290
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7719,6 +7734,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1206 lxc/project.go:218
 msgid "yes"
 msgstr ""

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-08 16:23-0800\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -391,7 +391,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:282
+#: lxc/project.go:308
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:162
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1201,7 +1201,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:103
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1215,7 +1215,7 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/project.go:390 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
 #: lxc/storage_volume.go:1188
 #, c-format
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:95 lxc/project.go:96
 msgid "Create projects"
 msgstr ""
 
@@ -1530,7 +1530,7 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
-#: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:756 lxc/project.go:600 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
@@ -1636,7 +1636,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:193 lxc/project.go:194
 msgid "Delete projects"
 msgstr ""
 
@@ -1736,10 +1736,10 @@ msgstr ""
 #: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
 #: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
 #: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
-#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:32 lxc/project.go:96
+#: lxc/project.go:194 lxc/project.go:288 lxc/project.go:424 lxc/project.go:498
+#: lxc/project.go:618 lxc/project.go:683 lxc/project.go:771 lxc/project.go:815
+#: lxc/project.go:876 lxc/project.go:943 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -2003,7 +2003,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:287 lxc/project.go:288
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2083,7 +2083,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/project.go:746 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
 #, c-format
 msgid "Error setting properties: %v"
@@ -2097,7 +2097,7 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
+#: lxc/profile.go:981 lxc/project.go:740 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
 #: lxc/storage_volume.go:2199
 #, c-format
@@ -2380,6 +2380,10 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
+#: lxc/project.go:197
+msgid "Force delete the project and everything it contains."
+msgstr ""
+
 #: lxc/cluster.go:1301
 msgid "Force evacuation without user confirmation"
 msgstr ""
@@ -2439,8 +2443,8 @@ msgstr ""
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:500
+#: lxc/project.go:945 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2506,7 +2510,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:942 lxc/project.go:943
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2554,7 +2558,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:428
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2618,7 +2622,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:423 lxc/project.go:424
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2712,7 +2716,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:594
 msgid "IMAGES"
 msgstr ""
 
@@ -3050,7 +3054,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1020
 msgid "LIMIT"
 msgstr ""
 
@@ -3352,7 +3356,7 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:497 lxc/project.go:498
 msgid "List projects"
 msgstr ""
 
@@ -3657,7 +3661,7 @@ msgstr ""
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -3911,9 +3915,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:404 lxc/project.go:149 lxc/project.go:242 lxc/project.go:344
+#: lxc/project.go:461 lxc/project.go:650 lxc/project.go:719 lxc/project.go:847
+#: lxc/project.go:976
 msgid "Missing project name"
 msgstr ""
 
@@ -4037,7 +4041,7 @@ msgstr ""
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:593
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
@@ -4051,11 +4055,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:599
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:598
 msgid "NETWORKS"
 msgstr ""
 
@@ -4067,9 +4071,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:551
+#: lxc/project.go:556 lxc/project.go:561 lxc/project.go:566 lxc/project.go:571
+#: lxc/project.go:576 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4365,7 +4369,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:595
 msgid "PROFILES"
 msgstr ""
 
@@ -4443,7 +4447,7 @@ msgstr ""
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/project.go:391 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
 #: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4535,19 +4539,23 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:175
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:264
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:665
 #, c-format
 msgid "Project %s renamed to %s"
+msgstr ""
+
+#: lxc/project.go:248
+msgid "Project deletion aborted"
 msgstr ""
 
 #: lxc/remote.go:107
@@ -4692,7 +4700,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:1019
 msgid "RESOURCE"
 msgstr ""
 
@@ -4744,7 +4752,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:910 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4789,6 +4797,13 @@ msgstr ""
 #: lxc/delete.go:48
 #, c-format
 msgid "Remove %s (yes/no): "
+msgstr ""
+
+#: lxc/project.go:214
+#, c-format
+msgid ""
+"Remove %s and everything it contains (instances, images, volumes, "
+"networks, ...) (yes/no): "
 msgstr ""
 
 #: lxc/cluster_group.go:522
@@ -4912,7 +4927,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:617 lxc/project.go:618
 msgid "Rename projects"
 msgstr ""
 
@@ -5069,7 +5084,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:597
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5077,7 +5092,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:596
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5265,11 +5280,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:682
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:683
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5381,7 +5396,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:690
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5526,7 +5541,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:814 lxc/project.go:815
 msgid "Show project options"
 msgstr ""
 
@@ -5772,7 +5787,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:875 lxc/project.go:876
 msgid "Switch the current project"
 msgstr ""
 
@@ -5951,7 +5966,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:448
+#: lxc/project.go:474
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6158,7 +6173,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:991
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6170,12 +6185,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:1021 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:601
 #: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
@@ -6302,7 +6317,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:770 lxc/project.go:771
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6354,7 +6369,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:775
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6515,9 +6530,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:553
+#: lxc/project.go:558 lxc/project.go:563 lxc/project.go:568 lxc/project.go:573
+#: lxc/project.go:578 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6553,7 +6568,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:495
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -7103,20 +7118,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:94 lxc/project.go:191 lxc/project.go:286 lxc/project.go:813
+#: lxc/project.go:874 lxc/project.go:941
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:422 lxc/project.go:769
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:681
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:615
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7184,7 +7199,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:583 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7544,7 +7559,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:98
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7552,7 +7567,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:290
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7722,6 +7737,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1206 lxc/project.go:218
 msgid "yes"
 msgstr ""

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-        "POT-Creation-Date: 2024-12-05 16:02+0000\n"
+        "POT-Creation-Date: 2024-12-08 16:23-0800\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -361,7 +361,7 @@ msgid   "### This is a YAML representation of the profile.\n"
         "### Note that the name is shown but cannot be changed"
 msgstr  ""
 
-#: lxc/project.go:282
+#: lxc/project.go:308
 msgid   "### This is a YAML representation of the project.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -830,7 +830,7 @@ msgstr  ""
 msgid   "Bad key/value pair: %s"
 msgstr  ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:162
 #, c-format
 msgid   "Bad key=value pair: %q"
 msgstr  ""
@@ -1127,7 +1127,7 @@ msgstr  ""
 msgid   "Config key/value to apply to the new instance"
 msgstr  ""
 
-#: lxc/project.go:102
+#: lxc/project.go:103
 msgid   "Config key/value to apply to the new project"
 msgstr  ""
 
@@ -1135,7 +1135,7 @@ msgstr  ""
 msgid   "Config key/value to apply to the target instance"
 msgstr  ""
 
-#: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281 lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156 lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759 lxc/network_acl.go:698 lxc/network_forward.go:767 lxc/network_load_balancer.go:738 lxc/network_peer.go:698 lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595 lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349 lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156 lxc/storage_volume.go:1188
+#: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281 lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156 lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759 lxc/network_acl.go:698 lxc/network_forward.go:767 lxc/network_load_balancer.go:738 lxc/network_peer.go:698 lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595 lxc/project.go:390 lxc/storage.go:359 lxc/storage_bucket.go:349 lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156 lxc/storage_volume.go:1188
 #, c-format
 msgid   "Config parsing error: %s"
 msgstr  ""
@@ -1395,7 +1395,7 @@ msgstr  ""
 msgid   "Create profiles"
 msgstr  ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:95 lxc/project.go:96
 msgid   "Create projects"
 msgstr  ""
 
@@ -1435,7 +1435,7 @@ msgstr  ""
 msgid   "DEFAULT TARGET ADDRESS"
 msgstr  ""
 
-#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504 lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086 lxc/network_acl.go:157 lxc/network_forward.go:157 lxc/network_load_balancer.go:160 lxc/network_peer.go:149 lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173 lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723 lxc/storage_bucket.go:513 lxc/storage_bucket.go:833 lxc/storage_volume.go:1738
+#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504 lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086 lxc/network_acl.go:157 lxc/network_forward.go:157 lxc/network_load_balancer.go:160 lxc/network_peer.go:149 lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173 lxc/profile.go:756 lxc/project.go:600 lxc/storage.go:723 lxc/storage_bucket.go:513 lxc/storage_bucket.go:833 lxc/storage_volume.go:1738
 msgid   "DESCRIPTION"
 msgstr  ""
 
@@ -1539,7 +1539,7 @@ msgstr  ""
 msgid   "Delete profiles"
 msgstr  ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:193 lxc/project.go:194
 msgid   "Delete projects"
 msgstr  ""
 
@@ -1559,7 +1559,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104 lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398 lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581 lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985 lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292 lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464 lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781 lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060 lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087 lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329 lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170 lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956 lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409 lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634 lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28 lxc/config_metadata.go:56 lxc/config_metadata.go:189 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:119 lxc/config_template.go:173 lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689 lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602 lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106 lxc/network.go:1185 lxc/network.go:1245 lxc/network.go:1341 lxc/network.go:1413 lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53 lxc/network_forward.go:33 lxc/network_forward.go:90 lxc/network_forward.go:179 lxc/network_forward.go:256 lxc/network_forward.go:404 lxc/network_forward.go:489 lxc/network_forward.go:599 lxc/network_forward.go:646 lxc/network_forward.go:800 lxc/network_forward.go:874 lxc/network_forward.go:889 lxc/network_forward.go:970 lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121 lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:165 lxc/network_zone.go:228 lxc/network_zone.go:301 lxc/network_zone.go:396 lxc/network_zone.go:484 lxc/network_zone.go:527 lxc/network_zone.go:654 lxc/network_zone.go:710 lxc/network_zone.go:767 lxc/network_zone.go:845 lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083 lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349 lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483 lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749 lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018 lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250 lxc/storage_bucket.go:383 lxc/storage_bucket.go:459 lxc/storage_bucket.go:536 lxc/storage_bucket.go:630 lxc/storage_bucket.go:699 lxc/storage_bucket.go:733 lxc/storage_bucket.go:774 lxc/storage_bucket.go:853 lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158 lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283 lxc/storage_volume.go:390 lxc/storage_volume.go:611 lxc/storage_volume.go:720 lxc/storage_volume.go:807 lxc/storage_volume.go:905 lxc/storage_volume.go:1002 lxc/storage_volume.go:1223 lxc/storage_volume.go:1354 lxc/storage_volume.go:1513 lxc/storage_volume.go:1597 lxc/storage_volume.go:1850 lxc/storage_volume.go:1949 lxc/storage_volume.go:2076 lxc/storage_volume.go:2234 lxc/storage_volume.go:2355 lxc/storage_volume.go:2417 lxc/storage_volume.go:2553 lxc/storage_volume.go:2636 lxc/storage_volume.go:2802 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104 lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398 lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581 lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985 lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292 lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464 lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781 lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060 lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087 lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329 lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170 lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956 lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409 lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634 lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28 lxc/config_metadata.go:56 lxc/config_metadata.go:189 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:119 lxc/config_template.go:173 lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689 lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602 lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106 lxc/network.go:1185 lxc/network.go:1245 lxc/network.go:1341 lxc/network.go:1413 lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53 lxc/network_forward.go:33 lxc/network_forward.go:90 lxc/network_forward.go:179 lxc/network_forward.go:256 lxc/network_forward.go:404 lxc/network_forward.go:489 lxc/network_forward.go:599 lxc/network_forward.go:646 lxc/network_forward.go:800 lxc/network_forward.go:874 lxc/network_forward.go:889 lxc/network_forward.go:970 lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121 lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:165 lxc/network_zone.go:228 lxc/network_zone.go:301 lxc/network_zone.go:396 lxc/network_zone.go:484 lxc/network_zone.go:527 lxc/network_zone.go:654 lxc/network_zone.go:710 lxc/network_zone.go:767 lxc/network_zone.go:845 lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083 lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349 lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483 lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:32 lxc/project.go:96 lxc/project.go:194 lxc/project.go:288 lxc/project.go:424 lxc/project.go:498 lxc/project.go:618 lxc/project.go:683 lxc/project.go:771 lxc/project.go:815 lxc/project.go:876 lxc/project.go:943 lxc/publish.go:34 lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749 lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018 lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250 lxc/storage_bucket.go:383 lxc/storage_bucket.go:459 lxc/storage_bucket.go:536 lxc/storage_bucket.go:630 lxc/storage_bucket.go:699 lxc/storage_bucket.go:733 lxc/storage_bucket.go:774 lxc/storage_bucket.go:853 lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158 lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283 lxc/storage_volume.go:390 lxc/storage_volume.go:611 lxc/storage_volume.go:720 lxc/storage_volume.go:807 lxc/storage_volume.go:905 lxc/storage_volume.go:1002 lxc/storage_volume.go:1223 lxc/storage_volume.go:1354 lxc/storage_volume.go:1513 lxc/storage_volume.go:1597 lxc/storage_volume.go:1850 lxc/storage_volume.go:1949 lxc/storage_volume.go:2076 lxc/storage_volume.go:2234 lxc/storage_volume.go:2355 lxc/storage_volume.go:2417 lxc/storage_volume.go:2553 lxc/storage_volume.go:2636 lxc/storage_volume.go:2802 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid   "Description"
 msgstr  ""
 
@@ -1791,7 +1791,7 @@ msgstr  ""
 msgid   "Edit profile configurations as YAML"
 msgstr  ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:287 lxc/project.go:288
 msgid   "Edit project configurations as YAML"
 msgstr  ""
 
@@ -1862,7 +1862,7 @@ msgstr  ""
 msgid   "Error retrieving aliases: %w"
 msgstr  ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319 lxc/network_acl.go:524 lxc/network_forward.go:572 lxc/network_load_balancer.go:559 lxc/network_peer.go:522 lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987 lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603 lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319 lxc/network_acl.go:524 lxc/network_forward.go:572 lxc/network_load_balancer.go:559 lxc/network_peer.go:522 lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987 lxc/project.go:746 lxc/storage.go:812 lxc/storage_bucket.go:603 lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
 #, c-format
 msgid   "Error setting properties: %v"
 msgstr  ""
@@ -1872,7 +1872,7 @@ msgstr  ""
 msgid   "Error unsetting properties: %v"
 msgstr  ""
 
-#: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518 lxc/network_forward.go:566 lxc/network_load_balancer.go:553 lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141 lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806 lxc/storage_bucket.go:597 lxc/storage_volume.go:2161 lxc/storage_volume.go:2199
+#: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518 lxc/network_forward.go:566 lxc/network_load_balancer.go:553 lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141 lxc/profile.go:981 lxc/project.go:740 lxc/storage.go:806 lxc/storage_bucket.go:597 lxc/storage_volume.go:2161 lxc/storage_volume.go:2199
 #, c-format
 msgid   "Error unsetting property: %v"
 msgstr  ""
@@ -2147,6 +2147,10 @@ msgstr  ""
 msgid   "Force creating files or directories"
 msgstr  ""
 
+#: lxc/project.go:197
+msgid   "Force delete the project and everything it contains."
+msgstr  ""
+
 #: lxc/cluster.go:1301
 msgid   "Force evacuation without user confirmation"
 msgstr  ""
@@ -2194,7 +2198,7 @@ msgid   "Forcefully removing a server from the cluster should only be done as a 
         "Are you really sure you want to force removing %s? (yes/no): "
 msgstr  ""
 
-#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904 lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442 lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434 lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009 lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59 lxc/network_forward.go:93 lxc/network_load_balancer.go:97 lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770 lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474 lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657 lxc/storage_bucket.go:460 lxc/storage_bucket.go:775 lxc/storage_volume.go:1614 lxc/warning.go:94
+#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904 lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442 lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434 lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009 lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59 lxc/network_forward.go:93 lxc/network_load_balancer.go:97 lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770 lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:500 lxc/project.go:945 lxc/remote.go:791 lxc/storage.go:657 lxc/storage_bucket.go:460 lxc/storage_bucket.go:775 lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid   "Format (csv|json|table|yaml|compact)"
 msgstr  ""
 
@@ -2258,7 +2262,7 @@ msgstr  ""
 msgid   "Get UEFI variables for instance"
 msgstr  ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:942 lxc/project.go:943
 msgid   "Get a summary of resource allocations"
 msgstr  ""
 
@@ -2306,7 +2310,7 @@ msgstr  ""
 msgid   "Get the key as a profile property"
 msgstr  ""
 
-#: lxc/project.go:402
+#: lxc/project.go:428
 msgid   "Get the key as a project property"
 msgstr  ""
 
@@ -2370,7 +2374,7 @@ msgstr  ""
 msgid   "Get values for profile configuration keys"
 msgstr  ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:423 lxc/project.go:424
 msgid   "Get values for project configuration keys"
 msgstr  ""
 
@@ -2464,7 +2468,7 @@ msgstr  ""
 msgid   "IDENTIFIER"
 msgstr  ""
 
-#: lxc/project.go:568
+#: lxc/project.go:594
 msgid   "IMAGES"
 msgstr  ""
 
@@ -2795,7 +2799,7 @@ msgstr  ""
 msgid   "LAST USED AT"
 msgstr  ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1020
 msgid   "LIMIT"
 msgstr  ""
 
@@ -3084,7 +3088,7 @@ msgstr  ""
 msgid   "List profiles"
 msgstr  ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:497 lxc/project.go:498
 msgid   "List projects"
 msgstr  ""
 
@@ -3384,7 +3388,7 @@ msgstr  ""
 msgid   "Manage profiles"
 msgstr  ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid   "Manage projects"
 msgstr  ""
 
@@ -3574,7 +3578,7 @@ msgstr  ""
 msgid   "Missing profile name"
 msgstr  ""
 
-#: lxc/profile.go:404 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318 lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821 lxc/project.go:950
+#: lxc/profile.go:404 lxc/project.go:149 lxc/project.go:242 lxc/project.go:344 lxc/project.go:461 lxc/project.go:650 lxc/project.go:719 lxc/project.go:847 lxc/project.go:976
 msgid   "Missing project name"
 msgstr  ""
 
@@ -3687,7 +3691,7 @@ msgstr  ""
 msgid   "Must supply instance name for: "
 msgstr  ""
 
-#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192 lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081 lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147 lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567 lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512 lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
+#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192 lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081 lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147 lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:593 lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512 lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid   "NAME"
 msgstr  ""
 
@@ -3699,11 +3703,11 @@ msgstr  ""
 msgid   "NETWORK"
 msgstr  ""
 
-#: lxc/project.go:573
+#: lxc/project.go:599
 msgid   "NETWORK ZONES"
 msgstr  ""
 
-#: lxc/project.go:572
+#: lxc/project.go:598
 msgid   "NETWORKS"
 msgstr  ""
 
@@ -3715,7 +3719,7 @@ msgstr  ""
 msgid   "NICs:"
 msgstr  ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525 lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545 lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:551 lxc/project.go:556 lxc/project.go:561 lxc/project.go:566 lxc/project.go:571 lxc/project.go:576 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid   "NO"
 msgstr  ""
 
@@ -4009,7 +4013,7 @@ msgstr  ""
 msgid   "PROCESSES"
 msgstr  ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:595
 msgid   "PROFILES"
 msgstr  ""
 
@@ -4079,7 +4083,7 @@ msgstr  ""
 msgid   "Press ctrl+c to finish"
 msgstr  ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860 lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357 lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239 lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760 lxc/network_acl.go:699 lxc/network_forward.go:768 lxc/network_load_balancer.go:739 lxc/network_peer.go:699 lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596 lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350 lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157 lxc/storage_volume.go:1189
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860 lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357 lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239 lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760 lxc/network_acl.go:699 lxc/network_forward.go:768 lxc/network_load_balancer.go:739 lxc/network_peer.go:699 lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596 lxc/project.go:391 lxc/storage.go:360 lxc/storage_bucket.go:350 lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157 lxc/storage_volume.go:1189
 msgid   "Press enter to open the editor again or ctrl+c to abort change"
 msgstr  ""
 
@@ -4169,19 +4173,23 @@ msgstr  ""
 msgid   "Profiles: "
 msgstr  ""
 
-#: lxc/project.go:174
+#: lxc/project.go:175
 #, c-format
 msgid   "Project %s created"
 msgstr  ""
 
-#: lxc/project.go:238
+#: lxc/project.go:264
 #, c-format
 msgid   "Project %s deleted"
 msgstr  ""
 
-#: lxc/project.go:639
+#: lxc/project.go:665
 #, c-format
 msgid   "Project %s renamed to %s"
+msgstr  ""
+
+#: lxc/project.go:248
+msgid   "Project deletion aborted"
 msgstr  ""
 
 #: lxc/remote.go:107
@@ -4310,7 +4318,7 @@ msgstr  ""
 msgid   "Query virtual machine images"
 msgstr  ""
 
-#: lxc/project.go:993
+#: lxc/project.go:1019
 msgid   "RESOURCE"
 msgstr  ""
 
@@ -4362,7 +4370,7 @@ msgstr  ""
 msgid   "Remote %s already exists"
 msgstr  ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047 lxc/remote.go:1095
+#: lxc/project.go:910 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047 lxc/remote.go:1095
 #, c-format
 msgid   "Remote %s doesn't exist"
 msgstr  ""
@@ -4406,6 +4414,11 @@ msgstr  ""
 #: lxc/delete.go:48
 #, c-format
 msgid   "Remove %s (yes/no): "
+msgstr  ""
+
+#: lxc/project.go:214
+#, c-format
+msgid   "Remove %s and everything it contains (instances, images, volumes, networks, ...) (yes/no): "
 msgstr  ""
 
 #: lxc/cluster_group.go:522
@@ -4528,7 +4541,7 @@ msgstr  ""
 msgid   "Rename profiles"
 msgstr  ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:617 lxc/project.go:618
 msgid   "Rename projects"
 msgstr  ""
 
@@ -4682,7 +4695,7 @@ msgstr  ""
 msgid   "STATUS"
 msgstr  ""
 
-#: lxc/project.go:571
+#: lxc/project.go:597
 msgid   "STORAGE BUCKETS"
 msgstr  ""
 
@@ -4690,7 +4703,7 @@ msgstr  ""
 msgid   "STORAGE POOL"
 msgstr  ""
 
-#: lxc/project.go:570
+#: lxc/project.go:596
 msgid   "STORAGE VOLUMES"
 msgstr  ""
 
@@ -4858,11 +4871,11 @@ msgid   "Set profile configuration keys\n"
         "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr  ""
 
-#: lxc/project.go:656
+#: lxc/project.go:682
 msgid   "Set project configuration keys"
 msgstr  ""
 
-#: lxc/project.go:657
+#: lxc/project.go:683
 msgid   "Set project configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
@@ -4966,7 +4979,7 @@ msgstr  ""
 msgid   "Set the key as a profile property"
 msgstr  ""
 
-#: lxc/project.go:664
+#: lxc/project.go:690
 msgid   "Set the key as a project property"
 msgstr  ""
 
@@ -5107,7 +5120,7 @@ msgstr  ""
 msgid   "Show profile configurations"
 msgstr  ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:814 lxc/project.go:815
 msgid   "Show project options"
 msgstr  ""
 
@@ -5351,7 +5364,7 @@ msgstr  ""
 msgid   "Swap (peak)"
 msgstr  ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:875 lxc/project.go:876
 msgid   "Switch the current project"
 msgstr  ""
 
@@ -5523,7 +5536,7 @@ msgstr  ""
 msgid   "The property %q does not exist on the profile %q: %v"
 msgstr  ""
 
-#: lxc/project.go:448
+#: lxc/project.go:474
 #, c-format
 msgid   "The property %q does not exist on the project %q: %v"
 msgstr  ""
@@ -5718,7 +5731,7 @@ msgstr  ""
 msgid   "Type: %s (ephemeral)"
 msgstr  ""
 
-#: lxc/project.go:965
+#: lxc/project.go:991
 msgid   "UNLIMITED"
 msgstr  ""
 
@@ -5730,11 +5743,11 @@ msgstr  ""
 msgid   "URL"
 msgstr  ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:1021 lxc/storage_volume.go:1741
 msgid   "USAGE"
 msgstr  ""
 
-#: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24 lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575 lxc/storage.go:724 lxc/storage_volume.go:1740
+#: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24 lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:601 lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid   "USED BY"
 msgstr  ""
 
@@ -5859,7 +5872,7 @@ msgstr  ""
 msgid   "Unset profile configuration keys"
 msgstr  ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:770 lxc/project.go:771
 msgid   "Unset project configuration keys"
 msgstr  ""
 
@@ -5911,7 +5924,7 @@ msgstr  ""
 msgid   "Unset the key as a profile property"
 msgstr  ""
 
-#: lxc/project.go:749
+#: lxc/project.go:775
 msgid   "Unset the key as a project property"
 msgstr  ""
 
@@ -6064,7 +6077,7 @@ msgstr  ""
 msgid   "Wipe the instance root disk and re-initialize. The original image is used to re-initialize the instance if a different image or --empty is not specified."
 msgstr  ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527 lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:553 lxc/project.go:558 lxc/project.go:563 lxc/project.go:568 lxc/project.go:573 lxc/project.go:578 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid   "YES"
 msgstr  ""
 
@@ -6096,7 +6109,7 @@ msgstr  ""
 msgid   "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr  ""
 
-#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897 lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437 lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32 lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83 lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469 lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
+#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897 lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437 lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32 lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83 lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:495 lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid   "[<remote>:]"
 msgstr  ""
 
@@ -6612,19 +6625,19 @@ msgstr  ""
 msgid   "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr  ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787 lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:94 lxc/project.go:191 lxc/project.go:286 lxc/project.go:813 lxc/project.go:874 lxc/project.go:941
 msgid   "[<remote>:]<project>"
 msgstr  ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:422 lxc/project.go:769
 msgid   "[<remote>:]<project> <key>"
 msgstr  ""
 
-#: lxc/project.go:655
+#: lxc/project.go:681
 msgid   "[<remote>:]<project> <key>=<value>..."
 msgstr  ""
 
-#: lxc/project.go:589
+#: lxc/project.go:615
 msgid   "[<remote>:]<project> <new-name>"
 msgstr  ""
 
@@ -6692,7 +6705,7 @@ msgstr  ""
 msgid   "[[<remote>:]<member>]"
 msgstr  ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:583 lxc/remote.go:840
 msgid   "current"
 msgstr  ""
 
@@ -6992,14 +7005,14 @@ msgid   "lxc profile edit <profile> < profile.yaml\n"
         "    Update a profile using the content of profile.yaml"
 msgstr  ""
 
-#: lxc/project.go:97
+#: lxc/project.go:98
 msgid   "lxc project create p1\n"
         "\n"
         "lxc project create p1 < config.yaml\n"
         "    Create a project with configuration from config.yaml"
 msgstr  ""
 
-#: lxc/project.go:264
+#: lxc/project.go:290
 msgid   "lxc project edit <project> < project.yaml\n"
         "    Update a project using the content of project.yaml"
 msgstr  ""
@@ -7147,7 +7160,7 @@ msgstr  ""
 msgid   "y"
 msgstr  ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001 lxc/image.go:1206
+#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001 lxc/image.go:1206 lxc/project.go:218
 msgid   "yes"
 msgstr  ""
 

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-08 16:23-0800\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -391,7 +391,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:282
+#: lxc/project.go:308
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:162
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1201,7 +1201,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:103
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1215,7 +1215,7 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/project.go:390 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
 #: lxc/storage_volume.go:1188
 #, c-format
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:95 lxc/project.go:96
 msgid "Create projects"
 msgstr ""
 
@@ -1530,7 +1530,7 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
-#: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:756 lxc/project.go:600 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
@@ -1636,7 +1636,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:193 lxc/project.go:194
 msgid "Delete projects"
 msgstr ""
 
@@ -1736,10 +1736,10 @@ msgstr ""
 #: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
 #: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
 #: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
-#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:32 lxc/project.go:96
+#: lxc/project.go:194 lxc/project.go:288 lxc/project.go:424 lxc/project.go:498
+#: lxc/project.go:618 lxc/project.go:683 lxc/project.go:771 lxc/project.go:815
+#: lxc/project.go:876 lxc/project.go:943 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -2003,7 +2003,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:287 lxc/project.go:288
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2083,7 +2083,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/project.go:746 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
 #, c-format
 msgid "Error setting properties: %v"
@@ -2097,7 +2097,7 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
+#: lxc/profile.go:981 lxc/project.go:740 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
 #: lxc/storage_volume.go:2199
 #, c-format
@@ -2380,6 +2380,10 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
+#: lxc/project.go:197
+msgid "Force delete the project and everything it contains."
+msgstr ""
+
 #: lxc/cluster.go:1301
 msgid "Force evacuation without user confirmation"
 msgstr ""
@@ -2439,8 +2443,8 @@ msgstr ""
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:500
+#: lxc/project.go:945 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2506,7 +2510,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:942 lxc/project.go:943
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2554,7 +2558,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:428
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2618,7 +2622,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:423 lxc/project.go:424
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2712,7 +2716,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:594
 msgid "IMAGES"
 msgstr ""
 
@@ -3050,7 +3054,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1020
 msgid "LIMIT"
 msgstr ""
 
@@ -3352,7 +3356,7 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:497 lxc/project.go:498
 msgid "List projects"
 msgstr ""
 
@@ -3657,7 +3661,7 @@ msgstr ""
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -3911,9 +3915,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:404 lxc/project.go:149 lxc/project.go:242 lxc/project.go:344
+#: lxc/project.go:461 lxc/project.go:650 lxc/project.go:719 lxc/project.go:847
+#: lxc/project.go:976
 msgid "Missing project name"
 msgstr ""
 
@@ -4037,7 +4041,7 @@ msgstr ""
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:593
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
@@ -4051,11 +4055,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:599
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:598
 msgid "NETWORKS"
 msgstr ""
 
@@ -4067,9 +4071,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:551
+#: lxc/project.go:556 lxc/project.go:561 lxc/project.go:566 lxc/project.go:571
+#: lxc/project.go:576 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4365,7 +4369,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:595
 msgid "PROFILES"
 msgstr ""
 
@@ -4443,7 +4447,7 @@ msgstr ""
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/project.go:391 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
 #: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4535,19 +4539,23 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:175
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:264
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:665
 #, c-format
 msgid "Project %s renamed to %s"
+msgstr ""
+
+#: lxc/project.go:248
+msgid "Project deletion aborted"
 msgstr ""
 
 #: lxc/remote.go:107
@@ -4692,7 +4700,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:1019
 msgid "RESOURCE"
 msgstr ""
 
@@ -4744,7 +4752,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:910 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4789,6 +4797,13 @@ msgstr ""
 #: lxc/delete.go:48
 #, c-format
 msgid "Remove %s (yes/no): "
+msgstr ""
+
+#: lxc/project.go:214
+#, c-format
+msgid ""
+"Remove %s and everything it contains (instances, images, volumes, "
+"networks, ...) (yes/no): "
 msgstr ""
 
 #: lxc/cluster_group.go:522
@@ -4912,7 +4927,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:617 lxc/project.go:618
 msgid "Rename projects"
 msgstr ""
 
@@ -5069,7 +5084,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:597
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5077,7 +5092,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:596
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5265,11 +5280,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:682
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:683
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5381,7 +5396,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:690
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5526,7 +5541,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:814 lxc/project.go:815
 msgid "Show project options"
 msgstr ""
 
@@ -5772,7 +5787,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:875 lxc/project.go:876
 msgid "Switch the current project"
 msgstr ""
 
@@ -5951,7 +5966,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:448
+#: lxc/project.go:474
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6158,7 +6173,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:991
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6170,12 +6185,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:1021 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:601
 #: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
@@ -6302,7 +6317,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:770 lxc/project.go:771
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6354,7 +6369,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:775
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6515,9 +6530,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:553
+#: lxc/project.go:558 lxc/project.go:563 lxc/project.go:568 lxc/project.go:573
+#: lxc/project.go:578 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6553,7 +6568,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:495
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -7103,20 +7118,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:94 lxc/project.go:191 lxc/project.go:286 lxc/project.go:813
+#: lxc/project.go:874 lxc/project.go:941
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:422 lxc/project.go:769
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:681
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:615
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7184,7 +7199,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:583 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7544,7 +7559,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:98
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7552,7 +7567,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:290
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7722,6 +7737,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1206 lxc/project.go:218
 msgid "yes"
 msgstr ""

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-08 16:23-0800\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -391,7 +391,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:282
+#: lxc/project.go:308
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:162
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1201,7 +1201,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:103
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1215,7 +1215,7 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/project.go:390 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
 #: lxc/storage_volume.go:1188
 #, c-format
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:95 lxc/project.go:96
 msgid "Create projects"
 msgstr ""
 
@@ -1530,7 +1530,7 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
-#: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:756 lxc/project.go:600 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
@@ -1636,7 +1636,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:193 lxc/project.go:194
 msgid "Delete projects"
 msgstr ""
 
@@ -1736,10 +1736,10 @@ msgstr ""
 #: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
 #: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
 #: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
-#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:32 lxc/project.go:96
+#: lxc/project.go:194 lxc/project.go:288 lxc/project.go:424 lxc/project.go:498
+#: lxc/project.go:618 lxc/project.go:683 lxc/project.go:771 lxc/project.go:815
+#: lxc/project.go:876 lxc/project.go:943 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -2003,7 +2003,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:287 lxc/project.go:288
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2083,7 +2083,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/project.go:746 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
 #, c-format
 msgid "Error setting properties: %v"
@@ -2097,7 +2097,7 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
+#: lxc/profile.go:981 lxc/project.go:740 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
 #: lxc/storage_volume.go:2199
 #, c-format
@@ -2380,6 +2380,10 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
+#: lxc/project.go:197
+msgid "Force delete the project and everything it contains."
+msgstr ""
+
 #: lxc/cluster.go:1301
 msgid "Force evacuation without user confirmation"
 msgstr ""
@@ -2439,8 +2443,8 @@ msgstr ""
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:500
+#: lxc/project.go:945 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2506,7 +2510,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:942 lxc/project.go:943
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2554,7 +2558,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:428
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2618,7 +2622,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:423 lxc/project.go:424
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2712,7 +2716,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:594
 msgid "IMAGES"
 msgstr ""
 
@@ -3050,7 +3054,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1020
 msgid "LIMIT"
 msgstr ""
 
@@ -3352,7 +3356,7 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:497 lxc/project.go:498
 msgid "List projects"
 msgstr ""
 
@@ -3657,7 +3661,7 @@ msgstr ""
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -3911,9 +3915,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:404 lxc/project.go:149 lxc/project.go:242 lxc/project.go:344
+#: lxc/project.go:461 lxc/project.go:650 lxc/project.go:719 lxc/project.go:847
+#: lxc/project.go:976
 msgid "Missing project name"
 msgstr ""
 
@@ -4037,7 +4041,7 @@ msgstr ""
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:593
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
@@ -4051,11 +4055,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:599
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:598
 msgid "NETWORKS"
 msgstr ""
 
@@ -4067,9 +4071,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:551
+#: lxc/project.go:556 lxc/project.go:561 lxc/project.go:566 lxc/project.go:571
+#: lxc/project.go:576 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4365,7 +4369,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:595
 msgid "PROFILES"
 msgstr ""
 
@@ -4443,7 +4447,7 @@ msgstr ""
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/project.go:391 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
 #: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4535,19 +4539,23 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:175
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:264
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:665
 #, c-format
 msgid "Project %s renamed to %s"
+msgstr ""
+
+#: lxc/project.go:248
+msgid "Project deletion aborted"
 msgstr ""
 
 #: lxc/remote.go:107
@@ -4692,7 +4700,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:1019
 msgid "RESOURCE"
 msgstr ""
 
@@ -4744,7 +4752,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:910 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4789,6 +4797,13 @@ msgstr ""
 #: lxc/delete.go:48
 #, c-format
 msgid "Remove %s (yes/no): "
+msgstr ""
+
+#: lxc/project.go:214
+#, c-format
+msgid ""
+"Remove %s and everything it contains (instances, images, volumes, "
+"networks, ...) (yes/no): "
 msgstr ""
 
 #: lxc/cluster_group.go:522
@@ -4912,7 +4927,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:617 lxc/project.go:618
 msgid "Rename projects"
 msgstr ""
 
@@ -5069,7 +5084,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:597
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5077,7 +5092,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:596
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5265,11 +5280,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:682
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:683
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5381,7 +5396,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:690
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5526,7 +5541,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:814 lxc/project.go:815
 msgid "Show project options"
 msgstr ""
 
@@ -5772,7 +5787,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:875 lxc/project.go:876
 msgid "Switch the current project"
 msgstr ""
 
@@ -5951,7 +5966,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:448
+#: lxc/project.go:474
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6158,7 +6173,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:991
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6170,12 +6185,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:1021 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:601
 #: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
@@ -6302,7 +6317,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:770 lxc/project.go:771
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6354,7 +6369,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:775
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6515,9 +6530,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:553
+#: lxc/project.go:558 lxc/project.go:563 lxc/project.go:568 lxc/project.go:573
+#: lxc/project.go:578 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6553,7 +6568,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:495
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -7103,20 +7118,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:94 lxc/project.go:191 lxc/project.go:286 lxc/project.go:813
+#: lxc/project.go:874 lxc/project.go:941
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:422 lxc/project.go:769
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:681
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:615
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7184,7 +7199,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:583 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7544,7 +7559,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:98
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7552,7 +7567,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:290
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7722,6 +7737,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1206 lxc/project.go:218
 msgid "yes"
 msgstr ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-08 16:23-0800\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -601,7 +601,7 @@ msgstr ""
 "###\n"
 "### NB: de naam is weergegeven, maar kan niet worden veranderd"
 
-#: lxc/project.go:282
+#: lxc/project.go:308
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -1098,7 +1098,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:162
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:103
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1439,7 +1439,7 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/project.go:390 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
 #: lxc/storage_volume.go:1188
 #, c-format
@@ -1709,7 +1709,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:95 lxc/project.go:96
 msgid "Create projects"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
-#: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:756 lxc/project.go:600 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
@@ -1860,7 +1860,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:193 lxc/project.go:194
 msgid "Delete projects"
 msgstr ""
 
@@ -1960,10 +1960,10 @@ msgstr ""
 #: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
 #: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
 #: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
-#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:32 lxc/project.go:96
+#: lxc/project.go:194 lxc/project.go:288 lxc/project.go:424 lxc/project.go:498
+#: lxc/project.go:618 lxc/project.go:683 lxc/project.go:771 lxc/project.go:815
+#: lxc/project.go:876 lxc/project.go:943 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -2227,7 +2227,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:287 lxc/project.go:288
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2307,7 +2307,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/project.go:746 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
 #, c-format
 msgid "Error setting properties: %v"
@@ -2321,7 +2321,7 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
+#: lxc/profile.go:981 lxc/project.go:740 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
 #: lxc/storage_volume.go:2199
 #, c-format
@@ -2604,6 +2604,10 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
+#: lxc/project.go:197
+msgid "Force delete the project and everything it contains."
+msgstr ""
+
 #: lxc/cluster.go:1301
 msgid "Force evacuation without user confirmation"
 msgstr ""
@@ -2663,8 +2667,8 @@ msgstr ""
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:500
+#: lxc/project.go:945 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2730,7 +2734,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:942 lxc/project.go:943
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2778,7 +2782,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:428
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2842,7 +2846,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:423 lxc/project.go:424
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2936,7 +2940,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:594
 msgid "IMAGES"
 msgstr ""
 
@@ -3274,7 +3278,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1020
 msgid "LIMIT"
 msgstr ""
 
@@ -3576,7 +3580,7 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:497 lxc/project.go:498
 msgid "List projects"
 msgstr ""
 
@@ -3881,7 +3885,7 @@ msgstr ""
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -4135,9 +4139,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:404 lxc/project.go:149 lxc/project.go:242 lxc/project.go:344
+#: lxc/project.go:461 lxc/project.go:650 lxc/project.go:719 lxc/project.go:847
+#: lxc/project.go:976
 msgid "Missing project name"
 msgstr ""
 
@@ -4261,7 +4265,7 @@ msgstr ""
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:593
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
@@ -4275,11 +4279,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:599
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:598
 msgid "NETWORKS"
 msgstr ""
 
@@ -4291,9 +4295,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:551
+#: lxc/project.go:556 lxc/project.go:561 lxc/project.go:566 lxc/project.go:571
+#: lxc/project.go:576 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4589,7 +4593,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:595
 msgid "PROFILES"
 msgstr ""
 
@@ -4667,7 +4671,7 @@ msgstr ""
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/project.go:391 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
 #: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4759,19 +4763,23 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:175
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:264
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:665
 #, c-format
 msgid "Project %s renamed to %s"
+msgstr ""
+
+#: lxc/project.go:248
+msgid "Project deletion aborted"
 msgstr ""
 
 #: lxc/remote.go:107
@@ -4916,7 +4924,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:1019
 msgid "RESOURCE"
 msgstr ""
 
@@ -4968,7 +4976,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:910 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -5013,6 +5021,13 @@ msgstr ""
 #: lxc/delete.go:48
 #, c-format
 msgid "Remove %s (yes/no): "
+msgstr ""
+
+#: lxc/project.go:214
+#, c-format
+msgid ""
+"Remove %s and everything it contains (instances, images, volumes, "
+"networks, ...) (yes/no): "
 msgstr ""
 
 #: lxc/cluster_group.go:522
@@ -5136,7 +5151,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:617 lxc/project.go:618
 msgid "Rename projects"
 msgstr ""
 
@@ -5293,7 +5308,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:597
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5301,7 +5316,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:596
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5489,11 +5504,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:682
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:683
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5605,7 +5620,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:690
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5750,7 +5765,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:814 lxc/project.go:815
 msgid "Show project options"
 msgstr ""
 
@@ -5996,7 +6011,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:875 lxc/project.go:876
 msgid "Switch the current project"
 msgstr ""
 
@@ -6175,7 +6190,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:448
+#: lxc/project.go:474
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6382,7 +6397,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:991
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6394,12 +6409,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:1021 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:601
 #: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
@@ -6526,7 +6541,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:770 lxc/project.go:771
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6578,7 +6593,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:775
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6739,9 +6754,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:553
+#: lxc/project.go:558 lxc/project.go:563 lxc/project.go:568 lxc/project.go:573
+#: lxc/project.go:578 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6777,7 +6792,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:495
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -7327,20 +7342,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:94 lxc/project.go:191 lxc/project.go:286 lxc/project.go:813
+#: lxc/project.go:874 lxc/project.go:941
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:422 lxc/project.go:769
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:681
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:615
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7408,7 +7423,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:583 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7768,7 +7783,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:98
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7776,7 +7791,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:290
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7946,7 +7961,7 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1206 lxc/project.go:218
 msgid "yes"
 msgstr ""
 

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-08 16:23-0800\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -391,7 +391,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:282
+#: lxc/project.go:308
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:162
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1201,7 +1201,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:103
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1215,7 +1215,7 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/project.go:390 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
 #: lxc/storage_volume.go:1188
 #, c-format
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:95 lxc/project.go:96
 msgid "Create projects"
 msgstr ""
 
@@ -1530,7 +1530,7 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
-#: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:756 lxc/project.go:600 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
@@ -1636,7 +1636,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:193 lxc/project.go:194
 msgid "Delete projects"
 msgstr ""
 
@@ -1736,10 +1736,10 @@ msgstr ""
 #: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
 #: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
 #: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
-#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:32 lxc/project.go:96
+#: lxc/project.go:194 lxc/project.go:288 lxc/project.go:424 lxc/project.go:498
+#: lxc/project.go:618 lxc/project.go:683 lxc/project.go:771 lxc/project.go:815
+#: lxc/project.go:876 lxc/project.go:943 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -2003,7 +2003,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:287 lxc/project.go:288
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2083,7 +2083,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/project.go:746 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
 #, c-format
 msgid "Error setting properties: %v"
@@ -2097,7 +2097,7 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
+#: lxc/profile.go:981 lxc/project.go:740 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
 #: lxc/storage_volume.go:2199
 #, c-format
@@ -2380,6 +2380,10 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
+#: lxc/project.go:197
+msgid "Force delete the project and everything it contains."
+msgstr ""
+
 #: lxc/cluster.go:1301
 msgid "Force evacuation without user confirmation"
 msgstr ""
@@ -2439,8 +2443,8 @@ msgstr ""
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:500
+#: lxc/project.go:945 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2506,7 +2510,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:942 lxc/project.go:943
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2554,7 +2558,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:428
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2618,7 +2622,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:423 lxc/project.go:424
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2712,7 +2716,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:594
 msgid "IMAGES"
 msgstr ""
 
@@ -3050,7 +3054,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1020
 msgid "LIMIT"
 msgstr ""
 
@@ -3352,7 +3356,7 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:497 lxc/project.go:498
 msgid "List projects"
 msgstr ""
 
@@ -3657,7 +3661,7 @@ msgstr ""
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -3911,9 +3915,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:404 lxc/project.go:149 lxc/project.go:242 lxc/project.go:344
+#: lxc/project.go:461 lxc/project.go:650 lxc/project.go:719 lxc/project.go:847
+#: lxc/project.go:976
 msgid "Missing project name"
 msgstr ""
 
@@ -4037,7 +4041,7 @@ msgstr ""
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:593
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
@@ -4051,11 +4055,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:599
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:598
 msgid "NETWORKS"
 msgstr ""
 
@@ -4067,9 +4071,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:551
+#: lxc/project.go:556 lxc/project.go:561 lxc/project.go:566 lxc/project.go:571
+#: lxc/project.go:576 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4365,7 +4369,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:595
 msgid "PROFILES"
 msgstr ""
 
@@ -4443,7 +4447,7 @@ msgstr ""
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/project.go:391 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
 #: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4535,19 +4539,23 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:175
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:264
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:665
 #, c-format
 msgid "Project %s renamed to %s"
+msgstr ""
+
+#: lxc/project.go:248
+msgid "Project deletion aborted"
 msgstr ""
 
 #: lxc/remote.go:107
@@ -4692,7 +4700,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:1019
 msgid "RESOURCE"
 msgstr ""
 
@@ -4744,7 +4752,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:910 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4789,6 +4797,13 @@ msgstr ""
 #: lxc/delete.go:48
 #, c-format
 msgid "Remove %s (yes/no): "
+msgstr ""
+
+#: lxc/project.go:214
+#, c-format
+msgid ""
+"Remove %s and everything it contains (instances, images, volumes, "
+"networks, ...) (yes/no): "
 msgstr ""
 
 #: lxc/cluster_group.go:522
@@ -4912,7 +4927,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:617 lxc/project.go:618
 msgid "Rename projects"
 msgstr ""
 
@@ -5069,7 +5084,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:597
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5077,7 +5092,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:596
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5265,11 +5280,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:682
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:683
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5381,7 +5396,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:690
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5526,7 +5541,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:814 lxc/project.go:815
 msgid "Show project options"
 msgstr ""
 
@@ -5772,7 +5787,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:875 lxc/project.go:876
 msgid "Switch the current project"
 msgstr ""
 
@@ -5951,7 +5966,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:448
+#: lxc/project.go:474
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6158,7 +6173,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:991
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6170,12 +6185,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:1021 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:601
 #: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
@@ -6302,7 +6317,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:770 lxc/project.go:771
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6354,7 +6369,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:775
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6515,9 +6530,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:553
+#: lxc/project.go:558 lxc/project.go:563 lxc/project.go:568 lxc/project.go:573
+#: lxc/project.go:578 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6553,7 +6568,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:495
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -7103,20 +7118,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:94 lxc/project.go:191 lxc/project.go:286 lxc/project.go:813
+#: lxc/project.go:874 lxc/project.go:941
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:422 lxc/project.go:769
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:681
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:615
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7184,7 +7199,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:583 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7544,7 +7559,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:98
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7552,7 +7567,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:290
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7722,6 +7737,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1206 lxc/project.go:218
 msgid "yes"
 msgstr ""

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-08 16:23-0800\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -635,7 +635,7 @@ msgstr ""
 "###\n"
 "### Nazwa jest widoczna, ale nie może zostać zmieniona"
 
-#: lxc/project.go:282
+#: lxc/project.go:308
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -1136,7 +1136,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:162
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1463,7 +1463,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:103
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1477,7 +1477,7 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/project.go:390 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
 #: lxc/storage_volume.go:1188
 #, c-format
@@ -1747,7 +1747,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:95 lxc/project.go:96
 msgid "Create projects"
 msgstr ""
 
@@ -1792,7 +1792,7 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
-#: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:756 lxc/project.go:600 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
@@ -1898,7 +1898,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:193 lxc/project.go:194
 msgid "Delete projects"
 msgstr ""
 
@@ -1998,10 +1998,10 @@ msgstr ""
 #: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
 #: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
 #: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
-#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:32 lxc/project.go:96
+#: lxc/project.go:194 lxc/project.go:288 lxc/project.go:424 lxc/project.go:498
+#: lxc/project.go:618 lxc/project.go:683 lxc/project.go:771 lxc/project.go:815
+#: lxc/project.go:876 lxc/project.go:943 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -2265,7 +2265,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:287 lxc/project.go:288
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2345,7 +2345,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/project.go:746 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
 #, c-format
 msgid "Error setting properties: %v"
@@ -2359,7 +2359,7 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
+#: lxc/profile.go:981 lxc/project.go:740 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
 #: lxc/storage_volume.go:2199
 #, c-format
@@ -2642,6 +2642,10 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
+#: lxc/project.go:197
+msgid "Force delete the project and everything it contains."
+msgstr ""
+
 #: lxc/cluster.go:1301
 msgid "Force evacuation without user confirmation"
 msgstr ""
@@ -2701,8 +2705,8 @@ msgstr ""
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:500
+#: lxc/project.go:945 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2768,7 +2772,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:942 lxc/project.go:943
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2816,7 +2820,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:428
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2880,7 +2884,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:423 lxc/project.go:424
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2974,7 +2978,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:594
 msgid "IMAGES"
 msgstr ""
 
@@ -3312,7 +3316,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1020
 msgid "LIMIT"
 msgstr ""
 
@@ -3614,7 +3618,7 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:497 lxc/project.go:498
 msgid "List projects"
 msgstr ""
 
@@ -3919,7 +3923,7 @@ msgstr ""
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -4173,9 +4177,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:404 lxc/project.go:149 lxc/project.go:242 lxc/project.go:344
+#: lxc/project.go:461 lxc/project.go:650 lxc/project.go:719 lxc/project.go:847
+#: lxc/project.go:976
 msgid "Missing project name"
 msgstr ""
 
@@ -4299,7 +4303,7 @@ msgstr ""
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:593
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
@@ -4313,11 +4317,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:599
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:598
 msgid "NETWORKS"
 msgstr ""
 
@@ -4329,9 +4333,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:551
+#: lxc/project.go:556 lxc/project.go:561 lxc/project.go:566 lxc/project.go:571
+#: lxc/project.go:576 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4627,7 +4631,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:595
 msgid "PROFILES"
 msgstr ""
 
@@ -4705,7 +4709,7 @@ msgstr ""
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/project.go:391 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
 #: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4797,19 +4801,23 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:175
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:264
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:665
 #, c-format
 msgid "Project %s renamed to %s"
+msgstr ""
+
+#: lxc/project.go:248
+msgid "Project deletion aborted"
 msgstr ""
 
 #: lxc/remote.go:107
@@ -4954,7 +4962,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:1019
 msgid "RESOURCE"
 msgstr ""
 
@@ -5006,7 +5014,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:910 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -5051,6 +5059,13 @@ msgstr ""
 #: lxc/delete.go:48
 #, c-format
 msgid "Remove %s (yes/no): "
+msgstr ""
+
+#: lxc/project.go:214
+#, c-format
+msgid ""
+"Remove %s and everything it contains (instances, images, volumes, "
+"networks, ...) (yes/no): "
 msgstr ""
 
 #: lxc/cluster_group.go:522
@@ -5174,7 +5189,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:617 lxc/project.go:618
 msgid "Rename projects"
 msgstr ""
 
@@ -5331,7 +5346,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:597
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5339,7 +5354,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:596
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5527,11 +5542,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:682
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:683
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5643,7 +5658,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:690
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5788,7 +5803,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:814 lxc/project.go:815
 msgid "Show project options"
 msgstr ""
 
@@ -6034,7 +6049,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:875 lxc/project.go:876
 msgid "Switch the current project"
 msgstr ""
 
@@ -6213,7 +6228,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:448
+#: lxc/project.go:474
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6420,7 +6435,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:991
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6432,12 +6447,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:1021 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:601
 #: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
@@ -6564,7 +6579,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:770 lxc/project.go:771
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6616,7 +6631,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:775
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6777,9 +6792,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:553
+#: lxc/project.go:558 lxc/project.go:563 lxc/project.go:568 lxc/project.go:573
+#: lxc/project.go:578 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6815,7 +6830,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:495
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -7365,20 +7380,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:94 lxc/project.go:191 lxc/project.go:286 lxc/project.go:813
+#: lxc/project.go:874 lxc/project.go:941
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:422 lxc/project.go:769
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:681
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:615
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7446,7 +7461,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:583 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7806,7 +7821,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:98
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7814,7 +7829,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:290
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7984,7 +7999,7 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1206 lxc/project.go:218
 msgid "yes"
 msgstr ""
 

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-08 16:23-0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:282
+#: lxc/project.go:308
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -871,7 +871,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:162
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1198,7 +1198,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:103
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1212,7 +1212,7 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/project.go:390 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
 #: lxc/storage_volume.go:1188
 #, c-format
@@ -1482,7 +1482,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:95 lxc/project.go:96
 msgid "Create projects"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
-#: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:756 lxc/project.go:600 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
@@ -1633,7 +1633,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:193 lxc/project.go:194
 msgid "Delete projects"
 msgstr ""
 
@@ -1733,10 +1733,10 @@ msgstr ""
 #: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
 #: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
 #: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
-#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:32 lxc/project.go:96
+#: lxc/project.go:194 lxc/project.go:288 lxc/project.go:424 lxc/project.go:498
+#: lxc/project.go:618 lxc/project.go:683 lxc/project.go:771 lxc/project.go:815
+#: lxc/project.go:876 lxc/project.go:943 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -2000,7 +2000,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:287 lxc/project.go:288
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2080,7 +2080,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/project.go:746 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
 #, c-format
 msgid "Error setting properties: %v"
@@ -2094,7 +2094,7 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
+#: lxc/profile.go:981 lxc/project.go:740 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
 #: lxc/storage_volume.go:2199
 #, c-format
@@ -2377,6 +2377,10 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
+#: lxc/project.go:197
+msgid "Force delete the project and everything it contains."
+msgstr ""
+
 #: lxc/cluster.go:1301
 msgid "Force evacuation without user confirmation"
 msgstr ""
@@ -2436,8 +2440,8 @@ msgstr ""
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:500
+#: lxc/project.go:945 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2503,7 +2507,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:942 lxc/project.go:943
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2551,7 +2555,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:428
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2615,7 +2619,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:423 lxc/project.go:424
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2709,7 +2713,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:594
 msgid "IMAGES"
 msgstr ""
 
@@ -3047,7 +3051,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1020
 msgid "LIMIT"
 msgstr ""
 
@@ -3349,7 +3353,7 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:497 lxc/project.go:498
 msgid "List projects"
 msgstr ""
 
@@ -3654,7 +3658,7 @@ msgstr ""
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -3908,9 +3912,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:404 lxc/project.go:149 lxc/project.go:242 lxc/project.go:344
+#: lxc/project.go:461 lxc/project.go:650 lxc/project.go:719 lxc/project.go:847
+#: lxc/project.go:976
 msgid "Missing project name"
 msgstr ""
 
@@ -4034,7 +4038,7 @@ msgstr ""
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:593
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
@@ -4048,11 +4052,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:599
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:598
 msgid "NETWORKS"
 msgstr ""
 
@@ -4064,9 +4068,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:551
+#: lxc/project.go:556 lxc/project.go:561 lxc/project.go:566 lxc/project.go:571
+#: lxc/project.go:576 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4362,7 +4366,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:595
 msgid "PROFILES"
 msgstr ""
 
@@ -4440,7 +4444,7 @@ msgstr ""
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/project.go:391 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
 #: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4532,19 +4536,23 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:175
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:264
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:665
 #, c-format
 msgid "Project %s renamed to %s"
+msgstr ""
+
+#: lxc/project.go:248
+msgid "Project deletion aborted"
 msgstr ""
 
 #: lxc/remote.go:107
@@ -4689,7 +4697,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:1019
 msgid "RESOURCE"
 msgstr ""
 
@@ -4741,7 +4749,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:910 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4786,6 +4794,13 @@ msgstr ""
 #: lxc/delete.go:48
 #, c-format
 msgid "Remove %s (yes/no): "
+msgstr ""
+
+#: lxc/project.go:214
+#, c-format
+msgid ""
+"Remove %s and everything it contains (instances, images, volumes, "
+"networks, ...) (yes/no): "
 msgstr ""
 
 #: lxc/cluster_group.go:522
@@ -4909,7 +4924,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:617 lxc/project.go:618
 msgid "Rename projects"
 msgstr ""
 
@@ -5066,7 +5081,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:597
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5074,7 +5089,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:596
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5262,11 +5277,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:682
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:683
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5378,7 +5393,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:690
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5523,7 +5538,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:814 lxc/project.go:815
 msgid "Show project options"
 msgstr ""
 
@@ -5769,7 +5784,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:875 lxc/project.go:876
 msgid "Switch the current project"
 msgstr ""
 
@@ -5948,7 +5963,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:448
+#: lxc/project.go:474
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6155,7 +6170,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:991
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6167,12 +6182,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:1021 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:601
 #: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
@@ -6299,7 +6314,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:770 lxc/project.go:771
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6351,7 +6366,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:775
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6512,9 +6527,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:553
+#: lxc/project.go:558 lxc/project.go:563 lxc/project.go:568 lxc/project.go:573
+#: lxc/project.go:578 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6550,7 +6565,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:495
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -7100,20 +7115,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:94 lxc/project.go:191 lxc/project.go:286 lxc/project.go:813
+#: lxc/project.go:874 lxc/project.go:941
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:422 lxc/project.go:769
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:681
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:615
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7181,7 +7196,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:583 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7541,7 +7556,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:98
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7549,7 +7564,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:290
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7719,6 +7734,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1206 lxc/project.go:218
 msgid "yes"
 msgstr ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-08 16:23-0800\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -622,7 +622,7 @@ msgstr ""
 "###\n"
 "### Note que o nome é exibido, porém não pode ser alterado"
 
-#: lxc/project.go:282
+#: lxc/project.go:308
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -1150,7 +1150,7 @@ msgstr "Erro de sintaxe, esperado <dispositivo>,<chave>=<valor>: %s"
 msgid "Bad key/value pair: %s"
 msgstr "par de chave/valor inválido %s"
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:162
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "par de chave=valor inválido %s"
@@ -1489,7 +1489,7 @@ msgstr "Definir um algoritmo de compressão: para imagem ou nenhum"
 msgid "Config key/value to apply to the new instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
-#: lxc/project.go:102
+#: lxc/project.go:103
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1504,7 +1504,7 @@ msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/project.go:390 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
 #: lxc/storage_volume.go:1188
 #, c-format
@@ -1795,7 +1795,7 @@ msgstr "Criar novas redes"
 msgid "Create profiles"
 msgstr "Criar perfis"
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:95 lxc/project.go:96
 msgid "Create projects"
 msgstr "Criar projetos"
 
@@ -1841,7 +1841,7 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
-#: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:756 lxc/project.go:600 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
@@ -1960,7 +1960,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:193 lxc/project.go:194
 msgid "Delete projects"
 msgstr "Apagar projetos"
 
@@ -2061,10 +2061,10 @@ msgstr ""
 #: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
 #: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
 #: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
-#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:32 lxc/project.go:96
+#: lxc/project.go:194 lxc/project.go:288 lxc/project.go:424 lxc/project.go:498
+#: lxc/project.go:618 lxc/project.go:683 lxc/project.go:771 lxc/project.go:815
+#: lxc/project.go:876 lxc/project.go:943 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -2351,7 +2351,7 @@ msgstr "Editar configurações de rede como YAML"
 msgid "Edit profile configurations as YAML"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:287 lxc/project.go:288
 #, fuzzy
 msgid "Edit project configurations as YAML"
 msgstr "Editar configurações de perfil como YAML"
@@ -2434,7 +2434,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/project.go:746 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
@@ -2448,7 +2448,7 @@ msgstr "Editar propriedades da imagem"
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
+#: lxc/profile.go:981 lxc/project.go:740 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
 #: lxc/storage_volume.go:2199
 #, c-format
@@ -2732,6 +2732,10 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
+#: lxc/project.go:197
+msgid "Force delete the project and everything it contains."
+msgstr ""
+
 #: lxc/cluster.go:1301
 msgid "Force evacuation without user confirmation"
 msgstr ""
@@ -2792,8 +2796,8 @@ msgstr ""
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:500
+#: lxc/project.go:945 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2860,7 +2864,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr "Adicionar perfis aos containers"
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:942 lxc/project.go:943
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2914,7 +2918,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:428
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2989,7 +2993,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:423 lxc/project.go:424
 #, fuzzy
 msgid "Get values for project configuration keys"
 msgstr "Editar configurações de perfil como YAML"
@@ -3085,7 +3089,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:594
 msgid "IMAGES"
 msgstr ""
 
@@ -3427,7 +3431,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1020
 msgid "LIMIT"
 msgstr ""
 
@@ -3738,7 +3742,7 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:497 lxc/project.go:498
 msgid "List projects"
 msgstr ""
 
@@ -4065,7 +4069,7 @@ msgstr "Editar arquivos no container"
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -4339,9 +4343,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:404 lxc/project.go:149 lxc/project.go:242 lxc/project.go:344
+#: lxc/project.go:461 lxc/project.go:650 lxc/project.go:719 lxc/project.go:847
+#: lxc/project.go:976
 msgid "Missing project name"
 msgstr ""
 
@@ -4468,7 +4472,7 @@ msgstr ""
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:593
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
@@ -4482,11 +4486,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:599
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:598
 msgid "NETWORKS"
 msgstr ""
 
@@ -4498,9 +4502,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:551
+#: lxc/project.go:556 lxc/project.go:561 lxc/project.go:566 lxc/project.go:571
+#: lxc/project.go:576 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4796,7 +4800,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:595
 msgid "PROFILES"
 msgstr ""
 
@@ -4875,7 +4879,7 @@ msgstr ""
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/project.go:391 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
 #: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4972,19 +4976,23 @@ msgstr "Copiar perfis"
 msgid "Profiles: "
 msgstr "Copiar perfis"
 
-#: lxc/project.go:174
+#: lxc/project.go:175
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:264
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:665
 #, c-format
 msgid "Project %s renamed to %s"
+msgstr ""
+
+#: lxc/project.go:248
+msgid "Project deletion aborted"
 msgstr ""
 
 #: lxc/remote.go:107
@@ -5130,7 +5138,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:1019
 msgid "RESOURCE"
 msgstr ""
 
@@ -5184,7 +5192,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:910 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -5231,6 +5239,13 @@ msgstr ""
 #: lxc/delete.go:48
 #, c-format
 msgid "Remove %s (yes/no): "
+msgstr ""
+
+#: lxc/project.go:214
+#, c-format
+msgid ""
+"Remove %s and everything it contains (instances, images, volumes, "
+"networks, ...) (yes/no): "
 msgstr ""
 
 #: lxc/cluster_group.go:522
@@ -5369,7 +5384,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:617 lxc/project.go:618
 msgid "Rename projects"
 msgstr ""
 
@@ -5536,7 +5551,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:597
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5544,7 +5559,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:596
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5743,12 +5758,12 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:682
 #, fuzzy
 msgid "Set project configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/project.go:657
+#: lxc/project.go:683
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5866,7 +5881,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:690
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -6029,7 +6044,7 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:814 lxc/project.go:815
 msgid "Show project options"
 msgstr ""
 
@@ -6281,7 +6296,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:875 lxc/project.go:876
 msgid "Switch the current project"
 msgstr ""
 
@@ -6464,7 +6479,7 @@ msgstr "Nome de membro do cluster"
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: lxc/project.go:448
+#: lxc/project.go:474
 #, fuzzy, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "Nome de membro do cluster"
@@ -6675,7 +6690,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:991
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6687,12 +6702,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:1021 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:601
 #: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
@@ -6835,7 +6850,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:770 lxc/project.go:771
 #, fuzzy
 msgid "Unset project configuration keys"
 msgstr "Editar configurações de perfil como YAML"
@@ -6895,7 +6910,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:775
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -7059,9 +7074,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:553
+#: lxc/project.go:558 lxc/project.go:563 lxc/project.go:568 lxc/project.go:573
+#: lxc/project.go:578 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -7098,7 +7113,7 @@ msgstr "Criar perfis"
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:495
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -7710,21 +7725,21 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:94 lxc/project.go:191 lxc/project.go:286 lxc/project.go:813
+#: lxc/project.go:874 lxc/project.go:941
 #, fuzzy
 msgid "[<remote>:]<project>"
 msgstr "Criar projetos"
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:422 lxc/project.go:769
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:681
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:615
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7804,7 +7819,7 @@ msgstr "Criar perfis"
 msgid "[[<remote>:]<member>]"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:583 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -8164,7 +8179,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:98
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -8172,7 +8187,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:290
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -8342,7 +8357,7 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1206 lxc/project.go:218
 msgid "yes"
 msgstr "sim"
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-08 16:23-0800\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -630,7 +630,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что имя отображается, но не может быть изменено"
 
-#: lxc/project.go:282
+#: lxc/project.go:308
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -1147,7 +1147,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:162
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Имя контейнера: %s"
@@ -1481,7 +1481,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:103
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1495,7 +1495,7 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/project.go:390 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
 #: lxc/storage_volume.go:1188
 #, c-format
@@ -1784,7 +1784,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:95 lxc/project.go:96
 msgid "Create projects"
 msgstr ""
 
@@ -1832,7 +1832,7 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
-#: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:756 lxc/project.go:600 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
@@ -1946,7 +1946,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:193 lxc/project.go:194
 msgid "Delete projects"
 msgstr ""
 
@@ -2048,10 +2048,10 @@ msgstr ""
 #: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
 #: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
 #: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
-#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:32 lxc/project.go:96
+#: lxc/project.go:194 lxc/project.go:288 lxc/project.go:424 lxc/project.go:498
+#: lxc/project.go:618 lxc/project.go:683 lxc/project.go:771 lxc/project.go:815
+#: lxc/project.go:876 lxc/project.go:943 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -2330,7 +2330,7 @@ msgstr "Копирование образа: %s"
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:287 lxc/project.go:288
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2411,7 +2411,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/project.go:746 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
@@ -2425,7 +2425,7 @@ msgstr "Копирование образа: %s"
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
+#: lxc/profile.go:981 lxc/project.go:740 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
 #: lxc/storage_volume.go:2199
 #, c-format
@@ -2717,6 +2717,10 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
+#: lxc/project.go:197
+msgid "Force delete the project and everything it contains."
+msgstr ""
+
 #: lxc/cluster.go:1301
 msgid "Force evacuation without user confirmation"
 msgstr ""
@@ -2777,8 +2781,8 @@ msgstr ""
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:500
+#: lxc/project.go:945 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2845,7 +2849,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:942 lxc/project.go:943
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2898,7 +2902,7 @@ msgstr "Копирование образа: %s"
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:428
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2971,7 +2975,7 @@ msgstr "Копирование образа: %s"
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:423 lxc/project.go:424
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -3067,7 +3071,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:594
 msgid "IMAGES"
 msgstr ""
 
@@ -3414,7 +3418,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1020
 msgid "LIMIT"
 msgstr ""
 
@@ -3730,7 +3734,7 @@ msgstr "Псевдонимы:"
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:497 lxc/project.go:498
 msgid "List projects"
 msgstr ""
 
@@ -4060,7 +4064,7 @@ msgstr "Копирование образа: %s"
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -4338,9 +4342,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:404 lxc/project.go:149 lxc/project.go:242 lxc/project.go:344
+#: lxc/project.go:461 lxc/project.go:650 lxc/project.go:719 lxc/project.go:847
+#: lxc/project.go:976
 #, fuzzy
 msgid "Missing project name"
 msgstr "Имя контейнера: %s"
@@ -4470,7 +4474,7 @@ msgstr ""
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:593
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
@@ -4484,11 +4488,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:599
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:598
 msgid "NETWORKS"
 msgstr ""
 
@@ -4500,9 +4504,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:551
+#: lxc/project.go:556 lxc/project.go:561 lxc/project.go:566 lxc/project.go:571
+#: lxc/project.go:576 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4802,7 +4806,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:595
 msgid "PROFILES"
 msgstr ""
 
@@ -4881,7 +4885,7 @@ msgstr ""
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/project.go:391 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
 #: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4973,19 +4977,23 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:175
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:264
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:665
 #, c-format
 msgid "Project %s renamed to %s"
+msgstr ""
+
+#: lxc/project.go:248
+msgid "Project deletion aborted"
 msgstr ""
 
 #: lxc/remote.go:107
@@ -5130,7 +5138,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:1019
 msgid "RESOURCE"
 msgstr ""
 
@@ -5186,7 +5194,7 @@ msgstr "Копирование образа: %s"
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:910 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -5232,6 +5240,13 @@ msgstr ""
 #: lxc/delete.go:48
 #, c-format
 msgid "Remove %s (yes/no): "
+msgstr ""
+
+#: lxc/project.go:214
+#, c-format
+msgid ""
+"Remove %s and everything it contains (instances, images, volumes, "
+"networks, ...) (yes/no): "
 msgstr ""
 
 #: lxc/cluster_group.go:522
@@ -5365,7 +5380,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:617 lxc/project.go:618
 msgid "Rename projects"
 msgstr ""
 
@@ -5531,7 +5546,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:597
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5539,7 +5554,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:596
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5734,11 +5749,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:682
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:683
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5856,7 +5871,7 @@ msgstr "Копирование образа: %s"
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:690
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -6016,7 +6031,7 @@ msgstr "Копирование образа: %s"
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:814 lxc/project.go:815
 msgid "Show project options"
 msgstr ""
 
@@ -6272,7 +6287,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:875 lxc/project.go:876
 msgid "Switch the current project"
 msgstr ""
 
@@ -6451,7 +6466,7 @@ msgstr "Копирование образа: %s"
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr "Копирование образа: %s"
 
-#: lxc/project.go:448
+#: lxc/project.go:474
 #, fuzzy, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr "Копирование образа: %s"
@@ -6660,7 +6675,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:991
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6672,12 +6687,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:1021 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:601
 #: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
@@ -6814,7 +6829,7 @@ msgstr "Копирование образа: %s"
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:770 lxc/project.go:771
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6873,7 +6888,7 @@ msgstr "Копирование образа: %s"
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:775
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -7039,9 +7054,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:553
+#: lxc/project.go:558 lxc/project.go:563 lxc/project.go:568 lxc/project.go:573
+#: lxc/project.go:578 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -7085,7 +7100,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:495
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 #, fuzzy
 msgid "[<remote>:]"
@@ -8131,8 +8146,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:94 lxc/project.go:191 lxc/project.go:286 lxc/project.go:813
+#: lxc/project.go:874 lxc/project.go:941
 #, fuzzy
 msgid "[<remote>:]<project>"
 msgstr ""
@@ -8140,7 +8155,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:422 lxc/project.go:769
 #, fuzzy
 msgid "[<remote>:]<project> <key>"
 msgstr ""
@@ -8148,7 +8163,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:655
+#: lxc/project.go:681
 #, fuzzy
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
@@ -8156,7 +8171,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:589
+#: lxc/project.go:615
 #, fuzzy
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
@@ -8292,7 +8307,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:583 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -8652,7 +8667,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:98
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -8660,7 +8675,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:290
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -8830,7 +8845,7 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1206 lxc/project.go:218
 msgid "yes"
 msgstr "да"
 

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-08 16:23-0800\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -391,7 +391,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:282
+#: lxc/project.go:308
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:162
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1201,7 +1201,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:103
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1215,7 +1215,7 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/project.go:390 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
 #: lxc/storage_volume.go:1188
 #, c-format
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:95 lxc/project.go:96
 msgid "Create projects"
 msgstr ""
 
@@ -1530,7 +1530,7 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
-#: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:756 lxc/project.go:600 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
@@ -1636,7 +1636,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:193 lxc/project.go:194
 msgid "Delete projects"
 msgstr ""
 
@@ -1736,10 +1736,10 @@ msgstr ""
 #: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
 #: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
 #: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
-#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:32 lxc/project.go:96
+#: lxc/project.go:194 lxc/project.go:288 lxc/project.go:424 lxc/project.go:498
+#: lxc/project.go:618 lxc/project.go:683 lxc/project.go:771 lxc/project.go:815
+#: lxc/project.go:876 lxc/project.go:943 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -2003,7 +2003,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:287 lxc/project.go:288
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2083,7 +2083,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/project.go:746 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
 #, c-format
 msgid "Error setting properties: %v"
@@ -2097,7 +2097,7 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
+#: lxc/profile.go:981 lxc/project.go:740 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
 #: lxc/storage_volume.go:2199
 #, c-format
@@ -2380,6 +2380,10 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
+#: lxc/project.go:197
+msgid "Force delete the project and everything it contains."
+msgstr ""
+
 #: lxc/cluster.go:1301
 msgid "Force evacuation without user confirmation"
 msgstr ""
@@ -2439,8 +2443,8 @@ msgstr ""
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:500
+#: lxc/project.go:945 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2506,7 +2510,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:942 lxc/project.go:943
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2554,7 +2558,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:428
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2618,7 +2622,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:423 lxc/project.go:424
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2712,7 +2716,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:594
 msgid "IMAGES"
 msgstr ""
 
@@ -3050,7 +3054,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1020
 msgid "LIMIT"
 msgstr ""
 
@@ -3352,7 +3356,7 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:497 lxc/project.go:498
 msgid "List projects"
 msgstr ""
 
@@ -3657,7 +3661,7 @@ msgstr ""
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -3911,9 +3915,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:404 lxc/project.go:149 lxc/project.go:242 lxc/project.go:344
+#: lxc/project.go:461 lxc/project.go:650 lxc/project.go:719 lxc/project.go:847
+#: lxc/project.go:976
 msgid "Missing project name"
 msgstr ""
 
@@ -4037,7 +4041,7 @@ msgstr ""
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:593
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
@@ -4051,11 +4055,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:599
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:598
 msgid "NETWORKS"
 msgstr ""
 
@@ -4067,9 +4071,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:551
+#: lxc/project.go:556 lxc/project.go:561 lxc/project.go:566 lxc/project.go:571
+#: lxc/project.go:576 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4365,7 +4369,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:595
 msgid "PROFILES"
 msgstr ""
 
@@ -4443,7 +4447,7 @@ msgstr ""
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/project.go:391 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
 #: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4535,19 +4539,23 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:175
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:264
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:665
 #, c-format
 msgid "Project %s renamed to %s"
+msgstr ""
+
+#: lxc/project.go:248
+msgid "Project deletion aborted"
 msgstr ""
 
 #: lxc/remote.go:107
@@ -4692,7 +4700,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:1019
 msgid "RESOURCE"
 msgstr ""
 
@@ -4744,7 +4752,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:910 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4789,6 +4797,13 @@ msgstr ""
 #: lxc/delete.go:48
 #, c-format
 msgid "Remove %s (yes/no): "
+msgstr ""
+
+#: lxc/project.go:214
+#, c-format
+msgid ""
+"Remove %s and everything it contains (instances, images, volumes, "
+"networks, ...) (yes/no): "
 msgstr ""
 
 #: lxc/cluster_group.go:522
@@ -4912,7 +4927,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:617 lxc/project.go:618
 msgid "Rename projects"
 msgstr ""
 
@@ -5069,7 +5084,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:597
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5077,7 +5092,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:596
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5265,11 +5280,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:682
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:683
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5381,7 +5396,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:690
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5526,7 +5541,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:814 lxc/project.go:815
 msgid "Show project options"
 msgstr ""
 
@@ -5772,7 +5787,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:875 lxc/project.go:876
 msgid "Switch the current project"
 msgstr ""
 
@@ -5951,7 +5966,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:448
+#: lxc/project.go:474
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6158,7 +6173,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:991
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6170,12 +6185,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:1021 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:601
 #: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
@@ -6302,7 +6317,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:770 lxc/project.go:771
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6354,7 +6369,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:775
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6515,9 +6530,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:553
+#: lxc/project.go:558 lxc/project.go:563 lxc/project.go:568 lxc/project.go:573
+#: lxc/project.go:578 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6553,7 +6568,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:495
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -7103,20 +7118,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:94 lxc/project.go:191 lxc/project.go:286 lxc/project.go:813
+#: lxc/project.go:874 lxc/project.go:941
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:422 lxc/project.go:769
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:681
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:615
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7184,7 +7199,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:583 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7544,7 +7559,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:98
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7552,7 +7567,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:290
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7722,6 +7737,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1206 lxc/project.go:218
 msgid "yes"
 msgstr ""

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-08 16:23-0800\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -392,7 +392,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:282
+#: lxc/project.go:308
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -875,7 +875,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:162
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1202,7 +1202,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:103
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1216,7 +1216,7 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/project.go:390 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
 #: lxc/storage_volume.go:1188
 #, c-format
@@ -1486,7 +1486,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:95 lxc/project.go:96
 msgid "Create projects"
 msgstr ""
 
@@ -1531,7 +1531,7 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
-#: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:756 lxc/project.go:600 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
@@ -1637,7 +1637,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:193 lxc/project.go:194
 msgid "Delete projects"
 msgstr ""
 
@@ -1737,10 +1737,10 @@ msgstr ""
 #: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
 #: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
 #: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
-#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:32 lxc/project.go:96
+#: lxc/project.go:194 lxc/project.go:288 lxc/project.go:424 lxc/project.go:498
+#: lxc/project.go:618 lxc/project.go:683 lxc/project.go:771 lxc/project.go:815
+#: lxc/project.go:876 lxc/project.go:943 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -2004,7 +2004,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:287 lxc/project.go:288
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2084,7 +2084,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/project.go:746 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
 #, c-format
 msgid "Error setting properties: %v"
@@ -2098,7 +2098,7 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
+#: lxc/profile.go:981 lxc/project.go:740 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
 #: lxc/storage_volume.go:2199
 #, c-format
@@ -2381,6 +2381,10 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
+#: lxc/project.go:197
+msgid "Force delete the project and everything it contains."
+msgstr ""
+
 #: lxc/cluster.go:1301
 msgid "Force evacuation without user confirmation"
 msgstr ""
@@ -2440,8 +2444,8 @@ msgstr ""
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:500
+#: lxc/project.go:945 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2507,7 +2511,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:942 lxc/project.go:943
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2555,7 +2559,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:428
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2619,7 +2623,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:423 lxc/project.go:424
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2713,7 +2717,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:594
 msgid "IMAGES"
 msgstr ""
 
@@ -3051,7 +3055,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1020
 msgid "LIMIT"
 msgstr ""
 
@@ -3353,7 +3357,7 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:497 lxc/project.go:498
 msgid "List projects"
 msgstr ""
 
@@ -3658,7 +3662,7 @@ msgstr ""
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -3912,9 +3916,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:404 lxc/project.go:149 lxc/project.go:242 lxc/project.go:344
+#: lxc/project.go:461 lxc/project.go:650 lxc/project.go:719 lxc/project.go:847
+#: lxc/project.go:976
 msgid "Missing project name"
 msgstr ""
 
@@ -4038,7 +4042,7 @@ msgstr ""
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:593
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
@@ -4052,11 +4056,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:599
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:598
 msgid "NETWORKS"
 msgstr ""
 
@@ -4068,9 +4072,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:551
+#: lxc/project.go:556 lxc/project.go:561 lxc/project.go:566 lxc/project.go:571
+#: lxc/project.go:576 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4366,7 +4370,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:595
 msgid "PROFILES"
 msgstr ""
 
@@ -4444,7 +4448,7 @@ msgstr ""
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/project.go:391 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
 #: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4536,19 +4540,23 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:175
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:264
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:665
 #, c-format
 msgid "Project %s renamed to %s"
+msgstr ""
+
+#: lxc/project.go:248
+msgid "Project deletion aborted"
 msgstr ""
 
 #: lxc/remote.go:107
@@ -4693,7 +4701,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:1019
 msgid "RESOURCE"
 msgstr ""
 
@@ -4745,7 +4753,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:910 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4790,6 +4798,13 @@ msgstr ""
 #: lxc/delete.go:48
 #, c-format
 msgid "Remove %s (yes/no): "
+msgstr ""
+
+#: lxc/project.go:214
+#, c-format
+msgid ""
+"Remove %s and everything it contains (instances, images, volumes, "
+"networks, ...) (yes/no): "
 msgstr ""
 
 #: lxc/cluster_group.go:522
@@ -4913,7 +4928,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:617 lxc/project.go:618
 msgid "Rename projects"
 msgstr ""
 
@@ -5070,7 +5085,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:597
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5078,7 +5093,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:596
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5266,11 +5281,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:682
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:683
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5382,7 +5397,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:690
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5527,7 +5542,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:814 lxc/project.go:815
 msgid "Show project options"
 msgstr ""
 
@@ -5773,7 +5788,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:875 lxc/project.go:876
 msgid "Switch the current project"
 msgstr ""
 
@@ -5952,7 +5967,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:448
+#: lxc/project.go:474
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6159,7 +6174,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:991
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6171,12 +6186,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:1021 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:601
 #: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
@@ -6303,7 +6318,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:770 lxc/project.go:771
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6355,7 +6370,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:775
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6516,9 +6531,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:553
+#: lxc/project.go:558 lxc/project.go:563 lxc/project.go:568 lxc/project.go:573
+#: lxc/project.go:578 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6554,7 +6569,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:495
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -7104,20 +7119,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:94 lxc/project.go:191 lxc/project.go:286 lxc/project.go:813
+#: lxc/project.go:874 lxc/project.go:941
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:422 lxc/project.go:769
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:681
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:615
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7185,7 +7200,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:583 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7545,7 +7560,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:98
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7553,7 +7568,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:290
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7723,6 +7738,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1206 lxc/project.go:218
 msgid "yes"
 msgstr ""

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-08 16:23-0800\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -392,7 +392,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:282
+#: lxc/project.go:308
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -875,7 +875,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:162
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1202,7 +1202,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:103
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1216,7 +1216,7 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/project.go:390 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
 #: lxc/storage_volume.go:1188
 #, c-format
@@ -1486,7 +1486,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:95 lxc/project.go:96
 msgid "Create projects"
 msgstr ""
 
@@ -1531,7 +1531,7 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
-#: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:756 lxc/project.go:600 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
@@ -1637,7 +1637,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:193 lxc/project.go:194
 msgid "Delete projects"
 msgstr ""
 
@@ -1737,10 +1737,10 @@ msgstr ""
 #: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
 #: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
 #: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
-#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:32 lxc/project.go:96
+#: lxc/project.go:194 lxc/project.go:288 lxc/project.go:424 lxc/project.go:498
+#: lxc/project.go:618 lxc/project.go:683 lxc/project.go:771 lxc/project.go:815
+#: lxc/project.go:876 lxc/project.go:943 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -2004,7 +2004,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:287 lxc/project.go:288
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2084,7 +2084,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/project.go:746 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
 #, c-format
 msgid "Error setting properties: %v"
@@ -2098,7 +2098,7 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
+#: lxc/profile.go:981 lxc/project.go:740 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
 #: lxc/storage_volume.go:2199
 #, c-format
@@ -2381,6 +2381,10 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
+#: lxc/project.go:197
+msgid "Force delete the project and everything it contains."
+msgstr ""
+
 #: lxc/cluster.go:1301
 msgid "Force evacuation without user confirmation"
 msgstr ""
@@ -2440,8 +2444,8 @@ msgstr ""
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:500
+#: lxc/project.go:945 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2507,7 +2511,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:942 lxc/project.go:943
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2555,7 +2559,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:428
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2619,7 +2623,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:423 lxc/project.go:424
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2713,7 +2717,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:594
 msgid "IMAGES"
 msgstr ""
 
@@ -3051,7 +3055,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1020
 msgid "LIMIT"
 msgstr ""
 
@@ -3353,7 +3357,7 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:497 lxc/project.go:498
 msgid "List projects"
 msgstr ""
 
@@ -3658,7 +3662,7 @@ msgstr ""
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -3912,9 +3916,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:404 lxc/project.go:149 lxc/project.go:242 lxc/project.go:344
+#: lxc/project.go:461 lxc/project.go:650 lxc/project.go:719 lxc/project.go:847
+#: lxc/project.go:976
 msgid "Missing project name"
 msgstr ""
 
@@ -4038,7 +4042,7 @@ msgstr ""
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:593
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
@@ -4052,11 +4056,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:599
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:598
 msgid "NETWORKS"
 msgstr ""
 
@@ -4068,9 +4072,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:551
+#: lxc/project.go:556 lxc/project.go:561 lxc/project.go:566 lxc/project.go:571
+#: lxc/project.go:576 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4366,7 +4370,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:595
 msgid "PROFILES"
 msgstr ""
 
@@ -4444,7 +4448,7 @@ msgstr ""
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/project.go:391 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
 #: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4536,19 +4540,23 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:175
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:264
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:665
 #, c-format
 msgid "Project %s renamed to %s"
+msgstr ""
+
+#: lxc/project.go:248
+msgid "Project deletion aborted"
 msgstr ""
 
 #: lxc/remote.go:107
@@ -4693,7 +4701,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:1019
 msgid "RESOURCE"
 msgstr ""
 
@@ -4745,7 +4753,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:910 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4790,6 +4798,13 @@ msgstr ""
 #: lxc/delete.go:48
 #, c-format
 msgid "Remove %s (yes/no): "
+msgstr ""
+
+#: lxc/project.go:214
+#, c-format
+msgid ""
+"Remove %s and everything it contains (instances, images, volumes, "
+"networks, ...) (yes/no): "
 msgstr ""
 
 #: lxc/cluster_group.go:522
@@ -4913,7 +4928,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:617 lxc/project.go:618
 msgid "Rename projects"
 msgstr ""
 
@@ -5070,7 +5085,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:597
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5078,7 +5093,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:596
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5266,11 +5281,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:682
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:683
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5382,7 +5397,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:690
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5527,7 +5542,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:814 lxc/project.go:815
 msgid "Show project options"
 msgstr ""
 
@@ -5773,7 +5788,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:875 lxc/project.go:876
 msgid "Switch the current project"
 msgstr ""
 
@@ -5952,7 +5967,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:448
+#: lxc/project.go:474
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6159,7 +6174,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:991
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6171,12 +6186,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:1021 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:601
 #: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
@@ -6303,7 +6318,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:770 lxc/project.go:771
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6355,7 +6370,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:775
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6516,9 +6531,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:553
+#: lxc/project.go:558 lxc/project.go:563 lxc/project.go:568 lxc/project.go:573
+#: lxc/project.go:578 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6554,7 +6569,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:495
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -7104,20 +7119,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:94 lxc/project.go:191 lxc/project.go:286 lxc/project.go:813
+#: lxc/project.go:874 lxc/project.go:941
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:422 lxc/project.go:769
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:681
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:615
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7185,7 +7200,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:583 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7545,7 +7560,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:98
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7553,7 +7568,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:290
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7723,6 +7738,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1206 lxc/project.go:218
 msgid "yes"
 msgstr ""

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-08 16:23-0800\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -391,7 +391,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:282
+#: lxc/project.go:308
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:162
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1201,7 +1201,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:103
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1215,7 +1215,7 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/project.go:390 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
 #: lxc/storage_volume.go:1188
 #, c-format
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:95 lxc/project.go:96
 msgid "Create projects"
 msgstr ""
 
@@ -1530,7 +1530,7 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
-#: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:756 lxc/project.go:600 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
@@ -1636,7 +1636,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:193 lxc/project.go:194
 msgid "Delete projects"
 msgstr ""
 
@@ -1736,10 +1736,10 @@ msgstr ""
 #: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
 #: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
 #: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
-#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:32 lxc/project.go:96
+#: lxc/project.go:194 lxc/project.go:288 lxc/project.go:424 lxc/project.go:498
+#: lxc/project.go:618 lxc/project.go:683 lxc/project.go:771 lxc/project.go:815
+#: lxc/project.go:876 lxc/project.go:943 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -2003,7 +2003,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:287 lxc/project.go:288
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2083,7 +2083,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/project.go:746 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
 #, c-format
 msgid "Error setting properties: %v"
@@ -2097,7 +2097,7 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
+#: lxc/profile.go:981 lxc/project.go:740 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
 #: lxc/storage_volume.go:2199
 #, c-format
@@ -2380,6 +2380,10 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
+#: lxc/project.go:197
+msgid "Force delete the project and everything it contains."
+msgstr ""
+
 #: lxc/cluster.go:1301
 msgid "Force evacuation without user confirmation"
 msgstr ""
@@ -2439,8 +2443,8 @@ msgstr ""
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:500
+#: lxc/project.go:945 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2506,7 +2510,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:942 lxc/project.go:943
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2554,7 +2558,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:428
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2618,7 +2622,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:423 lxc/project.go:424
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2712,7 +2716,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:594
 msgid "IMAGES"
 msgstr ""
 
@@ -3050,7 +3054,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1020
 msgid "LIMIT"
 msgstr ""
 
@@ -3352,7 +3356,7 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:497 lxc/project.go:498
 msgid "List projects"
 msgstr ""
 
@@ -3657,7 +3661,7 @@ msgstr ""
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -3911,9 +3915,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:404 lxc/project.go:149 lxc/project.go:242 lxc/project.go:344
+#: lxc/project.go:461 lxc/project.go:650 lxc/project.go:719 lxc/project.go:847
+#: lxc/project.go:976
 msgid "Missing project name"
 msgstr ""
 
@@ -4037,7 +4041,7 @@ msgstr ""
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:593
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
@@ -4051,11 +4055,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:599
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:598
 msgid "NETWORKS"
 msgstr ""
 
@@ -4067,9 +4071,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:551
+#: lxc/project.go:556 lxc/project.go:561 lxc/project.go:566 lxc/project.go:571
+#: lxc/project.go:576 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4365,7 +4369,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:595
 msgid "PROFILES"
 msgstr ""
 
@@ -4443,7 +4447,7 @@ msgstr ""
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/project.go:391 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
 #: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4535,19 +4539,23 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:175
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:264
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:665
 #, c-format
 msgid "Project %s renamed to %s"
+msgstr ""
+
+#: lxc/project.go:248
+msgid "Project deletion aborted"
 msgstr ""
 
 #: lxc/remote.go:107
@@ -4692,7 +4700,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:1019
 msgid "RESOURCE"
 msgstr ""
 
@@ -4744,7 +4752,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:910 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4789,6 +4797,13 @@ msgstr ""
 #: lxc/delete.go:48
 #, c-format
 msgid "Remove %s (yes/no): "
+msgstr ""
+
+#: lxc/project.go:214
+#, c-format
+msgid ""
+"Remove %s and everything it contains (instances, images, volumes, "
+"networks, ...) (yes/no): "
 msgstr ""
 
 #: lxc/cluster_group.go:522
@@ -4912,7 +4927,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:617 lxc/project.go:618
 msgid "Rename projects"
 msgstr ""
 
@@ -5069,7 +5084,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:597
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5077,7 +5092,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:596
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5265,11 +5280,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:682
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:683
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5381,7 +5396,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:690
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5526,7 +5541,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:814 lxc/project.go:815
 msgid "Show project options"
 msgstr ""
 
@@ -5772,7 +5787,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:875 lxc/project.go:876
 msgid "Switch the current project"
 msgstr ""
 
@@ -5951,7 +5966,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:448
+#: lxc/project.go:474
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6158,7 +6173,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:991
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6170,12 +6185,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:1021 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:601
 #: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
@@ -6302,7 +6317,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:770 lxc/project.go:771
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6354,7 +6369,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:775
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6515,9 +6530,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:553
+#: lxc/project.go:558 lxc/project.go:563 lxc/project.go:568 lxc/project.go:573
+#: lxc/project.go:578 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6553,7 +6568,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:495
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -7103,20 +7118,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:94 lxc/project.go:191 lxc/project.go:286 lxc/project.go:813
+#: lxc/project.go:874 lxc/project.go:941
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:422 lxc/project.go:769
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:681
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:615
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7184,7 +7199,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:583 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7544,7 +7559,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:98
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7552,7 +7567,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:290
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7722,6 +7737,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1206 lxc/project.go:218
 msgid "yes"
 msgstr ""

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-08 16:23-0800\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -391,7 +391,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:282
+#: lxc/project.go:308
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:162
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1201,7 +1201,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:103
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1215,7 +1215,7 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/project.go:390 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
 #: lxc/storage_volume.go:1188
 #, c-format
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:95 lxc/project.go:96
 msgid "Create projects"
 msgstr ""
 
@@ -1530,7 +1530,7 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
-#: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:756 lxc/project.go:600 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
@@ -1636,7 +1636,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:193 lxc/project.go:194
 msgid "Delete projects"
 msgstr ""
 
@@ -1736,10 +1736,10 @@ msgstr ""
 #: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
 #: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
 #: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
-#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:32 lxc/project.go:96
+#: lxc/project.go:194 lxc/project.go:288 lxc/project.go:424 lxc/project.go:498
+#: lxc/project.go:618 lxc/project.go:683 lxc/project.go:771 lxc/project.go:815
+#: lxc/project.go:876 lxc/project.go:943 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -2003,7 +2003,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:287 lxc/project.go:288
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2083,7 +2083,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/project.go:746 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
 #, c-format
 msgid "Error setting properties: %v"
@@ -2097,7 +2097,7 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
+#: lxc/profile.go:981 lxc/project.go:740 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
 #: lxc/storage_volume.go:2199
 #, c-format
@@ -2380,6 +2380,10 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
+#: lxc/project.go:197
+msgid "Force delete the project and everything it contains."
+msgstr ""
+
 #: lxc/cluster.go:1301
 msgid "Force evacuation without user confirmation"
 msgstr ""
@@ -2439,8 +2443,8 @@ msgstr ""
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:500
+#: lxc/project.go:945 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2506,7 +2510,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:942 lxc/project.go:943
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2554,7 +2558,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:428
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2618,7 +2622,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:423 lxc/project.go:424
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2712,7 +2716,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:594
 msgid "IMAGES"
 msgstr ""
 
@@ -3050,7 +3054,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1020
 msgid "LIMIT"
 msgstr ""
 
@@ -3352,7 +3356,7 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:497 lxc/project.go:498
 msgid "List projects"
 msgstr ""
 
@@ -3657,7 +3661,7 @@ msgstr ""
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -3911,9 +3915,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:404 lxc/project.go:149 lxc/project.go:242 lxc/project.go:344
+#: lxc/project.go:461 lxc/project.go:650 lxc/project.go:719 lxc/project.go:847
+#: lxc/project.go:976
 msgid "Missing project name"
 msgstr ""
 
@@ -4037,7 +4041,7 @@ msgstr ""
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:593
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
@@ -4051,11 +4055,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:599
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:598
 msgid "NETWORKS"
 msgstr ""
 
@@ -4067,9 +4071,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:551
+#: lxc/project.go:556 lxc/project.go:561 lxc/project.go:566 lxc/project.go:571
+#: lxc/project.go:576 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4365,7 +4369,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:595
 msgid "PROFILES"
 msgstr ""
 
@@ -4443,7 +4447,7 @@ msgstr ""
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/project.go:391 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
 #: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4535,19 +4539,23 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:175
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:264
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:665
 #, c-format
 msgid "Project %s renamed to %s"
+msgstr ""
+
+#: lxc/project.go:248
+msgid "Project deletion aborted"
 msgstr ""
 
 #: lxc/remote.go:107
@@ -4692,7 +4700,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:1019
 msgid "RESOURCE"
 msgstr ""
 
@@ -4744,7 +4752,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:910 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4789,6 +4797,13 @@ msgstr ""
 #: lxc/delete.go:48
 #, c-format
 msgid "Remove %s (yes/no): "
+msgstr ""
+
+#: lxc/project.go:214
+#, c-format
+msgid ""
+"Remove %s and everything it contains (instances, images, volumes, "
+"networks, ...) (yes/no): "
 msgstr ""
 
 #: lxc/cluster_group.go:522
@@ -4912,7 +4927,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:617 lxc/project.go:618
 msgid "Rename projects"
 msgstr ""
 
@@ -5069,7 +5084,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:597
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5077,7 +5092,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:596
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5265,11 +5280,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:682
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:683
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5381,7 +5396,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:690
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5526,7 +5541,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:814 lxc/project.go:815
 msgid "Show project options"
 msgstr ""
 
@@ -5772,7 +5787,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:875 lxc/project.go:876
 msgid "Switch the current project"
 msgstr ""
 
@@ -5951,7 +5966,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:448
+#: lxc/project.go:474
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6158,7 +6173,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:991
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6170,12 +6185,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:1021 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:601
 #: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
@@ -6302,7 +6317,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:770 lxc/project.go:771
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6354,7 +6369,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:775
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6515,9 +6530,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:553
+#: lxc/project.go:558 lxc/project.go:563 lxc/project.go:568 lxc/project.go:573
+#: lxc/project.go:578 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6553,7 +6568,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:495
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -7103,20 +7118,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:94 lxc/project.go:191 lxc/project.go:286 lxc/project.go:813
+#: lxc/project.go:874 lxc/project.go:941
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:422 lxc/project.go:769
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:681
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:615
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7184,7 +7199,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:583 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7544,7 +7559,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:98
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7552,7 +7567,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:290
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7722,6 +7737,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1206 lxc/project.go:218
 msgid "yes"
 msgstr ""

--- a/po/th.po
+++ b/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-08 16:23-0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -388,7 +388,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:282
+#: lxc/project.go:308
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -871,7 +871,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:162
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1198,7 +1198,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:103
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1212,7 +1212,7 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/project.go:390 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
 #: lxc/storage_volume.go:1188
 #, c-format
@@ -1482,7 +1482,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:95 lxc/project.go:96
 msgid "Create projects"
 msgstr ""
 
@@ -1527,7 +1527,7 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
-#: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:756 lxc/project.go:600 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
@@ -1633,7 +1633,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:193 lxc/project.go:194
 msgid "Delete projects"
 msgstr ""
 
@@ -1733,10 +1733,10 @@ msgstr ""
 #: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
 #: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
 #: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
-#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:32 lxc/project.go:96
+#: lxc/project.go:194 lxc/project.go:288 lxc/project.go:424 lxc/project.go:498
+#: lxc/project.go:618 lxc/project.go:683 lxc/project.go:771 lxc/project.go:815
+#: lxc/project.go:876 lxc/project.go:943 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -2000,7 +2000,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:287 lxc/project.go:288
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2080,7 +2080,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/project.go:746 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
 #, c-format
 msgid "Error setting properties: %v"
@@ -2094,7 +2094,7 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
+#: lxc/profile.go:981 lxc/project.go:740 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
 #: lxc/storage_volume.go:2199
 #, c-format
@@ -2377,6 +2377,10 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
+#: lxc/project.go:197
+msgid "Force delete the project and everything it contains."
+msgstr ""
+
 #: lxc/cluster.go:1301
 msgid "Force evacuation without user confirmation"
 msgstr ""
@@ -2436,8 +2440,8 @@ msgstr ""
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:500
+#: lxc/project.go:945 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2503,7 +2507,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:942 lxc/project.go:943
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2551,7 +2555,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:428
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2615,7 +2619,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:423 lxc/project.go:424
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2709,7 +2713,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:594
 msgid "IMAGES"
 msgstr ""
 
@@ -3047,7 +3051,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1020
 msgid "LIMIT"
 msgstr ""
 
@@ -3349,7 +3353,7 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:497 lxc/project.go:498
 msgid "List projects"
 msgstr ""
 
@@ -3654,7 +3658,7 @@ msgstr ""
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -3908,9 +3912,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:404 lxc/project.go:149 lxc/project.go:242 lxc/project.go:344
+#: lxc/project.go:461 lxc/project.go:650 lxc/project.go:719 lxc/project.go:847
+#: lxc/project.go:976
 msgid "Missing project name"
 msgstr ""
 
@@ -4034,7 +4038,7 @@ msgstr ""
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:593
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
@@ -4048,11 +4052,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:599
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:598
 msgid "NETWORKS"
 msgstr ""
 
@@ -4064,9 +4068,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:551
+#: lxc/project.go:556 lxc/project.go:561 lxc/project.go:566 lxc/project.go:571
+#: lxc/project.go:576 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4362,7 +4366,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:595
 msgid "PROFILES"
 msgstr ""
 
@@ -4440,7 +4444,7 @@ msgstr ""
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/project.go:391 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
 #: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4532,19 +4536,23 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:175
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:264
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:665
 #, c-format
 msgid "Project %s renamed to %s"
+msgstr ""
+
+#: lxc/project.go:248
+msgid "Project deletion aborted"
 msgstr ""
 
 #: lxc/remote.go:107
@@ -4689,7 +4697,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:1019
 msgid "RESOURCE"
 msgstr ""
 
@@ -4741,7 +4749,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:910 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4786,6 +4794,13 @@ msgstr ""
 #: lxc/delete.go:48
 #, c-format
 msgid "Remove %s (yes/no): "
+msgstr ""
+
+#: lxc/project.go:214
+#, c-format
+msgid ""
+"Remove %s and everything it contains (instances, images, volumes, "
+"networks, ...) (yes/no): "
 msgstr ""
 
 #: lxc/cluster_group.go:522
@@ -4909,7 +4924,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:617 lxc/project.go:618
 msgid "Rename projects"
 msgstr ""
 
@@ -5066,7 +5081,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:597
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5074,7 +5089,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:596
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5262,11 +5277,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:682
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:683
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5378,7 +5393,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:690
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5523,7 +5538,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:814 lxc/project.go:815
 msgid "Show project options"
 msgstr ""
 
@@ -5769,7 +5784,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:875 lxc/project.go:876
 msgid "Switch the current project"
 msgstr ""
 
@@ -5948,7 +5963,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:448
+#: lxc/project.go:474
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6155,7 +6170,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:991
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6167,12 +6182,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:1021 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:601
 #: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
@@ -6299,7 +6314,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:770 lxc/project.go:771
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6351,7 +6366,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:775
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6512,9 +6527,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:553
+#: lxc/project.go:558 lxc/project.go:563 lxc/project.go:568 lxc/project.go:573
+#: lxc/project.go:578 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6550,7 +6565,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:495
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -7100,20 +7115,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:94 lxc/project.go:191 lxc/project.go:286 lxc/project.go:813
+#: lxc/project.go:874 lxc/project.go:941
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:422 lxc/project.go:769
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:681
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:615
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7181,7 +7196,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:583 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7541,7 +7556,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:98
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7549,7 +7564,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:290
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7719,6 +7734,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1206 lxc/project.go:218
 msgid "yes"
 msgstr ""

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-08 16:23-0800\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -391,7 +391,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:282
+#: lxc/project.go:308
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:162
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1201,7 +1201,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:103
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1215,7 +1215,7 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/project.go:390 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
 #: lxc/storage_volume.go:1188
 #, c-format
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:95 lxc/project.go:96
 msgid "Create projects"
 msgstr ""
 
@@ -1530,7 +1530,7 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
-#: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:756 lxc/project.go:600 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
@@ -1636,7 +1636,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:193 lxc/project.go:194
 msgid "Delete projects"
 msgstr ""
 
@@ -1736,10 +1736,10 @@ msgstr ""
 #: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
 #: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
 #: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
-#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:32 lxc/project.go:96
+#: lxc/project.go:194 lxc/project.go:288 lxc/project.go:424 lxc/project.go:498
+#: lxc/project.go:618 lxc/project.go:683 lxc/project.go:771 lxc/project.go:815
+#: lxc/project.go:876 lxc/project.go:943 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -2003,7 +2003,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:287 lxc/project.go:288
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2083,7 +2083,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/project.go:746 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
 #, c-format
 msgid "Error setting properties: %v"
@@ -2097,7 +2097,7 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
+#: lxc/profile.go:981 lxc/project.go:740 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
 #: lxc/storage_volume.go:2199
 #, c-format
@@ -2380,6 +2380,10 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
+#: lxc/project.go:197
+msgid "Force delete the project and everything it contains."
+msgstr ""
+
 #: lxc/cluster.go:1301
 msgid "Force evacuation without user confirmation"
 msgstr ""
@@ -2439,8 +2443,8 @@ msgstr ""
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:500
+#: lxc/project.go:945 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2506,7 +2510,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:942 lxc/project.go:943
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2554,7 +2558,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:428
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2618,7 +2622,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:423 lxc/project.go:424
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2712,7 +2716,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:594
 msgid "IMAGES"
 msgstr ""
 
@@ -3050,7 +3054,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1020
 msgid "LIMIT"
 msgstr ""
 
@@ -3352,7 +3356,7 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:497 lxc/project.go:498
 msgid "List projects"
 msgstr ""
 
@@ -3657,7 +3661,7 @@ msgstr ""
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -3911,9 +3915,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:404 lxc/project.go:149 lxc/project.go:242 lxc/project.go:344
+#: lxc/project.go:461 lxc/project.go:650 lxc/project.go:719 lxc/project.go:847
+#: lxc/project.go:976
 msgid "Missing project name"
 msgstr ""
 
@@ -4037,7 +4041,7 @@ msgstr ""
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:593
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
@@ -4051,11 +4055,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:599
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:598
 msgid "NETWORKS"
 msgstr ""
 
@@ -4067,9 +4071,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:551
+#: lxc/project.go:556 lxc/project.go:561 lxc/project.go:566 lxc/project.go:571
+#: lxc/project.go:576 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4365,7 +4369,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:595
 msgid "PROFILES"
 msgstr ""
 
@@ -4443,7 +4447,7 @@ msgstr ""
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/project.go:391 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
 #: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4535,19 +4539,23 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:175
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:264
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:665
 #, c-format
 msgid "Project %s renamed to %s"
+msgstr ""
+
+#: lxc/project.go:248
+msgid "Project deletion aborted"
 msgstr ""
 
 #: lxc/remote.go:107
@@ -4692,7 +4700,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:1019
 msgid "RESOURCE"
 msgstr ""
 
@@ -4744,7 +4752,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:910 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4789,6 +4797,13 @@ msgstr ""
 #: lxc/delete.go:48
 #, c-format
 msgid "Remove %s (yes/no): "
+msgstr ""
+
+#: lxc/project.go:214
+#, c-format
+msgid ""
+"Remove %s and everything it contains (instances, images, volumes, "
+"networks, ...) (yes/no): "
 msgstr ""
 
 #: lxc/cluster_group.go:522
@@ -4912,7 +4927,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:617 lxc/project.go:618
 msgid "Rename projects"
 msgstr ""
 
@@ -5069,7 +5084,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:597
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5077,7 +5092,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:596
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5265,11 +5280,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:682
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:683
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5381,7 +5396,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:690
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5526,7 +5541,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:814 lxc/project.go:815
 msgid "Show project options"
 msgstr ""
 
@@ -5772,7 +5787,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:875 lxc/project.go:876
 msgid "Switch the current project"
 msgstr ""
 
@@ -5951,7 +5966,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:448
+#: lxc/project.go:474
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6158,7 +6173,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:991
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6170,12 +6185,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:1021 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:601
 #: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
@@ -6302,7 +6317,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:770 lxc/project.go:771
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6354,7 +6369,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:775
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6515,9 +6530,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:553
+#: lxc/project.go:558 lxc/project.go:563 lxc/project.go:568 lxc/project.go:573
+#: lxc/project.go:578 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6553,7 +6568,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:495
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -7103,20 +7118,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:94 lxc/project.go:191 lxc/project.go:286 lxc/project.go:813
+#: lxc/project.go:874 lxc/project.go:941
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:422 lxc/project.go:769
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:681
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:615
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7184,7 +7199,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:583 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7544,7 +7559,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:98
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7552,7 +7567,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:290
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7722,6 +7737,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1206 lxc/project.go:218
 msgid "yes"
 msgstr ""

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-08 16:23-0800\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -391,7 +391,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:282
+#: lxc/project.go:308
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:162
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1201,7 +1201,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:103
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1215,7 +1215,7 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/project.go:390 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
 #: lxc/storage_volume.go:1188
 #, c-format
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:95 lxc/project.go:96
 msgid "Create projects"
 msgstr ""
 
@@ -1530,7 +1530,7 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
-#: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:756 lxc/project.go:600 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
@@ -1636,7 +1636,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:193 lxc/project.go:194
 msgid "Delete projects"
 msgstr ""
 
@@ -1736,10 +1736,10 @@ msgstr ""
 #: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
 #: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
 #: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
-#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:32 lxc/project.go:96
+#: lxc/project.go:194 lxc/project.go:288 lxc/project.go:424 lxc/project.go:498
+#: lxc/project.go:618 lxc/project.go:683 lxc/project.go:771 lxc/project.go:815
+#: lxc/project.go:876 lxc/project.go:943 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -2003,7 +2003,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:287 lxc/project.go:288
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2083,7 +2083,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/project.go:746 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
 #, c-format
 msgid "Error setting properties: %v"
@@ -2097,7 +2097,7 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
+#: lxc/profile.go:981 lxc/project.go:740 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
 #: lxc/storage_volume.go:2199
 #, c-format
@@ -2380,6 +2380,10 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
+#: lxc/project.go:197
+msgid "Force delete the project and everything it contains."
+msgstr ""
+
 #: lxc/cluster.go:1301
 msgid "Force evacuation without user confirmation"
 msgstr ""
@@ -2439,8 +2443,8 @@ msgstr ""
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:500
+#: lxc/project.go:945 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2506,7 +2510,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:942 lxc/project.go:943
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2554,7 +2558,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:428
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2618,7 +2622,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:423 lxc/project.go:424
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2712,7 +2716,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:594
 msgid "IMAGES"
 msgstr ""
 
@@ -3050,7 +3054,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1020
 msgid "LIMIT"
 msgstr ""
 
@@ -3352,7 +3356,7 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:497 lxc/project.go:498
 msgid "List projects"
 msgstr ""
 
@@ -3657,7 +3661,7 @@ msgstr ""
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -3911,9 +3915,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:404 lxc/project.go:149 lxc/project.go:242 lxc/project.go:344
+#: lxc/project.go:461 lxc/project.go:650 lxc/project.go:719 lxc/project.go:847
+#: lxc/project.go:976
 msgid "Missing project name"
 msgstr ""
 
@@ -4037,7 +4041,7 @@ msgstr ""
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:593
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
@@ -4051,11 +4055,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:599
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:598
 msgid "NETWORKS"
 msgstr ""
 
@@ -4067,9 +4071,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:551
+#: lxc/project.go:556 lxc/project.go:561 lxc/project.go:566 lxc/project.go:571
+#: lxc/project.go:576 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4365,7 +4369,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:595
 msgid "PROFILES"
 msgstr ""
 
@@ -4443,7 +4447,7 @@ msgstr ""
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/project.go:391 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
 #: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4535,19 +4539,23 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:175
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:264
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:665
 #, c-format
 msgid "Project %s renamed to %s"
+msgstr ""
+
+#: lxc/project.go:248
+msgid "Project deletion aborted"
 msgstr ""
 
 #: lxc/remote.go:107
@@ -4692,7 +4700,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:1019
 msgid "RESOURCE"
 msgstr ""
 
@@ -4744,7 +4752,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:910 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4789,6 +4797,13 @@ msgstr ""
 #: lxc/delete.go:48
 #, c-format
 msgid "Remove %s (yes/no): "
+msgstr ""
+
+#: lxc/project.go:214
+#, c-format
+msgid ""
+"Remove %s and everything it contains (instances, images, volumes, "
+"networks, ...) (yes/no): "
 msgstr ""
 
 #: lxc/cluster_group.go:522
@@ -4912,7 +4927,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:617 lxc/project.go:618
 msgid "Rename projects"
 msgstr ""
 
@@ -5069,7 +5084,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:597
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5077,7 +5092,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:596
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5265,11 +5280,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:682
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:683
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5381,7 +5396,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:690
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5526,7 +5541,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:814 lxc/project.go:815
 msgid "Show project options"
 msgstr ""
 
@@ -5772,7 +5787,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:875 lxc/project.go:876
 msgid "Switch the current project"
 msgstr ""
 
@@ -5951,7 +5966,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:448
+#: lxc/project.go:474
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6158,7 +6173,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:991
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6170,12 +6185,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:1021 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:601
 #: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
@@ -6302,7 +6317,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:770 lxc/project.go:771
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6354,7 +6369,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:775
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6515,9 +6530,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:553
+#: lxc/project.go:558 lxc/project.go:563 lxc/project.go:568 lxc/project.go:573
+#: lxc/project.go:578 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6553,7 +6568,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:495
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -7103,20 +7118,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:94 lxc/project.go:191 lxc/project.go:286 lxc/project.go:813
+#: lxc/project.go:874 lxc/project.go:941
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:422 lxc/project.go:769
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:681
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:615
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7184,7 +7199,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:583 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7544,7 +7559,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:98
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7552,7 +7567,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:290
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7722,6 +7737,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1206 lxc/project.go:218
 msgid "yes"
 msgstr ""

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-08 16:23-0800\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -391,7 +391,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:282
+#: lxc/project.go:308
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:162
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1201,7 +1201,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:103
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1215,7 +1215,7 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/project.go:390 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
 #: lxc/storage_volume.go:1188
 #, c-format
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:95 lxc/project.go:96
 msgid "Create projects"
 msgstr ""
 
@@ -1530,7 +1530,7 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
-#: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:756 lxc/project.go:600 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
@@ -1636,7 +1636,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:193 lxc/project.go:194
 msgid "Delete projects"
 msgstr ""
 
@@ -1736,10 +1736,10 @@ msgstr ""
 #: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
 #: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
 #: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
-#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:32 lxc/project.go:96
+#: lxc/project.go:194 lxc/project.go:288 lxc/project.go:424 lxc/project.go:498
+#: lxc/project.go:618 lxc/project.go:683 lxc/project.go:771 lxc/project.go:815
+#: lxc/project.go:876 lxc/project.go:943 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -2003,7 +2003,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:287 lxc/project.go:288
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2083,7 +2083,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/project.go:746 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
 #, c-format
 msgid "Error setting properties: %v"
@@ -2097,7 +2097,7 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
+#: lxc/profile.go:981 lxc/project.go:740 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
 #: lxc/storage_volume.go:2199
 #, c-format
@@ -2380,6 +2380,10 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
+#: lxc/project.go:197
+msgid "Force delete the project and everything it contains."
+msgstr ""
+
 #: lxc/cluster.go:1301
 msgid "Force evacuation without user confirmation"
 msgstr ""
@@ -2439,8 +2443,8 @@ msgstr ""
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:500
+#: lxc/project.go:945 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2506,7 +2510,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:942 lxc/project.go:943
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2554,7 +2558,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:428
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2618,7 +2622,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:423 lxc/project.go:424
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2712,7 +2716,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:594
 msgid "IMAGES"
 msgstr ""
 
@@ -3050,7 +3054,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1020
 msgid "LIMIT"
 msgstr ""
 
@@ -3352,7 +3356,7 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:497 lxc/project.go:498
 msgid "List projects"
 msgstr ""
 
@@ -3657,7 +3661,7 @@ msgstr ""
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -3911,9 +3915,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:404 lxc/project.go:149 lxc/project.go:242 lxc/project.go:344
+#: lxc/project.go:461 lxc/project.go:650 lxc/project.go:719 lxc/project.go:847
+#: lxc/project.go:976
 msgid "Missing project name"
 msgstr ""
 
@@ -4037,7 +4041,7 @@ msgstr ""
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:593
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
@@ -4051,11 +4055,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:599
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:598
 msgid "NETWORKS"
 msgstr ""
 
@@ -4067,9 +4071,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:551
+#: lxc/project.go:556 lxc/project.go:561 lxc/project.go:566 lxc/project.go:571
+#: lxc/project.go:576 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4365,7 +4369,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:595
 msgid "PROFILES"
 msgstr ""
 
@@ -4443,7 +4447,7 @@ msgstr ""
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/project.go:391 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
 #: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4535,19 +4539,23 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:175
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:264
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:665
 #, c-format
 msgid "Project %s renamed to %s"
+msgstr ""
+
+#: lxc/project.go:248
+msgid "Project deletion aborted"
 msgstr ""
 
 #: lxc/remote.go:107
@@ -4692,7 +4700,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:1019
 msgid "RESOURCE"
 msgstr ""
 
@@ -4744,7 +4752,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:910 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4789,6 +4797,13 @@ msgstr ""
 #: lxc/delete.go:48
 #, c-format
 msgid "Remove %s (yes/no): "
+msgstr ""
+
+#: lxc/project.go:214
+#, c-format
+msgid ""
+"Remove %s and everything it contains (instances, images, volumes, "
+"networks, ...) (yes/no): "
 msgstr ""
 
 #: lxc/cluster_group.go:522
@@ -4912,7 +4927,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:617 lxc/project.go:618
 msgid "Rename projects"
 msgstr ""
 
@@ -5069,7 +5084,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:597
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5077,7 +5092,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:596
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5265,11 +5280,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:682
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:683
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5381,7 +5396,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:690
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5526,7 +5541,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:814 lxc/project.go:815
 msgid "Show project options"
 msgstr ""
 
@@ -5772,7 +5787,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:875 lxc/project.go:876
 msgid "Switch the current project"
 msgstr ""
 
@@ -5951,7 +5966,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:448
+#: lxc/project.go:474
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6158,7 +6173,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:991
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6170,12 +6185,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:1021 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:601
 #: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
@@ -6302,7 +6317,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:770 lxc/project.go:771
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6354,7 +6369,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:775
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6515,9 +6530,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:553
+#: lxc/project.go:558 lxc/project.go:563 lxc/project.go:568 lxc/project.go:573
+#: lxc/project.go:578 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6553,7 +6568,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:495
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -7103,20 +7118,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:94 lxc/project.go:191 lxc/project.go:286 lxc/project.go:813
+#: lxc/project.go:874 lxc/project.go:941
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:422 lxc/project.go:769
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:681
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:615
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7184,7 +7199,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:583 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7544,7 +7559,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:98
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7552,7 +7567,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:290
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7722,6 +7737,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1206 lxc/project.go:218
 msgid "yes"
 msgstr ""

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-08 16:23-0800\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -392,7 +392,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:282
+#: lxc/project.go:308
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -875,7 +875,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:162
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1202,7 +1202,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:103
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1216,7 +1216,7 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/project.go:390 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
 #: lxc/storage_volume.go:1188
 #, c-format
@@ -1486,7 +1486,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:95 lxc/project.go:96
 msgid "Create projects"
 msgstr ""
 
@@ -1531,7 +1531,7 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
-#: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:756 lxc/project.go:600 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
@@ -1637,7 +1637,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:193 lxc/project.go:194
 msgid "Delete projects"
 msgstr ""
 
@@ -1737,10 +1737,10 @@ msgstr ""
 #: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
 #: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
 #: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
-#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:32 lxc/project.go:96
+#: lxc/project.go:194 lxc/project.go:288 lxc/project.go:424 lxc/project.go:498
+#: lxc/project.go:618 lxc/project.go:683 lxc/project.go:771 lxc/project.go:815
+#: lxc/project.go:876 lxc/project.go:943 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -2004,7 +2004,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:287 lxc/project.go:288
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2084,7 +2084,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/project.go:746 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
 #, c-format
 msgid "Error setting properties: %v"
@@ -2098,7 +2098,7 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
+#: lxc/profile.go:981 lxc/project.go:740 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
 #: lxc/storage_volume.go:2199
 #, c-format
@@ -2381,6 +2381,10 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
+#: lxc/project.go:197
+msgid "Force delete the project and everything it contains."
+msgstr ""
+
 #: lxc/cluster.go:1301
 msgid "Force evacuation without user confirmation"
 msgstr ""
@@ -2440,8 +2444,8 @@ msgstr ""
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:500
+#: lxc/project.go:945 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2507,7 +2511,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:942 lxc/project.go:943
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2555,7 +2559,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:428
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2619,7 +2623,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:423 lxc/project.go:424
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2713,7 +2717,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:594
 msgid "IMAGES"
 msgstr ""
 
@@ -3051,7 +3055,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1020
 msgid "LIMIT"
 msgstr ""
 
@@ -3353,7 +3357,7 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:497 lxc/project.go:498
 msgid "List projects"
 msgstr ""
 
@@ -3658,7 +3662,7 @@ msgstr ""
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -3912,9 +3916,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:404 lxc/project.go:149 lxc/project.go:242 lxc/project.go:344
+#: lxc/project.go:461 lxc/project.go:650 lxc/project.go:719 lxc/project.go:847
+#: lxc/project.go:976
 msgid "Missing project name"
 msgstr ""
 
@@ -4038,7 +4042,7 @@ msgstr ""
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:593
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
@@ -4052,11 +4056,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:599
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:598
 msgid "NETWORKS"
 msgstr ""
 
@@ -4068,9 +4072,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:551
+#: lxc/project.go:556 lxc/project.go:561 lxc/project.go:566 lxc/project.go:571
+#: lxc/project.go:576 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4366,7 +4370,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:595
 msgid "PROFILES"
 msgstr ""
 
@@ -4444,7 +4448,7 @@ msgstr ""
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/project.go:391 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
 #: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4536,19 +4540,23 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:175
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:264
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:665
 #, c-format
 msgid "Project %s renamed to %s"
+msgstr ""
+
+#: lxc/project.go:248
+msgid "Project deletion aborted"
 msgstr ""
 
 #: lxc/remote.go:107
@@ -4693,7 +4701,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:1019
 msgid "RESOURCE"
 msgstr ""
 
@@ -4745,7 +4753,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:910 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4790,6 +4798,13 @@ msgstr ""
 #: lxc/delete.go:48
 #, c-format
 msgid "Remove %s (yes/no): "
+msgstr ""
+
+#: lxc/project.go:214
+#, c-format
+msgid ""
+"Remove %s and everything it contains (instances, images, volumes, "
+"networks, ...) (yes/no): "
 msgstr ""
 
 #: lxc/cluster_group.go:522
@@ -4913,7 +4928,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:617 lxc/project.go:618
 msgid "Rename projects"
 msgstr ""
 
@@ -5070,7 +5085,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:597
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5078,7 +5093,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:596
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5266,11 +5281,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:682
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:683
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5382,7 +5397,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:690
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5527,7 +5542,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:814 lxc/project.go:815
 msgid "Show project options"
 msgstr ""
 
@@ -5773,7 +5788,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:875 lxc/project.go:876
 msgid "Switch the current project"
 msgstr ""
 
@@ -5952,7 +5967,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:448
+#: lxc/project.go:474
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6159,7 +6174,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:991
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6171,12 +6186,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:1021 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:601
 #: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
@@ -6303,7 +6318,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:770 lxc/project.go:771
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6355,7 +6370,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:775
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6516,9 +6531,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:553
+#: lxc/project.go:558 lxc/project.go:563 lxc/project.go:568 lxc/project.go:573
+#: lxc/project.go:578 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6554,7 +6569,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:495
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -7104,20 +7119,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:94 lxc/project.go:191 lxc/project.go:286 lxc/project.go:813
+#: lxc/project.go:874 lxc/project.go:941
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:422 lxc/project.go:769
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:681
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:615
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7185,7 +7200,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:583 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7545,7 +7560,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:98
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7553,7 +7568,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:290
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7723,6 +7738,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1206 lxc/project.go:218
 msgid "yes"
 msgstr ""

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-08 16:23-0800\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -534,7 +534,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:282
+#: lxc/project.go:308
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the project.\n"
@@ -1035,7 +1035,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:162
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1362,7 +1362,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:103
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1376,7 +1376,7 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/project.go:390 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
 #: lxc/storage_volume.go:1188
 #, c-format
@@ -1646,7 +1646,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:95 lxc/project.go:96
 msgid "Create projects"
 msgstr ""
 
@@ -1691,7 +1691,7 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
-#: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:756 lxc/project.go:600 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
@@ -1797,7 +1797,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:193 lxc/project.go:194
 msgid "Delete projects"
 msgstr ""
 
@@ -1897,10 +1897,10 @@ msgstr ""
 #: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
 #: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
 #: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
-#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:32 lxc/project.go:96
+#: lxc/project.go:194 lxc/project.go:288 lxc/project.go:424 lxc/project.go:498
+#: lxc/project.go:618 lxc/project.go:683 lxc/project.go:771 lxc/project.go:815
+#: lxc/project.go:876 lxc/project.go:943 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -2164,7 +2164,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:287 lxc/project.go:288
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2244,7 +2244,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/project.go:746 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
 #, c-format
 msgid "Error setting properties: %v"
@@ -2258,7 +2258,7 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
+#: lxc/profile.go:981 lxc/project.go:740 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
 #: lxc/storage_volume.go:2199
 #, c-format
@@ -2541,6 +2541,10 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
+#: lxc/project.go:197
+msgid "Force delete the project and everything it contains."
+msgstr ""
+
 #: lxc/cluster.go:1301
 msgid "Force evacuation without user confirmation"
 msgstr ""
@@ -2600,8 +2604,8 @@ msgstr ""
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:500
+#: lxc/project.go:945 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2667,7 +2671,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:942 lxc/project.go:943
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2715,7 +2719,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:428
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2779,7 +2783,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:423 lxc/project.go:424
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2873,7 +2877,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:594
 msgid "IMAGES"
 msgstr ""
 
@@ -3211,7 +3215,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1020
 msgid "LIMIT"
 msgstr ""
 
@@ -3513,7 +3517,7 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:497 lxc/project.go:498
 msgid "List projects"
 msgstr ""
 
@@ -3818,7 +3822,7 @@ msgstr ""
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -4072,9 +4076,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:404 lxc/project.go:149 lxc/project.go:242 lxc/project.go:344
+#: lxc/project.go:461 lxc/project.go:650 lxc/project.go:719 lxc/project.go:847
+#: lxc/project.go:976
 msgid "Missing project name"
 msgstr ""
 
@@ -4198,7 +4202,7 @@ msgstr ""
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:593
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
@@ -4212,11 +4216,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:599
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:598
 msgid "NETWORKS"
 msgstr ""
 
@@ -4228,9 +4232,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:551
+#: lxc/project.go:556 lxc/project.go:561 lxc/project.go:566 lxc/project.go:571
+#: lxc/project.go:576 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4526,7 +4530,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:595
 msgid "PROFILES"
 msgstr ""
 
@@ -4604,7 +4608,7 @@ msgstr ""
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/project.go:391 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
 #: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4696,19 +4700,23 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:175
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:264
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:665
 #, c-format
 msgid "Project %s renamed to %s"
+msgstr ""
+
+#: lxc/project.go:248
+msgid "Project deletion aborted"
 msgstr ""
 
 #: lxc/remote.go:107
@@ -4853,7 +4861,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:1019
 msgid "RESOURCE"
 msgstr ""
 
@@ -4905,7 +4913,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:910 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4950,6 +4958,13 @@ msgstr ""
 #: lxc/delete.go:48
 #, c-format
 msgid "Remove %s (yes/no): "
+msgstr ""
+
+#: lxc/project.go:214
+#, c-format
+msgid ""
+"Remove %s and everything it contains (instances, images, volumes, "
+"networks, ...) (yes/no): "
 msgstr ""
 
 #: lxc/cluster_group.go:522
@@ -5073,7 +5088,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:617 lxc/project.go:618
 msgid "Rename projects"
 msgstr ""
 
@@ -5230,7 +5245,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:597
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5238,7 +5253,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:596
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5426,11 +5441,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:682
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:683
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5542,7 +5557,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:690
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5687,7 +5702,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:814 lxc/project.go:815
 msgid "Show project options"
 msgstr ""
 
@@ -5933,7 +5948,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:875 lxc/project.go:876
 msgid "Switch the current project"
 msgstr ""
 
@@ -6112,7 +6127,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:448
+#: lxc/project.go:474
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6319,7 +6334,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:991
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6331,12 +6346,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:1021 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:601
 #: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
@@ -6463,7 +6478,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:770 lxc/project.go:771
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6515,7 +6530,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:775
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6676,9 +6691,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:553
+#: lxc/project.go:558 lxc/project.go:563 lxc/project.go:568 lxc/project.go:573
+#: lxc/project.go:578 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6714,7 +6729,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:495
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -7264,20 +7279,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:94 lxc/project.go:191 lxc/project.go:286 lxc/project.go:813
+#: lxc/project.go:874 lxc/project.go:941
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:422 lxc/project.go:769
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:681
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:615
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7345,7 +7360,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:583 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7705,7 +7720,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:98
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7713,7 +7728,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:290
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7883,7 +7898,7 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1206 lxc/project.go:218
 msgid "yes"
 msgstr ""
 

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-08 16:23-0800\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -391,7 +391,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:282
+#: lxc/project.go:308
 msgid ""
 "### This is a YAML representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:162
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
@@ -1201,7 +1201,7 @@ msgstr ""
 msgid "Config key/value to apply to the new instance"
 msgstr ""
 
-#: lxc/project.go:102
+#: lxc/project.go:103
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
@@ -1215,7 +1215,7 @@ msgstr ""
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
-#: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
+#: lxc/project.go:390 lxc/storage.go:359 lxc/storage_bucket.go:349
 #: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
 #: lxc/storage_volume.go:1188
 #, c-format
@@ -1485,7 +1485,7 @@ msgstr ""
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:94 lxc/project.go:95
+#: lxc/project.go:95 lxc/project.go:96
 msgid "Create projects"
 msgstr ""
 
@@ -1530,7 +1530,7 @@ msgstr ""
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
-#: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
+#: lxc/profile.go:756 lxc/project.go:600 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
 #: lxc/storage_volume.go:1738
 msgid "DESCRIPTION"
@@ -1636,7 +1636,7 @@ msgstr ""
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:190 lxc/project.go:191
+#: lxc/project.go:193 lxc/project.go:194
 msgid "Delete projects"
 msgstr ""
 
@@ -1736,10 +1736,10 @@ msgstr ""
 #: lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271
 #: lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629
 #: lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920
-#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95
-#: lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472
-#: lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789
-#: lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34
+#: lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:32 lxc/project.go:96
+#: lxc/project.go:194 lxc/project.go:288 lxc/project.go:424 lxc/project.go:498
+#: lxc/project.go:618 lxc/project.go:683 lxc/project.go:771 lxc/project.go:815
+#: lxc/project.go:876 lxc/project.go:943 lxc/publish.go:34 lxc/query.go:34
 #: lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749
 #: lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018
 #: lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32
@@ -2003,7 +2003,7 @@ msgstr ""
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:261 lxc/project.go:262
+#: lxc/project.go:287 lxc/project.go:288
 msgid "Edit project configurations as YAML"
 msgstr ""
 
@@ -2083,7 +2083,7 @@ msgstr ""
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
-#: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
+#: lxc/project.go:746 lxc/storage.go:812 lxc/storage_bucket.go:603
 #: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
 #, c-format
 msgid "Error setting properties: %v"
@@ -2097,7 +2097,7 @@ msgstr ""
 #: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
-#: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
+#: lxc/profile.go:981 lxc/project.go:740 lxc/storage.go:806
 #: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
 #: lxc/storage_volume.go:2199
 #, c-format
@@ -2380,6 +2380,10 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
+#: lxc/project.go:197
+msgid "Force delete the project and everything it contains."
+msgstr ""
+
 #: lxc/cluster.go:1301
 msgid "Force evacuation without user confirmation"
 msgstr ""
@@ -2439,8 +2443,8 @@ msgstr ""
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
-#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
-#: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
+#: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:500
+#: lxc/project.go:945 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
 #: lxc/storage_volume.go:1614 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
@@ -2506,7 +2510,7 @@ msgstr ""
 msgid "Get UEFI variables for instance"
 msgstr ""
 
-#: lxc/project.go:916 lxc/project.go:917
+#: lxc/project.go:942 lxc/project.go:943
 msgid "Get a summary of resource allocations"
 msgstr ""
 
@@ -2554,7 +2558,7 @@ msgstr ""
 msgid "Get the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:402
+#: lxc/project.go:428
 msgid "Get the key as a project property"
 msgstr ""
 
@@ -2618,7 +2622,7 @@ msgstr ""
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:397 lxc/project.go:398
+#: lxc/project.go:423 lxc/project.go:424
 msgid "Get values for project configuration keys"
 msgstr ""
 
@@ -2712,7 +2716,7 @@ msgstr ""
 msgid "IDENTIFIER"
 msgstr ""
 
-#: lxc/project.go:568
+#: lxc/project.go:594
 msgid "IMAGES"
 msgstr ""
 
@@ -3050,7 +3054,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/project.go:994
+#: lxc/project.go:1020
 msgid "LIMIT"
 msgstr ""
 
@@ -3352,7 +3356,7 @@ msgstr ""
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:471 lxc/project.go:472
+#: lxc/project.go:497 lxc/project.go:498
 msgid "List projects"
 msgstr ""
 
@@ -3657,7 +3661,7 @@ msgstr ""
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:30 lxc/project.go:31
+#: lxc/project.go:31 lxc/project.go:32
 msgid "Manage projects"
 msgstr ""
 
@@ -3911,9 +3915,9 @@ msgstr ""
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/profile.go:404 lxc/project.go:148 lxc/project.go:228 lxc/project.go:318
-#: lxc/project.go:435 lxc/project.go:624 lxc/project.go:693 lxc/project.go:821
-#: lxc/project.go:950
+#: lxc/profile.go:404 lxc/project.go:149 lxc/project.go:242 lxc/project.go:344
+#: lxc/project.go:461 lxc/project.go:650 lxc/project.go:719 lxc/project.go:847
+#: lxc/project.go:976
 msgid "Missing project name"
 msgstr ""
 
@@ -4037,7 +4041,7 @@ msgstr ""
 #: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
-#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
+#: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:593
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
 #: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
 msgid "NAME"
@@ -4051,11 +4055,11 @@ msgstr ""
 msgid "NETWORK"
 msgstr ""
 
-#: lxc/project.go:573
+#: lxc/project.go:599
 msgid "NETWORK ZONES"
 msgstr ""
 
-#: lxc/project.go:572
+#: lxc/project.go:598
 msgid "NETWORKS"
 msgstr ""
 
@@ -4067,9 +4071,9 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
-#: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
-#: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:551
+#: lxc/project.go:556 lxc/project.go:561 lxc/project.go:566 lxc/project.go:571
+#: lxc/project.go:576 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
 msgstr ""
 
@@ -4365,7 +4369,7 @@ msgstr ""
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:576 lxc/project.go:569
+#: lxc/list.go:576 lxc/project.go:595
 msgid "PROFILES"
 msgstr ""
 
@@ -4443,7 +4447,7 @@ msgstr ""
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
-#: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
+#: lxc/project.go:391 lxc/storage.go:360 lxc/storage_bucket.go:350
 #: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
 #: lxc/storage_volume.go:1189
 msgid "Press enter to open the editor again or ctrl+c to abort change"
@@ -4535,19 +4539,23 @@ msgstr ""
 msgid "Profiles: "
 msgstr ""
 
-#: lxc/project.go:174
+#: lxc/project.go:175
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:238
+#: lxc/project.go:264
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:639
+#: lxc/project.go:665
 #, c-format
 msgid "Project %s renamed to %s"
+msgstr ""
+
+#: lxc/project.go:248
+msgid "Project deletion aborted"
 msgstr ""
 
 #: lxc/remote.go:107
@@ -4692,7 +4700,7 @@ msgstr ""
 msgid "Query virtual machine images"
 msgstr ""
 
-#: lxc/project.go:993
+#: lxc/project.go:1019
 msgid "RESOURCE"
 msgstr ""
 
@@ -4744,7 +4752,7 @@ msgstr ""
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:884 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
+#: lxc/project.go:910 lxc/remote.go:902 lxc/remote.go:983 lxc/remote.go:1047
 #: lxc/remote.go:1095
 #, c-format
 msgid "Remote %s doesn't exist"
@@ -4789,6 +4797,13 @@ msgstr ""
 #: lxc/delete.go:48
 #, c-format
 msgid "Remove %s (yes/no): "
+msgstr ""
+
+#: lxc/project.go:214
+#, c-format
+msgid ""
+"Remove %s and everything it contains (instances, images, volumes, "
+"networks, ...) (yes/no): "
 msgstr ""
 
 #: lxc/cluster_group.go:522
@@ -4912,7 +4927,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:591 lxc/project.go:592
+#: lxc/project.go:617 lxc/project.go:618
 msgid "Rename projects"
 msgstr ""
 
@@ -5069,7 +5084,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/project.go:571
+#: lxc/project.go:597
 msgid "STORAGE BUCKETS"
 msgstr ""
 
@@ -5077,7 +5092,7 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/project.go:570
+#: lxc/project.go:596
 msgid "STORAGE VOLUMES"
 msgstr ""
 
@@ -5265,11 +5280,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:656
+#: lxc/project.go:682
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:657
+#: lxc/project.go:683
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -5381,7 +5396,7 @@ msgstr ""
 msgid "Set the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:664
+#: lxc/project.go:690
 msgid "Set the key as a project property"
 msgstr ""
 
@@ -5526,7 +5541,7 @@ msgstr ""
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:788 lxc/project.go:789
+#: lxc/project.go:814 lxc/project.go:815
 msgid "Show project options"
 msgstr ""
 
@@ -5772,7 +5787,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:849 lxc/project.go:850
+#: lxc/project.go:875 lxc/project.go:876
 msgid "Switch the current project"
 msgstr ""
 
@@ -5951,7 +5966,7 @@ msgstr ""
 msgid "The property %q does not exist on the profile %q: %v"
 msgstr ""
 
-#: lxc/project.go:448
+#: lxc/project.go:474
 #, c-format
 msgid "The property %q does not exist on the project %q: %v"
 msgstr ""
@@ -6158,7 +6173,7 @@ msgstr ""
 msgid "Type: %s (ephemeral)"
 msgstr ""
 
-#: lxc/project.go:965
+#: lxc/project.go:991
 msgid "UNLIMITED"
 msgstr ""
 
@@ -6170,12 +6185,12 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:1021 lxc/storage_volume.go:1741
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
-#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
+#: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:601
 #: lxc/storage.go:724 lxc/storage_volume.go:1740
 msgid "USED BY"
 msgstr ""
@@ -6302,7 +6317,7 @@ msgstr ""
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:744 lxc/project.go:745
+#: lxc/project.go:770 lxc/project.go:771
 msgid "Unset project configuration keys"
 msgstr ""
 
@@ -6354,7 +6369,7 @@ msgstr ""
 msgid "Unset the key as a profile property"
 msgstr ""
 
-#: lxc/project.go:749
+#: lxc/project.go:775
 msgid "Unset the key as a project property"
 msgstr ""
 
@@ -6515,9 +6530,9 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
-#: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
-#: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:553
+#: lxc/project.go:558 lxc/project.go:563 lxc/project.go:568 lxc/project.go:573
+#: lxc/project.go:578 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
 msgstr ""
 
@@ -6553,7 +6568,7 @@ msgstr ""
 #: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
-#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
+#: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:495
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
 msgstr ""
@@ -7103,20 +7118,20 @@ msgstr ""
 msgid "[<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:93 lxc/project.go:188 lxc/project.go:260 lxc/project.go:787
-#: lxc/project.go:848 lxc/project.go:915
+#: lxc/project.go:94 lxc/project.go:191 lxc/project.go:286 lxc/project.go:813
+#: lxc/project.go:874 lxc/project.go:941
 msgid "[<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:396 lxc/project.go:743
+#: lxc/project.go:422 lxc/project.go:769
 msgid "[<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/project.go:655
+#: lxc/project.go:681
 msgid "[<remote>:]<project> <key>=<value>..."
 msgstr ""
 
-#: lxc/project.go:589
+#: lxc/project.go:615
 msgid "[<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -7184,7 +7199,7 @@ msgstr ""
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
-#: lxc/project.go:557 lxc/remote.go:840
+#: lxc/project.go:583 lxc/remote.go:840
 msgid "current"
 msgstr ""
 
@@ -7544,7 +7559,7 @@ msgid ""
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:97
+#: lxc/project.go:98
 msgid ""
 "lxc project create p1\n"
 "\n"
@@ -7552,7 +7567,7 @@ msgid ""
 "    Create a project with configuration from config.yaml"
 msgstr ""
 
-#: lxc/project.go:264
+#: lxc/project.go:290
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -7722,6 +7737,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1206 lxc/project.go:218
 msgid "yes"
 msgstr ""

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -427,6 +427,7 @@ var APIExtensions = []string{
 	"metadata_configuration_scope",
 	"unix_device_hotplug_ownership_inherit",
 	"unix_device_hotplug_subsystem_device_option",
+	"projects_force_delete",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
Currently in draft state as this PR relies on deleting resources via requests to the server's own API. This is not ideal, and I am investigating if it is possible to avoid this. Right now it looks like this is the simplest option, but we could likely add implementation for each resource to perform the deletes without invoking the LXD API. Perhaps we could factor out some of the logic in the delete handlers so that we can reference it locally. Still looking into this -- WIP.

---

This PR adds support for forced deletion of projects. If the `--force` flag is provided when attempting to delete a project, and if the user confirms that forced deletion is what they want, then all resources associated with the project will be deleted and the project will be removed.

This PR also simplifies the `projectIsEmpty` function to utilize `projectUsedBy` instead of checking each resource manually.

Includes cherry-picks from https://github.com/lxc/incus/pull/900.

Closes: https://github.com/canonical/lxd/pull/14316.