### PR TITLE
db: Print last dqlite entry

### DIFF
--- a/doc/howto/cluster_form.md
+++ b/doc/howto/cluster_form.md
@@ -13,8 +13,7 @@ See {ref}`clustering-members` for more information.
 
 You can form the LXD cluster interactively by providing configuration information during the initialization process or by using preseed files that contain the full configuration.
 
-To quickly and automatically set up a basic LXD cluster, you can use MicroCloud.
-Note, however, that this project is still in an early phase.
+To quickly and automatically set up a basic LXD cluster, you can use {ref}`MicroCloud <use-microcloud>`.
 
 ## Configure the cluster interactively
 
@@ -231,6 +230,7 @@ cluster:
 
 See {ref}`preseed-yaml-file-fields` for the complete fields of the preseed YAML file.
 
+(use-microcloud)=
 ## Use MicroCloud
 
 ```{youtube} https://www.youtube.com/watch?v=iWZYUU8lX5A

--- a/doc/howto/cluster_recover.md
+++ b/doc/howto/cluster_recover.md
@@ -69,7 +69,7 @@ LXD automatically takes a backup of the database before making changes (see {ref
 
 If some members of your cluster are no longer reachable, or if the cluster itself is unreachable due to a change in IP address or listening port number, you can reconfigure the cluster.
 
-To do so, choose one database member to edit the cluster configuration.
+To do so, choose the {ref}`most up-to-date database member <up-to-date_cluster_member>` to edit the cluster configuration.
 Once the cluster edit is complete you will need to manually copy the reconfigured global database to every other surviving member.
 
 You can change the IP addresses or listening port numbers for each member as required.
@@ -146,6 +146,18 @@ unpack the tarball in its place:
     cd /var/snap/lxd/common/lxd
     sudo rm -r database
     sudo tar -xf db_backup.TIMESTAMP.tar.gz
+
+(up-to-date_cluster_member)=
+## Find the most up-to-date cluster member
+On every shutdown, LXD's {ref}`database members <clustering-member-roles>` log
+the Raft term and index:
+
+    Dqlite last entry    index=1039 term=672
+
+To determine which database member is most up to date:
+
+- If two members have different terms, the member with the higher term is more up to date.
+- If two members have the same term, the member with the higher index is more up to date.
 
 ## Manually alter Raft membership
 

--- a/lxd/cluster/gateway.go
+++ b/lxd/cluster/gateway.go
@@ -517,7 +517,7 @@ func (g *Gateway) DemoteOfflineNode(raftID uint64) error {
 
 // Shutdown this gateway, stopping the gRPC server and possibly the raft factory.
 func (g *Gateway) Shutdown() error {
-	logger.Infof("Stop database gateway")
+	logger.Info("Stop database gateway")
 
 	var err error
 	if g.server != nil {
@@ -533,6 +533,18 @@ func (g *Gateway) Shutdown() error {
 		g.lock.Lock()
 		g.memoryDial = nil
 		g.lock.Unlock()
+
+		// Record the raft term and index in the logs on every shutdown. This
+		// allows an administrator to determine the furthest-ahead cluster member
+		// in case recovery is needed.
+		lastEntryInfo, err := dqlite.ReadLastEntryInfo(g.db.Dir())
+		if err != nil {
+			return err
+		}
+
+		// This isn't really a warning, but it's important that this break through
+		// the snap's default log level of 'Warn'.
+		logger.Warn("Dqlite last entry", logger.Ctx{"term": lastEntryInfo.Term, "index": lastEntryInfo.Index})
 	}
 
 	return err

--- a/lxd/cluster/gateway.go
+++ b/lxd/cluster/gateway.go
@@ -565,7 +565,7 @@ func (g *Gateway) Sync() {
 		return
 	}
 
-	dir := filepath.Join(g.db.Dir(), "global")
+	dir := g.db.DqliteDir()
 	for _, file := range files {
 		path := filepath.Join(dir, file.Name)
 		err := os.WriteFile(path, file.Data, 0600)
@@ -588,7 +588,7 @@ func (g *Gateway) Reset(networkCert *shared.CertInfo) error {
 		return err
 	}
 
-	err = os.RemoveAll(filepath.Join(g.db.Dir(), "global"))
+	err = os.RemoveAll(g.db.DqliteDir())
 	if err != nil {
 		return err
 	}
@@ -725,7 +725,7 @@ func (g *Gateway) init(bootstrap bool) error {
 		return fmt.Errorf("Failed to create raft factory: %w", err)
 	}
 
-	dir := filepath.Join(g.db.Dir(), "global")
+	dir := g.db.DqliteDir()
 	if shared.PathExists(filepath.Join(dir, "logs.db")) {
 		return fmt.Errorf("Unsupported upgrade path, please first upgrade to LXD 4.0")
 	}

--- a/lxd/cluster/gateway_test.go
+++ b/lxd/cluster/gateway_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/canonical/go-dqlite/v3/driver"
@@ -187,7 +186,7 @@ func TestGateway_RaftNodesNotLeader(t *testing.T) {
 
 // Create a new test Gateway with the given parameters, and ensure no error happens.
 func newGateway(t *testing.T, node *db.Node, networkCert *shared.CertInfo, s *state.State) *cluster.Gateway {
-	require.NoError(t, os.Mkdir(filepath.Join(node.Dir(), "global"), 0755))
+	require.NoError(t, os.Mkdir(node.DqliteDir(), 0755))
 	stateFunc := func() *state.State { return s }
 	gateway, err := cluster.NewGateway(context.Background(), node, networkCert, stateFunc, cluster.Latency(0.2), cluster.LogLevel("TRACE"))
 	require.NoError(t, err)

--- a/lxd/cluster/info.go
+++ b/lxd/cluster/info.go
@@ -3,7 +3,6 @@ package cluster
 import (
 	"context"
 	"os"
-	"path/filepath"
 
 	"github.com/canonical/lxd/lxd/db"
 	"github.com/canonical/lxd/lxd/node"
@@ -38,7 +37,7 @@ func loadInfo(database *db.Node) (*db.RaftNode, error) {
 	logger.Info("Starting database node", logger.Ctx{"id": info.ID, "local": info.Address, "role": info.Role})
 
 	// Data directory
-	dir := filepath.Join(database.Dir(), "global")
+	dir := database.DqliteDir()
 	if !shared.PathExists(dir) {
 		err := os.Mkdir(dir, 0750)
 		if err != nil {

--- a/lxd/cluster/recover.go
+++ b/lxd/cluster/recover.go
@@ -98,7 +98,7 @@ func Recover(database *db.Node) error {
 		return fmt.Errorf("This LXD instance is not clustered")
 	}
 
-	dir := filepath.Join(database.Dir(), "global")
+	dir := database.DqliteDir()
 
 	cluster := []dqlite.NodeInfo{
 		{
@@ -237,7 +237,7 @@ func Reconfigure(database *db.Node, raftNodes []db.RaftNode) (string, error) {
 		}
 	}
 
-	dir := filepath.Join(database.Dir(), "global")
+	dir := database.DqliteDir()
 	// Replace cluster configuration in dqlite.
 	err = dqlite.ReconfigureMembershipExt(dir, nodes)
 	if err != nil {
@@ -310,7 +310,7 @@ func writeRecoveryTarball(databaseDir string, raftNodes []db.RaftNode) (string, 
 // and writes a global patch file to update the global database with any changed
 // addresses.
 func DatabaseReplaceFromTarball(tarballPath string, database *db.Node) error {
-	globalDBDir := path.Join(database.Dir(), "global")
+	globalDBDir := database.DqliteDir()
 	unpackDir := filepath.Join(database.Dir(), "global.recover")
 
 	logger.Warn("Recovery tarball located; attempting DB recovery", logger.Ctx{"tarball": tarballPath})

--- a/lxd/db/db.go
+++ b/lxd/db/db.go
@@ -93,6 +93,11 @@ func (n *Node) Dir() string {
 	return n.dir
 }
 
+// DqliteDir returns the global database directory used by dqlite.
+func (n *Node) DqliteDir() string {
+	return filepath.Join(n.Dir(), "global")
+}
+
 // Transaction creates a new NodeTx object and transactionally executes the
 // node-level database interactions invoked by the given function. If the
 // function returns no error, all database changes are committed to the


### PR DESCRIPTION
The Dqlite LTS provides a new API [`ReadLastEntryInfo`](https://pkg.go.dev/github.com/canonical/go-dqlite/v2#ReadLastEntryInfo) to provide the raft term and index of a dqlite db on disk. This allows us to be more precise with the definition of "most up-to-date cluster member" in the recovery docs.