### PR TITLE
Set Target after network/storage lookup (from Incus)

### DIFF
--- a/lxc/init.go
+++ b/lxc/init.go
@@ -161,10 +161,6 @@ func (c *cmdInit) create(conf *config.Config, args []string, launch bool) (lxd.I
 		return nil, "", err
 	}
 
-	if c.flagTarget != "" {
-		d = d.UseTarget(c.flagTarget)
-	}
-
 	// Overwrite profiles.
 	if c.flagProfile != nil {
 		profiles = c.flagProfile
@@ -262,6 +258,11 @@ func (c *cmdInit) create(conf *config.Config, args []string, launch bool) (lxd.I
 	instanceDBType := api.InstanceTypeContainer
 	if c.flagVM {
 		instanceDBType = api.InstanceTypeVM
+	}
+
+	// Set the target if provided.
+	if c.flagTarget != "" {
+		d = d.UseTarget(c.flagTarget)
 	}
 
 	// Setup instance creation request

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -3660,12 +3660,12 @@ EOF
   lxc init testimage cluster:c1
   lxc info cluster:c1 | grep -q "Location: node1"
 
-  # c2 should go to node2
-  lxc init testimage cluster:c2 --target=@blah
+  # c2 should go to node2. Additionally it should be possible to specify the network.
+  lxc init testimage cluster:c2 --target=@blah --network "${bridge}"
   lxc info cluster:c2 | grep -q "Location: node2"
 
-  # c3 should go to node2 again
-  lxc init testimage cluster:c3 --target=@blah
+  # c3 should go to node2 again. Additionally it should be possible to specify the storage pool.
+  lxc init testimage cluster:c3 --target=@blah --storage data
   lxc info cluster:c3 | grep -q "Location: node2"
 
   # Direct targeting of node2 should work


### PR DESCRIPTION
In LXD init, if the `--storage` or `--network` flags are provided the CLI will check the storage pool or network exists before setting up a device on the instance config. When targeting a cluster group this would lead to calls like `GET /1.0/storage-pools/foo?target=@bar` which doesn't make sense. 

This commit (cherry-picked from Incus) moves setting the cluster group target to after those lookups.

I've added tests have checked that they fail before this change and pass afterwards.