### PR TITLE
lxd: Log error on `resultErrListAppend`

### DIFF
--- a/lxd/instances_get.go
+++ b/lxd/instances_get.go
@@ -25,6 +25,7 @@ import (
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/entity"
 	"github.com/canonical/lxd/shared/filter"
+	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/lxd/shared/version"
 )
 
@@ -304,6 +305,8 @@ func instancesGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	resultErrListAppend := func(inst db.Instance, err error) {
+		logger.Error("Failed getting instance info", logger.Ctx{"err": err, "project": inst.Project, "instance": inst.Name})
+
 		instFull := &api.InstanceFull{
 			Instance: api.Instance{
 				Name:       inst.Name,


### PR DESCRIPTION
I noticed this `err` parameter was unused. So I had this idea of, instead of removing it, logging these erros, as the errors used with that function are currently not being disclosed to the user in any way. This way it is clear why one was not able to get info on that particular instance when looking in the logs. If this logging is not desirable, I will update the PR to just remove the unused parameter.