### PR TITLE
github: Use squid/candidate for microceph (stable-5.21)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -313,6 +313,8 @@ jobs:
       - name: Setup MicroCeph
         if: ${{ matrix.backend == 'ceph' }}
         uses: ./.github/actions/setup-microceph
+        with:
+          microceph-channel: "squid/candidate"
 
       - name: Make GOCOVERDIR
         run: |


### PR DESCRIPTION
To align with expectations of microcloud 2.x LTS to be used with microceph squid.