### PR TITLE
lxc: Actually support `lxc warning delete --all`

### DIFF
--- a/lxc/warning.go
+++ b/lxc/warning.go
@@ -367,15 +367,30 @@ func (c *cmdWarningDelete) command() *cobra.Command {
 
 func (c *cmdWarningDelete) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
-	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
+	exit, err := c.global.CheckArgs(cmd, args, 0, 1)
 	if exit {
 		return err
 	}
 
-	// Parse remote
-	remoteName, UUID, err := c.global.conf.ParseRemote(args[0])
-	if err != nil {
-		return err
+	if !c.flagAll && len(args) < 1 {
+		return errors.New(i18n.G("Specify a warning UUID or use --all"))
+	}
+
+	var remoteName string
+	var UUID string
+
+	if len(args) > 0 {
+		// Parse remote
+		remoteName, UUID, err = c.global.conf.ParseRemote(args[0])
+		if err != nil {
+			return err
+		}
+	} else {
+		remoteName = c.global.conf.DefaultRemote
+	}
+
+	if UUID != "" && c.flagAll {
+		return errors.New(i18n.G("No need to specify a warning UUID when using --all"))
 	}
 
 	remoteServer, err := c.global.conf.GetInstanceServer(remoteName)

--- a/lxc/warning.go
+++ b/lxc/warning.go
@@ -352,7 +352,7 @@ type cmdWarningDelete struct {
 
 func (c *cmdWarningDelete) command() *cobra.Command {
 	cmd := &cobra.Command{}
-	cmd.Use = usage("delete", i18n.G("[<remote>:]<warning-uuid>"))
+	cmd.Use = usage("delete", i18n.G("[<remote>:][<warning-uuid>]"))
 	cmd.Aliases = []string{"rm"}
 	cmd.Short = i18n.G("Delete warning")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(

--- a/lxc/warning.go
+++ b/lxc/warning.go
@@ -398,5 +398,22 @@ func (c *cmdWarningDelete) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if c.flagAll {
+		// Delete all warnings
+		warnings, err := remoteServer.GetWarnings()
+		if err != nil {
+			return err
+		}
+
+		for _, warning := range warnings {
+			err = remoteServer.DeleteWarning(warning.UUID)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+
 	return remoteServer.DeleteWarning(UUID)
 }

--- a/po/ar.po
+++ b/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-18 15:21-0500\n"
+"POT-Creation-Date: 2024-11-18 20:34-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -762,7 +762,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:392
+#: lxc/console.go:402
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -798,11 +798,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:39
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:37
+#: lxc/console.go:40
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -1685,7 +1685,7 @@ msgstr ""
 #: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32
+#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
@@ -2277,7 +2277,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:370
+#: lxc/console.go:380
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -3061,7 +3061,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:391
+#: lxc/console.go:401
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -4252,6 +4252,10 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
+#: lxc/warning.go:393
+msgid "No need to specify a warning UUID when using --all"
+msgstr ""
+
 #: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
 msgid "No storage pool for source volume specified"
 msgstr ""
@@ -4980,7 +4984,7 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:47
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5627,11 +5631,15 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
+#: lxc/warning.go:376
+msgid "Specify a warning UUID or use --all"
+msgstr ""
+
 #: lxc/action.go:32 lxc/action.go:33
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:95
+#: lxc/launch.go:92
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5822,7 +5830,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:130
+#: lxc/console.go:133
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -6034,7 +6042,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:219
+#: lxc/console.go:222
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6111,7 +6119,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:304 lxc/launch.go:127
+#: lxc/action.go:304 lxc/launch.go:124
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6124,7 +6132,7 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:45
+#: lxc/console.go:48
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
@@ -6197,7 +6205,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:168
+#: lxc/console.go:171
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6212,7 +6220,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:113
+#: lxc/console.go:116
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6710,7 +6718,7 @@ msgstr ""
 
 #: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -7107,7 +7115,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:260 lxc/warning.go:302
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
@@ -7153,6 +7161,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1590
 msgid "[<remote>:][<pool>] [<filter>...]"
+msgstr ""
+
+#: lxc/warning.go:355
+msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
 #: lxc/remote.go:89

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-18 15:21-0500\n"
+"POT-Creation-Date: 2024-11-18 20:34-0300\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:392
+#: lxc/console.go:402
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -801,11 +801,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:39
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:37
+#: lxc/console.go:40
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -1688,7 +1688,7 @@ msgstr ""
 #: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32
+#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
@@ -2280,7 +2280,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:370
+#: lxc/console.go:380
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:391
+#: lxc/console.go:401
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -4255,6 +4255,10 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
+#: lxc/warning.go:393
+msgid "No need to specify a warning UUID when using --all"
+msgstr ""
+
 #: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
 msgid "No storage pool for source volume specified"
 msgstr ""
@@ -4983,7 +4987,7 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:47
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5630,11 +5634,15 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
+#: lxc/warning.go:376
+msgid "Specify a warning UUID or use --all"
+msgstr ""
+
 #: lxc/action.go:32 lxc/action.go:33
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:95
+#: lxc/launch.go:92
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5825,7 +5833,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:130
+#: lxc/console.go:133
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -6037,7 +6045,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:219
+#: lxc/console.go:222
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6114,7 +6122,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:304 lxc/launch.go:127
+#: lxc/action.go:304 lxc/launch.go:124
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6127,7 +6135,7 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:45
+#: lxc/console.go:48
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
@@ -6200,7 +6208,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:168
+#: lxc/console.go:171
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6215,7 +6223,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:113
+#: lxc/console.go:116
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6713,7 +6721,7 @@ msgstr ""
 
 #: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -7110,7 +7118,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:260 lxc/warning.go:302
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
@@ -7156,6 +7164,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1590
 msgid "[<remote>:][<pool>] [<filter>...]"
+msgstr ""
+
+#: lxc/warning.go:355
+msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
 #: lxc/remote.go:89

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-18 15:21-0500\n"
+"POT-Creation-Date: 2024-11-18 20:34-0300\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:392
+#: lxc/console.go:402
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -801,11 +801,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:39
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:37
+#: lxc/console.go:40
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -1688,7 +1688,7 @@ msgstr ""
 #: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32
+#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
@@ -2280,7 +2280,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:370
+#: lxc/console.go:380
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:391
+#: lxc/console.go:401
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -4255,6 +4255,10 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
+#: lxc/warning.go:393
+msgid "No need to specify a warning UUID when using --all"
+msgstr ""
+
 #: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
 msgid "No storage pool for source volume specified"
 msgstr ""
@@ -4983,7 +4987,7 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:47
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5630,11 +5634,15 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
+#: lxc/warning.go:376
+msgid "Specify a warning UUID or use --all"
+msgstr ""
+
 #: lxc/action.go:32 lxc/action.go:33
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:95
+#: lxc/launch.go:92
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5825,7 +5833,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:130
+#: lxc/console.go:133
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -6037,7 +6045,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:219
+#: lxc/console.go:222
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6114,7 +6122,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:304 lxc/launch.go:127
+#: lxc/action.go:304 lxc/launch.go:124
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6127,7 +6135,7 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:45
+#: lxc/console.go:48
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
@@ -6200,7 +6208,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:168
+#: lxc/console.go:171
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6215,7 +6223,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:113
+#: lxc/console.go:116
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6713,7 +6721,7 @@ msgstr ""
 
 #: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -7110,7 +7118,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:260 lxc/warning.go:302
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
@@ -7156,6 +7164,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1590
 msgid "[<remote>:][<pool>] [<filter>...]"
+msgstr ""
+
+#: lxc/warning.go:355
+msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
 #: lxc/remote.go:89

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-18 15:21-0500\n"
+"POT-Creation-Date: 2024-11-18 20:34-0300\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:392
+#: lxc/console.go:402
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -801,11 +801,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:39
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:37
+#: lxc/console.go:40
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -1688,7 +1688,7 @@ msgstr ""
 #: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32
+#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
@@ -2280,7 +2280,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:370
+#: lxc/console.go:380
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:391
+#: lxc/console.go:401
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -4255,6 +4255,10 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
+#: lxc/warning.go:393
+msgid "No need to specify a warning UUID when using --all"
+msgstr ""
+
 #: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
 msgid "No storage pool for source volume specified"
 msgstr ""
@@ -4983,7 +4987,7 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:47
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5630,11 +5634,15 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
+#: lxc/warning.go:376
+msgid "Specify a warning UUID or use --all"
+msgstr ""
+
 #: lxc/action.go:32 lxc/action.go:33
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:95
+#: lxc/launch.go:92
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5825,7 +5833,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:130
+#: lxc/console.go:133
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -6037,7 +6045,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:219
+#: lxc/console.go:222
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6114,7 +6122,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:304 lxc/launch.go:127
+#: lxc/action.go:304 lxc/launch.go:124
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6127,7 +6135,7 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:45
+#: lxc/console.go:48
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
@@ -6200,7 +6208,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:168
+#: lxc/console.go:171
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6215,7 +6223,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:113
+#: lxc/console.go:116
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6713,7 +6721,7 @@ msgstr ""
 
 #: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -7110,7 +7118,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:260 lxc/warning.go:302
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
@@ -7156,6 +7164,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1590
 msgid "[<remote>:][<pool>] [<filter>...]"
+msgstr ""
+
+#: lxc/warning.go:355
+msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
 #: lxc/remote.go:89

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-18 15:21-0500\n"
+"POT-Creation-Date: 2024-11-18 20:34-0300\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:392
+#: lxc/console.go:402
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -801,11 +801,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:39
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:37
+#: lxc/console.go:40
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -1688,7 +1688,7 @@ msgstr ""
 #: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32
+#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
@@ -2280,7 +2280,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:370
+#: lxc/console.go:380
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:391
+#: lxc/console.go:401
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -4255,6 +4255,10 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
+#: lxc/warning.go:393
+msgid "No need to specify a warning UUID when using --all"
+msgstr ""
+
 #: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
 msgid "No storage pool for source volume specified"
 msgstr ""
@@ -4983,7 +4987,7 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:47
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5630,11 +5634,15 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
+#: lxc/warning.go:376
+msgid "Specify a warning UUID or use --all"
+msgstr ""
+
 #: lxc/action.go:32 lxc/action.go:33
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:95
+#: lxc/launch.go:92
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5825,7 +5833,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:130
+#: lxc/console.go:133
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -6037,7 +6045,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:219
+#: lxc/console.go:222
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6114,7 +6122,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:304 lxc/launch.go:127
+#: lxc/action.go:304 lxc/launch.go:124
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6127,7 +6135,7 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:45
+#: lxc/console.go:48
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
@@ -6200,7 +6208,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:168
+#: lxc/console.go:171
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6215,7 +6223,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:113
+#: lxc/console.go:116
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6713,7 +6721,7 @@ msgstr ""
 
 #: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -7110,7 +7118,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:260 lxc/warning.go:302
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
@@ -7156,6 +7164,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1590
 msgid "[<remote>:][<pool>] [<filter>...]"
+msgstr ""
+
+#: lxc/warning.go:355
+msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
 #: lxc/remote.go:89

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-18 15:21-0500\n"
+"POT-Creation-Date: 2024-11-18 20:34-0300\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -1042,7 +1042,7 @@ msgstr "Architektur: %s\n"
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:392
+#: lxc/console.go:402
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1083,12 +1083,12 @@ msgstr "Netzwerkschnittstellen an Container anbinden"
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:39
 #, fuzzy
 msgid "Attach to instance consoles"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/console.go:37
+#: lxc/console.go:40
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -2032,7 +2032,7 @@ msgstr ""
 #: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32
+#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
@@ -2669,7 +2669,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed parsing SSH host key: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/console.go:370
+#: lxc/console.go:380
 #, fuzzy, c-format
 msgid "Failed starting command: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -3494,7 +3494,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:391
+#: lxc/console.go:401
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -4791,6 +4791,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
+#: lxc/warning.go:393
+#, fuzzy
+msgid "No need to specify a warning UUID when using --all"
+msgstr "der Name des Ursprung Containers muss angegeben werden"
+
 #: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
 msgid "No storage pool for source volume specified"
 msgstr ""
@@ -5562,7 +5567,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:47
 #, fuzzy
 msgid "Retrieve the container's console log"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -6264,12 +6269,16 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Source:"
 msgstr ""
 
+#: lxc/warning.go:376
+msgid "Specify a warning UUID or use --all"
+msgstr ""
+
 #: lxc/action.go:32 lxc/action.go:33
 #, fuzzy
 msgid "Start instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/launch.go:95
+#: lxc/launch.go:92
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -6469,7 +6478,7 @@ msgstr "--refresh kann nur mit Containern verwendet werden"
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:130
+#: lxc/console.go:133
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -6690,7 +6699,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:219
+#: lxc/console.go:222
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6768,7 +6777,7 @@ msgstr "--refresh kann nur mit Containern verwendet werden"
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:304 lxc/launch.go:127
+#: lxc/action.go:304 lxc/launch.go:124
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6782,7 +6791,7 @@ msgstr ""
 msgid "Type of certificate"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/console.go:45
+#: lxc/console.go:48
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
@@ -6856,7 +6865,7 @@ msgstr "Unbekannter Befehl %s für Abbild"
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:168
+#: lxc/console.go:171
 #, fuzzy, c-format
 msgid "Unknown console type %q"
 msgstr "Unbekannter Befehl %s für Abbild"
@@ -6871,7 +6880,7 @@ msgstr "Unbekannter Befehl %s für Abbild"
 msgid "Unknown key: %s"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/console.go:113
+#: lxc/console.go:116
 #, fuzzy, c-format
 msgid "Unknown output type %q"
 msgstr "Unbekannter Befehl %s für Abbild"
@@ -7576,7 +7585,7 @@ msgstr ""
 
 #: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 #, fuzzy
 msgid "[<remote>:]<instance>"
 msgstr ""
@@ -8368,7 +8377,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:260 lxc/warning.go:302
 #, fuzzy
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
@@ -8466,6 +8475,15 @@ msgstr ""
 "Ändert den Laufzustand eines Containers in %s.\n"
 "\n"
 "lxd %s <Name>\n"
+
+#: lxc/warning.go:355
+#, fuzzy
+msgid "[<remote>:][<warning-uuid>]"
+msgstr ""
+"Löscht einen Container oder Container Sicherungspunkt.\n"
+"\n"
+"Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
+"Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
 #: lxc/remote.go:89
 #, fuzzy

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-18 15:21-0500\n"
+"POT-Creation-Date: 2024-11-18 20:34-0300\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -768,7 +768,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:392
+#: lxc/console.go:402
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -804,11 +804,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:39
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:37
+#: lxc/console.go:40
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -1700,7 +1700,7 @@ msgstr ""
 #: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32
+#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
@@ -2302,7 +2302,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:370
+#: lxc/console.go:380
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -3099,7 +3099,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:391
+#: lxc/console.go:401
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -4319,6 +4319,10 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
+#: lxc/warning.go:393
+msgid "No need to specify a warning UUID when using --all"
+msgstr ""
+
 #: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
 msgid "No storage pool for source volume specified"
 msgstr ""
@@ -5053,7 +5057,7 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:47
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5725,11 +5729,15 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
+#: lxc/warning.go:376
+msgid "Specify a warning UUID or use --all"
+msgstr ""
+
 #: lxc/action.go:32 lxc/action.go:33
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:95
+#: lxc/launch.go:92
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5920,7 +5928,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:130
+#: lxc/console.go:133
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -6133,7 +6141,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:219
+#: lxc/console.go:222
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6210,7 +6218,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:304 lxc/launch.go:127
+#: lxc/action.go:304 lxc/launch.go:124
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6223,7 +6231,7 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:45
+#: lxc/console.go:48
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
@@ -6296,7 +6304,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:168
+#: lxc/console.go:171
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6311,7 +6319,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:113
+#: lxc/console.go:116
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6826,7 +6834,7 @@ msgstr ""
 
 #: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -7223,7 +7231,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:260 lxc/warning.go:302
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
@@ -7269,6 +7277,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1590
 msgid "[<remote>:][<pool>] [<filter>...]"
+msgstr ""
+
+#: lxc/warning.go:355
+msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
 #: lxc/remote.go:89

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-18 15:21-0500\n"
+"POT-Creation-Date: 2024-11-18 20:34-0300\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:392
+#: lxc/console.go:402
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -801,11 +801,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:39
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:37
+#: lxc/console.go:40
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -1688,7 +1688,7 @@ msgstr ""
 #: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32
+#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
@@ -2280,7 +2280,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:370
+#: lxc/console.go:380
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:391
+#: lxc/console.go:401
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -4255,6 +4255,10 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
+#: lxc/warning.go:393
+msgid "No need to specify a warning UUID when using --all"
+msgstr ""
+
 #: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
 msgid "No storage pool for source volume specified"
 msgstr ""
@@ -4983,7 +4987,7 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:47
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5630,11 +5634,15 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
+#: lxc/warning.go:376
+msgid "Specify a warning UUID or use --all"
+msgstr ""
+
 #: lxc/action.go:32 lxc/action.go:33
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:95
+#: lxc/launch.go:92
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5825,7 +5833,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:130
+#: lxc/console.go:133
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -6037,7 +6045,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:219
+#: lxc/console.go:222
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6114,7 +6122,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:304 lxc/launch.go:127
+#: lxc/action.go:304 lxc/launch.go:124
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6127,7 +6135,7 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:45
+#: lxc/console.go:48
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
@@ -6200,7 +6208,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:168
+#: lxc/console.go:171
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6215,7 +6223,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:113
+#: lxc/console.go:116
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6713,7 +6721,7 @@ msgstr ""
 
 #: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -7110,7 +7118,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:260 lxc/warning.go:302
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
@@ -7156,6 +7164,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1590
 msgid "[<remote>:][<pool>] [<filter>...]"
+msgstr ""
+
+#: lxc/warning.go:355
+msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
 #: lxc/remote.go:89

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-18 15:21-0500\n"
+"POT-Creation-Date: 2024-11-18 20:34-0300\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -1013,7 +1013,7 @@ msgstr "Arquitectura: %s"
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:392
+#: lxc/console.go:402
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1050,11 +1050,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:39
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:37
+#: lxc/console.go:40
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -1964,7 +1964,7 @@ msgstr ""
 #: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32
+#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
@@ -2570,7 +2570,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Failed parsing SSH host key: %w"
 msgstr "Acepta certificado"
 
-#: lxc/console.go:370
+#: lxc/console.go:380
 #, fuzzy, c-format
 msgid "Failed starting command: %w"
 msgstr "Acepta certificado"
@@ -3378,7 +3378,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:391
+#: lxc/console.go:401
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -4619,6 +4619,10 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
+#: lxc/warning.go:393
+msgid "No need to specify a warning UUID when using --all"
+msgstr ""
+
 #: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
 msgid "No storage pool for source volume specified"
 msgstr ""
@@ -5365,7 +5369,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:47
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -6041,11 +6045,15 @@ msgstr "Dispositivo %s añadido a %s"
 msgid "Source:"
 msgstr ""
 
+#: lxc/warning.go:376
+msgid "Specify a warning UUID or use --all"
+msgstr ""
+
 #: lxc/action.go:32 lxc/action.go:33
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:95
+#: lxc/launch.go:92
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -6238,7 +6246,7 @@ msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:130
+#: lxc/console.go:133
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -6453,7 +6461,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:219
+#: lxc/console.go:222
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6530,7 +6538,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:304 lxc/launch.go:127
+#: lxc/action.go:304 lxc/launch.go:124
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6545,7 +6553,7 @@ msgstr "Expira: %s"
 msgid "Type of certificate"
 msgstr "Acepta certificado"
 
-#: lxc/console.go:45
+#: lxc/console.go:48
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
@@ -6618,7 +6626,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:168
+#: lxc/console.go:171
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6633,7 +6641,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:113
+#: lxc/console.go:116
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -7189,7 +7197,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 
 #: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 #, fuzzy
 msgid "[<remote>:]<instance>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7677,7 +7685,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:260 lxc/warning.go:302
 #, fuzzy
 msgid "[<remote>:]<warning-uuid>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7735,6 +7743,11 @@ msgstr "No se puede proveer el nombre del container a la lista"
 #: lxc/storage_volume.go:1590
 #, fuzzy
 msgid "[<remote>:][<pool>] [<filter>...]"
+msgstr "No se puede proveer el nombre del container a la lista"
+
+#: lxc/warning.go:355
+#, fuzzy
+msgid "[<remote>:][<warning-uuid>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
 #: lxc/remote.go:89

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-18 15:21-0500\n"
+"POT-Creation-Date: 2024-11-18 20:34-0300\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:392
+#: lxc/console.go:402
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -801,11 +801,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:39
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:37
+#: lxc/console.go:40
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -1688,7 +1688,7 @@ msgstr ""
 #: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32
+#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
@@ -2280,7 +2280,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:370
+#: lxc/console.go:380
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:391
+#: lxc/console.go:401
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -4255,6 +4255,10 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
+#: lxc/warning.go:393
+msgid "No need to specify a warning UUID when using --all"
+msgstr ""
+
 #: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
 msgid "No storage pool for source volume specified"
 msgstr ""
@@ -4983,7 +4987,7 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:47
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5630,11 +5634,15 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
+#: lxc/warning.go:376
+msgid "Specify a warning UUID or use --all"
+msgstr ""
+
 #: lxc/action.go:32 lxc/action.go:33
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:95
+#: lxc/launch.go:92
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5825,7 +5833,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:130
+#: lxc/console.go:133
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -6037,7 +6045,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:219
+#: lxc/console.go:222
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6114,7 +6122,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:304 lxc/launch.go:127
+#: lxc/action.go:304 lxc/launch.go:124
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6127,7 +6135,7 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:45
+#: lxc/console.go:48
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
@@ -6200,7 +6208,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:168
+#: lxc/console.go:171
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6215,7 +6223,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:113
+#: lxc/console.go:116
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6713,7 +6721,7 @@ msgstr ""
 
 #: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -7110,7 +7118,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:260 lxc/warning.go:302
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
@@ -7156,6 +7164,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1590
 msgid "[<remote>:][<pool>] [<filter>...]"
+msgstr ""
+
+#: lxc/warning.go:355
+msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
 #: lxc/remote.go:89

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-18 15:21-0500\n"
+"POT-Creation-Date: 2024-11-18 20:34-0300\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:392
+#: lxc/console.go:402
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -801,11 +801,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:39
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:37
+#: lxc/console.go:40
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -1688,7 +1688,7 @@ msgstr ""
 #: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32
+#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
@@ -2280,7 +2280,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:370
+#: lxc/console.go:380
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:391
+#: lxc/console.go:401
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -4255,6 +4255,10 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
+#: lxc/warning.go:393
+msgid "No need to specify a warning UUID when using --all"
+msgstr ""
+
 #: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
 msgid "No storage pool for source volume specified"
 msgstr ""
@@ -4983,7 +4987,7 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:47
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5630,11 +5634,15 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
+#: lxc/warning.go:376
+msgid "Specify a warning UUID or use --all"
+msgstr ""
+
 #: lxc/action.go:32 lxc/action.go:33
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:95
+#: lxc/launch.go:92
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5825,7 +5833,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:130
+#: lxc/console.go:133
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -6037,7 +6045,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:219
+#: lxc/console.go:222
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6114,7 +6122,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:304 lxc/launch.go:127
+#: lxc/action.go:304 lxc/launch.go:124
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6127,7 +6135,7 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:45
+#: lxc/console.go:48
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
@@ -6200,7 +6208,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:168
+#: lxc/console.go:171
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6215,7 +6223,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:113
+#: lxc/console.go:116
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6713,7 +6721,7 @@ msgstr ""
 
 #: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -7110,7 +7118,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:260 lxc/warning.go:302
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
@@ -7156,6 +7164,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1590
 msgid "[<remote>:][<pool>] [<filter>...]"
+msgstr ""
+
+#: lxc/warning.go:355
+msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
 #: lxc/remote.go:89

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-18 15:21-0500\n"
+"POT-Creation-Date: 2024-11-18 20:34-0300\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -1046,7 +1046,7 @@ msgstr "Architecture : %s"
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:392
+#: lxc/console.go:402
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1086,12 +1086,12 @@ msgstr "Afficher la configuration étendue"
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:39
 #, fuzzy
 msgid "Attach to instance consoles"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: lxc/console.go:37
+#: lxc/console.go:40
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -2058,7 +2058,7 @@ msgstr "Récupération de l'image : %s"
 #: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32
+#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
@@ -2702,7 +2702,7 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed parsing SSH host key: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/console.go:370
+#: lxc/console.go:380
 #, fuzzy, c-format
 msgid "Failed starting command: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
@@ -3537,7 +3537,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:391
+#: lxc/console.go:401
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -4882,6 +4882,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
+#: lxc/warning.go:393
+#, fuzzy
+msgid "No need to specify a warning UUID when using --all"
+msgstr "vous devez spécifier un nom de conteneur source"
+
 #: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
 msgid "No storage pool for source volume specified"
 msgstr ""
@@ -5686,7 +5691,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:47
 #, fuzzy
 msgid "Retrieve the container's console log"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
@@ -6399,12 +6404,16 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Source:"
 msgstr "Source :"
 
+#: lxc/warning.go:376
+msgid "Specify a warning UUID or use --all"
+msgstr ""
+
 #: lxc/action.go:32 lxc/action.go:33
 #, fuzzy
 msgid "Start instances"
 msgstr "Création du conteneur"
 
-#: lxc/launch.go:95
+#: lxc/launch.go:92
 #, c-format
 msgid "Starting %s"
 msgstr "Démarrage de %s"
@@ -6606,7 +6615,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:130
+#: lxc/console.go:133
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -6831,7 +6840,7 @@ msgstr "Pour attacher un réseau à un conteneur, utiliser : lxc network attach"
 msgid "To create a new network, use: lxc network create"
 msgstr "Pour créer un réseau, utiliser : lxc network create"
 
-#: lxc/console.go:219
+#: lxc/console.go:222
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6911,7 +6920,7 @@ msgstr "--project ne peut pas être utilisé avec la commande query"
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:304 lxc/launch.go:127
+#: lxc/action.go:304 lxc/launch.go:124
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr "Essayer `lxc info --show-log %s` pour plus d'informations"
@@ -6926,7 +6935,7 @@ msgstr "Expire : %s"
 msgid "Type of certificate"
 msgstr "Accepter le certificat"
 
-#: lxc/console.go:45
+#: lxc/console.go:48
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
@@ -7000,7 +7009,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:168
+#: lxc/console.go:171
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -7015,7 +7024,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:113
+#: lxc/console.go:116
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -7745,7 +7754,7 @@ msgstr ""
 
 #: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 #, fuzzy
 msgid "[<remote>:]<instance>"
 msgstr ""
@@ -8615,7 +8624,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:260 lxc/warning.go:302
 #, fuzzy
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
@@ -8722,6 +8731,18 @@ msgstr ""
 "Change l'état d'un ou plusieurs conteneurs à %s.\n"
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
+
+#: lxc/warning.go:355
+#, fuzzy
+msgid "[<remote>:][<warning-uuid>]"
+msgstr ""
+"Supprimer des conteneurs ou des instantanés.\n"
+"\n"
+"lxc delete [<remote>:]<container>[/<snapshot>] [<remote>:][<container>[/"
+"<snapshot>]...]\n"
+"\n"
+"Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
+"(configuration, instantanés, …)."
 
 #: lxc/remote.go:89
 #, fuzzy

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-18 15:21-0500\n"
+"POT-Creation-Date: 2024-11-18 20:34-0300\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -766,7 +766,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:392
+#: lxc/console.go:402
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -802,11 +802,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:39
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:37
+#: lxc/console.go:40
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -1689,7 +1689,7 @@ msgstr ""
 #: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32
+#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
@@ -2281,7 +2281,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:370
+#: lxc/console.go:380
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -3065,7 +3065,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:391
+#: lxc/console.go:401
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -4256,6 +4256,10 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
+#: lxc/warning.go:393
+msgid "No need to specify a warning UUID when using --all"
+msgstr ""
+
 #: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
 msgid "No storage pool for source volume specified"
 msgstr ""
@@ -4984,7 +4988,7 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:47
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5631,11 +5635,15 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
+#: lxc/warning.go:376
+msgid "Specify a warning UUID or use --all"
+msgstr ""
+
 #: lxc/action.go:32 lxc/action.go:33
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:95
+#: lxc/launch.go:92
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5826,7 +5834,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:130
+#: lxc/console.go:133
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -6038,7 +6046,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:219
+#: lxc/console.go:222
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6115,7 +6123,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:304 lxc/launch.go:127
+#: lxc/action.go:304 lxc/launch.go:124
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6128,7 +6136,7 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:45
+#: lxc/console.go:48
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
@@ -6201,7 +6209,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:168
+#: lxc/console.go:171
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6216,7 +6224,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:113
+#: lxc/console.go:116
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6714,7 +6722,7 @@ msgstr ""
 
 #: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -7111,7 +7119,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:260 lxc/warning.go:302
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
@@ -7157,6 +7165,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1590
 msgid "[<remote>:][<pool>] [<filter>...]"
+msgstr ""
+
+#: lxc/warning.go:355
+msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
 #: lxc/remote.go:89

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-18 15:21-0500\n"
+"POT-Creation-Date: 2024-11-18 20:34-0300\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:392
+#: lxc/console.go:402
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -801,11 +801,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:39
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:37
+#: lxc/console.go:40
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -1688,7 +1688,7 @@ msgstr ""
 #: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32
+#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
@@ -2280,7 +2280,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:370
+#: lxc/console.go:380
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:391
+#: lxc/console.go:401
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -4255,6 +4255,10 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
+#: lxc/warning.go:393
+msgid "No need to specify a warning UUID when using --all"
+msgstr ""
+
 #: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
 msgid "No storage pool for source volume specified"
 msgstr ""
@@ -4983,7 +4987,7 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:47
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5630,11 +5634,15 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
+#: lxc/warning.go:376
+msgid "Specify a warning UUID or use --all"
+msgstr ""
+
 #: lxc/action.go:32 lxc/action.go:33
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:95
+#: lxc/launch.go:92
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5825,7 +5833,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:130
+#: lxc/console.go:133
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -6037,7 +6045,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:219
+#: lxc/console.go:222
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6114,7 +6122,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:304 lxc/launch.go:127
+#: lxc/action.go:304 lxc/launch.go:124
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6127,7 +6135,7 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:45
+#: lxc/console.go:48
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
@@ -6200,7 +6208,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:168
+#: lxc/console.go:171
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6215,7 +6223,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:113
+#: lxc/console.go:116
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6713,7 +6721,7 @@ msgstr ""
 
 #: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -7110,7 +7118,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:260 lxc/warning.go:302
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
@@ -7156,6 +7164,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1590
 msgid "[<remote>:][<pool>] [<filter>...]"
+msgstr ""
+
+#: lxc/warning.go:355
+msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
 #: lxc/remote.go:89

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-18 15:21-0500\n"
+"POT-Creation-Date: 2024-11-18 20:34-0300\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:392
+#: lxc/console.go:402
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -801,11 +801,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:39
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:37
+#: lxc/console.go:40
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -1688,7 +1688,7 @@ msgstr ""
 #: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32
+#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
@@ -2280,7 +2280,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:370
+#: lxc/console.go:380
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:391
+#: lxc/console.go:401
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -4255,6 +4255,10 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
+#: lxc/warning.go:393
+msgid "No need to specify a warning UUID when using --all"
+msgstr ""
+
 #: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
 msgid "No storage pool for source volume specified"
 msgstr ""
@@ -4983,7 +4987,7 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:47
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5630,11 +5634,15 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
+#: lxc/warning.go:376
+msgid "Specify a warning UUID or use --all"
+msgstr ""
+
 #: lxc/action.go:32 lxc/action.go:33
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:95
+#: lxc/launch.go:92
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5825,7 +5833,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:130
+#: lxc/console.go:133
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -6037,7 +6045,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:219
+#: lxc/console.go:222
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6114,7 +6122,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:304 lxc/launch.go:127
+#: lxc/action.go:304 lxc/launch.go:124
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6127,7 +6135,7 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:45
+#: lxc/console.go:48
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
@@ -6200,7 +6208,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:168
+#: lxc/console.go:171
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6215,7 +6223,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:113
+#: lxc/console.go:116
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6713,7 +6721,7 @@ msgstr ""
 
 #: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -7110,7 +7118,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:260 lxc/warning.go:302
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
@@ -7156,6 +7164,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1590
 msgid "[<remote>:][<pool>] [<filter>...]"
+msgstr ""
+
+#: lxc/warning.go:355
+msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
 #: lxc/remote.go:89

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-18 15:21-0500\n"
+"POT-Creation-Date: 2024-11-18 20:34-0300\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -1015,7 +1015,7 @@ msgstr "Architettura: %s"
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:392
+#: lxc/console.go:402
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1052,11 +1052,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:39
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:37
+#: lxc/console.go:40
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -1959,7 +1959,7 @@ msgstr ""
 #: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32
+#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
@@ -2566,7 +2566,7 @@ msgstr "Il nome del container è: %s"
 msgid "Failed parsing SSH host key: %w"
 msgstr "Accetta certificato"
 
-#: lxc/console.go:370
+#: lxc/console.go:380
 #, fuzzy, c-format
 msgid "Failed starting command: %w"
 msgstr "Accetta certificato"
@@ -3371,7 +3371,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:391
+#: lxc/console.go:401
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -4617,6 +4617,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
+#: lxc/warning.go:393
+#, fuzzy
+msgid "No need to specify a warning UUID when using --all"
+msgstr "Occorre specificare un nome di container come origine"
+
 #: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
 msgid "No storage pool for source volume specified"
 msgstr ""
@@ -5365,7 +5370,7 @@ msgstr "Il nome del container è: %s"
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:47
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -6037,12 +6042,16 @@ msgstr "errore di processamento degli alias %s\n"
 msgid "Source:"
 msgstr ""
 
+#: lxc/warning.go:376
+msgid "Specify a warning UUID or use --all"
+msgstr ""
+
 #: lxc/action.go:32 lxc/action.go:33
 #, fuzzy
 msgid "Start instances"
 msgstr "Creazione del container in corso"
 
-#: lxc/launch.go:95
+#: lxc/launch.go:92
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -6236,7 +6245,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:130
+#: lxc/console.go:133
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -6451,7 +6460,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:219
+#: lxc/console.go:222
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6528,7 +6537,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:304 lxc/launch.go:127
+#: lxc/action.go:304 lxc/launch.go:124
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6542,7 +6551,7 @@ msgstr ""
 msgid "Type of certificate"
 msgstr "Accetta certificato"
 
-#: lxc/console.go:45
+#: lxc/console.go:48
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
@@ -6616,7 +6625,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:168
+#: lxc/console.go:171
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6631,7 +6640,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:113
+#: lxc/console.go:116
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -7186,7 +7195,7 @@ msgstr "Creazione del container in corso"
 
 #: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 #, fuzzy
 msgid "[<remote>:]<instance>"
 msgstr "Creazione del container in corso"
@@ -7674,7 +7683,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:260 lxc/warning.go:302
 #, fuzzy
 msgid "[<remote>:]<warning-uuid>"
 msgstr "Creazione del container in corso"
@@ -7732,6 +7741,11 @@ msgstr "Creazione del container in corso"
 #: lxc/storage_volume.go:1590
 #, fuzzy
 msgid "[<remote>:][<pool>] [<filter>...]"
+msgstr "Creazione del container in corso"
+
+#: lxc/warning.go:355
+#, fuzzy
+msgid "[<remote>:][<warning-uuid>]"
 msgstr "Creazione del container in corso"
 
 #: lxc/remote.go:89

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-18 15:21-0500\n"
+"POT-Creation-Date: 2024-11-18 20:34-0300\n"
 "PO-Revision-Date: 2023-03-10 15:14+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -1023,7 +1023,7 @@ msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 "本当に %s しますか? （対象: クラスターメンバー %q） (yes/no) [default=no]: "
 
-#: lxc/console.go:392
+#: lxc/console.go:402
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr "どちらもみつかりませんでした。raw SPICE ソケットはこちらにあります:"
 
@@ -1059,11 +1059,11 @@ msgstr "新たにストレージボリュームをインスタンスに追加し
 msgid "Attach new storage volumes to profiles"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
 
-#: lxc/console.go:36
+#: lxc/console.go:39
 msgid "Attach to instance consoles"
 msgstr "インスタンスのコンソールに接続します"
 
-#: lxc/console.go:37
+#: lxc/console.go:40
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -1989,7 +1989,7 @@ msgstr "警告を削除します"
 #: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32
+#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
@@ -2619,7 +2619,7 @@ msgstr "デバイス上書きのためのプロファイル %q のロードに�
 msgid "Failed parsing SSH host key: %w"
 msgstr "SSH ホスト鍵の読み取りに失敗しました: %w"
 
-#: lxc/console.go:370
+#: lxc/console.go:380
 #, c-format
 msgid "Failed starting command: %w"
 msgstr "コマンドの実行に失敗しました: %w"
@@ -3452,7 +3452,7 @@ msgstr "LOCATION"
 msgid "LXD - Command line client"
 msgstr "LXD - コマンドラインクライアント"
 
-#: lxc/console.go:391
+#: lxc/console.go:401
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 "LXD は spicy か remote-viewer がインストールされている場合は自動的にどちらか"
@@ -4838,6 +4838,12 @@ msgstr "マッチするポートが見つかりません"
 msgid "No matching rule(s) found"
 msgstr "マッチするルールが見つかりません"
 
+#: lxc/warning.go:393
+#, fuzzy
+msgid "No need to specify a warning UUID when using --all"
+msgstr ""
+"--target オプションを使うときはコピー先のインスタンス名を指定してください"
+
 #: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
 msgid "No storage pool for source volume specified"
 msgstr "コピー元のボリュームに対するストレージプールが指定されていません"
@@ -5587,7 +5593,7 @@ msgstr "クラスターメンバーをリストアしています: %s"
 msgid "Restrict the certificate to one or more projects"
 msgstr "証明書の使用を1つ以上のプロジェクトに制限します"
 
-#: lxc/console.go:44
+#: lxc/console.go:47
 #, fuzzy
 msgid "Retrieve the container's console log"
 msgstr "インスタンスのコンソールログを取得します"
@@ -6310,11 +6316,15 @@ msgstr "一部のインスタンスで %s が失敗しました"
 msgid "Source:"
 msgstr "取得元:"
 
+#: lxc/warning.go:376
+msgid "Specify a warning UUID or use --all"
+msgstr ""
+
 #: lxc/action.go:32 lxc/action.go:33
 msgid "Start instances"
 msgstr "インスタンスを起動します"
 
-#: lxc/launch.go:95
+#: lxc/launch.go:92
 #, c-format
 msgid "Starting %s"
 msgstr "%s を起動中"
@@ -6506,7 +6516,7 @@ msgstr "--mode と --target-project は同時に指定できません"
 msgid "The --mode flag can't be used with --target"
 msgstr "--mode と --target は同時に指定できません"
 
-#: lxc/console.go:130
+#: lxc/console.go:133
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr "--show-log フラグは 'console' アウトプットタイプの時だけ使えます"
 
@@ -6740,7 +6750,7 @@ msgid "To create a new network, use: lxc network create"
 msgstr ""
 "新しいネットワークを作成するには、lxc network create を使用してください"
 
-#: lxc/console.go:219
+#: lxc/console.go:222
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr "コンソールから切り離すには <ctrl>+a q を押します"
 
@@ -6824,7 +6834,7 @@ msgstr "--project は query コマンドでは使えません"
 msgid "Trust token for %s: "
 msgstr "%s:%s のクラスターに join するためのトークンが削除されました"
 
-#: lxc/action.go:304 lxc/launch.go:127
+#: lxc/action.go:304 lxc/launch.go:124
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr "更に情報を得るために `lxc info --show-log %s` を実行してみてください"
@@ -6837,7 +6847,7 @@ msgstr "タイプ"
 msgid "Type of certificate"
 msgstr "証明書の形式"
 
-#: lxc/console.go:45
+#: lxc/console.go:48
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
@@ -6912,7 +6922,7 @@ msgstr "クライアント %q の未知のチャンネルタイプ: %s"
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr "未知のカラム名の短縮形です '%c' ('%s' 中)"
 
-#: lxc/console.go:168
+#: lxc/console.go:171
 #, c-format
 msgid "Unknown console type %q"
 msgstr "未知のコンソールタイプ %q"
@@ -6927,7 +6937,7 @@ msgstr "未知のファイルタイプ '%s'"
 msgid "Unknown key: %s"
 msgstr "未知の設定: %s"
 
-#: lxc/console.go:113
+#: lxc/console.go:116
 #, c-format
 msgid "Unknown output type %q"
 msgstr "未知の出力タイプ: %q"
@@ -7453,7 +7463,7 @@ msgstr "[<remote>:]<image> [[<remote>:]<image>...]"
 
 #: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr "[<remote>:]<instance>"
 
@@ -7874,7 +7884,7 @@ msgstr "[<remote>:]<project> <new-name>"
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:260 lxc/warning.go:302
 msgid "[<remote>:]<warning-uuid>"
 msgstr "[<remote>:]<warning-uuid>"
 
@@ -7922,6 +7932,11 @@ msgstr "[<remote>:][<instance>] <key>=<value>..."
 #, fuzzy
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr "[<remote>:]<pool> [<filter>...]"
+
+#: lxc/warning.go:355
+#, fuzzy
+msgid "[<remote>:][<warning-uuid>]"
+msgstr "[<remote>:]<warning-uuid>"
 
 #: lxc/remote.go:89
 msgid "[<remote>] <IP|FQDN|URL|token>"

--- a/po/ka.po
+++ b/po/ka.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-18 15:21-0500\n"
+"POT-Creation-Date: 2024-11-18 20:34-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -762,7 +762,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:392
+#: lxc/console.go:402
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -798,11 +798,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:39
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:37
+#: lxc/console.go:40
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -1685,7 +1685,7 @@ msgstr ""
 #: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32
+#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
@@ -2277,7 +2277,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:370
+#: lxc/console.go:380
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -3061,7 +3061,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:391
+#: lxc/console.go:401
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -4252,6 +4252,10 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
+#: lxc/warning.go:393
+msgid "No need to specify a warning UUID when using --all"
+msgstr ""
+
 #: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
 msgid "No storage pool for source volume specified"
 msgstr ""
@@ -4980,7 +4984,7 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:47
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5627,11 +5631,15 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
+#: lxc/warning.go:376
+msgid "Specify a warning UUID or use --all"
+msgstr ""
+
 #: lxc/action.go:32 lxc/action.go:33
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:95
+#: lxc/launch.go:92
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5822,7 +5830,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:130
+#: lxc/console.go:133
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -6034,7 +6042,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:219
+#: lxc/console.go:222
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6111,7 +6119,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:304 lxc/launch.go:127
+#: lxc/action.go:304 lxc/launch.go:124
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6124,7 +6132,7 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:45
+#: lxc/console.go:48
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
@@ -6197,7 +6205,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:168
+#: lxc/console.go:171
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6212,7 +6220,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:113
+#: lxc/console.go:116
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6710,7 +6718,7 @@ msgstr ""
 
 #: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -7107,7 +7115,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:260 lxc/warning.go:302
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
@@ -7153,6 +7161,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1590
 msgid "[<remote>:][<pool>] [<filter>...]"
+msgstr ""
+
+#: lxc/warning.go:355
+msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
 #: lxc/remote.go:89

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-18 15:21-0500\n"
+"POT-Creation-Date: 2024-11-18 20:34-0300\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:392
+#: lxc/console.go:402
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -801,11 +801,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:39
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:37
+#: lxc/console.go:40
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -1688,7 +1688,7 @@ msgstr ""
 #: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32
+#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
@@ -2280,7 +2280,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:370
+#: lxc/console.go:380
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:391
+#: lxc/console.go:401
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -4255,6 +4255,10 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
+#: lxc/warning.go:393
+msgid "No need to specify a warning UUID when using --all"
+msgstr ""
+
 #: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
 msgid "No storage pool for source volume specified"
 msgstr ""
@@ -4983,7 +4987,7 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:47
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5630,11 +5634,15 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
+#: lxc/warning.go:376
+msgid "Specify a warning UUID or use --all"
+msgstr ""
+
 #: lxc/action.go:32 lxc/action.go:33
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:95
+#: lxc/launch.go:92
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5825,7 +5833,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:130
+#: lxc/console.go:133
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -6037,7 +6045,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:219
+#: lxc/console.go:222
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6114,7 +6122,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:304 lxc/launch.go:127
+#: lxc/action.go:304 lxc/launch.go:124
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6127,7 +6135,7 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:45
+#: lxc/console.go:48
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
@@ -6200,7 +6208,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:168
+#: lxc/console.go:171
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6215,7 +6223,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:113
+#: lxc/console.go:116
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6713,7 +6721,7 @@ msgstr ""
 
 #: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -7110,7 +7118,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:260 lxc/warning.go:302
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
@@ -7156,6 +7164,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1590
 msgid "[<remote>:][<pool>] [<filter>...]"
+msgstr ""
+
+#: lxc/warning.go:355
+msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
 #: lxc/remote.go:89

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-        "POT-Creation-Date: 2024-10-18 15:21-0500\n"
+        "POT-Creation-Date: 2024-11-18 20:34-0300\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -724,7 +724,7 @@ msgstr  ""
 msgid   "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr  ""
 
-#: lxc/console.go:392
+#: lxc/console.go:402
 msgid   "As neither could be found, the raw SPICE socket can be found at:"
 msgstr  ""
 
@@ -760,11 +760,11 @@ msgstr  ""
 msgid   "Attach new storage volumes to profiles"
 msgstr  ""
 
-#: lxc/console.go:36
+#: lxc/console.go:39
 msgid   "Attach to instance consoles"
 msgstr  ""
 
-#: lxc/console.go:37
+#: lxc/console.go:40
 msgid   "Attach to instance consoles\n"
         "\n"
         "This command allows you to interact with the boot console of an instance\n"
@@ -1559,7 +1559,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104 lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398 lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581 lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985 lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292 lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464 lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781 lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060 lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087 lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329 lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170 lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:955 lxc/config.go:995 lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409 lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634 lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28 lxc/config_metadata.go:56 lxc/config_metadata.go:189 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:119 lxc/config_template.go:173 lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689 lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106 lxc/network.go:1185 lxc/network.go:1245 lxc/network.go:1341 lxc/network.go:1413 lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53 lxc/network_forward.go:33 lxc/network_forward.go:90 lxc/network_forward.go:179 lxc/network_forward.go:256 lxc/network_forward.go:404 lxc/network_forward.go:489 lxc/network_forward.go:599 lxc/network_forward.go:646 lxc/network_forward.go:800 lxc/network_forward.go:874 lxc/network_forward.go:889 lxc/network_forward.go:970 lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121 lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:165 lxc/network_zone.go:228 lxc/network_zone.go:301 lxc/network_zone.go:396 lxc/network_zone.go:484 lxc/network_zone.go:527 lxc/network_zone.go:654 lxc/network_zone.go:710 lxc/network_zone.go:767 lxc/network_zone.go:845 lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083 lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349 lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483 lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749 lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018 lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250 lxc/storage_bucket.go:383 lxc/storage_bucket.go:459 lxc/storage_bucket.go:536 lxc/storage_bucket.go:630 lxc/storage_bucket.go:699 lxc/storage_bucket.go:733 lxc/storage_bucket.go:774 lxc/storage_bucket.go:853 lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158 lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283 lxc/storage_volume.go:390 lxc/storage_volume.go:611 lxc/storage_volume.go:720 lxc/storage_volume.go:807 lxc/storage_volume.go:905 lxc/storage_volume.go:1002 lxc/storage_volume.go:1223 lxc/storage_volume.go:1354 lxc/storage_volume.go:1513 lxc/storage_volume.go:1597 lxc/storage_volume.go:1850 lxc/storage_volume.go:1949 lxc/storage_volume.go:2076 lxc/storage_volume.go:2234 lxc/storage_volume.go:2355 lxc/storage_volume.go:2417 lxc/storage_volume.go:2553 lxc/storage_volume.go:2636 lxc/storage_volume.go:2802 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104 lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398 lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581 lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985 lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292 lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464 lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781 lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060 lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087 lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329 lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170 lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:955 lxc/config.go:995 lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409 lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634 lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28 lxc/config_metadata.go:56 lxc/config_metadata.go:189 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:119 lxc/config_template.go:173 lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689 lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106 lxc/network.go:1185 lxc/network.go:1245 lxc/network.go:1341 lxc/network.go:1413 lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53 lxc/network_forward.go:33 lxc/network_forward.go:90 lxc/network_forward.go:179 lxc/network_forward.go:256 lxc/network_forward.go:404 lxc/network_forward.go:489 lxc/network_forward.go:599 lxc/network_forward.go:646 lxc/network_forward.go:800 lxc/network_forward.go:874 lxc/network_forward.go:889 lxc/network_forward.go:970 lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121 lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:165 lxc/network_zone.go:228 lxc/network_zone.go:301 lxc/network_zone.go:396 lxc/network_zone.go:484 lxc/network_zone.go:527 lxc/network_zone.go:654 lxc/network_zone.go:710 lxc/network_zone.go:767 lxc/network_zone.go:845 lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083 lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349 lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483 lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749 lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018 lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250 lxc/storage_bucket.go:383 lxc/storage_bucket.go:459 lxc/storage_bucket.go:536 lxc/storage_bucket.go:630 lxc/storage_bucket.go:699 lxc/storage_bucket.go:733 lxc/storage_bucket.go:774 lxc/storage_bucket.go:853 lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158 lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283 lxc/storage_volume.go:390 lxc/storage_volume.go:611 lxc/storage_volume.go:720 lxc/storage_volume.go:807 lxc/storage_volume.go:905 lxc/storage_volume.go:1002 lxc/storage_volume.go:1223 lxc/storage_volume.go:1354 lxc/storage_volume.go:1513 lxc/storage_volume.go:1597 lxc/storage_volume.go:1850 lxc/storage_volume.go:1949 lxc/storage_volume.go:2076 lxc/storage_volume.go:2234 lxc/storage_volume.go:2355 lxc/storage_volume.go:2417 lxc/storage_volume.go:2553 lxc/storage_volume.go:2636 lxc/storage_volume.go:2802 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid   "Description"
 msgstr  ""
 
@@ -2048,7 +2048,7 @@ msgstr  ""
 msgid   "Failed parsing SSH host key: %w"
 msgstr  ""
 
-#: lxc/console.go:370
+#: lxc/console.go:380
 #, c-format
 msgid   "Failed starting command: %w"
 msgstr  ""
@@ -2807,7 +2807,7 @@ msgstr  ""
 msgid   "LXD - Command line client"
 msgstr  ""
 
-#: lxc/console.go:391
+#: lxc/console.go:401
 msgid   "LXD automatically uses either spicy or remote-viewer when present."
 msgstr  ""
 
@@ -3899,6 +3899,10 @@ msgstr  ""
 msgid   "No matching rule(s) found"
 msgstr  ""
 
+#: lxc/warning.go:393
+msgid   "No need to specify a warning UUID when using --all"
+msgstr  ""
+
 #: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
 msgid   "No storage pool for source volume specified"
 msgstr  ""
@@ -4598,7 +4602,7 @@ msgstr  ""
 msgid   "Restrict the certificate to one or more projects"
 msgstr  ""
 
-#: lxc/console.go:44
+#: lxc/console.go:47
 msgid   "Retrieve the container's console log"
 msgstr  ""
 
@@ -5210,11 +5214,15 @@ msgstr  ""
 msgid   "Source:"
 msgstr  ""
 
+#: lxc/warning.go:376
+msgid   "Specify a warning UUID or use --all"
+msgstr  ""
+
 #: lxc/action.go:32 lxc/action.go:33
 msgid   "Start instances"
 msgstr  ""
 
-#: lxc/launch.go:95
+#: lxc/launch.go:92
 #, c-format
 msgid   "Starting %s"
 msgstr  ""
@@ -5400,7 +5408,7 @@ msgstr  ""
 msgid   "The --mode flag can't be used with --target"
 msgstr  ""
 
-#: lxc/console.go:130
+#: lxc/console.go:133
 msgid   "The --show-log flag is only supported for by 'console' output type"
 msgstr  ""
 
@@ -5603,7 +5611,7 @@ msgstr  ""
 msgid   "To create a new network, use: lxc network create"
 msgstr  ""
 
-#: lxc/console.go:219
+#: lxc/console.go:222
 msgid   "To detach from the console, press: <ctrl>+a q"
 msgstr  ""
 
@@ -5678,7 +5686,7 @@ msgstr  ""
 msgid   "Trust token for %s: "
 msgstr  ""
 
-#: lxc/action.go:304 lxc/launch.go:127
+#: lxc/action.go:304 lxc/launch.go:124
 #, c-format
 msgid   "Try `lxc info --show-log %s` for more info"
 msgstr  ""
@@ -5691,7 +5699,7 @@ msgstr  ""
 msgid   "Type of certificate"
 msgstr  ""
 
-#: lxc/console.go:45
+#: lxc/console.go:48
 msgid   "Type of connection to establish: 'console' for serial console, 'vga' for SPICE graphical output"
 msgstr  ""
 
@@ -5758,7 +5766,7 @@ msgstr  ""
 msgid   "Unknown column shorthand char '%c' in '%s'"
 msgstr  ""
 
-#: lxc/console.go:168
+#: lxc/console.go:171
 #, c-format
 msgid   "Unknown console type %q"
 msgstr  ""
@@ -5773,7 +5781,7 @@ msgstr  ""
 msgid   "Unknown key: %s"
 msgstr  ""
 
-#: lxc/console.go:113
+#: lxc/console.go:116
 #, c-format
 msgid   "Unknown output type %q"
 msgstr  ""
@@ -6247,7 +6255,7 @@ msgstr  ""
 msgid   "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr  ""
 
-#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329 lxc/config_device.go:761 lxc/config_metadata.go:54 lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
+#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329 lxc/config_device.go:761 lxc/config_metadata.go:54 lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid   "[<remote>:]<instance>"
 msgstr  ""
 
@@ -6619,7 +6627,7 @@ msgstr  ""
 msgid   "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr  ""
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:260 lxc/warning.go:302
 msgid   "[<remote>:]<warning-uuid>"
 msgstr  ""
 
@@ -6665,6 +6673,10 @@ msgstr  ""
 
 #: lxc/storage_volume.go:1590
 msgid   "[<remote>:][<pool>] [<filter>...]"
+msgstr  ""
+
+#: lxc/warning.go:355
+msgid   "[<remote>:][<warning-uuid>]"
 msgstr  ""
 
 #: lxc/remote.go:89

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-18 15:21-0500\n"
+"POT-Creation-Date: 2024-11-18 20:34-0300\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:392
+#: lxc/console.go:402
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -801,11 +801,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:39
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:37
+#: lxc/console.go:40
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -1688,7 +1688,7 @@ msgstr ""
 #: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32
+#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
@@ -2280,7 +2280,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:370
+#: lxc/console.go:380
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:391
+#: lxc/console.go:401
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -4255,6 +4255,10 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
+#: lxc/warning.go:393
+msgid "No need to specify a warning UUID when using --all"
+msgstr ""
+
 #: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
 msgid "No storage pool for source volume specified"
 msgstr ""
@@ -4983,7 +4987,7 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:47
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5630,11 +5634,15 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
+#: lxc/warning.go:376
+msgid "Specify a warning UUID or use --all"
+msgstr ""
+
 #: lxc/action.go:32 lxc/action.go:33
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:95
+#: lxc/launch.go:92
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5825,7 +5833,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:130
+#: lxc/console.go:133
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -6037,7 +6045,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:219
+#: lxc/console.go:222
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6114,7 +6122,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:304 lxc/launch.go:127
+#: lxc/action.go:304 lxc/launch.go:124
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6127,7 +6135,7 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:45
+#: lxc/console.go:48
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
@@ -6200,7 +6208,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:168
+#: lxc/console.go:171
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6215,7 +6223,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:113
+#: lxc/console.go:116
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6713,7 +6721,7 @@ msgstr ""
 
 #: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -7110,7 +7118,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:260 lxc/warning.go:302
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
@@ -7156,6 +7164,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1590
 msgid "[<remote>:][<pool>] [<filter>...]"
+msgstr ""
+
+#: lxc/warning.go:355
+msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
 #: lxc/remote.go:89

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-18 15:21-0500\n"
+"POT-Creation-Date: 2024-11-18 20:34-0300\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:392
+#: lxc/console.go:402
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -801,11 +801,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:39
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:37
+#: lxc/console.go:40
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -1688,7 +1688,7 @@ msgstr ""
 #: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32
+#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
@@ -2280,7 +2280,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:370
+#: lxc/console.go:380
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:391
+#: lxc/console.go:401
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -4255,6 +4255,10 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
+#: lxc/warning.go:393
+msgid "No need to specify a warning UUID when using --all"
+msgstr ""
+
 #: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
 msgid "No storage pool for source volume specified"
 msgstr ""
@@ -4983,7 +4987,7 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:47
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5630,11 +5634,15 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
+#: lxc/warning.go:376
+msgid "Specify a warning UUID or use --all"
+msgstr ""
+
 #: lxc/action.go:32 lxc/action.go:33
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:95
+#: lxc/launch.go:92
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5825,7 +5833,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:130
+#: lxc/console.go:133
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -6037,7 +6045,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:219
+#: lxc/console.go:222
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6114,7 +6122,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:304 lxc/launch.go:127
+#: lxc/action.go:304 lxc/launch.go:124
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6127,7 +6135,7 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:45
+#: lxc/console.go:48
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
@@ -6200,7 +6208,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:168
+#: lxc/console.go:171
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6215,7 +6223,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:113
+#: lxc/console.go:116
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6713,7 +6721,7 @@ msgstr ""
 
 #: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -7110,7 +7118,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:260 lxc/warning.go:302
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
@@ -7156,6 +7164,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1590
 msgid "[<remote>:][<pool>] [<filter>...]"
+msgstr ""
+
+#: lxc/warning.go:355
+msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
 #: lxc/remote.go:89

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-18 15:21-0500\n"
+"POT-Creation-Date: 2024-11-18 20:34-0300\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -989,7 +989,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:392
+#: lxc/console.go:402
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1025,11 +1025,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:39
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:37
+#: lxc/console.go:40
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -1912,7 +1912,7 @@ msgstr ""
 #: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32
+#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
@@ -2504,7 +2504,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:370
+#: lxc/console.go:380
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -3288,7 +3288,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:391
+#: lxc/console.go:401
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -4479,6 +4479,10 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
+#: lxc/warning.go:393
+msgid "No need to specify a warning UUID when using --all"
+msgstr ""
+
 #: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
 msgid "No storage pool for source volume specified"
 msgstr ""
@@ -5207,7 +5211,7 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:47
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5854,11 +5858,15 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
+#: lxc/warning.go:376
+msgid "Specify a warning UUID or use --all"
+msgstr ""
+
 #: lxc/action.go:32 lxc/action.go:33
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:95
+#: lxc/launch.go:92
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -6049,7 +6057,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:130
+#: lxc/console.go:133
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -6261,7 +6269,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:219
+#: lxc/console.go:222
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6338,7 +6346,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:304 lxc/launch.go:127
+#: lxc/action.go:304 lxc/launch.go:124
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6351,7 +6359,7 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:45
+#: lxc/console.go:48
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
@@ -6424,7 +6432,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:168
+#: lxc/console.go:171
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6439,7 +6447,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:113
+#: lxc/console.go:116
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6937,7 +6945,7 @@ msgstr ""
 
 #: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -7334,7 +7342,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:260 lxc/warning.go:302
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
@@ -7380,6 +7388,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1590
 msgid "[<remote>:][<pool>] [<filter>...]"
+msgstr ""
+
+#: lxc/warning.go:355
+msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
 #: lxc/remote.go:89

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-18 15:21-0500\n"
+"POT-Creation-Date: 2024-11-18 20:34-0300\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:392
+#: lxc/console.go:402
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -801,11 +801,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:39
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:37
+#: lxc/console.go:40
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -1688,7 +1688,7 @@ msgstr ""
 #: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32
+#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
@@ -2280,7 +2280,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:370
+#: lxc/console.go:380
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:391
+#: lxc/console.go:401
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -4255,6 +4255,10 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
+#: lxc/warning.go:393
+msgid "No need to specify a warning UUID when using --all"
+msgstr ""
+
 #: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
 msgid "No storage pool for source volume specified"
 msgstr ""
@@ -4983,7 +4987,7 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:47
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5630,11 +5634,15 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
+#: lxc/warning.go:376
+msgid "Specify a warning UUID or use --all"
+msgstr ""
+
 #: lxc/action.go:32 lxc/action.go:33
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:95
+#: lxc/launch.go:92
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5825,7 +5833,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:130
+#: lxc/console.go:133
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -6037,7 +6045,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:219
+#: lxc/console.go:222
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6114,7 +6122,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:304 lxc/launch.go:127
+#: lxc/action.go:304 lxc/launch.go:124
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6127,7 +6135,7 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:45
+#: lxc/console.go:48
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
@@ -6200,7 +6208,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:168
+#: lxc/console.go:171
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6215,7 +6223,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:113
+#: lxc/console.go:116
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6713,7 +6721,7 @@ msgstr ""
 
 #: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -7110,7 +7118,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:260 lxc/warning.go:302
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
@@ -7156,6 +7164,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1590
 msgid "[<remote>:][<pool>] [<filter>...]"
+msgstr ""
+
+#: lxc/warning.go:355
+msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
 #: lxc/remote.go:89

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-18 15:21-0500\n"
+"POT-Creation-Date: 2024-11-18 20:34-0300\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -1027,7 +1027,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:392
+#: lxc/console.go:402
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1063,11 +1063,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:39
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:37
+#: lxc/console.go:40
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -1950,7 +1950,7 @@ msgstr ""
 #: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32
+#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
@@ -2542,7 +2542,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:370
+#: lxc/console.go:380
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -3326,7 +3326,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:391
+#: lxc/console.go:401
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -4517,6 +4517,10 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
+#: lxc/warning.go:393
+msgid "No need to specify a warning UUID when using --all"
+msgstr ""
+
 #: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
 msgid "No storage pool for source volume specified"
 msgstr ""
@@ -5245,7 +5249,7 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:47
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5892,11 +5896,15 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
+#: lxc/warning.go:376
+msgid "Specify a warning UUID or use --all"
+msgstr ""
+
 #: lxc/action.go:32 lxc/action.go:33
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:95
+#: lxc/launch.go:92
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -6087,7 +6095,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:130
+#: lxc/console.go:133
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -6299,7 +6307,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:219
+#: lxc/console.go:222
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6376,7 +6384,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:304 lxc/launch.go:127
+#: lxc/action.go:304 lxc/launch.go:124
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6389,7 +6397,7 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:45
+#: lxc/console.go:48
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
@@ -6462,7 +6470,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:168
+#: lxc/console.go:171
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6477,7 +6485,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:113
+#: lxc/console.go:116
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6975,7 +6983,7 @@ msgstr ""
 
 #: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -7372,7 +7380,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:260 lxc/warning.go:302
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
@@ -7418,6 +7426,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1590
 msgid "[<remote>:][<pool>] [<filter>...]"
+msgstr ""
+
+#: lxc/warning.go:355
+msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
 #: lxc/remote.go:89

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-18 15:21-0500\n"
+"POT-Creation-Date: 2024-11-18 20:34-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -762,7 +762,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:392
+#: lxc/console.go:402
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -798,11 +798,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:39
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:37
+#: lxc/console.go:40
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -1685,7 +1685,7 @@ msgstr ""
 #: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32
+#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
@@ -2277,7 +2277,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:370
+#: lxc/console.go:380
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -3061,7 +3061,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:391
+#: lxc/console.go:401
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -4252,6 +4252,10 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
+#: lxc/warning.go:393
+msgid "No need to specify a warning UUID when using --all"
+msgstr ""
+
 #: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
 msgid "No storage pool for source volume specified"
 msgstr ""
@@ -4980,7 +4984,7 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:47
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5627,11 +5631,15 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
+#: lxc/warning.go:376
+msgid "Specify a warning UUID or use --all"
+msgstr ""
+
 #: lxc/action.go:32 lxc/action.go:33
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:95
+#: lxc/launch.go:92
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5822,7 +5830,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:130
+#: lxc/console.go:133
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -6034,7 +6042,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:219
+#: lxc/console.go:222
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6111,7 +6119,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:304 lxc/launch.go:127
+#: lxc/action.go:304 lxc/launch.go:124
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6124,7 +6132,7 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:45
+#: lxc/console.go:48
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
@@ -6197,7 +6205,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:168
+#: lxc/console.go:171
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6212,7 +6220,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:113
+#: lxc/console.go:116
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6710,7 +6718,7 @@ msgstr ""
 
 #: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -7107,7 +7115,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:260 lxc/warning.go:302
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
@@ -7153,6 +7161,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1590
 msgid "[<remote>:][<pool>] [<filter>...]"
+msgstr ""
+
+#: lxc/warning.go:355
+msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
 #: lxc/remote.go:89

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-18 15:21-0500\n"
+"POT-Creation-Date: 2024-11-18 20:34-0300\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -1034,7 +1034,7 @@ msgstr "Arquitetura: %v"
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:392
+#: lxc/console.go:402
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1075,12 +1075,12 @@ msgstr "Desconectar volumes de armazenamento dos containers"
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:39
 #, fuzzy
 msgid "Attach to instance consoles"
 msgstr "Anexar interfaces de rede aos perfis"
 
-#: lxc/console.go:37
+#: lxc/console.go:40
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -2013,7 +2013,7 @@ msgstr ""
 #: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32
+#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
@@ -2631,7 +2631,7 @@ msgstr "Nome de membro do cluster"
 msgid "Failed parsing SSH host key: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/console.go:370
+#: lxc/console.go:380
 #, fuzzy, c-format
 msgid "Failed starting command: %w"
 msgstr "Aceitar certificado"
@@ -3440,7 +3440,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:391
+#: lxc/console.go:401
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -4685,6 +4685,10 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
+#: lxc/warning.go:393
+msgid "No need to specify a warning UUID when using --all"
+msgstr ""
+
 #: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
 msgid "No storage pool for source volume specified"
 msgstr ""
@@ -5446,7 +5450,7 @@ msgstr "Nome de membro do cluster"
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:47
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -6137,11 +6141,15 @@ msgstr "Dispositivo %s adicionado a %s"
 msgid "Source:"
 msgstr ""
 
+#: lxc/warning.go:376
+msgid "Specify a warning UUID or use --all"
+msgstr ""
+
 #: lxc/action.go:32 lxc/action.go:33
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:95
+#: lxc/launch.go:92
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -6335,7 +6343,7 @@ msgstr "--refresh só pode ser usado com containers"
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:130
+#: lxc/console.go:133
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -6551,7 +6559,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:219
+#: lxc/console.go:222
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6629,7 +6637,7 @@ msgstr "--refresh só pode ser usado com containers"
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:304 lxc/launch.go:127
+#: lxc/action.go:304 lxc/launch.go:124
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6643,7 +6651,7 @@ msgstr ""
 msgid "Type of certificate"
 msgstr "Aceitar certificado"
 
-#: lxc/console.go:45
+#: lxc/console.go:48
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
@@ -6717,7 +6725,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:168
+#: lxc/console.go:171
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6732,7 +6740,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:113
+#: lxc/console.go:116
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -7281,7 +7289,7 @@ msgstr ""
 
 #: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -7718,7 +7726,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr "Criar perfis"
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:260 lxc/warning.go:302
 #, fuzzy
 msgid "[<remote>:]<warning-uuid>"
 msgstr "Criar perfis"
@@ -7772,6 +7780,11 @@ msgstr ""
 #: lxc/storage_volume.go:1590
 #, fuzzy
 msgid "[<remote>:][<pool>] [<filter>...]"
+msgstr "Criar perfis"
+
+#: lxc/warning.go:355
+#, fuzzy
+msgid "[<remote>:][<warning-uuid>]"
 msgstr "Criar perfis"
 
 #: lxc/remote.go:89

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-18 15:21-0500\n"
+"POT-Creation-Date: 2024-11-18 20:34-0300\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -1035,7 +1035,7 @@ msgstr "Архитектура: %v"
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:392
+#: lxc/console.go:402
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -1073,11 +1073,11 @@ msgstr "Копирование образа: %s"
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:39
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:37
+#: lxc/console.go:40
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -2000,7 +2000,7 @@ msgstr ""
 #: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32
+#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
@@ -2616,7 +2616,7 @@ msgstr "Копирование образа: %s"
 msgid "Failed parsing SSH host key: %w"
 msgstr "Принять сертификат"
 
-#: lxc/console.go:370
+#: lxc/console.go:380
 #, fuzzy, c-format
 msgid "Failed starting command: %w"
 msgstr "Принять сертификат"
@@ -3427,7 +3427,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:391
+#: lxc/console.go:401
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -4690,6 +4690,10 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
+#: lxc/warning.go:393
+msgid "No need to specify a warning UUID when using --all"
+msgstr ""
+
 #: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
 msgid "No storage pool for source volume specified"
 msgstr ""
@@ -5441,7 +5445,7 @@ msgstr "Копирование образа: %s"
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:47
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -6125,11 +6129,15 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Source:"
 msgstr ""
 
+#: lxc/warning.go:376
+msgid "Specify a warning UUID or use --all"
+msgstr ""
+
 #: lxc/action.go:32 lxc/action.go:33
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:95
+#: lxc/launch.go:92
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -6324,7 +6332,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:130
+#: lxc/console.go:133
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -6537,7 +6545,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:219
+#: lxc/console.go:222
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6614,7 +6622,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:304 lxc/launch.go:127
+#: lxc/action.go:304 lxc/launch.go:124
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6628,7 +6636,7 @@ msgstr ""
 msgid "Type of certificate"
 msgstr "Принять сертификат"
 
-#: lxc/console.go:45
+#: lxc/console.go:48
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
@@ -6701,7 +6709,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:168
+#: lxc/console.go:171
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6716,7 +6724,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:113
+#: lxc/console.go:116
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -7392,7 +7400,7 @@ msgstr ""
 
 #: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 #, fuzzy
 msgid "[<remote>:]<instance>"
 msgstr ""
@@ -8157,7 +8165,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:260 lxc/warning.go:302
 #, fuzzy
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
@@ -8248,6 +8256,14 @@ msgstr ""
 #: lxc/storage_volume.go:1590
 #, fuzzy
 msgid "[<remote>:][<pool>] [<filter>...]"
+msgstr ""
+"Изменение состояния одного или нескольких контейнеров %s.\n"
+"\n"
+"lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
+
+#: lxc/warning.go:355
+#, fuzzy
+msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 "Изменение состояния одного или нескольких контейнеров %s.\n"
 "\n"

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-18 15:21-0500\n"
+"POT-Creation-Date: 2024-11-18 20:34-0300\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:392
+#: lxc/console.go:402
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -801,11 +801,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:39
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:37
+#: lxc/console.go:40
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -1688,7 +1688,7 @@ msgstr ""
 #: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32
+#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
@@ -2280,7 +2280,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:370
+#: lxc/console.go:380
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:391
+#: lxc/console.go:401
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -4255,6 +4255,10 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
+#: lxc/warning.go:393
+msgid "No need to specify a warning UUID when using --all"
+msgstr ""
+
 #: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
 msgid "No storage pool for source volume specified"
 msgstr ""
@@ -4983,7 +4987,7 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:47
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5630,11 +5634,15 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
+#: lxc/warning.go:376
+msgid "Specify a warning UUID or use --all"
+msgstr ""
+
 #: lxc/action.go:32 lxc/action.go:33
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:95
+#: lxc/launch.go:92
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5825,7 +5833,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:130
+#: lxc/console.go:133
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -6037,7 +6045,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:219
+#: lxc/console.go:222
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6114,7 +6122,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:304 lxc/launch.go:127
+#: lxc/action.go:304 lxc/launch.go:124
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6127,7 +6135,7 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:45
+#: lxc/console.go:48
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
@@ -6200,7 +6208,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:168
+#: lxc/console.go:171
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6215,7 +6223,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:113
+#: lxc/console.go:116
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6713,7 +6721,7 @@ msgstr ""
 
 #: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -7110,7 +7118,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:260 lxc/warning.go:302
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
@@ -7156,6 +7164,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1590
 msgid "[<remote>:][<pool>] [<filter>...]"
+msgstr ""
+
+#: lxc/warning.go:355
+msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
 #: lxc/remote.go:89

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-18 15:21-0500\n"
+"POT-Creation-Date: 2024-11-18 20:34-0300\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -766,7 +766,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:392
+#: lxc/console.go:402
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -802,11 +802,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:39
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:37
+#: lxc/console.go:40
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -1689,7 +1689,7 @@ msgstr ""
 #: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32
+#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
@@ -2281,7 +2281,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:370
+#: lxc/console.go:380
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -3065,7 +3065,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:391
+#: lxc/console.go:401
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -4256,6 +4256,10 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
+#: lxc/warning.go:393
+msgid "No need to specify a warning UUID when using --all"
+msgstr ""
+
 #: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
 msgid "No storage pool for source volume specified"
 msgstr ""
@@ -4984,7 +4988,7 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:47
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5631,11 +5635,15 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
+#: lxc/warning.go:376
+msgid "Specify a warning UUID or use --all"
+msgstr ""
+
 #: lxc/action.go:32 lxc/action.go:33
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:95
+#: lxc/launch.go:92
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5826,7 +5834,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:130
+#: lxc/console.go:133
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -6038,7 +6046,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:219
+#: lxc/console.go:222
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6115,7 +6123,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:304 lxc/launch.go:127
+#: lxc/action.go:304 lxc/launch.go:124
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6128,7 +6136,7 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:45
+#: lxc/console.go:48
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
@@ -6201,7 +6209,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:168
+#: lxc/console.go:171
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6216,7 +6224,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:113
+#: lxc/console.go:116
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6714,7 +6722,7 @@ msgstr ""
 
 #: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -7111,7 +7119,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:260 lxc/warning.go:302
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
@@ -7157,6 +7165,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1590
 msgid "[<remote>:][<pool>] [<filter>...]"
+msgstr ""
+
+#: lxc/warning.go:355
+msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
 #: lxc/remote.go:89

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-18 15:21-0500\n"
+"POT-Creation-Date: 2024-11-18 20:34-0300\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -766,7 +766,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:392
+#: lxc/console.go:402
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -802,11 +802,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:39
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:37
+#: lxc/console.go:40
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -1689,7 +1689,7 @@ msgstr ""
 #: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32
+#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
@@ -2281,7 +2281,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:370
+#: lxc/console.go:380
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -3065,7 +3065,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:391
+#: lxc/console.go:401
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -4256,6 +4256,10 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
+#: lxc/warning.go:393
+msgid "No need to specify a warning UUID when using --all"
+msgstr ""
+
 #: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
 msgid "No storage pool for source volume specified"
 msgstr ""
@@ -4984,7 +4988,7 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:47
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5631,11 +5635,15 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
+#: lxc/warning.go:376
+msgid "Specify a warning UUID or use --all"
+msgstr ""
+
 #: lxc/action.go:32 lxc/action.go:33
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:95
+#: lxc/launch.go:92
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5826,7 +5834,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:130
+#: lxc/console.go:133
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -6038,7 +6046,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:219
+#: lxc/console.go:222
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6115,7 +6123,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:304 lxc/launch.go:127
+#: lxc/action.go:304 lxc/launch.go:124
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6128,7 +6136,7 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:45
+#: lxc/console.go:48
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
@@ -6201,7 +6209,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:168
+#: lxc/console.go:171
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6216,7 +6224,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:113
+#: lxc/console.go:116
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6714,7 +6722,7 @@ msgstr ""
 
 #: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -7111,7 +7119,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:260 lxc/warning.go:302
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
@@ -7157,6 +7165,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1590
 msgid "[<remote>:][<pool>] [<filter>...]"
+msgstr ""
+
+#: lxc/warning.go:355
+msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
 #: lxc/remote.go:89

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-18 15:21-0500\n"
+"POT-Creation-Date: 2024-11-18 20:34-0300\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:392
+#: lxc/console.go:402
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -801,11 +801,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:39
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:37
+#: lxc/console.go:40
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -1688,7 +1688,7 @@ msgstr ""
 #: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32
+#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
@@ -2280,7 +2280,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:370
+#: lxc/console.go:380
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:391
+#: lxc/console.go:401
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -4255,6 +4255,10 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
+#: lxc/warning.go:393
+msgid "No need to specify a warning UUID when using --all"
+msgstr ""
+
 #: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
 msgid "No storage pool for source volume specified"
 msgstr ""
@@ -4983,7 +4987,7 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:47
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5630,11 +5634,15 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
+#: lxc/warning.go:376
+msgid "Specify a warning UUID or use --all"
+msgstr ""
+
 #: lxc/action.go:32 lxc/action.go:33
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:95
+#: lxc/launch.go:92
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5825,7 +5833,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:130
+#: lxc/console.go:133
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -6037,7 +6045,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:219
+#: lxc/console.go:222
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6114,7 +6122,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:304 lxc/launch.go:127
+#: lxc/action.go:304 lxc/launch.go:124
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6127,7 +6135,7 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:45
+#: lxc/console.go:48
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
@@ -6200,7 +6208,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:168
+#: lxc/console.go:171
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6215,7 +6223,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:113
+#: lxc/console.go:116
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6713,7 +6721,7 @@ msgstr ""
 
 #: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -7110,7 +7118,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:260 lxc/warning.go:302
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
@@ -7156,6 +7164,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1590
 msgid "[<remote>:][<pool>] [<filter>...]"
+msgstr ""
+
+#: lxc/warning.go:355
+msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
 #: lxc/remote.go:89

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-18 15:21-0500\n"
+"POT-Creation-Date: 2024-11-18 20:34-0300\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:392
+#: lxc/console.go:402
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -801,11 +801,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:39
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:37
+#: lxc/console.go:40
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -1688,7 +1688,7 @@ msgstr ""
 #: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32
+#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
@@ -2280,7 +2280,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:370
+#: lxc/console.go:380
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:391
+#: lxc/console.go:401
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -4255,6 +4255,10 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
+#: lxc/warning.go:393
+msgid "No need to specify a warning UUID when using --all"
+msgstr ""
+
 #: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
 msgid "No storage pool for source volume specified"
 msgstr ""
@@ -4983,7 +4987,7 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:47
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5630,11 +5634,15 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
+#: lxc/warning.go:376
+msgid "Specify a warning UUID or use --all"
+msgstr ""
+
 #: lxc/action.go:32 lxc/action.go:33
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:95
+#: lxc/launch.go:92
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5825,7 +5833,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:130
+#: lxc/console.go:133
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -6037,7 +6045,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:219
+#: lxc/console.go:222
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6114,7 +6122,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:304 lxc/launch.go:127
+#: lxc/action.go:304 lxc/launch.go:124
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6127,7 +6135,7 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:45
+#: lxc/console.go:48
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
@@ -6200,7 +6208,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:168
+#: lxc/console.go:171
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6215,7 +6223,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:113
+#: lxc/console.go:116
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6713,7 +6721,7 @@ msgstr ""
 
 #: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -7110,7 +7118,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:260 lxc/warning.go:302
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
@@ -7156,6 +7164,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1590
 msgid "[<remote>:][<pool>] [<filter>...]"
+msgstr ""
+
+#: lxc/warning.go:355
+msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
 #: lxc/remote.go:89

--- a/po/th.po
+++ b/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-18 15:21-0500\n"
+"POT-Creation-Date: 2024-11-18 20:34-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -762,7 +762,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:392
+#: lxc/console.go:402
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -798,11 +798,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:39
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:37
+#: lxc/console.go:40
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -1685,7 +1685,7 @@ msgstr ""
 #: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32
+#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
@@ -2277,7 +2277,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:370
+#: lxc/console.go:380
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -3061,7 +3061,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:391
+#: lxc/console.go:401
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -4252,6 +4252,10 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
+#: lxc/warning.go:393
+msgid "No need to specify a warning UUID when using --all"
+msgstr ""
+
 #: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
 msgid "No storage pool for source volume specified"
 msgstr ""
@@ -4980,7 +4984,7 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:47
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5627,11 +5631,15 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
+#: lxc/warning.go:376
+msgid "Specify a warning UUID or use --all"
+msgstr ""
+
 #: lxc/action.go:32 lxc/action.go:33
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:95
+#: lxc/launch.go:92
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5822,7 +5830,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:130
+#: lxc/console.go:133
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -6034,7 +6042,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:219
+#: lxc/console.go:222
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6111,7 +6119,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:304 lxc/launch.go:127
+#: lxc/action.go:304 lxc/launch.go:124
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6124,7 +6132,7 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:45
+#: lxc/console.go:48
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
@@ -6197,7 +6205,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:168
+#: lxc/console.go:171
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6212,7 +6220,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:113
+#: lxc/console.go:116
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6710,7 +6718,7 @@ msgstr ""
 
 #: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -7107,7 +7115,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:260 lxc/warning.go:302
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
@@ -7153,6 +7161,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1590
 msgid "[<remote>:][<pool>] [<filter>...]"
+msgstr ""
+
+#: lxc/warning.go:355
+msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
 #: lxc/remote.go:89

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-18 15:21-0500\n"
+"POT-Creation-Date: 2024-11-18 20:34-0300\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:392
+#: lxc/console.go:402
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -801,11 +801,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:39
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:37
+#: lxc/console.go:40
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -1688,7 +1688,7 @@ msgstr ""
 #: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32
+#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
@@ -2280,7 +2280,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:370
+#: lxc/console.go:380
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:391
+#: lxc/console.go:401
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -4255,6 +4255,10 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
+#: lxc/warning.go:393
+msgid "No need to specify a warning UUID when using --all"
+msgstr ""
+
 #: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
 msgid "No storage pool for source volume specified"
 msgstr ""
@@ -4983,7 +4987,7 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:47
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5630,11 +5634,15 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
+#: lxc/warning.go:376
+msgid "Specify a warning UUID or use --all"
+msgstr ""
+
 #: lxc/action.go:32 lxc/action.go:33
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:95
+#: lxc/launch.go:92
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5825,7 +5833,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:130
+#: lxc/console.go:133
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -6037,7 +6045,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:219
+#: lxc/console.go:222
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6114,7 +6122,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:304 lxc/launch.go:127
+#: lxc/action.go:304 lxc/launch.go:124
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6127,7 +6135,7 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:45
+#: lxc/console.go:48
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
@@ -6200,7 +6208,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:168
+#: lxc/console.go:171
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6215,7 +6223,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:113
+#: lxc/console.go:116
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6713,7 +6721,7 @@ msgstr ""
 
 #: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -7110,7 +7118,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:260 lxc/warning.go:302
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
@@ -7156,6 +7164,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1590
 msgid "[<remote>:][<pool>] [<filter>...]"
+msgstr ""
+
+#: lxc/warning.go:355
+msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
 #: lxc/remote.go:89

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-18 15:21-0500\n"
+"POT-Creation-Date: 2024-11-18 20:34-0300\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:392
+#: lxc/console.go:402
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -801,11 +801,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:39
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:37
+#: lxc/console.go:40
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -1688,7 +1688,7 @@ msgstr ""
 #: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32
+#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
@@ -2280,7 +2280,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:370
+#: lxc/console.go:380
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:391
+#: lxc/console.go:401
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -4255,6 +4255,10 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
+#: lxc/warning.go:393
+msgid "No need to specify a warning UUID when using --all"
+msgstr ""
+
 #: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
 msgid "No storage pool for source volume specified"
 msgstr ""
@@ -4983,7 +4987,7 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:47
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5630,11 +5634,15 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
+#: lxc/warning.go:376
+msgid "Specify a warning UUID or use --all"
+msgstr ""
+
 #: lxc/action.go:32 lxc/action.go:33
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:95
+#: lxc/launch.go:92
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5825,7 +5833,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:130
+#: lxc/console.go:133
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -6037,7 +6045,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:219
+#: lxc/console.go:222
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6114,7 +6122,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:304 lxc/launch.go:127
+#: lxc/action.go:304 lxc/launch.go:124
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6127,7 +6135,7 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:45
+#: lxc/console.go:48
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
@@ -6200,7 +6208,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:168
+#: lxc/console.go:171
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6215,7 +6223,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:113
+#: lxc/console.go:116
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6713,7 +6721,7 @@ msgstr ""
 
 #: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -7110,7 +7118,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:260 lxc/warning.go:302
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
@@ -7156,6 +7164,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1590
 msgid "[<remote>:][<pool>] [<filter>...]"
+msgstr ""
+
+#: lxc/warning.go:355
+msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
 #: lxc/remote.go:89

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-18 15:21-0500\n"
+"POT-Creation-Date: 2024-11-18 20:34-0300\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:392
+#: lxc/console.go:402
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -801,11 +801,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:39
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:37
+#: lxc/console.go:40
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -1688,7 +1688,7 @@ msgstr ""
 #: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32
+#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
@@ -2280,7 +2280,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:370
+#: lxc/console.go:380
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:391
+#: lxc/console.go:401
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -4255,6 +4255,10 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
+#: lxc/warning.go:393
+msgid "No need to specify a warning UUID when using --all"
+msgstr ""
+
 #: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
 msgid "No storage pool for source volume specified"
 msgstr ""
@@ -4983,7 +4987,7 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:47
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5630,11 +5634,15 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
+#: lxc/warning.go:376
+msgid "Specify a warning UUID or use --all"
+msgstr ""
+
 #: lxc/action.go:32 lxc/action.go:33
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:95
+#: lxc/launch.go:92
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5825,7 +5833,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:130
+#: lxc/console.go:133
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -6037,7 +6045,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:219
+#: lxc/console.go:222
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6114,7 +6122,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:304 lxc/launch.go:127
+#: lxc/action.go:304 lxc/launch.go:124
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6127,7 +6135,7 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:45
+#: lxc/console.go:48
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
@@ -6200,7 +6208,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:168
+#: lxc/console.go:171
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6215,7 +6223,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:113
+#: lxc/console.go:116
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6713,7 +6721,7 @@ msgstr ""
 
 #: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -7110,7 +7118,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:260 lxc/warning.go:302
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
@@ -7156,6 +7164,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1590
 msgid "[<remote>:][<pool>] [<filter>...]"
+msgstr ""
+
+#: lxc/warning.go:355
+msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
 #: lxc/remote.go:89

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-18 15:21-0500\n"
+"POT-Creation-Date: 2024-11-18 20:34-0300\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -766,7 +766,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:392
+#: lxc/console.go:402
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -802,11 +802,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:39
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:37
+#: lxc/console.go:40
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -1689,7 +1689,7 @@ msgstr ""
 #: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32
+#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
@@ -2281,7 +2281,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:370
+#: lxc/console.go:380
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -3065,7 +3065,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:391
+#: lxc/console.go:401
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -4256,6 +4256,10 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
+#: lxc/warning.go:393
+msgid "No need to specify a warning UUID when using --all"
+msgstr ""
+
 #: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
 msgid "No storage pool for source volume specified"
 msgstr ""
@@ -4984,7 +4988,7 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:47
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5631,11 +5635,15 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
+#: lxc/warning.go:376
+msgid "Specify a warning UUID or use --all"
+msgstr ""
+
 #: lxc/action.go:32 lxc/action.go:33
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:95
+#: lxc/launch.go:92
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5826,7 +5834,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:130
+#: lxc/console.go:133
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -6038,7 +6046,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:219
+#: lxc/console.go:222
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6115,7 +6123,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:304 lxc/launch.go:127
+#: lxc/action.go:304 lxc/launch.go:124
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6128,7 +6136,7 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:45
+#: lxc/console.go:48
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
@@ -6201,7 +6209,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:168
+#: lxc/console.go:171
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6216,7 +6224,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:113
+#: lxc/console.go:116
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6714,7 +6722,7 @@ msgstr ""
 
 #: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -7111,7 +7119,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:260 lxc/warning.go:302
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
@@ -7157,6 +7165,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1590
 msgid "[<remote>:][<pool>] [<filter>...]"
+msgstr ""
+
+#: lxc/warning.go:355
+msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
 #: lxc/remote.go:89

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-18 15:21-0500\n"
+"POT-Creation-Date: 2024-11-18 20:34-0300\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -926,7 +926,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:392
+#: lxc/console.go:402
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -962,11 +962,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:39
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:37
+#: lxc/console.go:40
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -1849,7 +1849,7 @@ msgstr ""
 #: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32
+#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
@@ -2441,7 +2441,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:370
+#: lxc/console.go:380
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -3225,7 +3225,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:391
+#: lxc/console.go:401
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -4416,6 +4416,10 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
+#: lxc/warning.go:393
+msgid "No need to specify a warning UUID when using --all"
+msgstr ""
+
 #: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
 msgid "No storage pool for source volume specified"
 msgstr ""
@@ -5144,7 +5148,7 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:47
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5791,11 +5795,15 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
+#: lxc/warning.go:376
+msgid "Specify a warning UUID or use --all"
+msgstr ""
+
 #: lxc/action.go:32 lxc/action.go:33
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:95
+#: lxc/launch.go:92
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5986,7 +5994,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:130
+#: lxc/console.go:133
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -6198,7 +6206,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:219
+#: lxc/console.go:222
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6275,7 +6283,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:304 lxc/launch.go:127
+#: lxc/action.go:304 lxc/launch.go:124
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6288,7 +6296,7 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:45
+#: lxc/console.go:48
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
@@ -6361,7 +6369,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:168
+#: lxc/console.go:171
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6376,7 +6384,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:113
+#: lxc/console.go:116
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6874,7 +6882,7 @@ msgstr ""
 
 #: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -7271,7 +7279,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:260 lxc/warning.go:302
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
@@ -7317,6 +7325,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1590
 msgid "[<remote>:][<pool>] [<filter>...]"
+msgstr ""
+
+#: lxc/warning.go:355
+msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
 #: lxc/remote.go:89

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-10-18 15:21-0500\n"
+"POT-Creation-Date: 2024-11-18 20:34-0300\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
 
-#: lxc/console.go:392
+#: lxc/console.go:402
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
@@ -801,11 +801,11 @@ msgstr ""
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
-#: lxc/console.go:36
+#: lxc/console.go:39
 msgid "Attach to instance consoles"
 msgstr ""
 
-#: lxc/console.go:37
+#: lxc/console.go:40
 msgid ""
 "Attach to instance consoles\n"
 "\n"
@@ -1688,7 +1688,7 @@ msgstr ""
 #: lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34
 #: lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
-#: lxc/config_trust.go:651 lxc/console.go:37 lxc/copy.go:42 lxc/delete.go:32
+#: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
@@ -2280,7 +2280,7 @@ msgstr ""
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
 
-#: lxc/console.go:370
+#: lxc/console.go:380
 #, c-format
 msgid "Failed starting command: %w"
 msgstr ""
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/console.go:391
+#: lxc/console.go:401
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
@@ -4255,6 +4255,10 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
+#: lxc/warning.go:393
+msgid "No need to specify a warning UUID when using --all"
+msgstr ""
+
 #: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
 msgid "No storage pool for source volume specified"
 msgstr ""
@@ -4983,7 +4987,7 @@ msgstr ""
 msgid "Restrict the certificate to one or more projects"
 msgstr ""
 
-#: lxc/console.go:44
+#: lxc/console.go:47
 msgid "Retrieve the container's console log"
 msgstr ""
 
@@ -5630,11 +5634,15 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
+#: lxc/warning.go:376
+msgid "Specify a warning UUID or use --all"
+msgstr ""
+
 #: lxc/action.go:32 lxc/action.go:33
 msgid "Start instances"
 msgstr ""
 
-#: lxc/launch.go:95
+#: lxc/launch.go:92
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -5825,7 +5833,7 @@ msgstr ""
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/console.go:130
+#: lxc/console.go:133
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
@@ -6037,7 +6045,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/console.go:219
+#: lxc/console.go:222
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
@@ -6114,7 +6122,7 @@ msgstr ""
 msgid "Trust token for %s: "
 msgstr ""
 
-#: lxc/action.go:304 lxc/launch.go:127
+#: lxc/action.go:304 lxc/launch.go:124
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -6127,7 +6135,7 @@ msgstr ""
 msgid "Type of certificate"
 msgstr ""
 
-#: lxc/console.go:45
+#: lxc/console.go:48
 msgid ""
 "Type of connection to establish: 'console' for serial console, 'vga' for "
 "SPICE graphical output"
@@ -6200,7 +6208,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/console.go:168
+#: lxc/console.go:171
 #, c-format
 msgid "Unknown console type %q"
 msgstr ""
@@ -6215,7 +6223,7 @@ msgstr ""
 msgid "Unknown key: %s"
 msgstr ""
 
-#: lxc/console.go:113
+#: lxc/console.go:116
 #, c-format
 msgid "Unknown output type %q"
 msgstr ""
@@ -6713,7 +6721,7 @@ msgstr ""
 
 #: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
-#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:35
+#: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
 msgstr ""
 
@@ -7110,7 +7118,7 @@ msgstr ""
 msgid "[<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/warning.go:260 lxc/warning.go:302 lxc/warning.go:355
+#: lxc/warning.go:260 lxc/warning.go:302
 msgid "[<remote>:]<warning-uuid>"
 msgstr ""
 
@@ -7156,6 +7164,10 @@ msgstr ""
 
 #: lxc/storage_volume.go:1590
 msgid "[<remote>:][<pool>] [<filter>...]"
+msgstr ""
+
+#: lxc/warning.go:355
+msgid "[<remote>:][<warning-uuid>]"
 msgstr ""
 
 #: lxc/remote.go:89

--- a/test/suites/warnings.sh
+++ b/test/suites/warnings.sh
@@ -1,6 +1,6 @@
 test_warnings() {
     # Delete previous warnings
-    lxc query --wait /1.0/warnings\?recursion=1 | jq -r '.[].uuid' | xargs -n1 lxc warning delete
+    lxc warning delete --all
 
     # Create a global warning (no node and no project)
     lxc query --wait -X POST -d '{\"type_code\": 0, \"message\": \"global warning\"}' /internal/testing/warnings
@@ -64,4 +64,8 @@ test_warnings() {
     lxc warning rm "${uuid}"
     ! lxc warning list | grep -q "${uuid}" || false
     ! lxc warning show "${uuid}" || false
+
+    # Delete all warnings
+    lxc warning delete --all
+    [ -z "$(lxc warning ls --format csv)" ]
 }


### PR DESCRIPTION
While implementing the tests for https://github.com/canonical/lxd/pull/14323, I came across the `--all` option on the help page for `lxc warning delete` as shown:

```
lxc warning delete --help              
Description:
  Delete warning

Usage:
  lxc warning delete [<remote>:]<warning-uuid> [flags]

Aliases:
  delete, rm

**Flags:
  -a, --all   Delete all warnings**

Global Flags:
      --debug          Show all debug messages
      ...
```

But, aside from the help message, there was no implementation for deleting all warnings. So I took the liberty of implementing it myself since it would help with my tests.