### PR TITLE
doc: Document how to inspect a LXD coredump with GDB

### DIFF
--- a/doc/.wordlist.txt
+++ b/doc/.wordlist.txt
@@ -15,6 +15,7 @@ EKS
 enablement
 favicon
 Furo
+GDB
 Git
 GitHub
 Grafana
@@ -43,6 +44,7 @@ pre
 QCow
 Quickstart
 ReadMe
+REPL
 reST
 reStructuredText
 RTD


### PR DESCRIPTION
Adds developer docs for coredump inspection. I wrote it specifically about our CI because this wouldn't be possible with the stripped binaries that are added to the snap.