### PR TITLE
github: Move chmod of go.mod, go.sum before go mod download

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,13 +79,13 @@ jobs:
       - name: Download go dependencies
         run: |
           set -eux
+          sudo chmod o+w {go.mod,go.sum}
           go mod download
 
       - name: Check compatibility with min Go version
         run: |
           set -eux
           GOMIN="$(sed -n 's/^GOMIN=\([0-9.]\+\)$/\1/p' Makefile)"
-          sudo chmod o+w {go.mod,go.sum}
           go mod tidy -go="${GOMIN}"
 
           DOC_GOMIN="$(sed -n 's/^LXD requires Go \([0-9.]\+\) .*/\1/p' doc/requirements.md)"


### PR DESCRIPTION
Sometimes it needs to modify them.

Related to fixing tests on https://github.com/canonical/lxd/pull/14388