### PR TITLE
github: stop adding notification comments to issues/PRs

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -22,20 +22,3 @@ jobs:
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           sync-labels: true
-  notify:
-    name: Notify
-    permissions:
-      contents: read
-      pull-requests: write
-      issues: write
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Notify
-        uses: iamfj/action-label-notification@4e60f368a1f941089eeda54fdeb120f3f49ff66c # v1.0.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          mapping: >
-            - label: Documentation
-              recipients:
-                - '@mionaalex'


### PR DESCRIPTION
> Heads up @foo - the "Documentation" label was applied to this issue.