### PR TITLE
lxc: Use TrustToken field if supported by the server

### DIFF
--- a/lxc/remote.go
+++ b/lxc/remote.go
@@ -255,9 +255,17 @@ func (c *cmdRemoteAdd) addRemoteFromToken(addr string, server string, token stri
 		}
 	}
 
+	// Implicitly runs GetServer which updates the servers extensions.
 	d, err := conf.GetInstanceServer(server)
 	if err != nil {
 		return api.StatusErrorf(http.StatusServiceUnavailable, "%s: %w", i18n.G("Unavailable remote server"), err)
+	}
+
+	req := api.CertificatesPost{}
+	if d.HasExtension("explicit_trust_token") {
+		req.TrustToken = token
+	} else {
+		req.Password = token
 	}
 
 	// Add client certificate to trust store. Even if we are already trusted (src.Auth == "trusted"),


### PR DESCRIPTION
When adding a remote by putting the token in the positional argument (not `--token`) also check if the server supports the `explicit_trust_token` extension and send the password using the `TrustToken` field instead.

This check is currently only in place when using the `--token` flag.