### PR TITLE
lxd/networks: Emit lifecycle event for OVN networks (from Incus)

### DIFF
--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -518,6 +518,14 @@ func networksPost(d *Daemon, r *http.Request) response.Response {
 			if err != nil {
 				return response.SmartError(err)
 			}
+
+			n, err := network.LoadByName(s, projectName, req.Name)
+			if err != nil {
+				return response.SmartError(fmt.Errorf("Failed loading network: %w", err))
+			}
+
+			requestor := request.CreateRequestor(r)
+			s.Events.SendLifecycle(projectName, lifecycle.NetworkCreated.Event(n, requestor, nil))
 		}
 
 		err = networksPostCluster(s, projectName, netInfo, req, clientType, netType)


### PR DESCRIPTION
Adds a missing lifecycle event on creation of cluster wide networks (e.g. when one is created first on a per member basis).