### PR TITLE
Docs: Fix ovn ipv4/6 address description

### DIFF
--- a/doc/metadata.txt
+++ b/doc/metadata.txt
@@ -3429,7 +3429,7 @@ Specify a comma-separated list of DNS zone names.
 ```{config:option} ipv4.address network-ovn-network-conf
 :condition: "standard mode"
 :defaultdesc: "initial value on creation: `auto`"
-:shortdesc: "IPv4 address for the bridge"
+:shortdesc: "IPv4 address for the OVN network"
 :type: "string"
 Use CIDR notation.
 
@@ -3470,7 +3470,7 @@ You can set the option to `none` to turn off IPv4, or to `auto` to generate a ne
 ```{config:option} ipv6.address network-ovn-network-conf
 :condition: "standard mode"
 :defaultdesc: "initial value on creation: `auto`"
-:shortdesc: "IPv6 address for the bridge"
+:shortdesc: "IPv6 address for the OVN network"
 :type: "string"
 Use CIDR notation.
 

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -3887,7 +3887,7 @@
 							"condition": "standard mode",
 							"defaultdesc": "initial value on creation: `auto`",
 							"longdesc": "Use CIDR notation.\n\nYou can set the option to `none` to turn off IPv4, or to `auto` to generate a new random unused subnet.",
-							"shortdesc": "IPv4 address for the bridge",
+							"shortdesc": "IPv4 address for the OVN network",
 							"type": "string"
 						}
 					},
@@ -3931,7 +3931,7 @@
 							"condition": "standard mode",
 							"defaultdesc": "initial value on creation: `auto`",
 							"longdesc": "Use CIDR notation.\n\nYou can set the option to `none` to turn off IPv6, or to `auto` to generate a new random unused subnet.",
-							"shortdesc": "IPv6 address for the bridge",
+							"shortdesc": "IPv6 address for the OVN network",
 							"type": "string"
 						}
 					},

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -408,7 +408,7 @@ func (n *ovn) Validate(config map[string]string) error {
 		//  type: string
 		//  condition: standard mode
 		//  defaultdesc: initial value on creation: `auto`
-		//  shortdesc: IPv4 address for the bridge
+		//  shortdesc: IPv4 address for the OVN network
 		"ipv4.address": validate.Optional(func(value string) error {
 			if validate.IsOneOf("none", "auto")(value) == nil {
 				return nil
@@ -432,7 +432,7 @@ func (n *ovn) Validate(config map[string]string) error {
 		//  type: string
 		//  condition: standard mode
 		//  defaultdesc: initial value on creation: `auto`
-		//  shortdesc: IPv6 address for the bridge
+		//  shortdesc: IPv6 address for the OVN network
 		"ipv6.address": validate.Optional(func(value string) error {
 			if validate.IsOneOf("none", "auto")(value) == nil {
 				return nil


### PR DESCRIPTION
# Done
- fix OVN ipv4/6 address description, this was wrongly referencing a "bridge"