### PR TITLE
Allow vm `security.shared`

### DIFF
--- a/doc/explanation/storage.md
+++ b/doc/explanation/storage.md
@@ -122,7 +122,7 @@ Storage volumes can be of the following types:
 : LXD automatically creates one of these storage volumes when you launch an instance.
   It is used as the root disk for the instance, and it is destroyed when the instance is deleted.
 
-  This storage volume is created in the storage pool that is specified in the profile used when launching the instance (or the default profile, if no profile is specified).
+  This storage volume is created in the storage pool that is specified when launching the instance (or in the default profile, if no pool or profile is specified).
   The storage pool can be explicitly specified by providing the `--storage` flag to the launch command.
 
 `image`
@@ -157,7 +157,7 @@ Each storage volume uses one of the following content types:
 
   Custom storage volumes of content type `block` can only be attached to virtual machines.
   By default, they can only be attached to one instance at a time, because simultaneous access can lead to data corruption.
-  Sharing a custom storage volumes of content type `block` is made possible through the usage of the `security.shared` configuration key.
+  Sharing custom storage volumes of content type `block` is made possible through the usage of the `security.shared` configuration key.
 
 `iso`
 : This content type is used for custom ISO volumes.

--- a/doc/metadata.txt
+++ b/doc/metadata.txt
@@ -4791,7 +4791,7 @@ prior to creating the storage pool.
 <!-- config group storage-btrfs-pool-conf end -->
 <!-- config group storage-btrfs-volume-conf start -->
 ```{config:option} security.shared storage-btrfs-volume-conf
-:condition: "custom block volume"
+:condition: "virtual-machine or custom block volume"
 :defaultdesc: "same as `volume.security.shared` or `false`"
 :shortdesc: "Enable volume sharing"
 :type: "bool"
@@ -4955,7 +4955,7 @@ If not set, `ext4` is assumed.
 ```
 
 ```{config:option} security.shared storage-ceph-volume-conf
-:condition: "custom block volume"
+:condition: "virtual-machine or custom block volume"
 :defaultdesc: "same as `volume.security.shared` or `false`"
 :shortdesc: "Enable volume sharing"
 :type: "bool"
@@ -5104,7 +5104,7 @@ when creating a missing OSD pool.
 <!-- config group storage-cephfs-pool-conf end -->
 <!-- config group storage-cephfs-volume-conf start -->
 ```{config:option} security.shared storage-cephfs-volume-conf
-:condition: "custom block volume"
+:condition: "virtual-machine or custom block volume"
 :defaultdesc: "same as `volume.security.shared` or `false`"
 :shortdesc: "Enable volume sharing"
 :type: "bool"
