### PR TITLE
Make `security.devlxd.images` live-updatable for VMs

### DIFF
--- a/doc/metadata.txt
+++ b/doc/metadata.txt
@@ -2144,7 +2144,7 @@ See {ref}`dev-lxd` for more information.
 
 ```{config:option} security.devlxd.images instance-security
 :defaultdesc: "`false`"
-:liveupdate: "no"
+:liveupdate: "yes"
 :shortdesc: "Controls the availability of the `/1.0/images` API over `devlxd`"
 :type: "bool"
 

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -5610,6 +5610,7 @@ func (d *qemu) Update(args db.InstanceArgs, userRequested bool) error {
 			"security.agent.metrics",
 			"security.csm",
 			"security.devlxd",
+			"security.devlxd.images",
 			"security.secureboot",
 		}
 

--- a/lxd/instance/instancetype/instance.go
+++ b/lxd/instance/instancetype/instance.go
@@ -340,7 +340,7 @@ var InstanceConfigKeysAny = map[string]func(value string) error{
 	// ---
 	//  type: bool
 	//  defaultdesc: `false`
-	//  liveupdate: no
+	//  liveupdate: yes
 	//  shortdesc: Controls the availability of the `/1.0/images` API over `devlxd`
 	"security.devlxd.images": validate.Optional(validate.IsBool),
 

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -2411,7 +2411,7 @@
 					{
 						"security.devlxd.images": {
 							"defaultdesc": "`false`",
-							"liveupdate": "no",
+							"liveupdate": "yes",
 							"longdesc": "",
 							"shortdesc": "Controls the availability of the `/1.0/images` API over `devlxd`",
 							"type": "bool"


### PR DESCRIPTION
#13878 Added `security.devlxd.images` for virtual machines but this key was not live-updatable. There was no particular reason for this. The endpoint is always available in the LXD agent and access is restricted by the host daemon.

This PR allows the config key to be set while the instance is running.

Closes #14206 