### PR TITLE
Network: Consider volatile IP in ovnNetworkExternalSubnets

### DIFF
--- a/lxd/network/driver_common.go
+++ b/lxd/network/driver_common.go
@@ -63,6 +63,7 @@ const (
 	subnetUsageNetworkLoadBalancer
 	subnetUsageInstance
 	subnetUsageProxy
+	subnetUsageVolatileIP
 )
 
 // externalSubnetUsage represents usage of a subnet by a network or NIC.


### PR DESCRIPTION
This PR updates `ovn.ovnNetworkExternalSubnets` to consider the volatile IP of each OVN network using a given uplink. This is added to prevent the use of one OVN network's volatile IP on another OVN network, namely in the cases of creating network forwards and IP passthrough.