### PR TITLE
Prevent use of one OVN network's volatile IP on another OVN network (stable-5.0)

### DIFF
--- a/lxd/network/driver_common.go
+++ b/lxd/network/driver_common.go
@@ -53,6 +53,7 @@ const (
 	subnetUsageNetworkForward
 	subnetUsageInstance
 	subnetUsageProxy
+	subnetUsageVolatileIP
 )
 
 // externalSubnetUsage represents usage of a subnet by a network or NIC.


### PR DESCRIPTION
Since we would like to prevent the use of one OVN network's volatile IP on another OVN network, we should consider this when retrieving external subnet information during validation.