@@ -5252,7 +5252,7 @@ to be placed on the socket I/O.
 <!-- config group storage-dir-pool-conf end -->
 <!-- config group storage-dir-volume-conf start -->
 ```{config:option} security.shared storage-dir-volume-conf
-:condition: "custom block volume"
+:condition: "virtual-machine or custom block volume"
 :defaultdesc: "same as `volume.security.shared` or `false`"
 :shortdesc: "Enable volume sharing"
 :type: "bool"
@@ -5447,7 +5447,7 @@ The size must be at least 4096 bytes, and a multiple of 512 bytes.
 ```
 
 ```{config:option} security.shared storage-lvm-volume-conf
-:condition: "custom block volume"
+:condition: "virtual-machine or custom block volume"
 :defaultdesc: "same as `volume.security.shared` or `false`"
 :shortdesc: "Enable volume sharing"
 :type: "bool"
@@ -5634,7 +5634,7 @@ If not set, `ext4` is assumed.
 ```
 
 ```{config:option} security.shared storage-powerflex-volume-conf
-:condition: "custom block volume"
+:condition: "virtual-machine or custom block volume"
 :defaultdesc: "same as `volume.security.shared` or `false`"
 :shortdesc: "Enable volume sharing"
 :type: "bool"
@@ -5788,7 +5788,7 @@ If not set, `ext4` is assumed.
 ```
 
 ```{config:option} security.shared storage-zfs-volume-conf
-:condition: "custom block volume"
+:condition: "virtual-machine or custom block volume"
 :defaultdesc: "same as `volume.security.shared` or `false`"
 :shortdesc: "Enable volume sharing"
 :type: "bool"

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -5411,7 +5411,7 @@
 				"keys": [
 					{
 						"security.shared": {
-							"condition": "custom block volume",
+							"condition": "virtual-machine or custom block volume",
 							"defaultdesc": "same as `volume.security.shared` or `false`",
 							"longdesc": "Enabling this option allows sharing the volume across multiple instances despite the possibility of data loss.\n",
 							"shortdesc": "Enable volume sharing",
@@ -5588,7 +5588,7 @@
 					},
 					{
 						"security.shared": {
-							"condition": "custom block volume",
+							"condition": "virtual-machine or custom block volume",
 							"defaultdesc": "same as `volume.security.shared` or `false`",
 							"longdesc": "Enabling this option allows sharing the volume across multiple instances despite the possibility of data loss.\n",
 							"shortdesc": "Enable volume sharing",
@@ -5745,7 +5745,7 @@
 				"keys": [
 					{
 						"security.shared": {
-							"condition": "custom block volume",
+							"condition": "virtual-machine or custom block volume",
 							"defaultdesc": "same as `volume.security.shared` or `false`",
 							"longdesc": "Enabling this option allows sharing the volume across multiple instances despite the possibility of data loss.\n",
 							"shortdesc": "Enable volume sharing",
@@ -5910,7 +5910,7 @@
 				"keys": [
 					{
 						"security.shared": {
-							"condition": "custom block volume",
+							"condition": "virtual-machine or custom block volume",
 							"defaultdesc": "same as `volume.security.shared` or `false`",
 							"longdesc": "Enabling this option allows sharing the volume across multiple instances despite the possibility of data loss.\n",
 							"shortdesc": "Enable volume sharing",
@@ -6117,7 +6117,7 @@
 					},
 					{
 						"security.shared": {
-							"condition": "custom block volume",
+							"condition": "virtual-machine or custom block volume",
 							"defaultdesc": "same as `volume.security.shared` or `false`",
 							"longdesc": "Enabling this option allows sharing the volume across multiple instances despite the possibility of data loss.\n",
 							"shortdesc": "Enable volume sharing",
@@ -6316,7 +6316,7 @@
 					},
 					{
 						"security.shared": {
-							"condition": "custom block volume",
+							"condition": "virtual-machine or custom block volume",
 							"defaultdesc": "same as `volume.security.shared` or `false`",
 							"longdesc": "Enabling this option allows sharing the volume across multiple instances despite the possibility of data loss.\n",
 							"shortdesc": "Enable volume sharing",
@@ -6474,7 +6474,7 @@
 					},
 					{
 						"security.shared": {
-							"condition": "custom block volume",
+							"condition": "virtual-machine or custom block volume",
 							"defaultdesc": "same as `volume.security.shared` or `false`",
 							"longdesc": "Enabling this option allows sharing the volume across multiple instances despite the possibility of data loss.\n",
 							"shortdesc": "Enable volume sharing",

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -537,14 +537,14 @@ func poolAndVolumeCommonRules(vol *drivers.Volume) map[string]func(string) error
 		rules["security.unmapped"] = validate.Optional(validate.IsBool)
 	}
 
-	// security.shared is only relevant for custom block volumes.
-	if vol == nil || (vol.Type() == drivers.VolumeTypeCustom && vol.ContentType() == drivers.ContentTypeBlock) {
+	// security.shared guards virtual-machine and custom block volumes.
+	if vol == nil || ((vol.Type() == drivers.VolumeTypeCustom || vol.Type() == drivers.VolumeTypeVM) && vol.ContentType() == drivers.ContentTypeBlock) {
 		// lxdmeta:generate(entities=storage-btrfs,storage-cephfs,storage-ceph,storage-dir,storage-lvm,storage-zfs,storage-powerflex; group=volume-conf; key=security.shared)
 		// Enabling this option allows sharing the volume across multiple instances despite the possibility of data loss.
 		//
 		// ---
 		//  type: bool
-		//  condition: custom block volume
+		//  condition: virtual-machine or custom block volume
 		//  defaultdesc: same as `volume.security.shared` or `false`
 		//  shortdesc: Enable volume sharing
 		rules["security.shared"] = validate.Optional(validate.IsBool)


### PR DESCRIPTION
This is a preparatory change for attaching `virtual-machine` ~~and `container`~~ type volumes to instances.

`security.shared` will be required for in order to attach `virtual-machine` volumes to other VMs.

Also a few bits I noticed in the docs.