### PR TITLE
VM: Add missing `disk` block node name overflow handling

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -4113,7 +4113,7 @@ func (d *qemu) addDriveConfig(qemuDev map[string]string, bootIndexes map[string]
 		revert := revert.New()
 		defer revert.Fail()
 
-		nodeName := fmt.Sprintf("%s%s", qemuDeviceNamePrefix, escapedDeviceName)
+		nodeName := qemuDeviceNameOrID(qemuDeviceNamePrefix, escapedDeviceName, "", qemuDeviceNameMaxLength)
 
 		if isRBDImage {
 			secretID := fmt.Sprintf("pool_%s_%s", blockDev["pool"], blockDev["user"])


### PR DESCRIPTION
Two commits were identified as potential imports in https://github.com/canonical/lxd/issues/13311:
The first commit adds a function `blockNodeName` which hashes block node names if they exceed 31 characters. The second commit applies the node name overflow function when adding a QEMU config to a drive.

@simondeziel pointed out that we already have a function `qemuDeviceNameOrID` so this PR just adds missing node name overflow handling.