### PR TITLE
Tests: Remove `gen_cert` util

### DIFF
--- a/test/includes/lxc.sh
+++ b/test/includes/lxc.sh
@@ -36,19 +36,3 @@ lxc_remote() {
         eval "timeout --foreground 120 ${cmd}"
     fi
 }
-
-gen_cert() {
-    # Temporarily move the existing cert to trick LXC into generating a
-    # second cert.  LXC will only generate a cert when adding a remote
-    # server with a HTTPS scheme.  The remote server URL just needs to
-    # be syntactically correct to get past initial checks; in fact, we
-    # don't want it to succeed, that way we don't have to delete it later.
-    [ -f "${LXD_CONF}/${1}.crt" ] && return
-    mv "${LXD_CONF}/client.crt" "${LXD_CONF}/client.crt.bak"
-    mv "${LXD_CONF}/client.key" "${LXD_CONF}/client.key.bak"
-    echo y | lxc_remote remote add "remote-placeholder-$$" https://0.0.0.0 || true
-    mv "${LXD_CONF}/client.crt" "${LXD_CONF}/${1}.crt"
-    mv "${LXD_CONF}/client.key" "${LXD_CONF}/${1}.key"
-    mv "${LXD_CONF}/client.crt.bak" "${LXD_CONF}/client.crt"
-    mv "${LXD_CONF}/client.key.bak" "${LXD_CONF}/client.key"
-}

--- a/test/suites/auth.sh
+++ b/test/suites/auth.sh
@@ -386,22 +386,23 @@ user_is_server_admin() {
   # Should be able to see server config.
   lxc_remote info "${remote}:" | grep -Fq 'core.https_address'
 
-  # Should be able to add/remove certificates.
-  gen_cert openfga-test
-  # shellcheck disable=SC2153
-  test_cert_fingerprint="$(cert_fingerprint "${LXD_CONF}/openfga-test.crt")"
-  certificate_add_token="$(lxc_remote config trust add "${remote}:" --name test --quiet)"
-  mv "${LXD_CONF}/client.crt" "${LXD_CONF}/client.crt.bak"
-  mv "${LXD_CONF}/client.key" "${LXD_CONF}/client.key.bak"
-  mv "${LXD_CONF}/openfga-test.crt" "${LXD_CONF}/client.crt"
-  mv "${LXD_CONF}/openfga-test.key" "${LXD_CONF}/client.key"
-  lxc_remote remote add test-remote "${certificate_add_token}"
-  mv "${LXD_CONF}/client.crt.bak" "${LXD_CONF}/client.crt"
-  mv "${LXD_CONF}/client.key.bak" "${LXD_CONF}/client.key"
-  lxc_remote config trust remove "${remote}:${test_cert_fingerprint}"
-  lxc_remote remote remove test-remote
+  ## Should be able to add/remove certificates.
+  # Create a temporary lxc config directory with some certs to test with.
+  TMP_LXD_CONF=$(mktemp -d -p "${TEST_DIR}" XXX)
+  LXD_CONF="${TMP_LXD_CONF}" gen_cert_and_key client
+  tmp_cert_fingerprint="$(cert_fingerprint "${TMP_LXD_CONF}/client.crt")"
 
-  # Should be able to create/edit/delete a storage pool.
+  # Can get a certificate add token as a server administrator.
+  certificate_add_token="$(lxc_remote config trust add "${remote}:" --name test --quiet)"
+
+  # The token works.
+  LXD_CONF="${TMP_LXD_CONF}" lxc_remote remote add test-remote "${certificate_add_token}"
+
+  # Clean up test certificate and config dir.
+  lxc_remote config trust remove "${remote}:${tmp_cert_fingerprint}"
+  rm -r "${TMP_LXD_CONF}"
+
+  ## Should be able to create/edit/delete a storage pool.
   lxc_remote storage create "${remote}:test-pool" dir
   lxc_remote storage set "${remote}:test-pool" rsync.compression=true
   lxc_remote storage show "${remote}:test-pool" | grep -Fq 'rsync.compression:'

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -136,7 +136,7 @@ test_basic_usage() {
   lxc delete foo
 
   # gen untrusted cert
-  gen_cert client3
+  gen_cert_and_key client3
 
   # don't allow requests without a cert to get trusted data
   [ "$(curl -k -s -o /dev/null -w "%{http_code}" -X GET "https://${LXD_ADDR}/1.0/containers/foo")" = "403" ]

--- a/test/suites/remote.sh
+++ b/test/suites/remote.sh
@@ -187,7 +187,7 @@ test_remote_admin() {
 
   # we just re-add our cert under a different name to test the cert
   # manipulation mechanism.
-  gen_cert client2
+  gen_cert_and_key client2
 
   # Test for #623
   token="$(lxc config trust add --name foo -q)"


### PR DESCRIPTION
The `gen_cert` util had a weird side-effect if I was concurrently running a LXD snap with OIDC configured. (I realise that there can be some test failures when doing this related to networks etc. but I do it regularly when running a single suite as I'm often using the snapped LXD for something else). I've put more details in the commit messages.

Additionally simplifies the `user_is_server_admin` function in the fine-grained auth tests. 