### PR TITLE
Safer path operations

### DIFF
--- a/lxd/project/project.go
+++ b/lxd/project/project.go
@@ -18,7 +18,7 @@ const separator = "_"
 // Instance adds the "<project>_" prefix to instance name when the given project name is not "default".
 func Instance(projectName string, instanceName string) string {
 	if projectName != api.ProjectDefaultName {
-		return fmt.Sprintf("%s%s%s", projectName, separator, instanceName)
+		return projectName + separator + instanceName
 	}
 
 	return instanceName
@@ -27,7 +27,7 @@ func Instance(projectName string, instanceName string) string {
 // DNS adds ".<project>" as a suffix to instance name when the given project name is not "default".
 func DNS(projectName string, instanceName string) string {
 	if projectName != api.ProjectDefaultName {
-		return fmt.Sprintf("%s.%s", instanceName, projectName)
+		return instanceName + "." + projectName
 	}
 
 	return instanceName
@@ -52,7 +52,7 @@ func InstanceParts(projectInstanceName string) (projectName string, instanceName
 
 // StorageVolume adds the "<project>_prefix" to the storage volume name. Even if the project name is "default".
 func StorageVolume(projectName string, storageVolumeName string) string {
-	return fmt.Sprintf("%s%s%s", projectName, separator, storageVolumeName)
+	return projectName + separator + storageVolumeName
 }
 
 // StorageVolumeParts takes a project prefixed storage volume name and returns the project and storage volume

--- a/shared/util.go
+++ b/shared/util.go
@@ -241,12 +241,12 @@ func VarPath(path ...string) string {
 // set, this path is $LXD_DIR/cache, otherwise it is /var/cache/lxd.
 func CachePath(path ...string) string {
 	varDir := os.Getenv("LXD_DIR")
-	logDir := "/var/cache/lxd"
+	cacheDir := "/var/cache/lxd"
 	if varDir != "" {
-		logDir = filepath.Join(varDir, "cache")
+		cacheDir = filepath.Join(varDir, "cache")
 	}
 
-	items := []string{logDir}
+	items := []string{cacheDir}
 	items = append(items, path...)
 	return filepath.Join(items...)
 }

--- a/shared/util.go
+++ b/shared/util.go
@@ -234,7 +234,14 @@ func VarPath(path ...string) string {
 
 	items := []string{varDir}
 	items = append(items, path...)
-	return filepath.Join(items...)
+
+	// Verify if the parent dir is still the expected one
+	fullPath, err := filepath.Abs(filepath.Join(items...))
+	if err != nil || !strings.HasPrefix(fullPath, varDir) {
+		return ""
+	}
+
+	return fullPath
 }
 
 // CachePath returns the directory that LXD should its cache under. If LXD_DIR is
@@ -248,7 +255,14 @@ func CachePath(path ...string) string {
 
 	items := []string{cacheDir}
 	items = append(items, path...)
-	return filepath.Join(items...)
+
+	// Verify if the parent dir is still the expected one
+	fullPath, err := filepath.Abs(filepath.Join(items...))
+	if err != nil || !strings.HasPrefix(fullPath, cacheDir) {
+		return ""
+	}
+
+	return fullPath
 }
 
 // LogPath returns the directory that LXD should put logs under. If LXD_DIR is
@@ -262,7 +276,14 @@ func LogPath(path ...string) string {
 
 	items := []string{logDir}
 	items = append(items, path...)
-	return filepath.Join(items...)
+
+	// Verify if the parent dir is still the expected one
+	fullPath, err := filepath.Abs(filepath.Join(items...))
+	if err != nil || !strings.HasPrefix(fullPath, logDir) {
+		return ""
+	}
+
+	return fullPath
 }
 
 // LXDFileHeaders is extracted from the `X-LXD-*` family of file permissions


### PR DESCRIPTION
Tentatively addresses https://github.com/canonical/lxd/security/code-scanning?query=path%3Alxd%2Finstance_logs.go+is%3Aopen+branch%3Amain+