### PR TITLE
gpu: fix CDI validation rules for gpu `id`

### DIFF
--- a/lxd/device/cdi/id.go
+++ b/lxd/device/cdi/id.go
@@ -2,6 +2,7 @@ package cdi
 
 import (
 	"fmt"
+	"strconv"
 
 	"tags.cncf.io/container-device-interface/pkg/parser"
 )
@@ -90,7 +91,12 @@ func ToCDI(id string) (ID, error) {
 	vendor, class, name, err := parser.ParseQualifiedName(id)
 	if err != nil {
 		// The ID is not a valid CDI qualified name but it could be a valid DRM device ID.
-		return ID{}, nil
+		_, err := strconv.Atoi(id)
+		if err == nil {
+			return ID{}, nil
+		}
+
+		return ID{}, err
 	}
 
 	vendorType, err := ToVendor(vendor)

--- a/lxd/device/cdi/id_test.go
+++ b/lxd/device/cdi/id_test.go
@@ -98,7 +98,7 @@ func TestToCDI(t *testing.T) {
 		{"Invalid vendor", "amd.com/gpu=0", ID{}, true},
 		{"Invalid class", "nvidia.com/cpu=0", ID{}, true},
 		{"Valid MIG format (all MIG indexes in device)", "nvidia.com/mig=0", ID{Vendor: NVIDIA, Class: MIG, Name: "0"}, false},
-		{"Non-CDI format", "not-a-cdi-format", ID{}, false},
+		{"Non-CDI format", "not-a-cdi-format", ID{}, true},
 	}
 
 	for _, tt := range tests {

--- a/lxd/device/gpu_physical.go
+++ b/lxd/device/gpu_physical.go
@@ -77,10 +77,14 @@ func (d *gpuPhysical) validateConfig(instConf instance.ConfigReader) error {
 		}
 
 		// If user requests CDI in conjunction with any nvidia.<options>=true we should forbid that.
+		cdiID, err := cdi.ToCDI(d.config["id"])
+		if err != nil {
+			return fmt.Errorf("Failed to parse GPU 'id': %w", err)
+		}
+
 		for k, v := range instConf.ExpandedConfig() {
 			if strings.HasPrefix(k, "nvidia.") && shared.IsTrue(v) {
-				_, err := cdi.ToCDI(d.config["id"])
-				if err == nil {
+				if cdiID.Vendor != "" && cdiID.Class != "" && cdiID.Name != "" {
 					return fmt.Errorf("CDI mode is incompatible with any NVIDIA instance configuration option (%q)", k)
 				}
 			}


### PR DESCRIPTION
This fixes the bug that were forbidding a user to add a GPU device through the DRM card ID (eventhough if this one exists)

Now, these two approach work fine:

```
lxc init ubuntu:24.04 c1

# CDI approach
lxc config device add c1 mygpu gpu gputype=physical id=nvidia.com/gpu=0
lxc start c1
lxc exec c1 -- nvidia-smi
lxc stop c1
lxc config device remove c1 mygpu

# DRM ID approach (DRM IDs most often start at '1')
lxc config device add c1 mygpu gpu gputype=physical id=1
lxc config set c1 nvidia.runtime true
lxc start c1
lxc exec c1 -- nvidia-smi
```