### PR TITLE
github: Always use the latest Trivy database cache

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -40,7 +40,9 @@ jobs:
         uses: actions/cache/restore@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
         with:
           path: /home/runner/vuln-cache
-          key: trivy-latest-cache
+          key: download-failed # Use a non existing key to fallback to restore-keys
+          restore-keys: |
+            trivy-cache-
 
       - name: Run Trivy vulnerability scanner
         run: |
@@ -52,12 +54,10 @@ jobs:
           --output trivy-lxd-repo-scan-results.sarif .
 
       - name: Cache Trivy vulnerability database
-        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
+        uses: actions/cache/save@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
         with:
           path: /home/runner/vuln-cache
-          key: trivy-latest-cache-${{ github.run_id }}
-          restore-keys: |
-            trivy-latest-cache
+          key: trivy-cache-${{ github.run_id }}
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@4f3212b61783c3c68e8309a0f18a699764811cda # v3.27.1
@@ -89,7 +89,9 @@ jobs:
         uses: actions/cache/restore@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
         with:
           path: /home/runner/vuln-cache
-          key: trivy-latest-cache
+          key: download-failed # Use a non existing key to fallback to restore-keys
+          restore-keys: |
+            trivy-cache-
 
       - name: Download snap for scan
         run: |

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -35,7 +35,7 @@ jobs:
         run: trivy fs --download-db-only --cache-dir /home/runner/vuln-cache
         continue-on-error: true
 
-      - name: Use previous downloaded database
+      - name: Use previously downloaded database
         if: ${{ steps.db_download.outcome == 'failure' }}
         uses: actions/cache/restore@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
         with:


### PR DESCRIPTION
Although we are now resilient to failures from the Trivy server by using our cache, we are still using an older version of the cache, so this assures we are always using the latest by using the `restore-keys` option appropriately.