### PR TITLE
lxd/device/cdi: Fix the case of adding a CDI device with the 'all' identifier

### DIFF
--- a/lxd/device/cdi/id.go
+++ b/lxd/device/cdi/id.go
@@ -6,6 +6,9 @@ import (
 	"tags.cncf.io/container-device-interface/pkg/parser"
 )
 
+// All represents a selection of all devices generated out of a CDI specification.
+var All = "all"
+
 // Vendor represents the compatible CDI vendor.
 type Vendor string
 


### PR DESCRIPTION
Adding a GPU with `nvidia.com/gpu=all` was actually not adding any physical card devices. This should fix it. With 'all', we should make the difference between CDI device index that are integer and the ones represented by a UUID that could contain the same cards. For example, these two devices are identical (target the same resources) though not named with the same convention:
```
    [
      {
        "name": "0",
        "containerEdits": {
          "deviceNodes": [
            {
              "path": "/dev/nvidia0",
                "hook",
                "create-symlinks",
                "--link",
                "../card1::/var/lib/snapd/hostfs/dev/dri/by-path/pci-0000:01:00.0-card",
                "hook",
                "create-symlinks",
                "--link",
                "../card1::/var/lib/snapd/hostfs/dev/dri/by-path/pci-0000:01:00.0-card",
                "--link",
                "../renderD128::/var/lib/snapd/hostfs/dev/dri/by-path/pci-0000:01:00.0-render"
              ]
            },
            {
              "hookName": "createContainer",
              "path": "/snap/lxd/30921/bin/nvidia-ctk",
              "args": [
                "nvidia-ctk",
                "hook",
                "chmod",
                "--mode",
                "755",
                "--path",
                "/dev/dri"
              ]
            }
          ]
        }
      },
      {
        "name": "GPU-8da9a1ee-3495-a369-a73a-b9d8ffbc1220",
        "containerEdits": {
          "deviceNodes": [
            {
              "path": "/dev/nvidia0",
              "hostPath": "/var/lib/snapd/hostfs/dev/nvidia0"
            },
            {
              "path": "/dev/dri/card1",
              "hostPath": "/var/lib/snapd/hostfs/dev/dri/card1"
            },
            {
              "path": "/dev/dri/renderD128",
              "hostPath": "/var/lib/snapd/hostfs/dev/dri/renderD128"
            }
          ],
          "hooks": [
            {
              "hookName": "createContainer",
              "path": "/snap/lxd/30921/bin/nvidia-ctk",
              "args": [
                "nvidia-ctk",
                "hook",
                "create-symlinks",
                "--link",
                "../card1::/var/lib/snapd/hostfs/dev/dri/by-path/pci-0000:01:00.0-card",
                "--link",
                "../renderD128::/var/lib/snapd/hostfs/dev/dri/by-path/pci-0000:01:00.0-render"
              ]
            },
            {
              "hookName": "createContainer",
              "path": "/snap/lxd/30921/bin/nvidia-ctk",
              "args": [
                "nvidia-ctk",
                "hook",
                "chmod",
                "--mode",
                "755",
                "--path",
                "/dev/dri"
              ]
            }
          ]
        }
      }
    ]
```