### PR TITLE
doc: fix defaultdesc format for instance configuration related to boot

### DIFF
--- a/doc/metadata.txt
+++ b/doc/metadata.txt
@@ -1644,7 +1644,7 @@ If set to `false`, restore the last state.
 ```
 
 ```{config:option} boot.autostart.delay instance-boot
-:defaultdesc: "0"
+:defaultdesc: "`0`"
 :liveupdate: "no"
 :shortdesc: "Delay after starting the instance"
 :type: "integer"
@@ -1652,7 +1652,7 @@ The number of seconds to wait after the instance started before starting the nex
 ```
 
 ```{config:option} boot.autostart.priority instance-boot
-:defaultdesc: "0"
+:defaultdesc: "`0`"
 :liveupdate: "no"
 :shortdesc: "What order to start the instances in"
 :type: "integer"
@@ -1667,7 +1667,7 @@ A log file can be found in `$LXD_DIR/logs/<instance_name>/edk2.log`.
 ```
 
 ```{config:option} boot.host_shutdown_timeout instance-boot
-:defaultdesc: "30"
+:defaultdesc: "`30`"
 :liveupdate: "yes"
 :shortdesc: "How long to wait for the instance to shut down"
 :type: "integer"
@@ -1675,7 +1675,7 @@ Number of seconds to wait for the instance to shut down before it is force-stopp
 ```
 
 ```{config:option} boot.stop.priority instance-boot
-:defaultdesc: "0"
+:defaultdesc: "`0`"
 :liveupdate: "no"
 :shortdesc: "What order to shut down the instances in"
 :type: "integer"

--- a/lxd/instance/instancetype/instance.go
+++ b/lxd/instance/instancetype/instance.go
@@ -121,7 +121,7 @@ var InstanceConfigKeysAny = map[string]func(value string) error{
 	// The number of seconds to wait after the instance started before starting the next one.
 	// ---
 	//  type: integer
-	//  defaultdesc: "0"
+	//  defaultdesc: `0`
 	//  liveupdate: no
 	//  shortdesc: Delay after starting the instance
 	"boot.autostart.delay": validate.Optional(validate.IsInt64),
@@ -130,7 +130,7 @@ var InstanceConfigKeysAny = map[string]func(value string) error{
 	// The instance with the highest value is started first.
 	// ---
 	//  type: integer
-	//  defaultdesc: "0"
+	//  defaultdesc: `0`
 	//  liveupdate: no
 	//  shortdesc: What order to start the instances in
 	"boot.autostart.priority": validate.Optional(validate.IsInt64),
@@ -139,7 +139,7 @@ var InstanceConfigKeysAny = map[string]func(value string) error{
 	// The instance with the highest value is shut down first.
 	// ---
 	//  type: integer
-	//  defaultdesc: "0"
+	//  defaultdesc: `0`
 	//  liveupdate: no
 	//  shortdesc: What order to shut down the instances in
 	"boot.stop.priority": validate.Optional(validate.IsInt64),
@@ -148,7 +148,7 @@ var InstanceConfigKeysAny = map[string]func(value string) error{
 	// Number of seconds to wait for the instance to shut down before it is force-stopped.
 	// ---
 	//  type: integer
-	//  defaultdesc: "30"
+	//  defaultdesc: `30`
 	//  liveupdate: yes
 	//  shortdesc: How long to wait for the instance to shut down
 	"boot.host_shutdown_timeout": validate.Optional(validate.IsInt64),

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -1905,7 +1905,7 @@
 					},
 					{
 						"boot.autostart.delay": {
-							"defaultdesc": "\"0\"",
+							"defaultdesc": "`0`",
 							"liveupdate": "no",
 							"longdesc": "The number of seconds to wait after the instance started before starting the next one.",
 							"shortdesc": "Delay after starting the instance",
@@ -1914,7 +1914,7 @@
 					},
 					{
 						"boot.autostart.priority": {
-							"defaultdesc": "\"0\"",
+							"defaultdesc": "`0`",
 							"liveupdate": "no",
 							"longdesc": "The instance with the highest value is started first.",
 							"shortdesc": "What order to start the instances in",
@@ -1930,7 +1930,7 @@
 					},
 					{
 						"boot.host_shutdown_timeout": {
-							"defaultdesc": "\"30\"",
+							"defaultdesc": "`30`",
 							"liveupdate": "yes",
 							"longdesc": "Number of seconds to wait for the instance to shut down before it is force-stopped.",
 							"shortdesc": "How long to wait for the instance to shut down",
@@ -1939,7 +1939,7 @@
 					},
 					{
 						"boot.stop.priority": {
-							"defaultdesc": "\"0\"",
+							"defaultdesc": "`0`",
 							"liveupdate": "no",
 							"longdesc": "The instance with the highest value is shut down first.",
 							"shortdesc": "What order to shut down the instances in",


### PR DESCRIPTION
# Done
- fix defaultdesc format for instance configuration related to boot for the documentation and metadata api