### PR TITLE
github: Use cache when Trivy DB download fails

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -30,16 +30,32 @@ jobs:
       - name: Install Trivy
         uses: ./.github/actions/install-trivy
 
+      - name: Download Trivy DB
+        id: db_download
+        run: trivy fs --download-db-only --cache-dir /home/runner/vuln-cache
+        continue-on-error: true
+
+      - name: Use previous downloaded database
+        if: ${{ steps.db_download.outcome == 'failure' }}
+        uses: actions/cache/restore@3624ceb22c1c5a301c8db4169662070a689d9ea8 # v4.1.1
+        with:
+          path: /home/runner/vuln-cache
+          key: trivy-latest-cache
+
       - name: Run Trivy vulnerability scanner
         run: |
-          trivy fs --quiet --scanners vuln,secret,misconfig --format sarif --cache-dir /home/runner/vuln-cache \
-          --severity LOW,MEDIUM,HIGH,CRITICAL --output trivy-lxd-repo-scan-results.sarif .
+          trivy fs --skip-db-update \
+          --scanners vuln,secret,misconfig \
+          --format sarif \
+          --cache-dir /home/runner/vuln-cache \
+          --severity LOW,MEDIUM,HIGH,CRITICAL \
+          --output trivy-lxd-repo-scan-results.sarif .
 
       - name: Cache Trivy vulnerability database
         uses: actions/cache/save@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
         with:
           path: /home/runner/vuln-cache
-          key: trivy-cache-${{ github.run_id }}
+          key: trivy-latest-cache
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@662472033e021d55d94146f66f6058822b0b39fd # v3.27.0
@@ -71,7 +87,7 @@ jobs:
         uses: actions/cache/restore@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
         with:
           path: /home/runner/vuln-cache
-          key: trivy-cache-${{ github.run_id }}
+          key: trivy-latest-cache
 
       - name: Download snap for scan
         run: |
@@ -80,8 +96,12 @@ jobs:
 
       - name: Run Trivy vulnerability scanner
         run: |
-          trivy rootfs --quiet --scanners vuln,secret,misconfig --format sarif --cache-dir /home/runner/vuln-cache \
-          --severity LOW,MEDIUM,HIGH,CRITICAL --output /home/runner/${{ matrix.version }}-stable.sarif squashfs-root
+          trivy fs --skip-db-update \
+          --scanners vuln,secret,misconfig \
+          --format sarif \
+          --cache-dir /home/runner/vuln-cache \
+          --severity LOW,MEDIUM,HIGH,CRITICAL \
+          --output /home/runner/${{ matrix.version }}-stable.sarif .
 
       - name: Flag snap scanning alerts
         run: |


### PR DESCRIPTION
This updates the Trivy workflow to cache the vulnerability database when the download is successful and, when it is not, use the latest cached database instead. Motivated by some failures seen on some recent runs: https://github.com/canonical/lxd/actions/runs/11603622604/job/32310941454