### PR TITLE
Optimize Project Queries during limits checks

### DIFF
--- a/lxd/db/instances.go
+++ b/lxd/db/instances.go
@@ -493,6 +493,37 @@ func (c *ClusterTx) instanceDevicesFill(ctx context.Context, snapshotsMode bool,
 // instanceProfiles loads the profile IDs to apply to an instance (in the application order) for all
 // instanceIDs in a single query and then updates the instanceApplyProfileIDs and profilesByID maps.
 func (c *ClusterTx) instanceProfilesFill(ctx context.Context, snapshotsMode bool, instanceArgs *map[int]InstanceArgs) error {
+	profilesByID := make(map[int]*api.Profile)
+
+	// Get all profiles.
+	profiles, err := cluster.GetProfiles(ctx, c.Tx())
+	if err != nil {
+		return fmt.Errorf("Failed loading profiles: %w", err)
+	}
+
+	// Get all the profile configs.
+	profileConfigs, err := cluster.GetConfig(ctx, c.Tx(), "profile")
+	if err != nil {
+		return fmt.Errorf("Failed loading profile configs: %w", err)
+	}
+
+	// Get all the profile devices.
+	profileDevices, err := cluster.GetDevices(ctx, c.Tx(), "profile")
+	if err != nil {
+		return fmt.Errorf("Failed loading profile devices: %w", err)
+	}
+
+	for _, profile := range profiles {
+		profilesByID[profile.ID], err = profile.ToAPI(ctx, c.tx, profileConfigs, profileDevices)
+		if err != nil {
+			return err
+		}
+	}
+
+	return c.instanceProfilesFillWithProfiles(ctx, snapshotsMode, instanceArgs, profilesByID)
+}
+
+func (c *ClusterTx) instanceProfilesFillWithProfiles(ctx context.Context, snapshotsMode bool, instanceArgs *map[int]InstanceArgs, profilesByID map[int]*api.Profile) error {
 	instances := *instanceArgs
 
 	// Get profiles referenced by instances.
@@ -534,7 +565,6 @@ func (c *ClusterTx) instanceProfilesFill(ctx context.Context, snapshotsMode bool
 	q.WriteString(`)
 		ORDER BY instances_profiles.instance_id, instances_profiles.apply_order`)
 
-	profilesByID := make(map[int]*api.Profile)
 	instanceApplyProfileIDs := make(map[int64][]int, len(instances))
 
 	err := query.Scan(ctx, c.Tx(), q.String(), func(scan func(dest ...any) error) error {
@@ -548,49 +578,10 @@ func (c *ClusterTx) instanceProfilesFill(ctx context.Context, snapshotsMode bool
 
 		instanceApplyProfileIDs[instanceID] = append(instanceApplyProfileIDs[instanceID], profileID)
 
-		// Record that this profile is referenced by at least one instance in the list.
-		_, ok := profilesByID[profileID]
-		if !ok {
-			profilesByID[profileID] = nil
-		}
-
 		return nil
 	})
 	if err != nil {
 		return err
-	}
-
-	// Get all profiles.
-	profiles, err := cluster.GetProfiles(context.TODO(), c.Tx())
-	if err != nil {
-		return fmt.Errorf("Failed loading profiles: %w", err)
-	}
-
-	// Get all the profile configs.
-	profileConfigs, err := cluster.GetConfig(context.TODO(), c.Tx(), "profile")
-	if err != nil {
-		return fmt.Errorf("Failed loading profile configs: %w", err)
-	}
-
-	// Get all the profile devices.
-	profileDevices, err := cluster.GetDevices(context.TODO(), c.Tx(), "profile")
-	if err != nil {
-		return fmt.Errorf("Failed loading profile devices: %w", err)
-	}
-
-	// Populate profilesByID map entry for referenced profiles.
-	// This way we only call ToAPI() on the profiles actually referenced by the instances in
-	// the list, which can reduce the number of queries run.
-	for _, profile := range profiles {
-		_, ok := profilesByID[profile.ID]
-		if !ok {
-			continue
-		}
-
-		profilesByID[profile.ID], err = profile.ToAPI(context.TODO(), c.tx, profileConfigs, profileDevices)
-		if err != nil {
-			return err
-		}
 	}
 
 	// Populate instance profiles list in apply order.

--- a/lxd/db/projects.go
+++ b/lxd/db/projects.go
@@ -4,8 +4,11 @@ package db
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/canonical/lxd/lxd/db/cluster"
+	"github.com/canonical/lxd/shared"
+	"github.com/canonical/lxd/shared/api"
 )
 
 // GetProject returns the project with the given key.
@@ -25,4 +28,132 @@ func (db *DB) GetProject(ctx context.Context, projectName string) (*cluster.Proj
 	}
 
 	return p, nil
+}
+
+// If the project has the profiles feature enabled, we use its own
+// profiles to expand the instances configs, otherwise we use the
+// profiles from the default project.
+func projectInheritsProfiles(project *api.Project) bool {
+	return shared.IsFalseOrEmpty(project.Config["features.profiles"])
+}
+
+// ProjectArgs is all the instances and profiles associated with a project.
+// If Project.Config["features.profiles"] is false, Profiles is the default
+// project's profiles.
+type ProjectArgs struct {
+	Profiles  []api.Profile
+	Instances []api.Instance
+}
+
+// GetProjectInstancesAndProfiles gets all instances and profiles associated
+// with some projects in as few queries as possible.
+// Returns a map[projectName]args.
+func (c *ClusterTx) GetProjectInstancesAndProfiles(ctx context.Context, projects ...*api.Project) (map[string]*ProjectArgs, error) {
+	projectArgs := make(map[string]*ProjectArgs, len(projects))
+	for _, project := range projects {
+		projectArgs[project.Name] = &ProjectArgs{}
+	}
+
+	var defaultProjectName = api.ProjectDefaultName
+	var profileFilters []cluster.ProfileFilter
+	var instanceFilters []cluster.InstanceFilter
+
+	for _, project := range projects {
+		instanceFilters = append(instanceFilters, cluster.InstanceFilter{
+			Project: &project.Name,
+		})
+
+		// Include the default project's profiles if any project inherits them.
+		if projectInheritsProfiles(project) {
+			profileFilters = append(profileFilters, cluster.ProfileFilter{
+				Project: &defaultProjectName,
+			})
+		} else {
+			profileFilters = append(profileFilters, cluster.ProfileFilter{
+				Project: &project.Name,
+			})
+		}
+	}
+
+	dbProfiles, err := cluster.GetProfiles(ctx, c.tx, profileFilters...)
+	if err != nil {
+		return nil, fmt.Errorf("Fetch profiles from database: %w", err)
+	}
+
+	dbProfileConfigs, err := cluster.GetConfig(ctx, c.tx, "profile")
+	if err != nil {
+		return nil, fmt.Errorf("Fetch profile configs from database: %w", err)
+	}
+
+	dbProfileDevices, err := cluster.GetDevices(ctx, c.tx, "profile")
+	if err != nil {
+		return nil, fmt.Errorf("Fetch profile devices from database: %w", err)
+	}
+
+	var defaultProfiles []api.Profile
+	profilesByID := make(map[int]*api.Profile, len(dbProfiles))
+	for _, profile := range dbProfiles {
+		apiProfile, err := profile.ToAPI(ctx, c.tx, dbProfileConfigs, dbProfileDevices)
+		if err != nil {
+			return nil, err
+		}
+
+		profilesByID[profile.ID] = apiProfile
+
+		if profile.Project == defaultProjectName {
+			defaultProfiles = append(defaultProfiles, *apiProfile)
+		} else {
+			projectArgs[profile.Project].Profiles = append(projectArgs[profile.Project].Profiles, *apiProfile)
+		}
+	}
+
+	defaultProject, ok := projectArgs[defaultProjectName]
+	if ok {
+		defaultProject.Profiles = defaultProfiles
+	}
+
+	// Add profiles to projects which inherit profiles from the default project
+	for _, project := range projects {
+		if project.Name != defaultProjectName || !projectInheritsProfiles(project) {
+			continue
+		}
+
+		projectArgs[project.Name].Profiles = defaultProfiles
+	}
+
+	// Get all instances using supplied filter.
+	dbInstances, err := cluster.GetInstances(ctx, c.tx, instanceFilters...)
+	if err != nil {
+		return nil, fmt.Errorf("Failed loading instances: %w", err)
+	}
+
+	// Fill instances with config and devices.
+	instanceArgs, err := c.InstancesToInstanceArgs(ctx, false, dbInstances...)
+	if err != nil {
+		return nil, err
+	}
+
+	hasSnapshots := false
+	for _, inst := range instanceArgs {
+		if inst.Snapshot {
+			hasSnapshots = true
+			break
+		}
+	}
+
+	err = c.instanceProfilesFillWithProfiles(ctx, hasSnapshots, &instanceArgs, profilesByID)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, instance := range instanceArgs {
+		apiInstance, err := instance.ToAPI()
+		if err != nil {
+			return nil, err
+		}
+
+		projectArgs[instance.Project].Instances = append(projectArgs[instance.Project].Instances, *apiInstance)
+	}
+
+	return projectArgs, nil
 }

--- a/lxd/project/limits/permissions.go
+++ b/lxd/project/limits/permissions.go
@@ -57,12 +57,7 @@ func HiddenStoragePools(ctx context.Context, tx *db.ClusterTx, projectName strin
 // AllowInstanceCreation returns an error if any project-specific limit or
 // restriction is violated when creating a new instance.
 func AllowInstanceCreation(globalConfig *clusterConfig.Config, tx *db.ClusterTx, projectName string, req api.InstancesPost) error {
-	var globalConfigDump map[string]any
-	if globalConfig != nil {
-		globalConfigDump = globalConfig.Dump()
-	}
-
-	info, err := fetchProject(globalConfigDump, tx, projectName, true)
+	info, err := fetchProject(tx, projectName, true)
 	if err != nil {
 		return err
 	}
@@ -266,12 +261,7 @@ func checkRestrictionsOnVolatileConfig(project api.Project, instanceType instanc
 // AllowVolumeCreation returns an error if any project-specific limit or
 // restriction is violated when creating a new custom volume in a project.
 func AllowVolumeCreation(globalConfig *clusterConfig.Config, tx *db.ClusterTx, projectName string, poolName string, req api.StorageVolumesPost) error {
-	var globalConfigDump map[string]any
-	if globalConfig != nil {
-		globalConfigDump = globalConfig.Dump()
-	}
-
-	info, err := fetchProject(globalConfigDump, tx, projectName, true)
+	info, err := fetchProject(tx, projectName, true)
 	if err != nil {
 		return err
 	}
@@ -310,7 +300,7 @@ func GetImageSpaceBudget(globalConfig *clusterConfig.Config, tx *db.ClusterTx, p
 		globalConfigDump = globalConfig.Dump()
 	}
 
-	info, err := fetchProject(globalConfigDump, tx, projectName, true)
+	info, err := fetchProject(tx, projectName, true)
 	if err != nil {
 		return -1, err
 	}
@@ -908,12 +898,7 @@ func isVMLowLevelOptionForbidden(key string) bool {
 func AllowInstanceUpdate(globalConfig *clusterConfig.Config, tx *db.ClusterTx, projectName, instanceName string, req api.InstancePut, currentConfig map[string]string) error {
 	var updatedInstance *api.Instance
 
-	var globalConfigDump map[string]any
-	if globalConfig != nil {
-		globalConfigDump = globalConfig.Dump()
-	}
-
-	info, err := fetchProject(globalConfigDump, tx, projectName, true)
+	info, err := fetchProject(tx, projectName, true)
 	if err != nil {
 		return err
 	}
@@ -958,12 +943,7 @@ func AllowInstanceUpdate(globalConfig *clusterConfig.Config, tx *db.ClusterTx, p
 // AllowVolumeUpdate returns an error if any project-specific limit or
 // restriction is violated when updating an existing custom volume.
 func AllowVolumeUpdate(globalConfig *clusterConfig.Config, tx *db.ClusterTx, projectName, volumeName string, req api.StorageVolumePut, currentConfig map[string]string) error {
-	var globalConfigDump map[string]any
-	if globalConfig != nil {
-		globalConfigDump = globalConfig.Dump()
-	}
-
-	info, err := fetchProject(globalConfigDump, tx, projectName, true)
+	info, err := fetchProject(tx, projectName, true)
 	if err != nil {
 		return err
 	}
@@ -997,12 +977,7 @@ func AllowVolumeUpdate(globalConfig *clusterConfig.Config, tx *db.ClusterTx, pro
 // AllowProfileUpdate checks that project limits and restrictions are not
 // violated when changing a profile.
 func AllowProfileUpdate(globalConfig *clusterConfig.Config, tx *db.ClusterTx, projectName, profileName string, req api.ProfilePut) error {
-	var globalConfigDump map[string]any
-	if globalConfig != nil {
-		globalConfigDump = globalConfig.Dump()
-	}
-
-	info, err := fetchProject(globalConfigDump, tx, projectName, true)
+	info, err := fetchProject(tx, projectName, true)
 	if err != nil {
 		return err
 	}
@@ -1036,7 +1011,7 @@ func AllowProjectUpdate(globalConfig *clusterConfig.Config, tx *db.ClusterTx, pr
 		globalConfigDump = globalConfig.Dump()
 	}
 
-	info, err := fetchProject(globalConfigDump, tx, projectName, false)
+	info, err := fetchProject(tx, projectName, false)
 	if err != nil {
 		return err
 	}

--- a/lxd/project/limits/permissions.go
+++ b/lxd/project/limits/permissions.go
@@ -1235,7 +1235,7 @@ type projectInfo struct {
 // If the skipIfNoLimits flag is true, then profiles, instances and volumes
 // won't be loaded if the profile has no limits set on it, and nil will be
 // returned.
-func fetchProject(globalConfig map[string]any, tx *db.ClusterTx, projectName string, skipIfNoLimits bool) (*projectInfo, error) {
+func fetchProject(tx *db.ClusterTx, projectName string, skipIfNoLimits bool) (*projectInfo, error) {
 	ctx := context.Background()
 	dbProject, err := cluster.GetProject(ctx, tx.Tx(), projectName)
 	if err != nil {

--- a/lxd/project/limits/state.go
+++ b/lxd/project/limits/state.go
@@ -16,7 +16,7 @@ func GetCurrentAllocations(globalConfig map[string]any, ctx context.Context, tx 
 	result := map[string]api.ProjectStateResource{}
 
 	// Get the project.
-	info, err := fetchProject(globalConfig, tx, projectName, false)
+	info, err := fetchProject(tx, projectName, false)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The use of `InstanceList` I introduced in #14318 causes 3 queries (`GetProfiles`, `GetConfig`, `GetDevices`) to be run twice. This eliminates the duplication.

## TODO
- [x] Rename `ProjectsList` -> `GetProjectInstancesAndProfiles`
- [ ] Rename `ProjectArgs` -> `ProjectInstances` (`ProjectEntities`? `ProjectInstancesAndProfiles`?, ...?)
- [x] Fix snapshots