### PR TITLE
Revert "lxd/instance/drivers/qmp: Return an error if no fd is found"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/canonical/lxd
 
-go 1.23
+go 1.23.3
 
 require (
 	github.com/NVIDIA/nvidia-container-toolkit v1.17.2

--- a/lxd/instance/drivers/qmp/commands.go
+++ b/lxd/instance/drivers/qmp/commands.go
@@ -225,8 +225,6 @@ func (m *Monitor) RemoveFDFromFDSet(name string) error {
 		return fmt.Errorf("Failed to query fd sets: %w", err)
 	}
 
-	found := false
-
 	for _, fdSet := range resp.Return {
 		for _, fd := range fdSet.FDs {
 			fields := strings.SplitN(fd.Opaque, ":", 2)
@@ -239,8 +237,6 @@ func (m *Monitor) RemoveFDFromFDSet(name string) error {
 			}
 
 			if opaque == name {
-				found = true
-
 				args := map[string]any{
 					"fdset-id": fdSet.ID,
 				}
@@ -251,11 +247,6 @@ func (m *Monitor) RemoveFDFromFDSet(name string) error {
 				}
 			}
 		}
-	}
-
-	// Return an error if no fd matched the provided name.
-	if !found {
-		return api.StatusErrorf(http.StatusNotFound, "No fd with name %q", name)
 	}
 
 	return nil


### PR DESCRIPTION
This reverts commit cbffaf10d16687f19efe69f472db285163b701c5 from https://github.com/canonical/lxd/pull/14479

It breaks various tests.