### PR TITLE
github: stop stripping libs and binaries

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -188,14 +188,6 @@ jobs:
       - name: Download minio/mc to add to system test dependencies
         uses: ./.github/actions/download-minio
 
-      - name: Strip binaries/libs
-        run: |
-          set -eux
-
-          strip --strip-all -v /home/runner/go/bin/dqlite/libs/*.so*
-          strip --strip-all -v /home/runner/go/bin/lxc*
-          strip --strip-all -v /home/runner/go/bin/lxd*
-
       - name: Upload system test dependencies
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:


### PR DESCRIPTION
There is no real speed benefit to stripping and no known downside to keeping debug symbols. The only minor change is going to be bigger cached artifacts.

On the plus side though, having debug symbols will make crash investigations much easier.