### PR TITLE
Auth: Mask errors returned by OpenFGADatastore

### DIFF
--- a/lxd/auth/drivers/openfga.go
+++ b/lxd/auth/drivers/openfga.go
@@ -250,6 +250,12 @@ func (e *embeddedOpenFGA) CheckPermission(ctx context.Context, entityURL *api.UR
 	l.Debug("Checking OpenFGA relation")
 	resp, err := e.server.Check(ctx, req)
 	if err != nil {
+		// If we have a not found error from the underlying OpenFGADatastore we should mask it to make requests consistent.
+		// (all not found errors returned before an access control decision is made are masked to prevent discovery).
+		if api.StatusErrorCheck(err, http.StatusNotFound) {
+			return api.NewGenericStatusError(http.StatusNotFound)
+		}
+
 		// Attempt to extract the internal error. This allows bubbling errors up from the OpenFGA datastore implementation.
 		// (Otherwise we just get "rpc error (4000): Internal Server Error" or similar which isn't useful).
 		var openFGAInternalError openFGAErrors.InternalError
@@ -275,6 +281,12 @@ func (e *embeddedOpenFGA) CheckPermission(ctx context.Context, entityURL *api.UR
 			l.Debug("Checking OpenFGA relation")
 			resp, err := e.server.Check(ctx, req)
 			if err != nil {
+				// If we have a not found error from the underlying OpenFGADatastore we should mask it to make requests consistent.
+				// (all not found errors returned before an access control decision is made are masked to prevent discovery).
+				if api.StatusErrorCheck(err, http.StatusNotFound) {
+					return api.NewGenericStatusError(http.StatusNotFound)
+				}
+
 				// Attempt to extract the internal error. This allows bubbling errors up from the OpenFGA datastore implementation.
 				// (Otherwise we just get "rpc error (4000): Internal Server Error" or similar which isn't useful).
 				var openFGAInternalError openFGAErrors.InternalError


### PR DESCRIPTION
While working on https://github.com/canonical/lxd/issues/14085 I set up a new fine-grained TLS identity and issued the following commands as that identity, without any permissions yet (I forgot I'd changed my default remote):
```
$ lxc auth group create tmp
Error: Forbidden
$ lxc auth group permission add tmp server admin
Error: Failed to check OpenFGA relation: No such entity "/1.0/auth/groups/tmp"
```
Creating the group failed, this is correct behaviour. 

When attempting to add a permission to the non-existent group, the request failed (correct) but the OpenFGA Authorization driver returned the above error. This is incorrect.

This PR checks if the error returned by a `Check` request on the embedded OpenFGA server is a `Not Found` error and returns a generic not found error. This makes errors returned by the authorizer consistent. We are masking all not found errors returned before access control decisions are made to prevent discovery. After this change, the same command returns:
```
$ lxc auth group permission add tmp server admin
Error: Not Found
```