### PR TITLE
lxc/completion: Rework instance config key completion functions

### DIFF
--- a/lxc/completion.go
+++ b/lxc/completion.go
@@ -222,9 +222,9 @@ func (g *cmdGlobal) cmpImages(toComplete string) ([]string, cobra.ShellCompDirec
 	return results, cmpDirectives
 }
 
-// cmpInstanceAllKeys provides shell completion for all instance configuration keys.
-// It takes an instance name and returns a list of all instance configuration keys along with a shell completion directive.
-func (g *cmdGlobal) cmpInstanceAllKeys(instanceName string) ([]string, cobra.ShellCompDirective) {
+// cmpInstanceKeys provides shell completion for all instance configuration keys.
+// It takes an instance name to determine instance type and returns a list of all instance configuration keys along with a shell completion directive.
+func (g *cmdGlobal) cmpInstanceKeys(instanceName string) ([]string, cobra.ShellCompDirective) {
 	var keys []string
 	cmpDirectives := cobra.ShellCompDirectiveNoFileComp
 
@@ -260,6 +260,27 @@ func (g *cmdGlobal) cmpInstanceAllKeys(instanceName string) ([]string, cobra.She
 		for k := range instancetype.InstanceConfigKeysVM {
 			keys = append(keys, k)
 		}
+	}
+
+	for k := range instancetype.InstanceConfigKeysAny {
+		keys = append(keys, k)
+	}
+
+	return keys, cmpDirectives
+}
+
+// cmpInstanceAllKeys provides shell completion for all possible instance configuration keys.
+// It returns a list of all possible instance configuration keys along with a shell completion directive.
+func (g *cmdGlobal) cmpInstanceAllKeys() ([]string, cobra.ShellCompDirective) {
+	keys := make([]string, 0, len(instancetype.InstanceConfigKeysContainer)+len(instancetype.InstanceConfigKeysVM)+len(instancetype.InstanceConfigKeysAny))
+	cmpDirectives := cobra.ShellCompDirectiveNoFileComp
+
+	for k := range instancetype.InstanceConfigKeysContainer {
+		keys = append(keys, k)
+	}
+
+	for k := range instancetype.InstanceConfigKeysVM {
+		keys = append(keys, k)
 	}
 
 	for k := range instancetype.InstanceConfigKeysAny {

--- a/lxc/config.go
+++ b/lxc/config.go
@@ -408,7 +408,7 @@ func (c *cmdConfigGet) command() *cobra.Command {
 		}
 
 		if len(args) == 1 {
-			return c.global.cmpInstanceAllKeys(args[0])
+			return c.global.cmpInstanceKeys(args[0])
 		}
 
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -565,7 +565,7 @@ lxc config set core.https_address=[::]:8443
 		}
 
 		if len(args) == 1 {
-			return c.global.cmpInstanceAllKeys(args[0])
+			return c.global.cmpInstanceKeys(args[0])
 		}
 
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -918,7 +918,7 @@ func (c *cmdConfigUnset) command() *cobra.Command {
 		}
 
 		if len(args) == 1 {
-			return c.global.cmpInstanceAllKeys(args[0])
+			return c.global.cmpInstanceKeys(args[0])
 		}
 
 		return nil, cobra.ShellCompDirectiveNoFileComp

--- a/lxc/profile.go
+++ b/lxc/profile.go
@@ -932,7 +932,7 @@ For backward compatibility, a single configuration key may still be set with:
 		}
 
 		if len(args) == 1 {
-			return c.global.cmpInstanceAllKeys(args[0])
+			return c.global.cmpInstanceAllKeys()
 		}
 
 		return nil, cobra.ShellCompDirectiveNoFileComp


### PR DESCRIPTION
This PR adds `cmpInstanceAllKeys()` to provide all possible instance config keys for `lxc profile set <profile>` completions. Function names and go doc comments have also been reworded for clarity.

Resolves: https://github.com/canonical/lxd/issues/14370.