### PR TITLE
api: Add `gpu_cdi` extension

### DIFF
--- a/doc/.custom_wordlist.txt
+++ b/doc/.custom_wordlist.txt
@@ -178,6 +178,7 @@ OVS
 Pbit
 PCI
 PCIe
+passthrough
 peerings
 PFs
 PiB

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2515,3 +2515,7 @@ contains the total available logical CPUs available when LXD started.
 ## `vm_limits_cpu_pin_strategy`
 
 Adds a new {config:option}`instance-resource-limits:limits.cpu.pin_strategy` configuration option for virtual machines. This option controls the CPU pinning strategy. When set to `none`, CPU auto pinning is disabled. When set to `auto`, CPU auto pinning is enabled.
+
+## `gpu_cdi`
+
+Adds support for using the Container Device Interface (CDI) specification to configure GPU passthrough in LXD containers. The `id` field of GPU devices now accepts CDI identifiers (for example, `{VENDOR_DOMAIN_NAME}/gpu=gpu{INDEX}`) for containers, in addition to DRM card IDs. This enables GPU passthrough for devices that don't use PCI addressing (like NVIDIA Tegra iGPUs) and provides a more flexible way to identify and configure GPU devices.

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -422,6 +422,7 @@ var APIExtensions = []string{
 	"network_ovn_uplink_vlan",
 	"state_logical_cpus",
 	"vm_limits_cpu_pin_strategy",
+	"gpu_cdi",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
Add an API extension for adding the CDI mode for GPU passthrough (see https://github.com/canonical/lxd/pull/13562)