### PR TITLE
GitHub: Don't purge aproxy snap when reclaiming disk space

### DIFF
--- a/.github/actions/reclaim-disk-space/action.yml
+++ b/.github/actions/reclaim-disk-space/action.yml
@@ -9,8 +9,9 @@ runs:
       run: |
         set -eux
 
-        # Purge snaps, if any
-        for s in $(snap list | awk '!/^(Name|core|snapd)/ {print $1}'); do
+        # Purge snaps, if any.
+        # The Canonical runners use aproxy for connectivity.
+        for s in $(snap list | awk '!/^(Name|core|snapd|aproxy)/ {print $1}'); do
           sudo snap remove --purge "${s}" || true
         done
 


### PR DESCRIPTION
When using this action on the Canonical runners (e.g. MicroCloud) we cannot purge the aproxy snap as it is a critical component to ensure connectivity between the runner and GitHub. Removing it will cause the runner to hang up.

See [this](https://github.com/canonical/microcloud/actions/runs/11934150325/job/33262745369) job for an example. The error message is something like the following:

```
The self-hosted runner: openstack-amd64-large-ps6-3-c9077065b675 lost communication with the server. Verify the machine is running and has a healthy network connection. Anything in your workflow that terminates the runner process, starves it for CPU/Memory, or blocks its network access can cause this error.
```