### PR TITLE
github: Fix database cache update

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -96,12 +96,12 @@ jobs:
 
       - name: Run Trivy vulnerability scanner
         run: |
-          trivy fs --skip-db-update \
+          trivy rootfs --skip-db-update \
           --scanners vuln,secret,misconfig \
           --format sarif \
           --cache-dir /home/runner/vuln-cache \
           --severity LOW,MEDIUM,HIGH,CRITICAL \
-          --output /home/runner/${{ matrix.version }}-stable.sarif .
+          --output /home/runner/${{ matrix.version }}-stable.sarif squashfs-root
 
       - name: Flag snap scanning alerts
         run: |

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -52,10 +52,12 @@ jobs:
           --output trivy-lxd-repo-scan-results.sarif .
 
       - name: Cache Trivy vulnerability database
-        uses: actions/cache/save@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
+        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
         with:
           path: /home/runner/vuln-cache
-          key: trivy-latest-cache
+          key: trivy-latest-cache-${{ github.run_id }}
+          restore-keys: |
+            trivy-latest-cache
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@4f3212b61783c3c68e8309a0f18a699764811cda # v3.27.1


### PR DESCRIPTION
A github cache can not be updated using the same key, so instead we update using a different key each time but use the same key to restore it.

This also fixes the snap scanning that was broken on a recent update to the workflow.