### PR TITLE
Pass request to `Render` backport (stable-5.21)

### DIFF
--- a/lxd-agent/devlxd.go
+++ b/lxd-agent/devlxd.go
@@ -176,7 +176,7 @@ var devLxdEventsGet = devLxdHandler{
 }
 
 func devlxdEventsGetHandler(d *Daemon, w http.ResponseWriter, r *http.Request) *devLxdResponse {
-	err := eventsGet(d, r).Render(w)
+	err := eventsGet(d, r).Render(w, r)
 	if err != nil {
 		return smartResponse(err)
 	}

--- a/lxd-agent/events.go
+++ b/lxd-agent/events.go
@@ -30,8 +30,8 @@ type eventsServe struct {
 }
 
 // Render starts event socket.
-func (r *eventsServe) Render(w http.ResponseWriter) error {
-	return eventsSocket(r.d, r.req, w)
+func (r *eventsServe) Render(w http.ResponseWriter, request *http.Request) error {
+	return eventsSocket(r.d, request, w)
 }
 
 func (r *eventsServe) String() string {

--- a/lxd-agent/server.go
+++ b/lxd-agent/server.go
@@ -23,7 +23,7 @@ func restServer(tlsConfig *tls.Config, cert *x509.Certificate, d *Daemon) *http.
 
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_ = response.SyncResponse(true, []string{"/1.0"}).Render(w)
+		_ = response.SyncResponse(true, []string{"/1.0"}).Render(w, r)
 	})
 
 	for _, c := range api10 {
@@ -46,7 +46,7 @@ func createCmd(restAPI *mux.Router, version string, c APIEndpoint, cert *x509.Ce
 
 		if !authenticate(r, cert) {
 			logger.Error("Not authorized")
-			_ = response.InternalError(fmt.Errorf("Not authorized")).Render(w)
+			_ = response.InternalError(fmt.Errorf("Not authorized")).Render(w, r)
 			return
 		}
 
@@ -57,7 +57,7 @@ func createCmd(restAPI *mux.Router, version string, c APIEndpoint, cert *x509.Ce
 			multiW := io.MultiWriter(newBody, captured)
 			_, err := io.Copy(multiW, r.Body)
 			if err != nil {
-				_ = response.InternalError(err).Render(w)
+				_ = response.InternalError(err).Render(w, r)
 				return
 			}
 
@@ -92,9 +92,9 @@ func createCmd(restAPI *mux.Router, version string, c APIEndpoint, cert *x509.Ce
 		}
 
 		// Handle errors
-		err := resp.Render(w)
+		err := resp.Render(w, r)
 		if err != nil {
-			writeErr := response.InternalError(err).Render(w)
+			writeErr := response.InternalError(err).Render(w, r)
 			if writeErr != nil {
 				logger.Error("Failed writing error for HTTP response", logger.Ctx{"url": uri, "err": err, "writeErr": writeErr})
 			}

--- a/lxd-agent/sftp.go
+++ b/lxd-agent/sftp.go
@@ -29,6 +29,7 @@ func (r *sftpServe) String() string {
 	return "sftp handler"
 }
 
+// Render hijacks the connection and starts a sftp server.
 func (r *sftpServe) Render(w http.ResponseWriter, request *http.Request) error {
 	// Upgrade to sftp.
 	if request.Header.Get("Upgrade") != "sftp" {

--- a/lxd-agent/sftp.go
+++ b/lxd-agent/sftp.go
@@ -29,9 +29,9 @@ func (r *sftpServe) String() string {
 	return "sftp handler"
 }
 
-func (r *sftpServe) Render(w http.ResponseWriter) error {
+func (r *sftpServe) Render(w http.ResponseWriter, request *http.Request) error {
 	// Upgrade to sftp.
-	if r.r.Header.Get("Upgrade") != "sftp" {
+	if request.Header.Get("Upgrade") != "sftp" {
 		http.Error(w, "Missing or invalid upgrade header", http.StatusBadRequest)
 		return nil
 	}

--- a/lxd/api.go
+++ b/lxd/api.go
@@ -174,7 +174,7 @@ func restServer(d *Daemon) *http.Server {
 		}
 
 		// Normal client handling.
-		_ = response.SyncResponse(true, []string{"/1.0"}).Render(w)
+		_ = response.SyncResponse(true, []string{"/1.0"}).Render(w, r)
 	})
 
 	for endpoint, f := range d.gateway.HandlerFuncs(d.heartbeatHandler, d.identityCache) {
@@ -206,7 +206,7 @@ func restServer(d *Daemon) *http.Server {
 	mux.NotFoundHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		logger.Info("Sending top level 404", logger.Ctx{"url": r.URL, "method": r.Method, "remote": r.RemoteAddr})
 		w.Header().Set("Content-Type", "application/json")
-		_ = response.NotFound(nil).Render(w)
+		_ = response.NotFound(nil).Render(w, r)
 	})
 
 	return &http.Server{
@@ -232,7 +232,7 @@ func hoistReqVM(f func(*Daemon, instance.Instance, http.ResponseWriter, *http.Re
 		}
 
 		resp := f(d, inst, w, r)
-		_ = resp.Render(w)
+		_ = resp.Render(w, r)
 	}
 }
 
@@ -248,7 +248,7 @@ func metricsServer(d *Daemon) *http.Server {
 
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_ = response.SyncResponse(true, []string{"/1.0"}).Render(w)
+		_ = response.SyncResponse(true, []string{"/1.0"}).Render(w, r)
 	})
 
 	for endpoint, f := range d.gateway.HandlerFuncs(d.heartbeatHandler, d.identityCache) {
@@ -261,7 +261,7 @@ func metricsServer(d *Daemon) *http.Server {
 	mux.NotFoundHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		logger.Info("Sending top level 404", logger.Ctx{"url": r.URL, "method": r.Method, "remote": r.RemoteAddr})
 		w.Header().Set("Content-Type", "application/json")
-		_ = response.NotFound(nil).Render(w)
+		_ = response.NotFound(nil).Render(w, r)
 	})
 
 	return &http.Server{Handler: &lxdHTTPServer{r: mux, d: d}}

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -949,7 +949,7 @@ func clusterPutDisable(d *Daemon, r *http.Request, req api.ClusterPut) response.
 	}()
 
 	return response.ManualResponse(func(w http.ResponseWriter) error {
-		err := response.EmptySyncResponse.Render(w)
+		err := response.EmptySyncResponse.Render(w, r)
 		if err != nil {
 			return err
 		}
@@ -2039,7 +2039,7 @@ func clusterNodeDelete(d *Daemon, r *http.Request) response.Response {
 		}
 
 		return response.ManualResponse(func(w http.ResponseWriter) error {
-			err := response.EmptySyncResponse.Render(w)
+			err := response.EmptySyncResponse.Render(w, r)
 			if err != nil {
 				return err
 			}

--- a/lxd/api_internal.go
+++ b/lxd/api_internal.go
@@ -247,7 +247,7 @@ func internalShutdown(d *Daemon, r *http.Request) response.Response {
 
 		// Run shutdown sequence synchronously.
 		stopErr := d.Stop(forceCtx, unix.SIGPWR)
-		err := response.SmartError(stopErr).Render(w)
+		err := response.SmartError(stopErr).Render(w, r)
 		if err != nil {
 			return err
 		}

--- a/lxd/auth/oidc/oidc.go
+++ b/lxd/auth/oidc/oidc.go
@@ -275,7 +275,7 @@ func (o *Verifier) getGroupsFromClaims(customClaims map[string]any) []string {
 func (o *Verifier) Login(w http.ResponseWriter, r *http.Request) {
 	err := o.ensureConfig(r.Context(), r.Host)
 	if err != nil {
-		_ = response.ErrorResponse(http.StatusInternalServerError, fmt.Errorf("Login failed: %w", err).Error()).Render(w)
+		_ = response.ErrorResponse(http.StatusInternalServerError, fmt.Errorf("Login failed: %w", err).Error()).Render(w, r)
 		return
 	}
 
@@ -287,7 +287,7 @@ func (o *Verifier) Login(w http.ResponseWriter, r *http.Request) {
 func (o *Verifier) Logout(w http.ResponseWriter, r *http.Request) {
 	err := o.setCookies(w, nil, uuid.UUID{}, "", "", true)
 	if err != nil {
-		_ = response.ErrorResponse(http.StatusInternalServerError, fmt.Errorf("Failed to delete login information: %w", err).Error()).Render(w)
+		_ = response.ErrorResponse(http.StatusInternalServerError, fmt.Errorf("Failed to delete login information: %w", err).Error()).Render(w, r)
 		return
 	}
 
@@ -298,7 +298,7 @@ func (o *Verifier) Logout(w http.ResponseWriter, r *http.Request) {
 func (o *Verifier) Callback(w http.ResponseWriter, r *http.Request) {
 	err := o.ensureConfig(r.Context(), r.Host)
 	if err != nil {
-		_ = response.ErrorResponse(http.StatusInternalServerError, fmt.Errorf("OIDC callback failed: %w", err).Error()).Render(w)
+		_ = response.ErrorResponse(http.StatusInternalServerError, fmt.Errorf("OIDC callback failed: %w", err).Error()).Render(w, r)
 		return
 	}
 
@@ -306,13 +306,13 @@ func (o *Verifier) Callback(w http.ResponseWriter, r *http.Request) {
 		sessionID := uuid.New()
 		secureCookie, err := o.secureCookieFromSession(sessionID)
 		if err != nil {
-			_ = response.ErrorResponse(http.StatusInternalServerError, fmt.Errorf("Failed to start a new session: %w", err).Error()).Render(w)
+			_ = response.ErrorResponse(http.StatusInternalServerError, fmt.Errorf("Failed to start a new session: %w", err).Error()).Render(w, r)
 			return
 		}
 
 		err = o.setCookies(w, secureCookie, sessionID, tokens.IDToken, tokens.RefreshToken, false)
 		if err != nil {
-			_ = response.ErrorResponse(http.StatusInternalServerError, fmt.Errorf("Failed to set login information: %w", err).Error()).Render(w)
+			_ = response.ErrorResponse(http.StatusInternalServerError, fmt.Errorf("Failed to set login information: %w", err).Error()).Render(w, r)
 			return
 		}
 

--- a/lxd/cluster/notify_test.go
+++ b/lxd/cluster/notify_test.go
@@ -274,7 +274,7 @@ func (h *notifyFixtures) Unavailable(i int, err error) {
 	mux.HandleFunc("/1.0/", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		err := response.Unavailable(err)
-		_ = err.Render(w)
+		_ = err.Render(w, r)
 	})
 
 	h.servers[i].Config.Handler = mux

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -637,7 +637,7 @@ func (d *Daemon) createCmd(restAPI *mux.Router, version string, c APIEndpoint) {
 			case <-d.setupChan:
 			default:
 				response := response.Unavailable(fmt.Errorf("LXD daemon setup in progress"))
-				_ = response.Render(w)
+				_ = response.Render(w, r)
 				return
 			}
 		}
@@ -654,11 +654,11 @@ func (d *Daemon) createCmd(restAPI *mux.Router, version string, c APIEndpoint) {
 
 				// Return 401 Unauthorized error. This indicates to the client that it needs to use the
 				// headers we've set above to get an access token and try again.
-				_ = response.Unauthorized(err).Render(w)
+				_ = response.Unauthorized(err).Render(w, r)
 				return
 			}
 
-			_ = response.Forbidden(err).Render(w)
+			_ = response.Forbidden(err).Render(w, r)
 			return
 		}
 
@@ -670,7 +670,7 @@ func (d *Daemon) createCmd(restAPI *mux.Router, version string, c APIEndpoint) {
 			// Except for the initial cluster accept request (done over trusted TLS)
 			if !trusted || c.Path != "cluster/accept" || protocol != api.AuthenticationMethodTLS {
 				logger.Warn("Rejecting remote internal API request", logger.Ctx{"ip": r.RemoteAddr})
-				_ = response.Forbidden(nil).Render(w)
+				_ = response.Forbidden(nil).Render(w, r)
 				return
 			}
 		}
@@ -720,7 +720,7 @@ func (d *Daemon) createCmd(restAPI *mux.Router, version string, c APIEndpoint) {
 			}
 
 			logger.Warn("Rejecting request from untrusted client", logger.Ctx{"ip": r.RemoteAddr})
-			_ = response.Forbidden(nil).Render(w)
+			_ = response.Forbidden(nil).Render(w, r)
 			return
 		}
 
@@ -731,7 +731,7 @@ func (d *Daemon) createCmd(restAPI *mux.Router, version string, c APIEndpoint) {
 			multiW := io.MultiWriter(newBody, captured)
 			_, err := io.Copy(multiW, r.Body)
 			if err != nil {
-				_ = response.InternalError(err).Render(w)
+				_ = response.InternalError(err).Render(w, r)
 				return
 			}
 
@@ -766,7 +766,7 @@ func (d *Daemon) createCmd(restAPI *mux.Router, version string, c APIEndpoint) {
 		}
 
 		if d.shutdownCtx.Err() == context.Canceled && !allowedDuringShutdown() {
-			_ = response.Unavailable(fmt.Errorf("LXD is shutting down")).Render(w)
+			_ = response.Unavailable(fmt.Errorf("LXD is shutting down")).Render(w, r)
 			return
 		}
 
@@ -814,9 +814,9 @@ func (d *Daemon) createCmd(restAPI *mux.Router, version string, c APIEndpoint) {
 		}
 
 		// Handle errors
-		err = resp.Render(w)
+		err = resp.Render(w, r)
 		if err != nil {
-			writeErr := response.SmartError(err).Render(w)
+			writeErr := response.SmartError(err).Render(w, r)
 			if writeErr != nil {
 				logger.Warn("Failed writing error for HTTP response", logger.Ctx{"url": uri, "err": err, "writeErr": writeErr})
 			}

--- a/lxd/devlxd.go
+++ b/lxd/devlxd.go
@@ -121,7 +121,7 @@ func devlxdImageExportHandler(d *Daemon, c instance.Instance, w http.ResponseWri
 
 	resp := imageExport(d, r)
 
-	err := resp.Render(w)
+	err := resp.Render(w, r)
 	if err != nil {
 		return response.DevLxdErrorResponse(api.StatusErrorf(http.StatusInternalServerError, "internal server error"), c.Type() == instancetype.VM)
 	}
@@ -390,7 +390,7 @@ func hoistReq(f func(*Daemon, instance.Instance, http.ResponseWriter, *http.Requ
 		}
 
 		resp := f(d, c, w, r)
-		_ = resp.Render(w)
+		_ = resp.Render(w, r)
 	}
 }
 

--- a/lxd/events.go
+++ b/lxd/events.go
@@ -35,7 +35,7 @@ type eventsServe struct {
 }
 
 // Render starts event socket.
-func (r *eventsServe) Render(w http.ResponseWriter) error {
+func (r *eventsServe) Render(w http.ResponseWriter, req *http.Request) error {
 	return eventsSocket(r.s, r.req, w)
 }
 

--- a/lxd/instance_sftp.go
+++ b/lxd/instance_sftp.go
@@ -109,7 +109,7 @@ func (r *sftpServeResponse) String() string {
 }
 
 // Render renders the server response.
-func (r *sftpServeResponse) Render(w http.ResponseWriter) error {
+func (r *sftpServeResponse) Render(w http.ResponseWriter, req *http.Request) error {
 	defer func() { _ = r.instConn.Close() }()
 
 	hijacker, ok := w.(http.Hijacker)

--- a/lxd/operations.go
+++ b/lxd/operations.go
@@ -983,17 +983,17 @@ func operationWaitGet(d *Daemon, r *http.Request) response.Response {
 			// Wait for the operation.
 			err = op.Wait(ctx)
 			if err != nil {
-				_ = response.SmartError(err).Render(w)
+				_ = response.SmartError(err).Render(w, r)
 				return nil
 			}
 
 			_, body, err := op.Render()
 			if err != nil {
-				_ = response.SmartError(err).Render(w)
+				_ = response.SmartError(err).Render(w, r)
 				return nil
 			}
 
-			_ = response.SyncResponse(true, body).Render(w)
+			_ = response.SyncResponse(true, body).Render(w, r)
 			return nil
 		}
 

--- a/lxd/operations/response.go
+++ b/lxd/operations/response.go
@@ -21,6 +21,7 @@ func OperationResponse(op *Operation) response.Response {
 	return &operationResponse{op}
 }
 
+// Render builds operationResponse and writes it to http.ResponseWriter.
 func (r *operationResponse) Render(w http.ResponseWriter, req *http.Request) error {
 	err := r.op.Start()
 	if err != nil {
@@ -79,6 +80,7 @@ func ForwardedOperationResponse(project string, op *api.Operation) response.Resp
 	}
 }
 
+// Render builds forwardedOperationResponse and writes it to http.ResponseWriter.
 func (r *forwardedOperationResponse) Render(w http.ResponseWriter, req *http.Request) error {
 	url := fmt.Sprintf("/%s/operations/%s", version.APIVersion, r.op.ID)
 	if r.project != "" {

--- a/lxd/operations/response.go
+++ b/lxd/operations/response.go
@@ -21,7 +21,7 @@ func OperationResponse(op *Operation) response.Response {
 	return &operationResponse{op}
 }
 
-func (r *operationResponse) Render(w http.ResponseWriter) error {
+func (r *operationResponse) Render(w http.ResponseWriter, req *http.Request) error {
 	err := r.op.Start()
 	if err != nil {
 		return err
@@ -79,7 +79,7 @@ func ForwardedOperationResponse(project string, op *api.Operation) response.Resp
 	}
 }
 
-func (r *forwardedOperationResponse) Render(w http.ResponseWriter) error {
+func (r *forwardedOperationResponse) Render(w http.ResponseWriter, req *http.Request) error {
 	url := fmt.Sprintf("/%s/operations/%s", version.APIVersion, r.op.ID)
 	if r.project != "" {
 		url += fmt.Sprintf("?project=%s", r.project)

--- a/lxd/operations/websocket.go
+++ b/lxd/operations/websocket.go
@@ -20,7 +20,7 @@ func OperationWebSocket(req *http.Request, op *Operation) response.Response {
 	return &operationWebSocket{req, op}
 }
 
-func (r *operationWebSocket) Render(w http.ResponseWriter) error {
+func (r *operationWebSocket) Render(w http.ResponseWriter, req *http.Request) error {
 	chanErr, err := r.op.Connect(r.req, w)
 	if err != nil {
 		return err
@@ -50,7 +50,7 @@ func ForwardedOperationWebSocket(req *http.Request, id string, source *websocket
 	return &forwardedOperationWebSocket{req, id, source}
 }
 
-func (r *forwardedOperationWebSocket) Render(w http.ResponseWriter) error {
+func (r *forwardedOperationWebSocket) Render(w http.ResponseWriter, req *http.Request) error {
 	// Upgrade target connection to websocket.
 	target, err := ws.Upgrader.Upgrade(w, r.req, nil)
 	if err != nil {

--- a/lxd/operations/websocket.go
+++ b/lxd/operations/websocket.go
@@ -20,6 +20,7 @@ func OperationWebSocket(req *http.Request, op *Operation) response.Response {
 	return &operationWebSocket{req, op}
 }
 
+// Render renders a websocket operation response.
 func (r *operationWebSocket) Render(w http.ResponseWriter, req *http.Request) error {
 	chanErr, err := r.op.Connect(r.req, w)
 	if err != nil {
@@ -50,6 +51,7 @@ func ForwardedOperationWebSocket(req *http.Request, id string, source *websocket
 	return &forwardedOperationWebSocket{req, id, source}
 }
 
+// Render renders a forwarded websocket operation response.
 func (r *forwardedOperationWebSocket) Render(w http.ResponseWriter, req *http.Request) error {
 	// Upgrade target connection to websocket.
 	target, err := ws.Upgrader.Upgrade(w, r.req, nil)

--- a/lxd/response/response.go
+++ b/lxd/response/response.go
@@ -39,6 +39,7 @@ type devLxdResponse struct {
 	contentType string
 }
 
+// Render renders a response for requests against the /dev/lxd socket.
 func (r *devLxdResponse) Render(w http.ResponseWriter, req *http.Request) error {
 	var err error
 
@@ -144,6 +145,7 @@ func SyncResponsePlain(success bool, compress bool, metadata string) Response {
 	return &syncResponse{success: success, metadata: metadata, plaintext: true, compress: compress}
 }
 
+// Render renders a synchronous response.
 func (r *syncResponse) Render(w http.ResponseWriter, req *http.Request) error {
 	// Set an appropriate ETag header
 	if r.etag != nil {
@@ -327,6 +329,7 @@ func (r *errorResponse) String() string {
 	return r.msg
 }
 
+// Render renders a response that indicates an error on the request handling.
 func (r *errorResponse) Render(w http.ResponseWriter, req *http.Request) error {
 	var output io.Writer
 
@@ -396,6 +399,7 @@ func FileResponse(r *http.Request, files []FileResponseEntry, headers map[string
 	return &fileResponse{r, files, headers}
 }
 
+// Render renders a file response.
 func (r *fileResponse) Render(w http.ResponseWriter, req *http.Request) error {
 	if r.headers != nil {
 		for k, v := range r.headers {
@@ -517,6 +521,7 @@ func ForwardedResponse(client lxd.InstanceServer, request *http.Request) Respons
 	}
 }
 
+// Render renders a response for a forwarded request.
 func (r *forwardedResponse) Render(w http.ResponseWriter, req *http.Request) error {
 	info, err := r.client.GetConnectionInfo()
 	if err != nil {
@@ -568,6 +573,7 @@ func ManualResponse(hook func(w http.ResponseWriter) error) Response {
 	return &manualResponse{hook: hook}
 }
 
+// Render renders a manual response.
 func (r *manualResponse) Render(w http.ResponseWriter, req *http.Request) error {
 	return r.hook(w)
 }


### PR DESCRIPTION
This backports the necessary commits into `stable-5.21` that allow passing the request into the response `Render` func.

See https://github.com/canonical/microcluster/pull/277#issuecomment-2459421554 for the origin of this request.