### PR TITLE
lxc/completion: Don't hide default completion command

### DIFF
--- a/lxc/main.go
+++ b/lxc/main.go
@@ -87,7 +87,6 @@ All of LXD's features can be driven through the various commands below.
 For help with any of those, simply call them with --help.`))
 	app.SilenceUsage = true
 	app.SilenceErrors = true
-	app.CompletionOptions = cobra.CompletionOptions{HiddenDefaultCmd: true}
 
 	// Global flags
 	globalCmd := cmdGlobal{cmd: app, asker: cli.NewAsker(bufio.NewReader(os.Stdin), nil)}


### PR DESCRIPTION
The completion command is a useful tool that includes detailed instructions for setting up completions across shell environments. Most CLI applications don't hide this by default so it's quite intuitive for a user to locate/use this command. Furthermore, the LXD snap completions are only set up for Bash shells.

With this change, running `lxc completion <shell> --help` shows instructions on generating completions.