### PR TITLE
Workaround container self-stop race

### DIFF
--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -8142,19 +8142,9 @@ func (d *lxc) NextIdmap() (*idmap.IdmapSet, error) {
 // statusCode returns instance status code.
 func (d *lxc) statusCode() api.StatusCode {
 	// Shortcut to avoid spamming liblxc during ongoing operations.
-	op := operationlock.Get(d.Project().Name, d.Name())
-	if op != nil {
-		if op.Action() == operationlock.ActionStart {
-			return api.Stopped
-		}
-
-		if op.Action() == operationlock.ActionStop {
-			if shared.IsTrue(d.LocalConfig()["volatile.last_state.ready"]) {
-				return api.Ready
-			}
-
-			return api.Running
-		}
+	operationStatus := d.operationStatusCode()
+	if operationStatus != nil {
+		return *operationStatus
 	}
 
 	state, err := d.getLxcState()

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -8235,19 +8235,9 @@ func (d *qemu) InitPID() int {
 
 func (d *qemu) statusCode() api.StatusCode {
 	// Shortcut to avoid spamming QMP during ongoing operations.
-	op := operationlock.Get(d.Project().Name, d.Name())
-	if op != nil {
-		if op.Action() == operationlock.ActionStart {
-			return api.Stopped
-		}
-
-		if op.Action() == operationlock.ActionStop {
-			if shared.IsTrue(d.LocalConfig()["volatile.last_state.ready"]) {
-				return api.Ready
-			}
-
-			return api.Running
-		}
+	operationStatus := d.operationStatusCode()
+	if operationStatus != nil {
+		return *operationStatus
 	}
 
 	// Connect to the monitor.


### PR DESCRIPTION
If an instance self-stops while `statusCode()` is waiting for `getLxcState()` to finish, `statusCode()` may return a stale instance state.

This PR is a workaround for the use-case in #13453 and significantly reduces the likelihood that `statusCode` returns a stale status.

In an ideal world, LXD would maintain a canonical cluster-wide view of instance state. This would allow making race-free decisions based on whether an instance is running or not. For example:
- Project CPU/RAM limits could be enforced at instance start instead of at instance creation
- Volumes with content-type block could be attached to more than one instance without `security.shared`; instance start could fail if another instance with any shared block volumes is already running.