### PR TITLE
Fix handling of long running connections (from Incus)

### DIFF
--- a/lxd/api.go
+++ b/lxd/api.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/gorilla/mux"
 
@@ -223,6 +224,7 @@ func restServer(d *Daemon) *http.Server {
 	return &http.Server{
 		Handler:     &lxdHTTPServer{r: mux, d: d},
 		ConnContext: lxdRequest.SaveConnectionInContext,
+		IdleTimeout: 30 * time.Second,
 	}
 }
 


### PR DESCRIPTION
When connecting to LXD via a load-balancer, long-polling LXD often fails because the connection is timing out. This PR mitigates the issue by adding a keep-alive timeout on the LXD server.