### PR TITLE
lxd: Show correct instance root disk size on API

### DIFF
--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -2516,13 +2516,13 @@ definitions:
     InstanceStateDisk:
         properties:
             total:
-                description: Total size in bytes
+                description: Total size in bytes. Uses -1 to convey that the instance has access to the entire pool's storage.
                 example: 502239232
                 format: int64
                 type: integer
                 x-go-name: Total
             usage:
-                description: Disk usage in bytes
+                description: Disk usage in bytes. Uses -1 to indicate that the storage driver for the instance's pool does not support retrieving the disk usage.
                 example: 502239232
                 format: int64
                 type: integer

--- a/lxc/info.go
+++ b/lxc/info.go
@@ -507,18 +507,30 @@ func (c *cmdInfo) instanceInfo(d lxd.InstanceServer, name string, showLog bool) 
 		fmt.Printf("  "+i18n.G("Processes: %d")+"\n", inst.State.Processes)
 
 		// Disk usage
-		diskInfo := ""
+		diskUsage := ""
+		diskTotal := ""
 		if inst.State.Disk != nil {
 			for entry, disk := range inst.State.Disk {
-				if disk.Usage != 0 {
-					diskInfo += fmt.Sprintf("    %s: %s\n", entry, units.GetByteSizeStringIEC(disk.Usage, 2))
+				// Only show usage when supported.
+				if disk.Usage != -1 {
+					diskUsage += fmt.Sprintf("    %s: %s\n", entry, units.GetByteSizeStringIEC(disk.Usage, 2))
+				}
+			}
+
+			for entry, disk := range inst.State.Disk {
+				// Only show total for disks that are bounded within the pool.
+				if disk.Total != -1 {
+					diskTotal += fmt.Sprintf("    %s: %s\n", entry, units.GetByteSizeStringIEC(disk.Usage, 2))
 				}
 			}
 		}
 
-		if diskInfo != "" {
-			fmt.Printf("  %s\n", i18n.G("Disk usage:"))
-			fmt.Print(diskInfo)
+		if diskUsage != "" {
+			fmt.Printf("  %s\n%s", i18n.G("Disk usage:"), diskUsage)
+		}
+
+		if diskTotal != "" {
+			fmt.Printf("  %s\n%s", i18n.G("Disk total:"), diskTotal)
 		}
 
 		// CPU usage

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -3261,12 +3261,14 @@ func (b *lxdBackend) GetInstanceUsage(inst instance.Instance) (*VolumeUsage, err
 	volStorageName := project.Instance(inst.Project().Name, inst.Name())
 	vol := b.GetVolume(volType, contentType, volStorageName, dbVol.Config)
 
-	// Get the usage.
+	// Get the usage
+	// If storage driver does not support getting the volume usage, proceed getting the total.
 	size, err := b.driver.GetVolumeUsage(vol)
-	if err != nil {
+	if err != nil && !errors.Is(err, drivers.ErrNotSupported) {
 		return nil, err
 	}
 
+	// If driver does not support getting volume usage, this value would be -1.
 	val.Used = size
 
 	// Get the total size.

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -3289,6 +3289,14 @@ func (b *lxdBackend) GetInstanceUsage(inst instance.Instance) (*VolumeUsage, err
 		}
 	}
 
+	// If the instance volume is neither block based/typed nor bound by the device's size config key,
+	// this means it is only bound by the pool limits and has access to the entire pool storage.
+	// So instead of showing the entire pool size for each instance disk, we return -1 to signify the root disk
+	// is unbounded below the pool level.
+	if val.Total == 0 {
+		val.Total = -1
+	}
+
 	return &val, nil
 }
 

--- a/po/ar.po
+++ b/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-09 03:18-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -855,7 +855,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -903,11 +903,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:577 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:944
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:578 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:945
 msgid "Bytes sent"
 msgstr ""
 
@@ -936,11 +936,11 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:527
+#: lxc/info.go:539
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:531
+#: lxc/info.go:543
 msgid "CPU usage:"
 msgstr ""
 
@@ -1865,7 +1865,11 @@ msgstr ""
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:520
+#: lxc/info.go:533
+msgid "Disk total:"
+msgstr ""
+
+#: lxc/info.go:529
 msgid "Disk usage:"
 msgstr ""
 
@@ -2138,7 +2142,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
 #: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
@@ -2663,7 +2667,7 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:578
 msgid "Host interface"
 msgstr ""
 
@@ -2717,7 +2721,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:582
+#: lxc/info.go:594
 msgid "IP addresses"
 msgstr ""
 
@@ -2879,7 +2883,7 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:692
+#: lxc/info.go:704
 msgid "Instance Only"
 msgstr ""
 
@@ -3433,7 +3437,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:720
+#: lxc/info.go:732
 msgid "Log:"
 msgstr ""
 
@@ -3449,7 +3453,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:570
+#: lxc/info.go:582
 msgid "MAC address"
 msgstr ""
 
@@ -3492,7 +3496,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:586
 msgid "MTU"
 msgstr ""
 
@@ -3740,15 +3744,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:550
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:554
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:566
 msgid "Memory usage:"
 msgstr ""
 
@@ -4088,7 +4092,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
 #: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
@@ -4201,7 +4205,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:595 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:943
 msgid "Network usage:"
 msgstr ""
 
@@ -4320,7 +4324,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4379,11 +4383,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:579 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:946
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:580 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:947
 msgid "Packets sent"
 msgstr ""
 
@@ -5619,7 +5623,7 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -5650,7 +5654,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:576
 msgid "State"
 msgstr ""
 
@@ -5659,7 +5663,7 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:641
+#: lxc/info.go:653
 msgid "Stateful"
 msgstr ""
 
@@ -5761,11 +5765,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:558
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:550
+#: lxc/info.go:562
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5806,7 +5810,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -6130,7 +6134,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:563
+#: lxc/info.go:575
 msgid "Type"
 msgstr ""
 
@@ -6375,7 +6379,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:724
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-09 03:18-0300\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -858,7 +858,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -906,11 +906,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:577 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:944
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:578 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:945
 msgid "Bytes sent"
 msgstr ""
 
@@ -939,11 +939,11 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:527
+#: lxc/info.go:539
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:531
+#: lxc/info.go:543
 msgid "CPU usage:"
 msgstr ""
 
@@ -1868,7 +1868,11 @@ msgstr ""
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:520
+#: lxc/info.go:533
+msgid "Disk total:"
+msgstr ""
+
+#: lxc/info.go:529
 msgid "Disk usage:"
 msgstr ""
 
@@ -2141,7 +2145,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
 #: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
@@ -2666,7 +2670,7 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:578
 msgid "Host interface"
 msgstr ""
 
@@ -2720,7 +2724,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:582
+#: lxc/info.go:594
 msgid "IP addresses"
 msgstr ""
 
@@ -2882,7 +2886,7 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:692
+#: lxc/info.go:704
 msgid "Instance Only"
 msgstr ""
 
@@ -3436,7 +3440,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:720
+#: lxc/info.go:732
 msgid "Log:"
 msgstr ""
 
@@ -3452,7 +3456,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:570
+#: lxc/info.go:582
 msgid "MAC address"
 msgstr ""
 
@@ -3495,7 +3499,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:586
 msgid "MTU"
 msgstr ""
 
@@ -3743,15 +3747,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:550
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:554
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:566
 msgid "Memory usage:"
 msgstr ""
 
@@ -4091,7 +4095,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
 #: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
@@ -4204,7 +4208,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:595 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:943
 msgid "Network usage:"
 msgstr ""
 
@@ -4323,7 +4327,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4382,11 +4386,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:579 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:946
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:580 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:947
 msgid "Packets sent"
 msgstr ""
 
@@ -5622,7 +5626,7 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -5653,7 +5657,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:576
 msgid "State"
 msgstr ""
 
@@ -5662,7 +5666,7 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:641
+#: lxc/info.go:653
 msgid "Stateful"
 msgstr ""
 
@@ -5764,11 +5768,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:558
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:550
+#: lxc/info.go:562
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5809,7 +5813,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -6133,7 +6137,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:563
+#: lxc/info.go:575
 msgid "Type"
 msgstr ""
 
@@ -6378,7 +6382,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:724
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-09 03:18-0300\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -858,7 +858,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -906,11 +906,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:577 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:944
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:578 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:945
 msgid "Bytes sent"
 msgstr ""
 
@@ -939,11 +939,11 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:527
+#: lxc/info.go:539
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:531
+#: lxc/info.go:543
 msgid "CPU usage:"
 msgstr ""
 
@@ -1868,7 +1868,11 @@ msgstr ""
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:520
+#: lxc/info.go:533
+msgid "Disk total:"
+msgstr ""
+
+#: lxc/info.go:529
 msgid "Disk usage:"
 msgstr ""
 
@@ -2141,7 +2145,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
 #: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
@@ -2666,7 +2670,7 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:578
 msgid "Host interface"
 msgstr ""
 
@@ -2720,7 +2724,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:582
+#: lxc/info.go:594
 msgid "IP addresses"
 msgstr ""
 
@@ -2882,7 +2886,7 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:692
+#: lxc/info.go:704
 msgid "Instance Only"
 msgstr ""
 
@@ -3436,7 +3440,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:720
+#: lxc/info.go:732
 msgid "Log:"
 msgstr ""
 
@@ -3452,7 +3456,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:570
+#: lxc/info.go:582
 msgid "MAC address"
 msgstr ""
 
@@ -3495,7 +3499,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:586
 msgid "MTU"
 msgstr ""
 
@@ -3743,15 +3747,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:550
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:554
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:566
 msgid "Memory usage:"
 msgstr ""
 
@@ -4091,7 +4095,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
 #: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
@@ -4204,7 +4208,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:595 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:943
 msgid "Network usage:"
 msgstr ""
 
@@ -4323,7 +4327,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4382,11 +4386,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:579 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:946
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:580 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:947
 msgid "Packets sent"
 msgstr ""
 
@@ -5622,7 +5626,7 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -5653,7 +5657,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:576
 msgid "State"
 msgstr ""
 
@@ -5662,7 +5666,7 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:641
+#: lxc/info.go:653
 msgid "Stateful"
 msgstr ""
 
@@ -5764,11 +5768,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:558
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:550
+#: lxc/info.go:562
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5809,7 +5813,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -6133,7 +6137,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:563
+#: lxc/info.go:575
 msgid "Type"
 msgstr ""
 
@@ -6378,7 +6382,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:724
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-09 03:18-0300\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -858,7 +858,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -906,11 +906,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:577 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:944
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:578 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:945
 msgid "Bytes sent"
 msgstr ""
 
@@ -939,11 +939,11 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:527
+#: lxc/info.go:539
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:531
+#: lxc/info.go:543
 msgid "CPU usage:"
 msgstr ""
 
@@ -1868,7 +1868,11 @@ msgstr ""
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:520
+#: lxc/info.go:533
+msgid "Disk total:"
+msgstr ""
+
+#: lxc/info.go:529
 msgid "Disk usage:"
 msgstr ""
 
@@ -2141,7 +2145,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
 #: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
@@ -2666,7 +2670,7 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:578
 msgid "Host interface"
 msgstr ""
 
@@ -2720,7 +2724,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:582
+#: lxc/info.go:594
 msgid "IP addresses"
 msgstr ""
 
@@ -2882,7 +2886,7 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:692
+#: lxc/info.go:704
 msgid "Instance Only"
 msgstr ""
 
@@ -3436,7 +3440,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:720
+#: lxc/info.go:732
 msgid "Log:"
 msgstr ""
 
@@ -3452,7 +3456,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:570
+#: lxc/info.go:582
 msgid "MAC address"
 msgstr ""
 
@@ -3495,7 +3499,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:586
 msgid "MTU"
 msgstr ""
 
@@ -3743,15 +3747,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:550
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:554
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:566
 msgid "Memory usage:"
 msgstr ""
 
@@ -4091,7 +4095,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
 #: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
@@ -4204,7 +4208,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:595 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:943
 msgid "Network usage:"
 msgstr ""
 
@@ -4323,7 +4327,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4382,11 +4386,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:579 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:946
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:580 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:947
 msgid "Packets sent"
 msgstr ""
 
@@ -5622,7 +5626,7 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -5653,7 +5657,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:576
 msgid "State"
 msgstr ""
 
@@ -5662,7 +5666,7 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:641
+#: lxc/info.go:653
 msgid "Stateful"
 msgstr ""
 
@@ -5764,11 +5768,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:558
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:550
+#: lxc/info.go:562
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5809,7 +5813,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -6133,7 +6137,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:563
+#: lxc/info.go:575
 msgid "Type"
 msgstr ""
 
@@ -6378,7 +6382,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:724
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-09 03:18-0300\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -858,7 +858,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -906,11 +906,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:577 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:944
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:578 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:945
 msgid "Bytes sent"
 msgstr ""
 
@@ -939,11 +939,11 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:527
+#: lxc/info.go:539
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:531
+#: lxc/info.go:543
 msgid "CPU usage:"
 msgstr ""
 
@@ -1868,7 +1868,11 @@ msgstr ""
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:520
+#: lxc/info.go:533
+msgid "Disk total:"
+msgstr ""
+
+#: lxc/info.go:529
 msgid "Disk usage:"
 msgstr ""
 
@@ -2141,7 +2145,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
 #: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
@@ -2666,7 +2670,7 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:578
 msgid "Host interface"
 msgstr ""
 
@@ -2720,7 +2724,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:582
+#: lxc/info.go:594
 msgid "IP addresses"
 msgstr ""
 
@@ -2882,7 +2886,7 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:692
+#: lxc/info.go:704
 msgid "Instance Only"
 msgstr ""
 
@@ -3436,7 +3440,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:720
+#: lxc/info.go:732
 msgid "Log:"
 msgstr ""
 
@@ -3452,7 +3456,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:570
+#: lxc/info.go:582
 msgid "MAC address"
 msgstr ""
 
@@ -3495,7 +3499,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:586
 msgid "MTU"
 msgstr ""
 
@@ -3743,15 +3747,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:550
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:554
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:566
 msgid "Memory usage:"
 msgstr ""
 
@@ -4091,7 +4095,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
 #: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
@@ -4204,7 +4208,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:595 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:943
 msgid "Network usage:"
 msgstr ""
 
@@ -4323,7 +4327,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4382,11 +4386,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:579 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:946
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:580 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:947
 msgid "Packets sent"
 msgstr ""
 
@@ -5622,7 +5626,7 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -5653,7 +5657,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:576
 msgid "State"
 msgstr ""
 
@@ -5662,7 +5666,7 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:641
+#: lxc/info.go:653
 msgid "Stateful"
 msgstr ""
 
@@ -5764,11 +5768,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:558
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:550
+#: lxc/info.go:562
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5809,7 +5813,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -6133,7 +6137,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:563
+#: lxc/info.go:575
 msgid "Type"
 msgstr ""
 
@@ -6378,7 +6382,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:724
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-09 03:18-0300\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -1143,7 +1143,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Backup exported successfully!"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/info.go:654 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -1191,11 +1191,11 @@ msgstr "Erstellt: %s"
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:577 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:944
 msgid "Bytes received"
 msgstr "Bytes empfangen"
 
-#: lxc/info.go:578 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:945
 msgid "Bytes sent"
 msgstr "Bytes gesendet"
 
@@ -1224,11 +1224,11 @@ msgstr " Prozessorauslastung:"
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:527
+#: lxc/info.go:539
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:531
+#: lxc/info.go:543
 #, fuzzy
 msgid "CPU usage:"
 msgstr " Prozessorauslastung:"
@@ -2222,7 +2222,12 @@ msgstr ""
 msgid "Disk %d:"
 msgstr " Prozessorauslastung:"
 
-#: lxc/info.go:520
+#: lxc/info.go:533
+#, fuzzy
+msgid "Disk total:"
+msgstr " Prozessorauslastung:"
+
+#: lxc/info.go:529
 #, fuzzy
 msgid "Disk usage:"
 msgstr " Prozessorauslastung:"
@@ -2527,7 +2532,7 @@ msgstr ""
 "\n"
 "lxc exec <Container> [--env EDITOR=/usr/bin/vim]... <Befehl>\n"
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
 #: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
@@ -3081,7 +3086,7 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:578
 #, fuzzy
 msgid "Host interface"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -3136,7 +3141,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:582
+#: lxc/info.go:594
 #, fuzzy
 msgid "IP addresses"
 msgstr "Profil %s erstellt\n"
@@ -3304,7 +3309,7 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:692
+#: lxc/info.go:704
 msgid "Instance Only"
 msgstr ""
 
@@ -3899,7 +3904,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:720
+#: lxc/info.go:732
 msgid "Log:"
 msgstr ""
 
@@ -3917,7 +3922,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:570
+#: lxc/info.go:582
 #, fuzzy
 msgid "MAC address"
 msgstr "Profil %s erstellt\n"
@@ -3965,7 +3970,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:586
 msgid "MTU"
 msgstr ""
 
@@ -4248,15 +4253,15 @@ msgstr "Gerät %s wurde von %s entfernt\n"
 msgid "Member %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/info.go:538
+#: lxc/info.go:550
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:554
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:566
 msgid "Memory usage:"
 msgstr ""
 
@@ -4623,7 +4628,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
 #: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
@@ -4737,7 +4742,7 @@ msgstr ""
 msgid "Network type"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/info.go:595 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:943
 #, fuzzy
 msgid "Network usage:"
 msgstr "Profil %s erstellt\n"
@@ -4862,7 +4867,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/info.go:693 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4921,11 +4926,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:579 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:946
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:580 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:947
 msgid "Packets sent"
 msgstr ""
 
@@ -6258,7 +6263,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -6290,7 +6295,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:576
 #, fuzzy
 msgid "State"
 msgstr "Erstellt: %s"
@@ -6300,7 +6305,7 @@ msgstr "Erstellt: %s"
 msgid "State: %s"
 msgstr "Erstellt: %s"
 
-#: lxc/info.go:641
+#: lxc/info.go:653
 msgid "Stateful"
 msgstr ""
 
@@ -6408,11 +6413,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:558
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:550
+#: lxc/info.go:562
 msgid "Swap (peak)"
 msgstr ""
 
@@ -6453,7 +6458,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -6789,7 +6794,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:563
+#: lxc/info.go:575
 msgid "Type"
 msgstr ""
 
@@ -7062,7 +7067,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:724
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-09 03:18-0300\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -861,7 +861,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -909,11 +909,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:577 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:944
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:578 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:945
 msgid "Bytes sent"
 msgstr ""
 
@@ -942,11 +942,11 @@ msgstr "  Χρήση CPU:"
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:527
+#: lxc/info.go:539
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:531
+#: lxc/info.go:543
 #, fuzzy
 msgid "CPU usage:"
 msgstr "  Χρήση CPU:"
@@ -1881,7 +1881,12 @@ msgstr ""
 msgid "Disk %d:"
 msgstr "  Χρήση CPU:"
 
-#: lxc/info.go:520
+#: lxc/info.go:533
+#, fuzzy
+msgid "Disk total:"
+msgstr "  Χρήση CPU:"
+
+#: lxc/info.go:529
 #, fuzzy
 msgid "Disk usage:"
 msgstr "  Χρήση CPU:"
@@ -2163,7 +2168,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
 #: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
@@ -2701,7 +2706,7 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:578
 msgid "Host interface"
 msgstr ""
 
@@ -2755,7 +2760,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:582
+#: lxc/info.go:594
 msgid "IP addresses"
 msgstr ""
 
@@ -2917,7 +2922,7 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:692
+#: lxc/info.go:704
 msgid "Instance Only"
 msgstr ""
 
@@ -3473,7 +3478,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:720
+#: lxc/info.go:732
 msgid "Log:"
 msgstr ""
 
@@ -3489,7 +3494,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:570
+#: lxc/info.go:582
 msgid "MAC address"
 msgstr ""
 
@@ -3532,7 +3537,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:586
 msgid "MTU"
 msgstr ""
 
@@ -3794,15 +3799,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:550
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:554
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:566
 #, fuzzy
 msgid "Memory usage:"
 msgstr "  Χρήση μνήμης:"
@@ -4153,7 +4158,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
 #: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
@@ -4267,7 +4272,7 @@ msgstr ""
 msgid "Network type"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/info.go:595 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:943
 #, fuzzy
 msgid "Network usage:"
 msgstr "  Χρήση δικτύου:"
@@ -4387,7 +4392,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4446,11 +4451,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:579 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:946
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:580 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:947
 msgid "Packets sent"
 msgstr ""
 
@@ -5717,7 +5722,7 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -5748,7 +5753,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:576
 msgid "State"
 msgstr ""
 
@@ -5757,7 +5762,7 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:641
+#: lxc/info.go:653
 msgid "Stateful"
 msgstr ""
 
@@ -5859,11 +5864,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:558
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:550
+#: lxc/info.go:562
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5904,7 +5909,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -6229,7 +6234,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:563
+#: lxc/info.go:575
 msgid "Type"
 msgstr ""
 
@@ -6491,7 +6496,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:724
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-09 03:18-0300\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -858,7 +858,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -906,11 +906,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:577 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:944
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:578 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:945
 msgid "Bytes sent"
 msgstr ""
 
@@ -939,11 +939,11 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:527
+#: lxc/info.go:539
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:531
+#: lxc/info.go:543
 msgid "CPU usage:"
 msgstr ""
 
@@ -1868,7 +1868,11 @@ msgstr ""
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:520
+#: lxc/info.go:533
+msgid "Disk total:"
+msgstr ""
+
+#: lxc/info.go:529
 msgid "Disk usage:"
 msgstr ""
 
@@ -2141,7 +2145,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
 #: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
@@ -2666,7 +2670,7 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:578
 msgid "Host interface"
 msgstr ""
 
@@ -2720,7 +2724,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:582
+#: lxc/info.go:594
 msgid "IP addresses"
 msgstr ""
 
@@ -2882,7 +2886,7 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:692
+#: lxc/info.go:704
 msgid "Instance Only"
 msgstr ""
 
@@ -3436,7 +3440,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:720
+#: lxc/info.go:732
 msgid "Log:"
 msgstr ""
 
@@ -3452,7 +3456,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:570
+#: lxc/info.go:582
 msgid "MAC address"
 msgstr ""
 
@@ -3495,7 +3499,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:586
 msgid "MTU"
 msgstr ""
 
@@ -3743,15 +3747,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:550
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:554
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:566
 msgid "Memory usage:"
 msgstr ""
 
@@ -4091,7 +4095,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
 #: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
@@ -4204,7 +4208,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:595 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:943
 msgid "Network usage:"
 msgstr ""
 
@@ -4323,7 +4327,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4382,11 +4386,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:579 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:946
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:580 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:947
 msgid "Packets sent"
 msgstr ""
 
@@ -5622,7 +5626,7 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -5653,7 +5657,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:576
 msgid "State"
 msgstr ""
 
@@ -5662,7 +5666,7 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:641
+#: lxc/info.go:653
 msgid "Stateful"
 msgstr ""
 
@@ -5764,11 +5768,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:558
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:550
+#: lxc/info.go:562
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5809,7 +5813,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -6133,7 +6137,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:563
+#: lxc/info.go:575
 msgid "Type"
 msgstr ""
 
@@ -6378,7 +6382,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:724
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-09 03:18-0300\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -1107,7 +1107,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -1156,11 +1156,11 @@ msgstr "Creado: %s"
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:577 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:944
 msgid "Bytes received"
 msgstr "Bytes recibidos"
 
-#: lxc/info.go:578 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:945
 msgid "Bytes sent"
 msgstr "Bytes enviados"
 
@@ -1189,11 +1189,11 @@ msgstr "CPU (%s):"
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:527
+#: lxc/info.go:539
 msgid "CPU usage (in seconds)"
 msgstr "Uso de CPU (en segundos)"
 
-#: lxc/info.go:531
+#: lxc/info.go:543
 msgid "CPU usage:"
 msgstr "Uso de CPU:"
 
@@ -2146,7 +2146,12 @@ msgstr ""
 msgid "Disk %d:"
 msgstr "Disco %d:"
 
-#: lxc/info.go:520
+#: lxc/info.go:533
+#, fuzzy
+msgid "Disk total:"
+msgstr "Uso del disco:"
+
+#: lxc/info.go:529
 msgid "Disk usage:"
 msgstr "Uso del disco:"
 
@@ -2429,7 +2434,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
 #: lxc/storage_volume.go:1564
 #, fuzzy
 msgid "Expires at"
@@ -2972,7 +2977,7 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:578
 #, fuzzy
 msgid "Host interface"
 msgstr "Aliases:"
@@ -3027,7 +3032,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:582
+#: lxc/info.go:594
 #, fuzzy
 msgid "IP addresses"
 msgstr "Expira: %s"
@@ -3192,7 +3197,7 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:692
+#: lxc/info.go:704
 #, fuzzy
 msgid "Instance Only"
 msgstr "Nombre del contenedor es: %s"
@@ -3765,7 +3770,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:720
+#: lxc/info.go:732
 msgid "Log:"
 msgstr "Registro:"
 
@@ -3781,7 +3786,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:570
+#: lxc/info.go:582
 #, fuzzy
 msgid "MAC address"
 msgstr "Expira: %s"
@@ -3825,7 +3830,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:586
 msgid "MTU"
 msgstr ""
 
@@ -4088,15 +4093,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:550
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:554
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:566
 msgid "Memory usage:"
 msgstr ""
 
@@ -4456,7 +4461,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
 #: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
@@ -4569,7 +4574,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:595 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:943
 msgid "Network usage:"
 msgstr ""
 
@@ -4688,7 +4693,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4747,11 +4752,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:579 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:946
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:580 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:947
 msgid "Packets sent"
 msgstr ""
 
@@ -6034,7 +6039,7 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -6065,7 +6070,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:576
 #, fuzzy
 msgid "State"
 msgstr "Auto actualización: %s"
@@ -6075,7 +6080,7 @@ msgstr "Auto actualización: %s"
 msgid "State: %s"
 msgstr "Auto actualización: %s"
 
-#: lxc/info.go:641
+#: lxc/info.go:653
 msgid "Stateful"
 msgstr ""
 
@@ -6177,11 +6182,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:558
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:550
+#: lxc/info.go:562
 msgid "Swap (peak)"
 msgstr ""
 
@@ -6222,7 +6227,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -6550,7 +6555,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:563
+#: lxc/info.go:575
 #, fuzzy
 msgid "Type"
 msgstr "Expira: %s"
@@ -6815,7 +6820,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:724
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-09 03:18-0300\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -858,7 +858,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -906,11 +906,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:577 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:944
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:578 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:945
 msgid "Bytes sent"
 msgstr ""
 
@@ -939,11 +939,11 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:527
+#: lxc/info.go:539
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:531
+#: lxc/info.go:543
 msgid "CPU usage:"
 msgstr ""
 
@@ -1868,7 +1868,11 @@ msgstr ""
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:520
+#: lxc/info.go:533
+msgid "Disk total:"
+msgstr ""
+
+#: lxc/info.go:529
 msgid "Disk usage:"
 msgstr ""
 
@@ -2141,7 +2145,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
 #: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
@@ -2666,7 +2670,7 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:578
 msgid "Host interface"
 msgstr ""
 
@@ -2720,7 +2724,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:582
+#: lxc/info.go:594
 msgid "IP addresses"
 msgstr ""
 
@@ -2882,7 +2886,7 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:692
+#: lxc/info.go:704
 msgid "Instance Only"
 msgstr ""
 
@@ -3436,7 +3440,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:720
+#: lxc/info.go:732
 msgid "Log:"
 msgstr ""
 
@@ -3452,7 +3456,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:570
+#: lxc/info.go:582
 msgid "MAC address"
 msgstr ""
 
@@ -3495,7 +3499,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:586
 msgid "MTU"
 msgstr ""
 
@@ -3743,15 +3747,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:550
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:554
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:566
 msgid "Memory usage:"
 msgstr ""
 
@@ -4091,7 +4095,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
 #: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
@@ -4204,7 +4208,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:595 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:943
 msgid "Network usage:"
 msgstr ""
 
@@ -4323,7 +4327,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4382,11 +4386,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:579 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:946
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:580 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:947
 msgid "Packets sent"
 msgstr ""
 
@@ -5622,7 +5626,7 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -5653,7 +5657,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:576
 msgid "State"
 msgstr ""
 
@@ -5662,7 +5666,7 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:641
+#: lxc/info.go:653
 msgid "Stateful"
 msgstr ""
 
@@ -5764,11 +5768,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:558
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:550
+#: lxc/info.go:562
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5809,7 +5813,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -6133,7 +6137,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:563
+#: lxc/info.go:575
 msgid "Type"
 msgstr ""
 
@@ -6378,7 +6382,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:724
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-09 03:18-0300\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -858,7 +858,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -906,11 +906,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:577 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:944
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:578 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:945
 msgid "Bytes sent"
 msgstr ""
 
@@ -939,11 +939,11 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:527
+#: lxc/info.go:539
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:531
+#: lxc/info.go:543
 msgid "CPU usage:"
 msgstr ""
 
@@ -1868,7 +1868,11 @@ msgstr ""
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:520
+#: lxc/info.go:533
+msgid "Disk total:"
+msgstr ""
+
+#: lxc/info.go:529
 msgid "Disk usage:"
 msgstr ""
 
@@ -2141,7 +2145,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
 #: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
@@ -2666,7 +2670,7 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:578
 msgid "Host interface"
 msgstr ""
 
@@ -2720,7 +2724,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:582
+#: lxc/info.go:594
 msgid "IP addresses"
 msgstr ""
 
@@ -2882,7 +2886,7 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:692
+#: lxc/info.go:704
 msgid "Instance Only"
 msgstr ""
 
@@ -3436,7 +3440,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:720
+#: lxc/info.go:732
 msgid "Log:"
 msgstr ""
 
@@ -3452,7 +3456,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:570
+#: lxc/info.go:582
 msgid "MAC address"
 msgstr ""
 
@@ -3495,7 +3499,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:586
 msgid "MTU"
 msgstr ""
 
@@ -3743,15 +3747,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:550
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:554
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:566
 msgid "Memory usage:"
 msgstr ""
 
@@ -4091,7 +4095,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
 #: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
@@ -4204,7 +4208,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:595 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:943
 msgid "Network usage:"
 msgstr ""
 
@@ -4323,7 +4327,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4382,11 +4386,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:579 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:946
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:580 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:947
 msgid "Packets sent"
 msgstr ""
 
@@ -5622,7 +5626,7 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -5653,7 +5657,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:576
 msgid "State"
 msgstr ""
 
@@ -5662,7 +5666,7 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:641
+#: lxc/info.go:653
 msgid "Stateful"
 msgstr ""
 
@@ -5764,11 +5768,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:558
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:550
+#: lxc/info.go:562
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5809,7 +5813,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -6133,7 +6137,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:563
+#: lxc/info.go:575
 msgid "Type"
 msgstr ""
 
@@ -6378,7 +6382,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:724
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-09 03:18-0300\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -1146,7 +1146,7 @@ msgstr "Copie de l'image : %s"
 msgid "Backup exported successfully!"
 msgstr "Image copiée avec succès !"
 
-#: lxc/info.go:654 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -1194,11 +1194,11 @@ msgstr "Créé : %s"
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:577 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:944
 msgid "Bytes received"
 msgstr "Octets reçus"
 
-#: lxc/info.go:578 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:945
 msgid "Bytes sent"
 msgstr "Octets émis"
 
@@ -1227,11 +1227,11 @@ msgstr "CPU utilisé :"
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:527
+#: lxc/info.go:539
 msgid "CPU usage (in seconds)"
 msgstr "CPU utilisé (en secondes)"
 
-#: lxc/info.go:531
+#: lxc/info.go:543
 msgid "CPU usage:"
 msgstr "CPU utilisé :"
 
@@ -2242,7 +2242,12 @@ msgstr "Désactiver stdin (lecture à partir de /dev/null)"
 msgid "Disk %d:"
 msgstr "  Disque utilisé :"
 
-#: lxc/info.go:520
+#: lxc/info.go:533
+#, fuzzy
+msgid "Disk total:"
+msgstr "  Disque utilisé :"
+
+#: lxc/info.go:529
 #, fuzzy
 msgid "Disk usage:"
 msgstr "  Disque utilisé :"
@@ -2557,7 +2562,7 @@ msgstr ""
 "sélectionné si à la fois stdin et stdout sont des terminaux (stderr\n"
 "est ignoré)."
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
 #: lxc/storage_volume.go:1564
 #, fuzzy
 msgid "Expires at"
@@ -3118,7 +3123,7 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr "NOM"
 
-#: lxc/info.go:566
+#: lxc/info.go:578
 #, fuzzy
 msgid "Host interface"
 msgstr "L'arrêt du conteneur a échoué !"
@@ -3174,7 +3179,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:582
+#: lxc/info.go:594
 #, fuzzy
 msgid "IP addresses"
 msgstr "Expire : %s"
@@ -3348,7 +3353,7 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:692
+#: lxc/info.go:704
 #, fuzzy
 msgid "Instance Only"
 msgstr "Le nom du conteneur est : %s"
@@ -3988,7 +3993,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:720
+#: lxc/info.go:732
 msgid "Log:"
 msgstr "Journal : "
 
@@ -4006,7 +4011,7 @@ msgstr "Création du conteneur"
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:570
+#: lxc/info.go:582
 #, fuzzy
 msgid "MAC address"
 msgstr "Expire : %s"
@@ -4050,7 +4055,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:586
 msgid "MTU"
 msgstr ""
 
@@ -4332,15 +4337,15 @@ msgstr "Profil %s supprimé de %s"
 msgid "Member %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
 
-#: lxc/info.go:538
+#: lxc/info.go:550
 msgid "Memory (current)"
 msgstr "Mémoire (courante)"
 
-#: lxc/info.go:542
+#: lxc/info.go:554
 msgid "Memory (peak)"
 msgstr "Mémoire (pointe)"
 
-#: lxc/info.go:554
+#: lxc/info.go:566
 #, fuzzy
 msgid "Memory usage:"
 msgstr "  Mémoire utilisée :"
@@ -4713,7 +4718,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
 #: lxc/storage_volume.go:1562
 #, fuzzy
 msgid "Name"
@@ -4828,7 +4833,7 @@ msgstr ""
 msgid "Network type"
 msgstr "Nom du réseau"
 
-#: lxc/info.go:595 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:943
 #, fuzzy
 msgid "Network usage:"
 msgstr "  Réseau utilisé :"
@@ -4963,7 +4968,7 @@ msgstr "Seuls les réseaux gérés par LXD peuvent être modifiés."
 msgid "Operation %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: lxc/info.go:693 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5023,11 +5028,11 @@ msgstr "PROTOCOLE"
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
-#: lxc/info.go:579 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:946
 msgid "Packets received"
 msgstr "Paquets reçus"
 
-#: lxc/info.go:580 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:947
 msgid "Packets sent"
 msgstr "Paquets émis"
 
@@ -6393,7 +6398,7 @@ msgstr "Copie de l'image : %s"
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr "Instantanés :"
 
@@ -6425,7 +6430,7 @@ msgstr "Création du conteneur"
 msgid "Starting %s"
 msgstr "Démarrage de %s"
 
-#: lxc/info.go:564
+#: lxc/info.go:576
 #, fuzzy
 msgid "State"
 msgstr "État : %s"
@@ -6435,7 +6440,7 @@ msgstr "État : %s"
 msgid "State: %s"
 msgstr "État : %s"
 
-#: lxc/info.go:641
+#: lxc/info.go:653
 #, fuzzy
 msgid "Stateful"
 msgstr "à suivi d'état"
@@ -6544,11 +6549,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:558
 msgid "Swap (current)"
 msgstr "Swap (courant)"
 
-#: lxc/info.go:550
+#: lxc/info.go:562
 msgid "Swap (peak)"
 msgstr "Swap (pointe)"
 
@@ -6591,7 +6596,7 @@ msgstr ""
 msgid "TYPE"
 msgstr "TYPE"
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
 #, fuzzy
 msgid "Taken at"
 msgstr "pris à %s"
@@ -6932,7 +6937,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr "Essayer `lxc info --show-log %s` pour plus d'informations"
 
-#: lxc/info.go:563
+#: lxc/info.go:575
 #, fuzzy
 msgid "Type"
 msgstr "Expire : %s"
@@ -7209,7 +7214,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:724
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-09 03:18-0300\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -859,7 +859,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -907,11 +907,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:577 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:944
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:578 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:945
 msgid "Bytes sent"
 msgstr ""
 
@@ -940,11 +940,11 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:527
+#: lxc/info.go:539
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:531
+#: lxc/info.go:543
 msgid "CPU usage:"
 msgstr ""
 
@@ -1869,7 +1869,11 @@ msgstr ""
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:520
+#: lxc/info.go:533
+msgid "Disk total:"
+msgstr ""
+
+#: lxc/info.go:529
 msgid "Disk usage:"
 msgstr ""
 
@@ -2142,7 +2146,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
 #: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
@@ -2667,7 +2671,7 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:578
 msgid "Host interface"
 msgstr ""
 
@@ -2721,7 +2725,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:582
+#: lxc/info.go:594
 msgid "IP addresses"
 msgstr ""
 
@@ -2883,7 +2887,7 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:692
+#: lxc/info.go:704
 msgid "Instance Only"
 msgstr ""
 
@@ -3437,7 +3441,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:720
+#: lxc/info.go:732
 msgid "Log:"
 msgstr ""
 
@@ -3453,7 +3457,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:570
+#: lxc/info.go:582
 msgid "MAC address"
 msgstr ""
 
@@ -3496,7 +3500,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:586
 msgid "MTU"
 msgstr ""
 
@@ -3744,15 +3748,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:550
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:554
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:566
 msgid "Memory usage:"
 msgstr ""
 
@@ -4092,7 +4096,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
 #: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
@@ -4205,7 +4209,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:595 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:943
 msgid "Network usage:"
 msgstr ""
 
@@ -4324,7 +4328,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4383,11 +4387,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:579 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:946
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:580 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:947
 msgid "Packets sent"
 msgstr ""
 
@@ -5623,7 +5627,7 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -5654,7 +5658,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:576
 msgid "State"
 msgstr ""
 
@@ -5663,7 +5667,7 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:641
+#: lxc/info.go:653
 msgid "Stateful"
 msgstr ""
 
@@ -5765,11 +5769,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:558
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:550
+#: lxc/info.go:562
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5810,7 +5814,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -6134,7 +6138,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:563
+#: lxc/info.go:575
 msgid "Type"
 msgstr ""
 
@@ -6379,7 +6383,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:724
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-09 03:18-0300\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -858,7 +858,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -906,11 +906,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:577 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:944
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:578 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:945
 msgid "Bytes sent"
 msgstr ""
 
@@ -939,11 +939,11 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:527
+#: lxc/info.go:539
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:531
+#: lxc/info.go:543
 msgid "CPU usage:"
 msgstr ""
 
@@ -1868,7 +1868,11 @@ msgstr ""
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:520
+#: lxc/info.go:533
+msgid "Disk total:"
+msgstr ""
+
+#: lxc/info.go:529
 msgid "Disk usage:"
 msgstr ""
 
@@ -2141,7 +2145,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
 #: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
@@ -2666,7 +2670,7 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:578
 msgid "Host interface"
 msgstr ""
 
@@ -2720,7 +2724,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:582
+#: lxc/info.go:594
 msgid "IP addresses"
 msgstr ""
 
@@ -2882,7 +2886,7 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:692
+#: lxc/info.go:704
 msgid "Instance Only"
 msgstr ""
 
@@ -3436,7 +3440,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:720
+#: lxc/info.go:732
 msgid "Log:"
 msgstr ""
 
@@ -3452,7 +3456,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:570
+#: lxc/info.go:582
 msgid "MAC address"
 msgstr ""
 
@@ -3495,7 +3499,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:586
 msgid "MTU"
 msgstr ""
 
@@ -3743,15 +3747,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:550
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:554
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:566
 msgid "Memory usage:"
 msgstr ""
 
@@ -4091,7 +4095,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
 #: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
@@ -4204,7 +4208,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:595 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:943
 msgid "Network usage:"
 msgstr ""
 
@@ -4323,7 +4327,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4382,11 +4386,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:579 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:946
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:580 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:947
 msgid "Packets sent"
 msgstr ""
 
@@ -5622,7 +5626,7 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -5653,7 +5657,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:576
 msgid "State"
 msgstr ""
 
@@ -5662,7 +5666,7 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:641
+#: lxc/info.go:653
 msgid "Stateful"
 msgstr ""
 
@@ -5764,11 +5768,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:558
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:550
+#: lxc/info.go:562
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5809,7 +5813,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -6133,7 +6137,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:563
+#: lxc/info.go:575
 msgid "Type"
 msgstr ""
 
@@ -6378,7 +6382,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:724
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-09 03:18-0300\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -858,7 +858,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -906,11 +906,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:577 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:944
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:578 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:945
 msgid "Bytes sent"
 msgstr ""
 
@@ -939,11 +939,11 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:527
+#: lxc/info.go:539
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:531
+#: lxc/info.go:543
 msgid "CPU usage:"
 msgstr ""
 
@@ -1868,7 +1868,11 @@ msgstr ""
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:520
+#: lxc/info.go:533
+msgid "Disk total:"
+msgstr ""
+
+#: lxc/info.go:529
 msgid "Disk usage:"
 msgstr ""
 
@@ -2141,7 +2145,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
 #: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
@@ -2666,7 +2670,7 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:578
 msgid "Host interface"
 msgstr ""
 
@@ -2720,7 +2724,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:582
+#: lxc/info.go:594
 msgid "IP addresses"
 msgstr ""
 
@@ -2882,7 +2886,7 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:692
+#: lxc/info.go:704
 msgid "Instance Only"
 msgstr ""
 
@@ -3436,7 +3440,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:720
+#: lxc/info.go:732
 msgid "Log:"
 msgstr ""
 
@@ -3452,7 +3456,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:570
+#: lxc/info.go:582
 msgid "MAC address"
 msgstr ""
 
@@ -3495,7 +3499,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:586
 msgid "MTU"
 msgstr ""
 
@@ -3743,15 +3747,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:550
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:554
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:566
 msgid "Memory usage:"
 msgstr ""
 
@@ -4091,7 +4095,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
 #: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
@@ -4204,7 +4208,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:595 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:943
 msgid "Network usage:"
 msgstr ""
 
@@ -4323,7 +4327,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4382,11 +4386,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:579 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:946
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:580 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:947
 msgid "Packets sent"
 msgstr ""
 
@@ -5622,7 +5626,7 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -5653,7 +5657,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:576
 msgid "State"
 msgstr ""
 
@@ -5662,7 +5666,7 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:641
+#: lxc/info.go:653
 msgid "Stateful"
 msgstr ""
 
@@ -5764,11 +5768,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:558
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:550
+#: lxc/info.go:562
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5809,7 +5813,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -6133,7 +6137,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:563
+#: lxc/info.go:575
 msgid "Type"
 msgstr ""
 
@@ -6378,7 +6382,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:724
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-09 03:18-0300\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -1109,7 +1109,7 @@ msgstr "Creazione del container in corso"
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -1157,11 +1157,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:577 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:944
 msgid "Bytes received"
 msgstr "Bytes ricevuti"
 
-#: lxc/info.go:578 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:945
 msgid "Bytes sent"
 msgstr "Byte inviati"
 
@@ -1190,11 +1190,11 @@ msgstr "Utilizzo CPU:"
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:527
+#: lxc/info.go:539
 msgid "CPU usage (in seconds)"
 msgstr "Utilizzo CPU (in secondi)"
 
-#: lxc/info.go:531
+#: lxc/info.go:543
 msgid "CPU usage:"
 msgstr "Utilizzo CPU:"
 
@@ -2141,7 +2141,12 @@ msgstr ""
 msgid "Disk %d:"
 msgstr "Utilizzo disco:"
 
-#: lxc/info.go:520
+#: lxc/info.go:533
+#, fuzzy
+msgid "Disk total:"
+msgstr "Utilizzo disco:"
+
+#: lxc/info.go:529
 msgid "Disk usage:"
 msgstr "Utilizzo disco:"
 
@@ -2426,7 +2431,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
 #: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
@@ -2966,7 +2971,7 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:578
 #, fuzzy
 msgid "Host interface"
 msgstr "Creazione del container in corso"
@@ -3021,7 +3026,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:582
+#: lxc/info.go:594
 msgid "IP addresses"
 msgstr ""
 
@@ -3185,7 +3190,7 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:692
+#: lxc/info.go:704
 #, fuzzy
 msgid "Instance Only"
 msgstr "Il nome del container è: %s"
@@ -3759,7 +3764,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:720
+#: lxc/info.go:732
 msgid "Log:"
 msgstr ""
 
@@ -3777,7 +3782,7 @@ msgstr "Creazione del container in corso"
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:570
+#: lxc/info.go:582
 msgid "MAC address"
 msgstr ""
 
@@ -3820,7 +3825,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:586
 msgid "MTU"
 msgstr ""
 
@@ -4088,15 +4093,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:550
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:554
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:566
 msgid "Memory usage:"
 msgstr ""
 
@@ -4454,7 +4459,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
 #: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
@@ -4567,7 +4572,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:595 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:943
 msgid "Network usage:"
 msgstr ""
 
@@ -4688,7 +4693,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4747,11 +4752,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:579 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:946
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:580 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:947
 msgid "Packets sent"
 msgstr ""
 
@@ -6031,7 +6036,7 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -6063,7 +6068,7 @@ msgstr "Creazione del container in corso"
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:576
 #, fuzzy
 msgid "State"
 msgstr "Aggiornamento automatico: %s"
@@ -6073,7 +6078,7 @@ msgstr "Aggiornamento automatico: %s"
 msgid "State: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: lxc/info.go:641
+#: lxc/info.go:653
 msgid "Stateful"
 msgstr ""
 
@@ -6176,11 +6181,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:558
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:550
+#: lxc/info.go:562
 msgid "Swap (peak)"
 msgstr ""
 
@@ -6221,7 +6226,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
 #, fuzzy
 msgid "Taken at"
 msgstr "salvato alle %s"
@@ -6549,7 +6554,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:563
+#: lxc/info.go:575
 msgid "Type"
 msgstr ""
 
@@ -6809,7 +6814,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:724
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-09 03:18-0300\n"
 "PO-Revision-Date: 2023-03-10 15:14+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -1120,7 +1120,7 @@ msgstr "ストレージボリュームのバックアップ中: %s"
 msgid "Backup exported successfully!"
 msgstr "バックアップのエクスポートが成功しました!"
 
-#: lxc/info.go:654 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr "バックアップ:"
 
@@ -1170,11 +1170,11 @@ msgstr "ブランド: %v"
 msgid "Bridge:"
 msgstr "ブリッジ:"
 
-#: lxc/info.go:577 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:944
 msgid "Bytes received"
 msgstr "受信バイト数"
 
-#: lxc/info.go:578 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:945
 msgid "Bytes sent"
 msgstr "送信バイト数"
 
@@ -1203,11 +1203,11 @@ msgstr "CPU (%s):"
 msgid "CPU USAGE"
 msgstr "CPU USAGE"
 
-#: lxc/info.go:527
+#: lxc/info.go:539
 msgid "CPU usage (in seconds)"
 msgstr "CPU使用量（秒）"
 
-#: lxc/info.go:531
+#: lxc/info.go:543
 msgid "CPU usage:"
 msgstr "CPU使用量:"
 
@@ -2175,7 +2175,12 @@ msgstr "標準入力を無効にします (/dev/null から読み込みます)"
 msgid "Disk %d:"
 msgstr "ディスク %d:"
 
-#: lxc/info.go:520
+#: lxc/info.go:533
+#, fuzzy
+msgid "Disk total:"
+msgstr "ディスク使用量:"
+
+#: lxc/info.go:529
 msgid "Disk usage:"
 msgstr "ディスク使用量:"
 
@@ -2477,7 +2482,7 @@ msgstr ""
 "デフォルトのモードは non-interactive です。もし標準入出力が両方ともターミナル"
 "の場合は interactive モードが選択されます (標準エラー出力は無視されます)。"
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
 #: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr "失効日時"
@@ -3033,7 +3038,7 @@ msgstr "MAC ADDRESS"
 msgid "HOSTNAME"
 msgstr "HOSTNAME"
 
-#: lxc/info.go:566
+#: lxc/info.go:578
 msgid "Host interface"
 msgstr "ホストインターフェース"
 
@@ -3087,7 +3092,7 @@ msgstr "IMAGES"
 msgid "IP ADDRESS"
 msgstr "IP ADDRESS"
 
-#: lxc/info.go:582
+#: lxc/info.go:594
 msgid "IP addresses"
 msgstr "IP アドレス"
 
@@ -3262,7 +3267,7 @@ msgstr "入力するデータ"
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:692
+#: lxc/info.go:704
 msgid "Instance Only"
 msgstr "インスタンスのみ"
 
@@ -3972,7 +3977,7 @@ msgstr "ロケーション: %s"
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr "ログレベルのフィルタリングは pretty フォーマットでのみ使えます"
 
-#: lxc/info.go:720
+#: lxc/info.go:732
 msgid "Log:"
 msgstr "ログ:"
 
@@ -3988,7 +3993,7 @@ msgstr "Lower devices"
 msgid "MAC ADDRESS"
 msgstr "MAC ADDRESS"
 
-#: lxc/info.go:570
+#: lxc/info.go:582
 msgid "MAC address"
 msgstr "MAC アドレス"
 
@@ -4031,7 +4036,7 @@ msgstr "MII 監視頻度"
 msgid "MII state"
 msgstr "MII 状態"
 
-#: lxc/info.go:574
+#: lxc/info.go:586
 msgid "MTU"
 msgstr "MTU"
 
@@ -4302,15 +4307,15 @@ msgstr "メンバ %s が削除されました"
 msgid "Member %s renamed to %s"
 msgstr "メンバ名 %s を %s に変更しました"
 
-#: lxc/info.go:538
+#: lxc/info.go:550
 msgid "Memory (current)"
 msgstr "メモリ (現在値)"
 
-#: lxc/info.go:542
+#: lxc/info.go:554
 msgid "Memory (peak)"
 msgstr "メモリ (ピーク)"
 
-#: lxc/info.go:554
+#: lxc/info.go:566
 msgid "Memory usage:"
 msgstr "メモリ消費量:"
 
@@ -4673,7 +4678,7 @@ msgstr "NVIDIA 情報:"
 msgid "NVRM Version: %v"
 msgstr "NVRM バージョン: %v"
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
 #: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr "名前"
@@ -4788,7 +4793,7 @@ msgstr ""
 msgid "Network type"
 msgstr "ネットワークタイプ:"
 
-#: lxc/info.go:595 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:943
 msgid "Network usage:"
 msgstr "ネットワーク使用状況:"
 
@@ -4910,7 +4915,7 @@ msgstr "管理対象のネットワークのみ変更できます"
 msgid "Operation %s deleted"
 msgstr "バックグラウンド操作 %s を削除しました"
 
-#: lxc/info.go:693 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr "最適化されたストレージ"
 
@@ -4969,11 +4974,11 @@ msgstr "PROTOCOL"
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
-#: lxc/info.go:579 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:946
 msgid "Packets received"
 msgstr "受信パケット"
 
-#: lxc/info.go:580 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:947
 msgid "Packets sent"
 msgstr "送信パケット"
 
@@ -6306,7 +6311,7 @@ msgstr "ストレージボリュームのスナップショットを取得しま
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr "スナップショットは読み取り専用です。設定を変更することはできません"
 
-#: lxc/info.go:607 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr "スナップショット:"
 
@@ -6337,7 +6342,7 @@ msgstr "インスタンスを起動します"
 msgid "Starting %s"
 msgstr "%s を起動中"
 
-#: lxc/info.go:564
+#: lxc/info.go:576
 msgid "State"
 msgstr "状態"
 
@@ -6346,7 +6351,7 @@ msgstr "状態"
 msgid "State: %s"
 msgstr "状態: %s"
 
-#: lxc/info.go:641
+#: lxc/info.go:653
 msgid "Stateful"
 msgstr "ステートフル"
 
@@ -6448,11 +6453,11 @@ msgstr "サポートするモード: %s"
 msgid "Supported ports: %s"
 msgstr "サポートするポート: %s"
 
-#: lxc/info.go:546
+#: lxc/info.go:558
 msgid "Swap (current)"
 msgstr "Swap (現在値)"
 
-#: lxc/info.go:550
+#: lxc/info.go:562
 msgid "Swap (peak)"
 msgstr "Swap (ピーク)"
 
@@ -6493,7 +6498,7 @@ msgstr "TOKEN"
 msgid "TYPE"
 msgstr "TYPE"
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr "取得日時"
 
@@ -6847,7 +6852,7 @@ msgstr "%s:%s のクラスターに join するためのトークンが削除さ
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr "更に情報を得るために `lxc info --show-log %s` を実行してみてください"
 
-#: lxc/info.go:563
+#: lxc/info.go:575
 msgid "Type"
 msgstr "タイプ"
 
@@ -7104,7 +7109,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:724
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr "サポートされていないインスタンスタイプです: %s"

--- a/po/ka.po
+++ b/po/ka.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-09 03:18-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -855,7 +855,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -903,11 +903,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:577 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:944
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:578 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:945
 msgid "Bytes sent"
 msgstr ""
 
@@ -936,11 +936,11 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:527
+#: lxc/info.go:539
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:531
+#: lxc/info.go:543
 msgid "CPU usage:"
 msgstr ""
 
@@ -1865,7 +1865,11 @@ msgstr ""
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:520
+#: lxc/info.go:533
+msgid "Disk total:"
+msgstr ""
+
+#: lxc/info.go:529
 msgid "Disk usage:"
 msgstr ""
 
@@ -2138,7 +2142,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
 #: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
@@ -2663,7 +2667,7 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:578
 msgid "Host interface"
 msgstr ""
 
@@ -2717,7 +2721,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:582
+#: lxc/info.go:594
 msgid "IP addresses"
 msgstr ""
 
@@ -2879,7 +2883,7 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:692
+#: lxc/info.go:704
 msgid "Instance Only"
 msgstr ""
 
@@ -3433,7 +3437,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:720
+#: lxc/info.go:732
 msgid "Log:"
 msgstr ""
 
@@ -3449,7 +3453,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:570
+#: lxc/info.go:582
 msgid "MAC address"
 msgstr ""
 
@@ -3492,7 +3496,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:586
 msgid "MTU"
 msgstr ""
 
@@ -3740,15 +3744,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:550
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:554
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:566
 msgid "Memory usage:"
 msgstr ""
 
@@ -4088,7 +4092,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
 #: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
@@ -4201,7 +4205,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:595 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:943
 msgid "Network usage:"
 msgstr ""
 
@@ -4320,7 +4324,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4379,11 +4383,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:579 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:946
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:580 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:947
 msgid "Packets sent"
 msgstr ""
 
@@ -5619,7 +5623,7 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -5650,7 +5654,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:576
 msgid "State"
 msgstr ""
 
@@ -5659,7 +5663,7 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:641
+#: lxc/info.go:653
 msgid "Stateful"
 msgstr ""
 
@@ -5761,11 +5765,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:558
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:550
+#: lxc/info.go:562
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5806,7 +5810,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -6130,7 +6134,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:563
+#: lxc/info.go:575
 msgid "Type"
 msgstr ""
 
@@ -6375,7 +6379,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:724
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-09 03:18-0300\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -858,7 +858,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -906,11 +906,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:577 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:944
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:578 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:945
 msgid "Bytes sent"
 msgstr ""
 
@@ -939,11 +939,11 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:527
+#: lxc/info.go:539
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:531
+#: lxc/info.go:543
 msgid "CPU usage:"
 msgstr ""
 
@@ -1868,7 +1868,11 @@ msgstr ""
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:520
+#: lxc/info.go:533
+msgid "Disk total:"
+msgstr ""
+
+#: lxc/info.go:529
 msgid "Disk usage:"
 msgstr ""
 
@@ -2141,7 +2145,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
 #: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
@@ -2666,7 +2670,7 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:578
 msgid "Host interface"
 msgstr ""
 
@@ -2720,7 +2724,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:582
+#: lxc/info.go:594
 msgid "IP addresses"
 msgstr ""
 
@@ -2882,7 +2886,7 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:692
+#: lxc/info.go:704
 msgid "Instance Only"
 msgstr ""
 
@@ -3436,7 +3440,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:720
+#: lxc/info.go:732
 msgid "Log:"
 msgstr ""
 
@@ -3452,7 +3456,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:570
+#: lxc/info.go:582
 msgid "MAC address"
 msgstr ""
 
@@ -3495,7 +3499,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:586
 msgid "MTU"
 msgstr ""
 
@@ -3743,15 +3747,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:550
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:554
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:566
 msgid "Memory usage:"
 msgstr ""
 
@@ -4091,7 +4095,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
 #: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
@@ -4204,7 +4208,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:595 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:943
 msgid "Network usage:"
 msgstr ""
 
@@ -4323,7 +4327,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4382,11 +4386,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:579 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:946
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:580 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:947
 msgid "Packets sent"
 msgstr ""
 
@@ -5622,7 +5626,7 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -5653,7 +5657,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:576
 msgid "State"
 msgstr ""
 
@@ -5662,7 +5666,7 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:641
+#: lxc/info.go:653
 msgid "Stateful"
 msgstr ""
 
@@ -5764,11 +5768,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:558
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:550
+#: lxc/info.go:562
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5809,7 +5813,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -6133,7 +6137,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:563
+#: lxc/info.go:575
 msgid "Type"
 msgstr ""
 
@@ -6378,7 +6382,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:724
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-        "POT-Creation-Date: 2024-12-05 16:02+0000\n"
+        "POT-Creation-Date: 2024-12-09 03:18-0300\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -816,7 +816,7 @@ msgstr  ""
 msgid   "Backup exported successfully!"
 msgstr  ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1527
 msgid   "Backups:"
 msgstr  ""
 
@@ -862,11 +862,11 @@ msgstr  ""
 msgid   "Bridge:"
 msgstr  ""
 
-#: lxc/info.go:577 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:944
 msgid   "Bytes received"
 msgstr  ""
 
-#: lxc/info.go:578 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:945
 msgid   "Bytes sent"
 msgstr  ""
 
@@ -895,11 +895,11 @@ msgstr  ""
 msgid   "CPU USAGE"
 msgstr  ""
 
-#: lxc/info.go:527
+#: lxc/info.go:539
 msgid   "CPU usage (in seconds)"
 msgstr  ""
 
-#: lxc/info.go:531
+#: lxc/info.go:543
 msgid   "CPU usage:"
 msgstr  ""
 
@@ -1658,7 +1658,11 @@ msgstr  ""
 msgid   "Disk %d:"
 msgstr  ""
 
-#: lxc/info.go:520
+#: lxc/info.go:533
+msgid   "Disk total:"
+msgstr  ""
+
+#: lxc/info.go:529
 msgid   "Disk usage:"
 msgstr  ""
 
@@ -1912,7 +1916,7 @@ msgid   "Execute commands in instances\n"
         "Mode defaults to non-interactive, interactive mode is selected if both stdin AND stdout are terminals (stderr is ignored)."
 msgstr  ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514 lxc/storage_volume.go:1564
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514 lxc/storage_volume.go:1564
 msgid   "Expires at"
 msgstr  ""
 
@@ -2418,7 +2422,7 @@ msgstr  ""
 msgid   "HOSTNAME"
 msgstr  ""
 
-#: lxc/info.go:566
+#: lxc/info.go:578
 msgid   "Host interface"
 msgstr  ""
 
@@ -2472,7 +2476,7 @@ msgstr  ""
 msgid   "IP ADDRESS"
 msgstr  ""
 
-#: lxc/info.go:582
+#: lxc/info.go:594
 msgid   "IP addresses"
 msgstr  ""
 
@@ -2630,7 +2634,7 @@ msgstr  ""
 msgid   "Inspect permissions"
 msgstr  ""
 
-#: lxc/info.go:692
+#: lxc/info.go:704
 msgid   "Instance Only"
 msgstr  ""
 
@@ -3166,7 +3170,7 @@ msgstr  ""
 msgid   "Log level filtering can only be used with pretty formatting"
 msgstr  ""
 
-#: lxc/info.go:720
+#: lxc/info.go:732
 msgid   "Log:"
 msgstr  ""
 
@@ -3182,7 +3186,7 @@ msgstr  ""
 msgid   "MAC ADDRESS"
 msgstr  ""
 
-#: lxc/info.go:570
+#: lxc/info.go:582
 msgid   "MAC address"
 msgstr  ""
 
@@ -3225,7 +3229,7 @@ msgstr  ""
 msgid   "MII state"
 msgstr  ""
 
-#: lxc/info.go:574
+#: lxc/info.go:586
 msgid   "MTU"
 msgstr  ""
 
@@ -3468,15 +3472,15 @@ msgstr  ""
 msgid   "Member %s renamed to %s"
 msgstr  ""
 
-#: lxc/info.go:538
+#: lxc/info.go:550
 msgid   "Memory (current)"
 msgstr  ""
 
-#: lxc/info.go:542
+#: lxc/info.go:554
 msgid   "Memory (peak)"
 msgstr  ""
 
-#: lxc/info.go:554
+#: lxc/info.go:566
 msgid   "Memory usage:"
 msgstr  ""
 
@@ -3737,7 +3741,7 @@ msgstr  ""
 msgid   "NVRM Version: %v"
 msgstr  ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512 lxc/storage_volume.go:1562
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512 lxc/storage_volume.go:1562
 msgid   "Name"
 msgstr  ""
 
@@ -3848,7 +3852,7 @@ msgstr  ""
 msgid   "Network type"
 msgstr  ""
 
-#: lxc/info.go:595 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:943
 msgid   "Network usage:"
 msgstr  ""
 
@@ -3967,7 +3971,7 @@ msgstr  ""
 msgid   "Operation %s deleted"
 msgstr  ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1566
 msgid   "Optimized Storage"
 msgstr  ""
 
@@ -4025,11 +4029,11 @@ msgstr  ""
 msgid   "PUBLIC"
 msgstr  ""
 
-#: lxc/info.go:579 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:946
 msgid   "Packets received"
 msgstr  ""
 
-#: lxc/info.go:580 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:947
 msgid   "Packets sent"
 msgstr  ""
 
@@ -5201,7 +5205,7 @@ msgstr  ""
 msgid   "Snapshots are read-only and can't have their configuration changed"
 msgstr  ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1491
 msgid   "Snapshots:"
 msgstr  ""
 
@@ -5232,7 +5236,7 @@ msgstr  ""
 msgid   "Starting %s"
 msgstr  ""
 
-#: lxc/info.go:564
+#: lxc/info.go:576
 msgid   "State"
 msgstr  ""
 
@@ -5241,7 +5245,7 @@ msgstr  ""
 msgid   "State: %s"
 msgstr  ""
 
-#: lxc/info.go:641
+#: lxc/info.go:653
 msgid   "Stateful"
 msgstr  ""
 
@@ -5343,11 +5347,11 @@ msgstr  ""
 msgid   "Supported ports: %s"
 msgstr  ""
 
-#: lxc/info.go:546
+#: lxc/info.go:558
 msgid   "Swap (current)"
 msgstr  ""
 
-#: lxc/info.go:550
+#: lxc/info.go:562
 msgid   "Swap (peak)"
 msgstr  ""
 
@@ -5385,7 +5389,7 @@ msgstr  ""
 msgid   "TYPE"
 msgstr  ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
 msgid   "Taken at"
 msgstr  ""
 
@@ -5696,7 +5700,7 @@ msgstr  ""
 msgid   "Try `lxc info --show-log %s` for more info"
 msgstr  ""
 
-#: lxc/info.go:563
+#: lxc/info.go:575
 msgid   "Type"
 msgstr  ""
 
@@ -5935,7 +5939,7 @@ msgstr  ""
 msgid   "Unsupported content type for attaching to instances"
 msgstr  ""
 
-#: lxc/info.go:712
+#: lxc/info.go:724
 #, c-format
 msgid   "Unsupported instance type: %s"
 msgstr  ""

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-09 03:18-0300\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -858,7 +858,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -906,11 +906,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:577 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:944
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:578 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:945
 msgid "Bytes sent"
 msgstr ""
 
@@ -939,11 +939,11 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:527
+#: lxc/info.go:539
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:531
+#: lxc/info.go:543
 msgid "CPU usage:"
 msgstr ""
 
@@ -1868,7 +1868,11 @@ msgstr ""
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:520
+#: lxc/info.go:533
+msgid "Disk total:"
+msgstr ""
+
+#: lxc/info.go:529
 msgid "Disk usage:"
 msgstr ""
 
@@ -2141,7 +2145,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
 #: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
@@ -2666,7 +2670,7 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:578
 msgid "Host interface"
 msgstr ""
 
@@ -2720,7 +2724,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:582
+#: lxc/info.go:594
 msgid "IP addresses"
 msgstr ""
 
@@ -2882,7 +2886,7 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:692
+#: lxc/info.go:704
 msgid "Instance Only"
 msgstr ""
 
@@ -3436,7 +3440,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:720
+#: lxc/info.go:732
 msgid "Log:"
 msgstr ""
 
@@ -3452,7 +3456,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:570
+#: lxc/info.go:582
 msgid "MAC address"
 msgstr ""
 
@@ -3495,7 +3499,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:586
 msgid "MTU"
 msgstr ""
 
@@ -3743,15 +3747,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:550
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:554
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:566
 msgid "Memory usage:"
 msgstr ""
 
@@ -4091,7 +4095,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
 #: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
@@ -4204,7 +4208,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:595 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:943
 msgid "Network usage:"
 msgstr ""
 
@@ -4323,7 +4327,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4382,11 +4386,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:579 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:946
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:580 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:947
 msgid "Packets sent"
 msgstr ""
 
@@ -5622,7 +5626,7 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -5653,7 +5657,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:576
 msgid "State"
 msgstr ""
 
@@ -5662,7 +5666,7 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:641
+#: lxc/info.go:653
 msgid "Stateful"
 msgstr ""
 
@@ -5764,11 +5768,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:558
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:550
+#: lxc/info.go:562
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5809,7 +5813,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -6133,7 +6137,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:563
+#: lxc/info.go:575
 msgid "Type"
 msgstr ""
 
@@ -6378,7 +6382,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:724
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-09 03:18-0300\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -858,7 +858,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -906,11 +906,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:577 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:944
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:578 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:945
 msgid "Bytes sent"
 msgstr ""
 
@@ -939,11 +939,11 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:527
+#: lxc/info.go:539
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:531
+#: lxc/info.go:543
 msgid "CPU usage:"
 msgstr ""
 
@@ -1868,7 +1868,11 @@ msgstr ""
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:520
+#: lxc/info.go:533
+msgid "Disk total:"
+msgstr ""
+
+#: lxc/info.go:529
 msgid "Disk usage:"
 msgstr ""
 
@@ -2141,7 +2145,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
 #: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
@@ -2666,7 +2670,7 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:578
 msgid "Host interface"
 msgstr ""
 
@@ -2720,7 +2724,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:582
+#: lxc/info.go:594
 msgid "IP addresses"
 msgstr ""
 
@@ -2882,7 +2886,7 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:692
+#: lxc/info.go:704
 msgid "Instance Only"
 msgstr ""
 
@@ -3436,7 +3440,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:720
+#: lxc/info.go:732
 msgid "Log:"
 msgstr ""
 
@@ -3452,7 +3456,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:570
+#: lxc/info.go:582
 msgid "MAC address"
 msgstr ""
 
@@ -3495,7 +3499,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:586
 msgid "MTU"
 msgstr ""
 
@@ -3743,15 +3747,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:550
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:554
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:566
 msgid "Memory usage:"
 msgstr ""
 
@@ -4091,7 +4095,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
 #: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
@@ -4204,7 +4208,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:595 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:943
 msgid "Network usage:"
 msgstr ""
 
@@ -4323,7 +4327,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4382,11 +4386,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:579 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:946
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:580 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:947
 msgid "Packets sent"
 msgstr ""
 
@@ -5622,7 +5626,7 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -5653,7 +5657,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:576
 msgid "State"
 msgstr ""
 
@@ -5662,7 +5666,7 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:641
+#: lxc/info.go:653
 msgid "Stateful"
 msgstr ""
 
@@ -5764,11 +5768,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:558
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:550
+#: lxc/info.go:562
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5809,7 +5813,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -6133,7 +6137,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:563
+#: lxc/info.go:575
 msgid "Type"
 msgstr ""
 
@@ -6378,7 +6382,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:724
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-09 03:18-0300\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -1082,7 +1082,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -1130,11 +1130,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:577 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:944
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:578 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:945
 msgid "Bytes sent"
 msgstr ""
 
@@ -1163,11 +1163,11 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:527
+#: lxc/info.go:539
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:531
+#: lxc/info.go:543
 msgid "CPU usage:"
 msgstr ""
 
@@ -2092,7 +2092,11 @@ msgstr ""
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:520
+#: lxc/info.go:533
+msgid "Disk total:"
+msgstr ""
+
+#: lxc/info.go:529
 msgid "Disk usage:"
 msgstr ""
 
@@ -2365,7 +2369,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
 #: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
@@ -2890,7 +2894,7 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:578
 msgid "Host interface"
 msgstr ""
 
@@ -2944,7 +2948,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:582
+#: lxc/info.go:594
 msgid "IP addresses"
 msgstr ""
 
@@ -3106,7 +3110,7 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:692
+#: lxc/info.go:704
 msgid "Instance Only"
 msgstr ""
 
@@ -3660,7 +3664,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:720
+#: lxc/info.go:732
 msgid "Log:"
 msgstr ""
 
@@ -3676,7 +3680,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:570
+#: lxc/info.go:582
 msgid "MAC address"
 msgstr ""
 
@@ -3719,7 +3723,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:586
 msgid "MTU"
 msgstr ""
 
@@ -3967,15 +3971,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:550
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:554
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:566
 msgid "Memory usage:"
 msgstr ""
 
@@ -4315,7 +4319,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
 #: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
@@ -4428,7 +4432,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:595 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:943
 msgid "Network usage:"
 msgstr ""
 
@@ -4547,7 +4551,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4606,11 +4610,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:579 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:946
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:580 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:947
 msgid "Packets sent"
 msgstr ""
 
@@ -5846,7 +5850,7 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -5877,7 +5881,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:576
 msgid "State"
 msgstr ""
 
@@ -5886,7 +5890,7 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:641
+#: lxc/info.go:653
 msgid "Stateful"
 msgstr ""
 
@@ -5988,11 +5992,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:558
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:550
+#: lxc/info.go:562
 msgid "Swap (peak)"
 msgstr ""
 
@@ -6033,7 +6037,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -6357,7 +6361,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:563
+#: lxc/info.go:575
 msgid "Type"
 msgstr ""
 
@@ -6602,7 +6606,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:724
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-09 03:18-0300\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -858,7 +858,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -906,11 +906,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:577 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:944
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:578 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:945
 msgid "Bytes sent"
 msgstr ""
 
@@ -939,11 +939,11 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:527
+#: lxc/info.go:539
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:531
+#: lxc/info.go:543
 msgid "CPU usage:"
 msgstr ""
 
@@ -1868,7 +1868,11 @@ msgstr ""
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:520
+#: lxc/info.go:533
+msgid "Disk total:"
+msgstr ""
+
+#: lxc/info.go:529
 msgid "Disk usage:"
 msgstr ""
 
@@ -2141,7 +2145,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
 #: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
@@ -2666,7 +2670,7 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:578
 msgid "Host interface"
 msgstr ""
 
@@ -2720,7 +2724,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:582
+#: lxc/info.go:594
 msgid "IP addresses"
 msgstr ""
 
@@ -2882,7 +2886,7 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:692
+#: lxc/info.go:704
 msgid "Instance Only"
 msgstr ""
 
@@ -3436,7 +3440,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:720
+#: lxc/info.go:732
 msgid "Log:"
 msgstr ""
 
@@ -3452,7 +3456,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:570
+#: lxc/info.go:582
 msgid "MAC address"
 msgstr ""
 
@@ -3495,7 +3499,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:586
 msgid "MTU"
 msgstr ""
 
@@ -3743,15 +3747,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:550
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:554
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:566
 msgid "Memory usage:"
 msgstr ""
 
@@ -4091,7 +4095,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
 #: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
@@ -4204,7 +4208,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:595 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:943
 msgid "Network usage:"
 msgstr ""
 
@@ -4323,7 +4327,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4382,11 +4386,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:579 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:946
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:580 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:947
 msgid "Packets sent"
 msgstr ""
 
@@ -5622,7 +5626,7 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -5653,7 +5657,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:576
 msgid "State"
 msgstr ""
 
@@ -5662,7 +5666,7 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:641
+#: lxc/info.go:653
 msgid "Stateful"
 msgstr ""
 
@@ -5764,11 +5768,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:558
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:550
+#: lxc/info.go:562
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5809,7 +5813,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -6133,7 +6137,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:563
+#: lxc/info.go:575
 msgid "Type"
 msgstr ""
 
@@ -6378,7 +6382,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:724
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-09 03:18-0300\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -1120,7 +1120,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -1168,11 +1168,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:577 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:944
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:578 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:945
 msgid "Bytes sent"
 msgstr ""
 
@@ -1201,11 +1201,11 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:527
+#: lxc/info.go:539
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:531
+#: lxc/info.go:543
 msgid "CPU usage:"
 msgstr ""
 
@@ -2130,7 +2130,11 @@ msgstr ""
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:520
+#: lxc/info.go:533
+msgid "Disk total:"
+msgstr ""
+
+#: lxc/info.go:529
 msgid "Disk usage:"
 msgstr ""
 
@@ -2403,7 +2407,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
 #: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
@@ -2928,7 +2932,7 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:578
 msgid "Host interface"
 msgstr ""
 
@@ -2982,7 +2986,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:582
+#: lxc/info.go:594
 msgid "IP addresses"
 msgstr ""
 
@@ -3144,7 +3148,7 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:692
+#: lxc/info.go:704
 msgid "Instance Only"
 msgstr ""
 
@@ -3698,7 +3702,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:720
+#: lxc/info.go:732
 msgid "Log:"
 msgstr ""
 
@@ -3714,7 +3718,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:570
+#: lxc/info.go:582
 msgid "MAC address"
 msgstr ""
 
@@ -3757,7 +3761,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:586
 msgid "MTU"
 msgstr ""
 
@@ -4005,15 +4009,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:550
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:554
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:566
 msgid "Memory usage:"
 msgstr ""
 
@@ -4353,7 +4357,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
 #: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
@@ -4466,7 +4470,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:595 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:943
 msgid "Network usage:"
 msgstr ""
 
@@ -4585,7 +4589,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4644,11 +4648,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:579 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:946
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:580 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:947
 msgid "Packets sent"
 msgstr ""
 
@@ -5884,7 +5888,7 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -5915,7 +5919,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:576
 msgid "State"
 msgstr ""
 
@@ -5924,7 +5928,7 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:641
+#: lxc/info.go:653
 msgid "Stateful"
 msgstr ""
 
@@ -6026,11 +6030,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:558
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:550
+#: lxc/info.go:562
 msgid "Swap (peak)"
 msgstr ""
 
@@ -6071,7 +6075,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -6395,7 +6399,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:563
+#: lxc/info.go:575
 msgid "Type"
 msgstr ""
 
@@ -6640,7 +6644,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:724
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-09 03:18-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -855,7 +855,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -903,11 +903,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:577 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:944
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:578 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:945
 msgid "Bytes sent"
 msgstr ""
 
@@ -936,11 +936,11 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:527
+#: lxc/info.go:539
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:531
+#: lxc/info.go:543
 msgid "CPU usage:"
 msgstr ""
 
@@ -1865,7 +1865,11 @@ msgstr ""
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:520
+#: lxc/info.go:533
+msgid "Disk total:"
+msgstr ""
+
+#: lxc/info.go:529
 msgid "Disk usage:"
 msgstr ""
 
@@ -2138,7 +2142,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
 #: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
@@ -2663,7 +2667,7 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:578
 msgid "Host interface"
 msgstr ""
 
@@ -2717,7 +2721,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:582
+#: lxc/info.go:594
 msgid "IP addresses"
 msgstr ""
 
@@ -2879,7 +2883,7 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:692
+#: lxc/info.go:704
 msgid "Instance Only"
 msgstr ""
 
@@ -3433,7 +3437,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:720
+#: lxc/info.go:732
 msgid "Log:"
 msgstr ""
 
@@ -3449,7 +3453,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:570
+#: lxc/info.go:582
 msgid "MAC address"
 msgstr ""
 
@@ -3492,7 +3496,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:586
 msgid "MTU"
 msgstr ""
 
@@ -3740,15 +3744,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:550
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:554
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:566
 msgid "Memory usage:"
 msgstr ""
 
@@ -4088,7 +4092,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
 #: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
@@ -4201,7 +4205,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:595 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:943
 msgid "Network usage:"
 msgstr ""
 
@@ -4320,7 +4324,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4379,11 +4383,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:579 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:946
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:580 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:947
 msgid "Packets sent"
 msgstr ""
 
@@ -5619,7 +5623,7 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -5650,7 +5654,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:576
 msgid "State"
 msgstr ""
 
@@ -5659,7 +5663,7 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:641
+#: lxc/info.go:653
 msgid "Stateful"
 msgstr ""
 
@@ -5761,11 +5765,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:558
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:550
+#: lxc/info.go:562
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5806,7 +5810,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -6130,7 +6134,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:563
+#: lxc/info.go:575
 msgid "Type"
 msgstr ""
 
@@ -6375,7 +6379,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:724
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-09 03:18-0300\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -1134,7 +1134,7 @@ msgstr "Editar arquivos no container"
 msgid "Backup exported successfully!"
 msgstr "Backup exportado com sucesso!"
 
-#: lxc/info.go:654 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -1182,11 +1182,11 @@ msgstr "Marca: %v"
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:577 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:944
 msgid "Bytes received"
 msgstr "Bytes recebido"
 
-#: lxc/info.go:578 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:945
 msgid "Bytes sent"
 msgstr "Bytes enviado"
 
@@ -1215,11 +1215,11 @@ msgstr "Utilização do CPU:"
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:527
+#: lxc/info.go:539
 msgid "CPU usage (in seconds)"
 msgstr "Utilização do CPU (em segundos)"
 
-#: lxc/info.go:531
+#: lxc/info.go:543
 msgid "CPU usage:"
 msgstr "Utilização do CPU:"
 
@@ -2197,7 +2197,12 @@ msgstr "Desabilitar stdin (ler de /dev/null)"
 msgid "Disk %d:"
 msgstr "Uso de disco:"
 
-#: lxc/info.go:520
+#: lxc/info.go:533
+#, fuzzy
+msgid "Disk total:"
+msgstr "Uso de disco:"
+
+#: lxc/info.go:529
 msgid "Disk usage:"
 msgstr "Uso de disco:"
 
@@ -2493,7 +2498,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
 #: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
@@ -3039,7 +3044,7 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr "HOSTNAME"
 
-#: lxc/info.go:566
+#: lxc/info.go:578
 msgid "Host interface"
 msgstr ""
 
@@ -3093,7 +3098,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:582
+#: lxc/info.go:594
 msgid "IP addresses"
 msgstr ""
 
@@ -3257,7 +3262,7 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:692
+#: lxc/info.go:704
 msgid "Instance Only"
 msgstr ""
 
@@ -3822,7 +3827,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:720
+#: lxc/info.go:732
 msgid "Log:"
 msgstr ""
 
@@ -3840,7 +3845,7 @@ msgstr "Editar arquivos no container"
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:570
+#: lxc/info.go:582
 msgid "MAC address"
 msgstr ""
 
@@ -3883,7 +3888,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:586
 msgid "MTU"
 msgstr ""
 
@@ -4157,15 +4162,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:550
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:554
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:566
 msgid "Memory usage:"
 msgstr ""
 
@@ -4522,7 +4527,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
 #: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
@@ -4635,7 +4640,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:595 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:943
 msgid "Network usage:"
 msgstr ""
 
@@ -4754,7 +4759,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4813,11 +4818,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:579 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:946
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:580 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:947
 msgid "Packets sent"
 msgstr ""
 
@@ -6130,7 +6135,7 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -6161,7 +6166,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:576
 msgid "State"
 msgstr ""
 
@@ -6170,7 +6175,7 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:641
+#: lxc/info.go:653
 msgid "Stateful"
 msgstr ""
 
@@ -6273,11 +6278,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:558
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:550
+#: lxc/info.go:562
 msgid "Swap (peak)"
 msgstr ""
 
@@ -6318,7 +6323,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -6649,7 +6654,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:563
+#: lxc/info.go:575
 msgid "Type"
 msgstr ""
 
@@ -6920,7 +6925,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:724
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-09 03:18-0300\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -1131,7 +1131,7 @@ msgstr "Копирование образа: %s"
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -1179,11 +1179,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:577 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:944
 msgid "Bytes received"
 msgstr "Получено байтов"
 
-#: lxc/info.go:578 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:945
 msgid "Bytes sent"
 msgstr "Отправлено байтов"
 
@@ -1212,11 +1212,11 @@ msgstr " Использование ЦП:"
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:527
+#: lxc/info.go:539
 msgid "CPU usage (in seconds)"
 msgstr "Использование ЦП (в секундах)"
 
-#: lxc/info.go:531
+#: lxc/info.go:543
 #, fuzzy
 msgid "CPU usage:"
 msgstr " Использование ЦП:"
@@ -2182,7 +2182,12 @@ msgstr ""
 msgid "Disk %d:"
 msgstr " Использование диска:"
 
-#: lxc/info.go:520
+#: lxc/info.go:533
+#, fuzzy
+msgid "Disk total:"
+msgstr " Использование диска:"
+
+#: lxc/info.go:529
 #, fuzzy
 msgid "Disk usage:"
 msgstr " Использование диска:"
@@ -2473,7 +2478,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
 #: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
@@ -3020,7 +3025,7 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:578
 #, fuzzy
 msgid "Host interface"
 msgstr "Псевдонимы:"
@@ -3075,7 +3080,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:582
+#: lxc/info.go:594
 msgid "IP addresses"
 msgstr ""
 
@@ -3241,7 +3246,7 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:692
+#: lxc/info.go:704
 #, fuzzy
 msgid "Instance Only"
 msgstr "Имя контейнера: %s"
@@ -3818,7 +3823,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:720
+#: lxc/info.go:732
 msgid "Log:"
 msgstr ""
 
@@ -3836,7 +3841,7 @@ msgstr "Копирование образа: %s"
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:570
+#: lxc/info.go:582
 msgid "MAC address"
 msgstr ""
 
@@ -3879,7 +3884,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:586
 msgid "MTU"
 msgstr ""
 
@@ -4154,15 +4159,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:550
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:554
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:566
 #, fuzzy
 msgid "Memory usage:"
 msgstr " Использование памяти:"
@@ -4524,7 +4529,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
 #: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
@@ -4638,7 +4643,7 @@ msgstr ""
 msgid "Network type"
 msgstr " Использование сети:"
 
-#: lxc/info.go:595 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:943
 #, fuzzy
 msgid "Network usage:"
 msgstr " Использование сети:"
@@ -4760,7 +4765,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4819,11 +4824,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:579 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:946
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:580 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:947
 msgid "Packets sent"
 msgstr ""
 
@@ -6118,7 +6123,7 @@ msgstr "Копирование образа: %s"
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -6149,7 +6154,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:576
 #, fuzzy
 msgid "State"
 msgstr "Авто-обновление: %s"
@@ -6159,7 +6164,7 @@ msgstr "Авто-обновление: %s"
 msgid "State: %s"
 msgstr "Авто-обновление: %s"
 
-#: lxc/info.go:641
+#: lxc/info.go:653
 msgid "Stateful"
 msgstr ""
 
@@ -6264,11 +6269,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:558
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:550
+#: lxc/info.go:562
 msgid "Swap (peak)"
 msgstr ""
 
@@ -6309,7 +6314,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -6634,7 +6639,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:563
+#: lxc/info.go:575
 msgid "Type"
 msgstr ""
 
@@ -6900,7 +6905,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:724
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-09 03:18-0300\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -858,7 +858,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -906,11 +906,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:577 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:944
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:578 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:945
 msgid "Bytes sent"
 msgstr ""
 
@@ -939,11 +939,11 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:527
+#: lxc/info.go:539
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:531
+#: lxc/info.go:543
 msgid "CPU usage:"
 msgstr ""
 
@@ -1868,7 +1868,11 @@ msgstr ""
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:520
+#: lxc/info.go:533
+msgid "Disk total:"
+msgstr ""
+
+#: lxc/info.go:529
 msgid "Disk usage:"
 msgstr ""
 
@@ -2141,7 +2145,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
 #: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
@@ -2666,7 +2670,7 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:578
 msgid "Host interface"
 msgstr ""
 
@@ -2720,7 +2724,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:582
+#: lxc/info.go:594
 msgid "IP addresses"
 msgstr ""
 
@@ -2882,7 +2886,7 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:692
+#: lxc/info.go:704
 msgid "Instance Only"
 msgstr ""
 
@@ -3436,7 +3440,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:720
+#: lxc/info.go:732
 msgid "Log:"
 msgstr ""
 
@@ -3452,7 +3456,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:570
+#: lxc/info.go:582
 msgid "MAC address"
 msgstr ""
 
@@ -3495,7 +3499,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:586
 msgid "MTU"
 msgstr ""
 
@@ -3743,15 +3747,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:550
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:554
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:566
 msgid "Memory usage:"
 msgstr ""
 
@@ -4091,7 +4095,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
 #: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
@@ -4204,7 +4208,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:595 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:943
 msgid "Network usage:"
 msgstr ""
 
@@ -4323,7 +4327,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4382,11 +4386,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:579 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:946
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:580 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:947
 msgid "Packets sent"
 msgstr ""
 
@@ -5622,7 +5626,7 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -5653,7 +5657,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:576
 msgid "State"
 msgstr ""
 
@@ -5662,7 +5666,7 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:641
+#: lxc/info.go:653
 msgid "Stateful"
 msgstr ""
 
@@ -5764,11 +5768,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:558
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:550
+#: lxc/info.go:562
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5809,7 +5813,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -6133,7 +6137,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:563
+#: lxc/info.go:575
 msgid "Type"
 msgstr ""
 
@@ -6378,7 +6382,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:724
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-09 03:18-0300\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -859,7 +859,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -907,11 +907,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:577 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:944
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:578 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:945
 msgid "Bytes sent"
 msgstr ""
 
@@ -940,11 +940,11 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:527
+#: lxc/info.go:539
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:531
+#: lxc/info.go:543
 msgid "CPU usage:"
 msgstr ""
 
@@ -1869,7 +1869,11 @@ msgstr ""
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:520
+#: lxc/info.go:533
+msgid "Disk total:"
+msgstr ""
+
+#: lxc/info.go:529
 msgid "Disk usage:"
 msgstr ""
 
@@ -2142,7 +2146,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
 #: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
@@ -2667,7 +2671,7 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:578
 msgid "Host interface"
 msgstr ""
 
@@ -2721,7 +2725,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:582
+#: lxc/info.go:594
 msgid "IP addresses"
 msgstr ""
 
@@ -2883,7 +2887,7 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:692
+#: lxc/info.go:704
 msgid "Instance Only"
 msgstr ""
 
@@ -3437,7 +3441,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:720
+#: lxc/info.go:732
 msgid "Log:"
 msgstr ""
 
@@ -3453,7 +3457,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:570
+#: lxc/info.go:582
 msgid "MAC address"
 msgstr ""
 
@@ -3496,7 +3500,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:586
 msgid "MTU"
 msgstr ""
 
@@ -3744,15 +3748,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:550
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:554
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:566
 msgid "Memory usage:"
 msgstr ""
 
@@ -4092,7 +4096,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
 #: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
@@ -4205,7 +4209,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:595 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:943
 msgid "Network usage:"
 msgstr ""
 
@@ -4324,7 +4328,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4383,11 +4387,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:579 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:946
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:580 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:947
 msgid "Packets sent"
 msgstr ""
 
@@ -5623,7 +5627,7 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -5654,7 +5658,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:576
 msgid "State"
 msgstr ""
 
@@ -5663,7 +5667,7 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:641
+#: lxc/info.go:653
 msgid "Stateful"
 msgstr ""
 
@@ -5765,11 +5769,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:558
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:550
+#: lxc/info.go:562
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5810,7 +5814,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -6134,7 +6138,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:563
+#: lxc/info.go:575
 msgid "Type"
 msgstr ""
 
@@ -6379,7 +6383,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:724
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-09 03:18-0300\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -859,7 +859,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -907,11 +907,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:577 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:944
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:578 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:945
 msgid "Bytes sent"
 msgstr ""
 
@@ -940,11 +940,11 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:527
+#: lxc/info.go:539
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:531
+#: lxc/info.go:543
 msgid "CPU usage:"
 msgstr ""
 
@@ -1869,7 +1869,11 @@ msgstr ""
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:520
+#: lxc/info.go:533
+msgid "Disk total:"
+msgstr ""
+
+#: lxc/info.go:529
 msgid "Disk usage:"
 msgstr ""
 
@@ -2142,7 +2146,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
 #: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
@@ -2667,7 +2671,7 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:578
 msgid "Host interface"
 msgstr ""
 
@@ -2721,7 +2725,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:582
+#: lxc/info.go:594
 msgid "IP addresses"
 msgstr ""
 
@@ -2883,7 +2887,7 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:692
+#: lxc/info.go:704
 msgid "Instance Only"
 msgstr ""
 
@@ -3437,7 +3441,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:720
+#: lxc/info.go:732
 msgid "Log:"
 msgstr ""
 
@@ -3453,7 +3457,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:570
+#: lxc/info.go:582
 msgid "MAC address"
 msgstr ""
 
@@ -3496,7 +3500,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:586
 msgid "MTU"
 msgstr ""
 
@@ -3744,15 +3748,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:550
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:554
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:566
 msgid "Memory usage:"
 msgstr ""
 
@@ -4092,7 +4096,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
 #: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
@@ -4205,7 +4209,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:595 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:943
 msgid "Network usage:"
 msgstr ""
 
@@ -4324,7 +4328,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4383,11 +4387,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:579 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:946
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:580 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:947
 msgid "Packets sent"
 msgstr ""
 
@@ -5623,7 +5627,7 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -5654,7 +5658,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:576
 msgid "State"
 msgstr ""
 
@@ -5663,7 +5667,7 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:641
+#: lxc/info.go:653
 msgid "Stateful"
 msgstr ""
 
@@ -5765,11 +5769,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:558
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:550
+#: lxc/info.go:562
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5810,7 +5814,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -6134,7 +6138,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:563
+#: lxc/info.go:575
 msgid "Type"
 msgstr ""
 
@@ -6379,7 +6383,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:724
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-09 03:18-0300\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -858,7 +858,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -906,11 +906,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:577 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:944
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:578 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:945
 msgid "Bytes sent"
 msgstr ""
 
@@ -939,11 +939,11 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:527
+#: lxc/info.go:539
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:531
+#: lxc/info.go:543
 msgid "CPU usage:"
 msgstr ""
 
@@ -1868,7 +1868,11 @@ msgstr ""
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:520
+#: lxc/info.go:533
+msgid "Disk total:"
+msgstr ""
+
+#: lxc/info.go:529
 msgid "Disk usage:"
 msgstr ""
 
@@ -2141,7 +2145,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
 #: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
@@ -2666,7 +2670,7 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:578
 msgid "Host interface"
 msgstr ""
 
@@ -2720,7 +2724,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:582
+#: lxc/info.go:594
 msgid "IP addresses"
 msgstr ""
 
@@ -2882,7 +2886,7 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:692
+#: lxc/info.go:704
 msgid "Instance Only"
 msgstr ""
 
@@ -3436,7 +3440,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:720
+#: lxc/info.go:732
 msgid "Log:"
 msgstr ""
 
@@ -3452,7 +3456,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:570
+#: lxc/info.go:582
 msgid "MAC address"
 msgstr ""
 
@@ -3495,7 +3499,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:586
 msgid "MTU"
 msgstr ""
 
@@ -3743,15 +3747,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:550
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:554
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:566
 msgid "Memory usage:"
 msgstr ""
 
@@ -4091,7 +4095,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
 #: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
@@ -4204,7 +4208,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:595 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:943
 msgid "Network usage:"
 msgstr ""
 
@@ -4323,7 +4327,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4382,11 +4386,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:579 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:946
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:580 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:947
 msgid "Packets sent"
 msgstr ""
 
@@ -5622,7 +5626,7 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -5653,7 +5657,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:576
 msgid "State"
 msgstr ""
 
@@ -5662,7 +5666,7 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:641
+#: lxc/info.go:653
 msgid "Stateful"
 msgstr ""
 
@@ -5764,11 +5768,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:558
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:550
+#: lxc/info.go:562
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5809,7 +5813,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -6133,7 +6137,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:563
+#: lxc/info.go:575
 msgid "Type"
 msgstr ""
 
@@ -6378,7 +6382,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:724
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-09 03:18-0300\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -858,7 +858,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -906,11 +906,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:577 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:944
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:578 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:945
 msgid "Bytes sent"
 msgstr ""
 
@@ -939,11 +939,11 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:527
+#: lxc/info.go:539
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:531
+#: lxc/info.go:543
 msgid "CPU usage:"
 msgstr ""
 
@@ -1868,7 +1868,11 @@ msgstr ""
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:520
+#: lxc/info.go:533
+msgid "Disk total:"
+msgstr ""
+
+#: lxc/info.go:529
 msgid "Disk usage:"
 msgstr ""
 
@@ -2141,7 +2145,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
 #: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
@@ -2666,7 +2670,7 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:578
 msgid "Host interface"
 msgstr ""
 
@@ -2720,7 +2724,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:582
+#: lxc/info.go:594
 msgid "IP addresses"
 msgstr ""
 
@@ -2882,7 +2886,7 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:692
+#: lxc/info.go:704
 msgid "Instance Only"
 msgstr ""
 
@@ -3436,7 +3440,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:720
+#: lxc/info.go:732
 msgid "Log:"
 msgstr ""
 
@@ -3452,7 +3456,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:570
+#: lxc/info.go:582
 msgid "MAC address"
 msgstr ""
 
@@ -3495,7 +3499,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:586
 msgid "MTU"
 msgstr ""
 
@@ -3743,15 +3747,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:550
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:554
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:566
 msgid "Memory usage:"
 msgstr ""
 
@@ -4091,7 +4095,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
 #: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
@@ -4204,7 +4208,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:595 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:943
 msgid "Network usage:"
 msgstr ""
 
@@ -4323,7 +4327,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4382,11 +4386,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:579 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:946
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:580 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:947
 msgid "Packets sent"
 msgstr ""
 
@@ -5622,7 +5626,7 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -5653,7 +5657,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:576
 msgid "State"
 msgstr ""
 
@@ -5662,7 +5666,7 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:641
+#: lxc/info.go:653
 msgid "Stateful"
 msgstr ""
 
@@ -5764,11 +5768,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:558
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:550
+#: lxc/info.go:562
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5809,7 +5813,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -6133,7 +6137,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:563
+#: lxc/info.go:575
 msgid "Type"
 msgstr ""
 
@@ -6378,7 +6382,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:724
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""

--- a/po/th.po
+++ b/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-09 03:18-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -855,7 +855,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -903,11 +903,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:577 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:944
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:578 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:945
 msgid "Bytes sent"
 msgstr ""
 
@@ -936,11 +936,11 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:527
+#: lxc/info.go:539
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:531
+#: lxc/info.go:543
 msgid "CPU usage:"
 msgstr ""
 
@@ -1865,7 +1865,11 @@ msgstr ""
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:520
+#: lxc/info.go:533
+msgid "Disk total:"
+msgstr ""
+
+#: lxc/info.go:529
 msgid "Disk usage:"
 msgstr ""
 
@@ -2138,7 +2142,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
 #: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
@@ -2663,7 +2667,7 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:578
 msgid "Host interface"
 msgstr ""
 
@@ -2717,7 +2721,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:582
+#: lxc/info.go:594
 msgid "IP addresses"
 msgstr ""
 
@@ -2879,7 +2883,7 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:692
+#: lxc/info.go:704
 msgid "Instance Only"
 msgstr ""
 
@@ -3433,7 +3437,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:720
+#: lxc/info.go:732
 msgid "Log:"
 msgstr ""
 
@@ -3449,7 +3453,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:570
+#: lxc/info.go:582
 msgid "MAC address"
 msgstr ""
 
@@ -3492,7 +3496,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:586
 msgid "MTU"
 msgstr ""
 
@@ -3740,15 +3744,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:550
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:554
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:566
 msgid "Memory usage:"
 msgstr ""
 
@@ -4088,7 +4092,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
 #: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
@@ -4201,7 +4205,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:595 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:943
 msgid "Network usage:"
 msgstr ""
 
@@ -4320,7 +4324,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4379,11 +4383,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:579 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:946
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:580 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:947
 msgid "Packets sent"
 msgstr ""
 
@@ -5619,7 +5623,7 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -5650,7 +5654,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:576
 msgid "State"
 msgstr ""
 
@@ -5659,7 +5663,7 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:641
+#: lxc/info.go:653
 msgid "Stateful"
 msgstr ""
 
@@ -5761,11 +5765,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:558
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:550
+#: lxc/info.go:562
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5806,7 +5810,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -6130,7 +6134,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:563
+#: lxc/info.go:575
 msgid "Type"
 msgstr ""
 
@@ -6375,7 +6379,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:724
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-09 03:18-0300\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -858,7 +858,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -906,11 +906,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:577 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:944
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:578 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:945
 msgid "Bytes sent"
 msgstr ""
 
@@ -939,11 +939,11 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:527
+#: lxc/info.go:539
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:531
+#: lxc/info.go:543
 msgid "CPU usage:"
 msgstr ""
 
@@ -1868,7 +1868,11 @@ msgstr ""
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:520
+#: lxc/info.go:533
+msgid "Disk total:"
+msgstr ""
+
+#: lxc/info.go:529
 msgid "Disk usage:"
 msgstr ""
 
@@ -2141,7 +2145,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
 #: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
@@ -2666,7 +2670,7 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:578
 msgid "Host interface"
 msgstr ""
 
@@ -2720,7 +2724,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:582
+#: lxc/info.go:594
 msgid "IP addresses"
 msgstr ""
 
@@ -2882,7 +2886,7 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:692
+#: lxc/info.go:704
 msgid "Instance Only"
 msgstr ""
 
@@ -3436,7 +3440,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:720
+#: lxc/info.go:732
 msgid "Log:"
 msgstr ""
 
@@ -3452,7 +3456,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:570
+#: lxc/info.go:582
 msgid "MAC address"
 msgstr ""
 
@@ -3495,7 +3499,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:586
 msgid "MTU"
 msgstr ""
 
@@ -3743,15 +3747,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:550
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:554
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:566
 msgid "Memory usage:"
 msgstr ""
 
@@ -4091,7 +4095,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
 #: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
@@ -4204,7 +4208,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:595 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:943
 msgid "Network usage:"
 msgstr ""
 
@@ -4323,7 +4327,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4382,11 +4386,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:579 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:946
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:580 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:947
 msgid "Packets sent"
 msgstr ""
 
@@ -5622,7 +5626,7 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -5653,7 +5657,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:576
 msgid "State"
 msgstr ""
 
@@ -5662,7 +5666,7 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:641
+#: lxc/info.go:653
 msgid "Stateful"
 msgstr ""
 
@@ -5764,11 +5768,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:558
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:550
+#: lxc/info.go:562
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5809,7 +5813,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -6133,7 +6137,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:563
+#: lxc/info.go:575
 msgid "Type"
 msgstr ""
 
@@ -6378,7 +6382,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:724
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-09 03:18-0300\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -858,7 +858,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -906,11 +906,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:577 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:944
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:578 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:945
 msgid "Bytes sent"
 msgstr ""
 
@@ -939,11 +939,11 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:527
+#: lxc/info.go:539
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:531
+#: lxc/info.go:543
 msgid "CPU usage:"
 msgstr ""
 
@@ -1868,7 +1868,11 @@ msgstr ""
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:520
+#: lxc/info.go:533
+msgid "Disk total:"
+msgstr ""
+
+#: lxc/info.go:529
 msgid "Disk usage:"
 msgstr ""
 
@@ -2141,7 +2145,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
 #: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
@@ -2666,7 +2670,7 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:578
 msgid "Host interface"
 msgstr ""
 
@@ -2720,7 +2724,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:582
+#: lxc/info.go:594
 msgid "IP addresses"
 msgstr ""
 
@@ -2882,7 +2886,7 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:692
+#: lxc/info.go:704
 msgid "Instance Only"
 msgstr ""
 
@@ -3436,7 +3440,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:720
+#: lxc/info.go:732
 msgid "Log:"
 msgstr ""
 
@@ -3452,7 +3456,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:570
+#: lxc/info.go:582
 msgid "MAC address"
 msgstr ""
 
@@ -3495,7 +3499,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:586
 msgid "MTU"
 msgstr ""
 
@@ -3743,15 +3747,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:550
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:554
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:566
 msgid "Memory usage:"
 msgstr ""
 
@@ -4091,7 +4095,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
 #: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
@@ -4204,7 +4208,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:595 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:943
 msgid "Network usage:"
 msgstr ""
 
@@ -4323,7 +4327,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4382,11 +4386,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:579 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:946
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:580 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:947
 msgid "Packets sent"
 msgstr ""
 
@@ -5622,7 +5626,7 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -5653,7 +5657,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:576
 msgid "State"
 msgstr ""
 
@@ -5662,7 +5666,7 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:641
+#: lxc/info.go:653
 msgid "Stateful"
 msgstr ""
 
@@ -5764,11 +5768,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:558
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:550
+#: lxc/info.go:562
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5809,7 +5813,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -6133,7 +6137,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:563
+#: lxc/info.go:575
 msgid "Type"
 msgstr ""
 
@@ -6378,7 +6382,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:724
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-09 03:18-0300\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -858,7 +858,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -906,11 +906,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:577 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:944
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:578 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:945
 msgid "Bytes sent"
 msgstr ""
 
@@ -939,11 +939,11 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:527
+#: lxc/info.go:539
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:531
+#: lxc/info.go:543
 msgid "CPU usage:"
 msgstr ""
 
@@ -1868,7 +1868,11 @@ msgstr ""
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:520
+#: lxc/info.go:533
+msgid "Disk total:"
+msgstr ""
+
+#: lxc/info.go:529
 msgid "Disk usage:"
 msgstr ""
 
@@ -2141,7 +2145,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
 #: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
@@ -2666,7 +2670,7 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:578
 msgid "Host interface"
 msgstr ""
 
@@ -2720,7 +2724,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:582
+#: lxc/info.go:594
 msgid "IP addresses"
 msgstr ""
 
@@ -2882,7 +2886,7 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:692
+#: lxc/info.go:704
 msgid "Instance Only"
 msgstr ""
 
@@ -3436,7 +3440,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:720
+#: lxc/info.go:732
 msgid "Log:"
 msgstr ""
 
@@ -3452,7 +3456,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:570
+#: lxc/info.go:582
 msgid "MAC address"
 msgstr ""
 
@@ -3495,7 +3499,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:586
 msgid "MTU"
 msgstr ""
 
@@ -3743,15 +3747,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:550
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:554
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:566
 msgid "Memory usage:"
 msgstr ""
 
@@ -4091,7 +4095,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
 #: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
@@ -4204,7 +4208,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:595 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:943
 msgid "Network usage:"
 msgstr ""
 
@@ -4323,7 +4327,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4382,11 +4386,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:579 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:946
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:580 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:947
 msgid "Packets sent"
 msgstr ""
 
@@ -5622,7 +5626,7 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -5653,7 +5657,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:576
 msgid "State"
 msgstr ""
 
@@ -5662,7 +5666,7 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:641
+#: lxc/info.go:653
 msgid "Stateful"
 msgstr ""
 
@@ -5764,11 +5768,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:558
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:550
+#: lxc/info.go:562
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5809,7 +5813,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -6133,7 +6137,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:563
+#: lxc/info.go:575
 msgid "Type"
 msgstr ""
 
@@ -6378,7 +6382,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:724
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-09 03:18-0300\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -859,7 +859,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -907,11 +907,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:577 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:944
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:578 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:945
 msgid "Bytes sent"
 msgstr ""
 
@@ -940,11 +940,11 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:527
+#: lxc/info.go:539
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:531
+#: lxc/info.go:543
 msgid "CPU usage:"
 msgstr ""
 
@@ -1869,7 +1869,11 @@ msgstr ""
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:520
+#: lxc/info.go:533
+msgid "Disk total:"
+msgstr ""
+
+#: lxc/info.go:529
 msgid "Disk usage:"
 msgstr ""
 
@@ -2142,7 +2146,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
 #: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
@@ -2667,7 +2671,7 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:578
 msgid "Host interface"
 msgstr ""
 
@@ -2721,7 +2725,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:582
+#: lxc/info.go:594
 msgid "IP addresses"
 msgstr ""
 
@@ -2883,7 +2887,7 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:692
+#: lxc/info.go:704
 msgid "Instance Only"
 msgstr ""
 
@@ -3437,7 +3441,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:720
+#: lxc/info.go:732
 msgid "Log:"
 msgstr ""
 
@@ -3453,7 +3457,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:570
+#: lxc/info.go:582
 msgid "MAC address"
 msgstr ""
 
@@ -3496,7 +3500,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:586
 msgid "MTU"
 msgstr ""
 
@@ -3744,15 +3748,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:550
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:554
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:566
 msgid "Memory usage:"
 msgstr ""
 
@@ -4092,7 +4096,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
 #: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
@@ -4205,7 +4209,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:595 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:943
 msgid "Network usage:"
 msgstr ""
 
@@ -4324,7 +4328,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4383,11 +4387,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:579 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:946
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:580 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:947
 msgid "Packets sent"
 msgstr ""
 
@@ -5623,7 +5627,7 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -5654,7 +5658,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:576
 msgid "State"
 msgstr ""
 
@@ -5663,7 +5667,7 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:641
+#: lxc/info.go:653
 msgid "Stateful"
 msgstr ""
 
@@ -5765,11 +5769,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:558
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:550
+#: lxc/info.go:562
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5810,7 +5814,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -6134,7 +6138,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:563
+#: lxc/info.go:575
 msgid "Type"
 msgstr ""
 
@@ -6379,7 +6383,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:724
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-09 03:18-0300\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -1067,11 +1067,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:577 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:944
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:578 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:945
 msgid "Bytes sent"
 msgstr ""
 
@@ -1100,11 +1100,11 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:527
+#: lxc/info.go:539
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:531
+#: lxc/info.go:543
 msgid "CPU usage:"
 msgstr ""
 
@@ -2029,7 +2029,11 @@ msgstr ""
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:520
+#: lxc/info.go:533
+msgid "Disk total:"
+msgstr ""
+
+#: lxc/info.go:529
 msgid "Disk usage:"
 msgstr ""
 
@@ -2302,7 +2306,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
 #: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
@@ -2827,7 +2831,7 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:578
 msgid "Host interface"
 msgstr ""
 
@@ -2881,7 +2885,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:582
+#: lxc/info.go:594
 msgid "IP addresses"
 msgstr ""
 
@@ -3043,7 +3047,7 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:692
+#: lxc/info.go:704
 msgid "Instance Only"
 msgstr ""
 
@@ -3597,7 +3601,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:720
+#: lxc/info.go:732
 msgid "Log:"
 msgstr ""
 
@@ -3613,7 +3617,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:570
+#: lxc/info.go:582
 msgid "MAC address"
 msgstr ""
 
@@ -3656,7 +3660,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:586
 msgid "MTU"
 msgstr ""
 
@@ -3904,15 +3908,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:550
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:554
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:566
 msgid "Memory usage:"
 msgstr ""
 
@@ -4252,7 +4256,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
 #: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
@@ -4365,7 +4369,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:595 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:943
 msgid "Network usage:"
 msgstr ""
 
@@ -4484,7 +4488,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4543,11 +4547,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:579 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:946
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:580 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:947
 msgid "Packets sent"
 msgstr ""
 
@@ -5783,7 +5787,7 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -5814,7 +5818,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:576
 msgid "State"
 msgstr ""
 
@@ -5823,7 +5827,7 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:641
+#: lxc/info.go:653
 msgid "Stateful"
 msgstr ""
 
@@ -5925,11 +5929,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:558
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:550
+#: lxc/info.go:562
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5970,7 +5974,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -6294,7 +6298,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:563
+#: lxc/info.go:575
 msgid "Type"
 msgstr ""
 
@@ -6539,7 +6543,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:724
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-05 16:02+0000\n"
+"POT-Creation-Date: 2024-12-09 03:18-0300\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -858,7 +858,7 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:654 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1527
 msgid "Backups:"
 msgstr ""
 
@@ -906,11 +906,11 @@ msgstr ""
 msgid "Bridge:"
 msgstr ""
 
-#: lxc/info.go:577 lxc/network.go:944
+#: lxc/info.go:589 lxc/network.go:944
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:578 lxc/network.go:945
+#: lxc/info.go:590 lxc/network.go:945
 msgid "Bytes sent"
 msgstr ""
 
@@ -939,11 +939,11 @@ msgstr ""
 msgid "CPU USAGE"
 msgstr ""
 
-#: lxc/info.go:527
+#: lxc/info.go:539
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:531
+#: lxc/info.go:543
 msgid "CPU usage:"
 msgstr ""
 
@@ -1868,7 +1868,11 @@ msgstr ""
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:520
+#: lxc/info.go:533
+msgid "Disk total:"
+msgstr ""
+
+#: lxc/info.go:529
 msgid "Disk usage:"
 msgstr ""
 
@@ -2141,7 +2145,7 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:640 lxc/info.go:691 lxc/storage_volume.go:1514
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
 #: lxc/storage_volume.go:1564
 msgid "Expires at"
 msgstr ""
@@ -2666,7 +2670,7 @@ msgstr ""
 msgid "HOSTNAME"
 msgstr ""
 
-#: lxc/info.go:566
+#: lxc/info.go:578
 msgid "Host interface"
 msgstr ""
 
@@ -2720,7 +2724,7 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/info.go:582
+#: lxc/info.go:594
 msgid "IP addresses"
 msgstr ""
 
@@ -2882,7 +2886,7 @@ msgstr ""
 msgid "Inspect permissions"
 msgstr ""
 
-#: lxc/info.go:692
+#: lxc/info.go:704
 msgid "Instance Only"
 msgstr ""
 
@@ -3436,7 +3440,7 @@ msgstr ""
 msgid "Log level filtering can only be used with pretty formatting"
 msgstr ""
 
-#: lxc/info.go:720
+#: lxc/info.go:732
 msgid "Log:"
 msgstr ""
 
@@ -3452,7 +3456,7 @@ msgstr ""
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/info.go:570
+#: lxc/info.go:582
 msgid "MAC address"
 msgstr ""
 
@@ -3495,7 +3499,7 @@ msgstr ""
 msgid "MII state"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:586
 msgid "MTU"
 msgstr ""
 
@@ -3743,15 +3747,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:538
+#: lxc/info.go:550
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:542
+#: lxc/info.go:554
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:554
+#: lxc/info.go:566
 msgid "Memory usage:"
 msgstr ""
 
@@ -4091,7 +4095,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:638 lxc/info.go:689 lxc/storage_volume.go:1512
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
 #: lxc/storage_volume.go:1562
 msgid "Name"
 msgstr ""
@@ -4204,7 +4208,7 @@ msgstr ""
 msgid "Network type"
 msgstr ""
 
-#: lxc/info.go:595 lxc/network.go:943
+#: lxc/info.go:607 lxc/network.go:943
 msgid "Network usage:"
 msgstr ""
 
@@ -4323,7 +4327,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:693 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1566
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4382,11 +4386,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:579 lxc/network.go:946
+#: lxc/info.go:591 lxc/network.go:946
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:580 lxc/network.go:947
+#: lxc/info.go:592 lxc/network.go:947
 msgid "Packets sent"
 msgstr ""
 
@@ -5622,7 +5626,7 @@ msgstr ""
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:607 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1491
 msgid "Snapshots:"
 msgstr ""
 
@@ -5653,7 +5657,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:564
+#: lxc/info.go:576
 msgid "State"
 msgstr ""
 
@@ -5662,7 +5666,7 @@ msgstr ""
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:641
+#: lxc/info.go:653
 msgid "Stateful"
 msgstr ""
 
@@ -5764,11 +5768,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:546
+#: lxc/info.go:558
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:550
+#: lxc/info.go:562
 msgid "Swap (peak)"
 msgstr ""
 
@@ -5809,7 +5813,7 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:639 lxc/info.go:690 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
 msgid "Taken at"
 msgstr ""
 
@@ -6133,7 +6137,7 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:563
+#: lxc/info.go:575
 msgid "Type"
 msgstr ""
 
@@ -6378,7 +6382,7 @@ msgstr ""
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
-#: lxc/info.go:712
+#: lxc/info.go:724
 #, c-format
 msgid "Unsupported instance type: %s"
 msgstr ""

--- a/shared/api/instance_state.go
+++ b/shared/api/instance_state.go
@@ -64,11 +64,11 @@ type InstanceState struct {
 //
 // API extension: instances.
 type InstanceStateDisk struct {
-	// Disk usage in bytes
+	// Disk usage in bytes. Uses -1 to indicate that the storage driver for the instance's pool does not support retrieving the disk usage.
 	// Example: 502239232
 	Usage int64 `json:"usage" yaml:"usage"`
 
-	// Total size in bytes
+	// Total size in bytes. Uses -1 to convey that the instance has access to the entire pool's storage.
 	// Example: 502239232
 	//
 	// API extension: instances_state_total

--- a/test/suites/storage.sh
+++ b/test/suites/storage.sh
@@ -931,8 +931,8 @@ EOF
     # Disable quotas. The usage should be 0.
     # shellcheck disable=SC2031
     btrfs quota disable "${LXD_DIR}/storage-pools/${pool_name}"
-    usage=$(lxc query /1.0/instances/c1/state | jq '.disk.root')
-    [ "${usage}" = "null" ]
+    # Usage -1 indicates the driver does not support getting instance usage.
+    [ "$(lxc query /1.0/instances/c1/state | jq '.disk.root.usage')" = "-1" ]
 
     # Enable quotas. The usage should then be > 0.
     # shellcheck disable=SC2031


### PR DESCRIPTION
This aims to get instance root disk sizes correctly, as it currently often shows as 0 or null on the API, either though `/1.0/instances?recursion=2` or `/1.0/instances/<instance_name>/state`, as reported by https://github.com/canonical/lxd/issues/14277.

This is still not a perfect solution but is a significant improvement as it:
 - Fixes not returning the disk total size when getting the disk usage is not supported by the driver (relevant for dir and lvm)
 - Returns default block size for block typed/based instances when the disk device does not have the `size` key set.
 - Returns disk size -1 for instances that have unbounded storage and have access to the entire pool storage.