### PR TITLE
API: Add `scope` to metadata configuration API

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2523,3 +2523,7 @@ Adds support for using the Container Device Interface (CDI) specification to con
 ## `images_all_projects`
 
 This adds support for listing images across all projects using the `all-projects` parameter in `GET /1.0/images` requests.
+
+## `metadata_configuration_scope`
+
+This adds scope metadata to `GET /1.0/metadata/configuration`. Options marked with a `global` scope are applied to all cluster members. Options with a `local` scope must be set on a per-member basis.

--- a/doc/metadata.txt
+++ b/doc/metadata.txt
@@ -2699,6 +2699,7 @@ Possible values are `enabled`, `disabled`, and `logged`.
 ```{config:option} bgp.ipv4.nexthop network-bridge-network-conf
 :condition: "BGP server"
 :defaultdesc: "local address"
+:scope: "local"
 :shortdesc: "Override the IPv4 next-hop for advertised prefixes"
 :type: "string"
 
@@ -2707,6 +2708,7 @@ Possible values are `enabled`, `disabled`, and `logged`.
 ```{config:option} bgp.ipv6.nexthop network-bridge-network-conf
 :condition: "BGP server"
 :defaultdesc: "local address"
+:scope: "local"
 :shortdesc: "Override the IPv6 next-hop for advertised prefixes"
 :type: "string"
 
@@ -2714,6 +2716,7 @@ Possible values are `enabled`, `disabled`, and `logged`.
 
 ```{config:option} bgp.peers.NAME.address network-bridge-network-conf
 :condition: "BGP server"
+:scope: "global"
 :shortdesc: "Peer address (IPv4 or IPv6)"
 :type: "string"
 
@@ -2721,6 +2724,7 @@ Possible values are `enabled`, `disabled`, and `logged`.
 
 ```{config:option} bgp.peers.NAME.asn network-bridge-network-conf
 :condition: "BGP server"
+:scope: "global"
 :shortdesc: "Peer AS number"
 :type: "integer"
 
@@ -2730,6 +2734,7 @@ Possible values are `enabled`, `disabled`, and `logged`.
 :condition: "BGP server"
 :defaultdesc: "`180`"
 :required: "no"
+:scope: "global"
 :shortdesc: "Peer session hold time"
 :type: "integer"
 Specify the hold time in seconds.
@@ -2739,6 +2744,7 @@ Specify the hold time in seconds.
 :condition: "BGP server"
 :defaultdesc: "(no password)"
 :required: "no"
+:scope: "global"
 :shortdesc: "Peer session password"
 :type: "string"
 
@@ -2746,18 +2752,21 @@ Specify the hold time in seconds.
 
 ```{config:option} bridge.driver network-bridge-network-conf
 :defaultdesc: "`native`"
+:scope: "global"
 :shortdesc: "Bridge driver"
 :type: "string"
 Possible values are `native` and `openvswitch`.
 ```
 
 ```{config:option} bridge.external_interfaces network-bridge-network-conf
+:scope: "local"
 :shortdesc: "Unconfigured network interfaces to include in the bridge"
 :type: "string"
 Specify a comma-separated list of unconfigured network interfaces to include in the bridge.
 ```
 
 ```{config:option} bridge.hwaddr network-bridge-network-conf
+:scope: "global"
 :shortdesc: "MAC address for the bridge"
 :type: "string"
 
@@ -2765,6 +2774,7 @@ Specify a comma-separated list of unconfigured network interfaces to include in 
 
 ```{config:option} bridge.mode network-bridge-network-conf
 :defaultdesc: "`standard`"
+:scope: "global"
 :shortdesc: "Bridge operation mode"
 :type: "string"
 Possible values are `standard` and `fan`.
@@ -2772,6 +2782,7 @@ Possible values are `standard` and `fan`.
 
 ```{config:option} bridge.mtu network-bridge-network-conf
 :defaultdesc: "`1500` if `bridge.mode=standard`, `1480` if `bridge.mode=fan` and `fan.type=ipip`, or `1450` if `bridge.mode=fan` and `fan.type=vxlan`"
+:scope: "global"
 :shortdesc: "Bridge MTU"
 :type: "integer"
 The default value varies depending on whether the bridge uses a tunnel or a fan setup.
@@ -2779,6 +2790,7 @@ The default value varies depending on whether the bridge uses a tunnel or a fan 
 
 ```{config:option} dns.domain network-bridge-network-conf
 :defaultdesc: "`lxd`"
+:scope: "global"
 :shortdesc: "Domain to advertise to DHCP clients and use for DNS resolution"
 :type: "string"
 
@@ -2786,6 +2798,7 @@ The default value varies depending on whether the bridge uses a tunnel or a fan 
 
 ```{config:option} dns.mode network-bridge-network-conf
 :defaultdesc: "`managed`"
+:scope: "global"
 :shortdesc: "DNS registration mode"
 :type: "string"
 Possible values are `none` for no DNS record, `managed` for LXD-generated static records, and `dynamic` for client-generated records.
@@ -2793,24 +2806,28 @@ Possible values are `none` for no DNS record, `managed` for LXD-generated static
 
 ```{config:option} dns.search network-bridge-network-conf
 :defaultdesc: "`dns.domain` value"
+:scope: "global"
 :shortdesc: "Full domain search list"
 :type: "string"
 Specify a comma-separated list of domains.
 ```
 
 ```{config:option} dns.zone.forward network-bridge-network-conf
+:scope: "global"
 :shortdesc: "DNS zone names for forward DNS records"
 :type: "string"
 Specify a comma-separated list of DNS zone names.
 ```
 
 ```{config:option} dns.zone.reverse.ipv4 network-bridge-network-conf
+:scope: "global"
 :shortdesc: "DNS zone name for IPv4 reverse DNS records"
 :type: "string"
 
 ```
 
 ```{config:option} dns.zone.reverse.ipv6 network-bridge-network-conf
+:scope: "global"
 :shortdesc: "DNS zone name for IPv6 reverse DNS records"
 :type: "string"
 
@@ -2819,6 +2836,7 @@ Specify a comma-separated list of DNS zone names.
 ```{config:option} fan.overlay_subnet network-bridge-network-conf
 :condition: "fan mode"
 :defaultdesc: "`240.0.0.0/8`"
+:scope: "global"
 :shortdesc: "Subnet to use as the overlay for the FAN"
 :type: "string"
 Use CIDR notation.
@@ -2827,6 +2845,7 @@ Use CIDR notation.
 ```{config:option} fan.type network-bridge-network-conf
 :condition: "fan mode"
 :defaultdesc: "`vxlan`"
+:scope: "global"
 :shortdesc: "Tunneling type for the FAN"
 :type: "string"
 Possible values are `vxlan` and `ipip`.
@@ -2835,6 +2854,7 @@ Possible values are `vxlan` and `ipip`.
 ```{config:option} fan.underlay_subnet network-bridge-network-conf
 :condition: "fan mode"
 :defaultdesc: "initial value on creation: `auto`"
+:scope: "global"
 :shortdesc: "Subnet to use as the underlay for the FAN"
 :type: "string"
 Use CIDR notation.
@@ -2845,6 +2865,7 @@ You can set the option to `auto` to use the default gateway subnet.
 ```{config:option} ipv4.address network-bridge-network-conf
 :condition: "standard mode"
 :defaultdesc: "initial value on creation: `auto`"
+:scope: "global"
 :shortdesc: "IPv4 address for the bridge"
 :type: "string"
 Use CIDR notation.
@@ -2855,6 +2876,7 @@ You can set the option to `none` to turn off IPv4, or to `auto` to generate a ne
 ```{config:option} ipv4.dhcp network-bridge-network-conf
 :condition: "IPv4 address"
 :defaultdesc: "`true`"
+:scope: "global"
 :shortdesc: "Whether to allocate IPv4 addresses using DHCP"
 :type: "bool"
 
@@ -2863,6 +2885,7 @@ You can set the option to `none` to turn off IPv4, or to `auto` to generate a ne
 ```{config:option} ipv4.dhcp.expiry network-bridge-network-conf
 :condition: "IPv4 DHCP"
 :defaultdesc: "`1h`"
+:scope: "global"
 :shortdesc: "When to expire DHCP leases"
 :type: "string"
 
@@ -2871,6 +2894,7 @@ You can set the option to `none` to turn off IPv4, or to `auto` to generate a ne
 ```{config:option} ipv4.dhcp.gateway network-bridge-network-conf
 :condition: "IPv4 DHCP"
 :defaultdesc: "IPv4 address"
+:scope: "global"
 :shortdesc: "Address of the gateway for the IPv4 subnet"
 :type: "string"
 
@@ -2879,6 +2903,7 @@ You can set the option to `none` to turn off IPv4, or to `auto` to generate a ne
 ```{config:option} ipv4.dhcp.ranges network-bridge-network-conf
 :condition: "IPv4 DHCP"
 :defaultdesc: "all addresses"
+:scope: "global"
 :shortdesc: "IPv4 ranges to use for DHCP"
 :type: "string"
 Specify a comma-separated list of IPv4 ranges in FIRST-LAST format.
@@ -2887,6 +2912,7 @@ Specify a comma-separated list of IPv4 ranges in FIRST-LAST format.
 ```{config:option} ipv4.firewall network-bridge-network-conf
 :condition: "IPv4 address"
 :defaultdesc: "`true`"
+:scope: "global"
 :shortdesc: "Whether to generate filtering firewall rules for this network"
 :type: "bool"
 
@@ -2895,6 +2921,7 @@ Specify a comma-separated list of IPv4 ranges in FIRST-LAST format.
 ```{config:option} ipv4.nat network-bridge-network-conf
 :condition: "IPv4 address"
 :defaultdesc: "`false` (initial value on creation if `ipv4.address` is set to `auto`: `true`)"
+:scope: "global"
 :shortdesc: "Whether to use NAT for IPv4"
 :type: "bool"
 
@@ -2902,6 +2929,7 @@ Specify a comma-separated list of IPv4 ranges in FIRST-LAST format.
 
 ```{config:option} ipv4.nat.address network-bridge-network-conf
 :condition: "IPv4 address"
+:scope: "global"
 :shortdesc: "Source address used for outbound traffic from the bridge"
 :type: "string"
 
@@ -2910,12 +2938,14 @@ Specify a comma-separated list of IPv4 ranges in FIRST-LAST format.
 ```{config:option} ipv4.nat.order network-bridge-network-conf
 :condition: "IPv4 address"
 :defaultdesc: "`before`"
+:scope: "global"
 :shortdesc: "Where to add the required NAT rules"
 :type: "string"
 Set this option to `before` to add the NAT rules before any pre-existing rules, or to `after` to add them after the pre-existing rules.
 ```
 
 ```{config:option} ipv4.ovn.ranges network-bridge-network-conf
+:scope: "global"
 :shortdesc: "IPv4 ranges to use for child OVN network routers"
 :type: "string"
 Specify a comma-separated list of IPv4 ranges in FIRST-LAST format.
@@ -2923,6 +2953,7 @@ Specify a comma-separated list of IPv4 ranges in FIRST-LAST format.
 
 ```{config:option} ipv4.routes network-bridge-network-conf
 :condition: "IPv4 address"
+:scope: "global"
 :shortdesc: "Additional IPv4 CIDR subnets to route to the bridge"
 :type: "string"
 Specify a comma-separated list of IPv4 CIDR subnets.
@@ -2931,6 +2962,7 @@ Specify a comma-separated list of IPv4 CIDR subnets.
 ```{config:option} ipv4.routing network-bridge-network-conf
 :condition: "IPv4 address"
 :defaultdesc: "`true`"
+:scope: "global"
 :shortdesc: "Whether to route IPv4 traffic in and out of the bridge"
 :type: "bool"
 
@@ -2939,6 +2971,7 @@ Specify a comma-separated list of IPv4 CIDR subnets.
 ```{config:option} ipv6.address network-bridge-network-conf
 :condition: "standard mode"
 :defaultdesc: "initial value on creation: `auto`"
+:scope: "global"
 :shortdesc: "IPv6 address for the bridge"
 :type: "string"
 Use CIDR notation.
@@ -2949,6 +2982,7 @@ You can set the option to `none` to turn off IPv6, or to `auto` to generate a ne
 ```{config:option} ipv6.dhcp network-bridge-network-conf
 :condition: "IPv6 address"
 :defaultdesc: "`true`"
+:scope: "global"
 :shortdesc: "Whether to provide additional network configuration over DHCP"
 :type: "bool"
 
@@ -2957,6 +2991,7 @@ You can set the option to `none` to turn off IPv6, or to `auto` to generate a ne
 ```{config:option} ipv6.dhcp.expiry network-bridge-network-conf
 :condition: "IPv6 DHCP"
 :defaultdesc: "`1h`"
+:scope: "global"
 :shortdesc: "When to expire DHCP leases"
 :type: "string"
 
@@ -2965,6 +3000,7 @@ You can set the option to `none` to turn off IPv6, or to `auto` to generate a ne
 ```{config:option} ipv6.dhcp.ranges network-bridge-network-conf
 :condition: "IPv6 stateful DHCP"
 :defaultdesc: "all addresses"
+:scope: "global"
 :shortdesc: "IPv6 ranges to use for DHCP"
 :type: "string"
 Specify a comma-separated list of IPv6 ranges in FIRST-LAST format.
@@ -2973,6 +3009,7 @@ Specify a comma-separated list of IPv6 ranges in FIRST-LAST format.
 ```{config:option} ipv6.dhcp.stateful network-bridge-network-conf
 :condition: "IPv6 DHCP"
 :defaultdesc: "`false`"
+:scope: "global"
 :shortdesc: "Whether to allocate IPv6 addresses using DHCP"
 :type: "bool"
 
@@ -2981,6 +3018,7 @@ Specify a comma-separated list of IPv6 ranges in FIRST-LAST format.
 ```{config:option} ipv6.firewall network-bridge-network-conf
 :condition: "IPv6 DHCP"
 :defaultdesc: "`true`"
+:scope: "global"
 :shortdesc: "Whether to generate filtering firewall rules for this network"
 :type: "bool"
 
@@ -2989,6 +3027,7 @@ Specify a comma-separated list of IPv6 ranges in FIRST-LAST format.
 ```{config:option} ipv6.nat network-bridge-network-conf
 :condition: "IPv6 address"
 :defaultdesc: "`false` (initial value on creation if `ipv6.address` is set to `auto`: `true`)"
+:scope: "global"
 :shortdesc: "Whether to use NAT for IPv6"
 :type: "bool"
 
@@ -2996,6 +3035,7 @@ Specify a comma-separated list of IPv6 ranges in FIRST-LAST format.
 
 ```{config:option} ipv6.nat.address network-bridge-network-conf
 :condition: "IPv6 address"
+:scope: "global"
 :shortdesc: "Source address used for outbound traffic from the bridge"
 :type: "string"
 
@@ -3004,12 +3044,14 @@ Specify a comma-separated list of IPv6 ranges in FIRST-LAST format.
 ```{config:option} ipv6.nat.order network-bridge-network-conf
 :condition: "IPv6 address"
 :defaultdesc: "`before`"
+:scope: "global"
 :shortdesc: "Where to add the required NAT rules"
 :type: "string"
 Set this option to `before` to add the NAT rules before any pre-existing rules, or to `after` to add them after the pre-existing rules.
 ```
 
 ```{config:option} ipv6.ovn.ranges network-bridge-network-conf
+:scope: "global"
 :shortdesc: "IPv6 ranges to use for child OVN network routers"
 :type: "string"
 Specify a comma-separated list of IPv6 ranges in FIRST-LAST format.
@@ -3017,6 +3059,7 @@ Specify a comma-separated list of IPv6 ranges in FIRST-LAST format.
 
 ```{config:option} ipv6.routes network-bridge-network-conf
 :condition: "IPv6 address"
+:scope: "global"
 :shortdesc: "Additional IPv6 CIDR subnets to route to the bridge"
 :type: "string"
 Specify a comma-separated list of IPv6 CIDR subnets.
@@ -3024,6 +3067,7 @@ Specify a comma-separated list of IPv6 CIDR subnets.
 
 ```{config:option} ipv6.routing network-bridge-network-conf
 :condition: "IPv6 address"
+:scope: "global"
 :shortdesc: "Whether to route IPv6 traffic in and out of the bridge"
 :type: "bool"
 
@@ -3031,6 +3075,7 @@ Specify a comma-separated list of IPv6 CIDR subnets.
 
 ```{config:option} maas.subnet.ipv4 network-bridge-network-conf
 :condition: "IPv4 address; using the `network` property on the NIC"
+:scope: "global"
 :shortdesc: "MAAS IPv4 subnet to register instances in"
 :type: "string"
 
@@ -3038,18 +3083,21 @@ Specify a comma-separated list of IPv6 CIDR subnets.
 
 ```{config:option} maas.subnet.ipv6 network-bridge-network-conf
 :condition: "IPv6 address; using the `network` property on the NIC"
+:scope: "global"
 :shortdesc: "MAAS IPv6 subnet to register instances in"
 :type: "string"
 
 ```
 
 ```{config:option} raw.dnsmasq network-bridge-network-conf
+:scope: "global"
 :shortdesc: "Additional `dnsmasq` configuration to append to the configuration file"
 :type: "string"
 
 ```
 
 ```{config:option} security.acls network-bridge-network-conf
+:scope: "global"
 :shortdesc: "Network ACLs to apply to NICs connected to this network"
 :type: "string"
 Specify a comma-separated list of network ACLs.
@@ -3059,6 +3107,7 @@ Also see {ref}`network-acls-bridge-limitations`.
 
 ```{config:option} security.acls.default.egress.action network-bridge-network-conf
 :condition: "`security.acls`"
+:scope: "global"
 :shortdesc: "Default action to use for egress traffic"
 :type: "string"
 The specified action is used for all egress traffic that doesn’t match any ACL rule.
@@ -3066,6 +3115,7 @@ The specified action is used for all egress traffic that doesn’t match any ACL
 
 ```{config:option} security.acls.default.egress.logged network-bridge-network-conf
 :condition: "`security.acls`"
+:scope: "global"
 :shortdesc: "Whether to log egress traffic that doesn’t match any ACL rule"
 :type: "bool"
 
@@ -3073,6 +3123,7 @@ The specified action is used for all egress traffic that doesn’t match any ACL
 
 ```{config:option} security.acls.default.ingress.action network-bridge-network-conf
 :condition: "`security.acls`"
+:scope: "global"
 :shortdesc: "Default action to use for ingress traffic"
 :type: "string"
 The specified action is used for all ingress traffic that doesn’t match any ACL rule.
@@ -3080,6 +3131,7 @@ The specified action is used for all ingress traffic that doesn’t match any AC
 
 ```{config:option} security.acls.default.ingress.logged network-bridge-network-conf
 :condition: "`security.acls`"
+:scope: "global"
 :shortdesc: "Whether to log ingress traffic that doesn’t match any ACL rule"
 :type: "bool"
 
@@ -3146,6 +3198,7 @@ Possible values are `vxlan` and `gre`.
 ```
 
 ```{config:option} user.* network-bridge-network-conf
+:scope: "global"
 :shortdesc: "User-provided free-form key/value pairs"
 :type: "string"
 
@@ -3321,6 +3374,7 @@ See {ref}`network-load-balancers-port-specifications`.
 <!-- config group network-macvlan-network-conf start -->
 ```{config:option} gvrp network-macvlan-network-conf
 :defaultdesc: "`false`"
+:scope: "global"
 :shortdesc: "Whether to use GARP VLAN Registration Protocol"
 :type: "bool"
 This option specifies whether to register the VLAN using the GARP VLAN Registration Protocol.
@@ -3328,6 +3382,7 @@ This option specifies whether to register the VLAN using the GARP VLAN Registrat
 
 ```{config:option} maas.subnet.ipv4 network-macvlan-network-conf
 :condition: "IPv4 address; using the `network` property on the NIC"
+:scope: "global"
 :shortdesc: "MAAS IPv4 subnet to register instances in"
 :type: "string"
 
@@ -3335,30 +3390,35 @@ This option specifies whether to register the VLAN using the GARP VLAN Registrat
 
 ```{config:option} maas.subnet.ipv6 network-macvlan-network-conf
 :condition: "IPv4 address; using the `network` property on the NIC"
+:scope: "global"
 :shortdesc: "MAAS IPv6 subnet to register instances in"
 :type: "string"
 
 ```
 
 ```{config:option} mtu network-macvlan-network-conf
+:scope: "global"
 :shortdesc: "MTU of the new interface"
 :type: "integer"
 
 ```
 
 ```{config:option} parent network-macvlan-network-conf
+:scope: "local"
 :shortdesc: "Parent interface to create `macvlan` NICs on"
 :type: "string"
 
 ```
 
 ```{config:option} user.* network-macvlan-network-conf
+:scope: "global"
 :shortdesc: "User-provided free-form key/value pairs"
 :type: "string"
 
 ```
 
 ```{config:option} vlan network-macvlan-network-conf
+:scope: "global"
 :shortdesc: "VLAN ID to attach to"
 :type: "integer"
 
@@ -3600,6 +3660,7 @@ This option must be set at create time.
 <!-- config group network-physical-network-conf start -->
 ```{config:option} bgp.peers.NAME.address network-physical-network-conf
 :condition: "BGP server"
+:scope: "global"
 :shortdesc: "Peer address for use by `ovn` downstream networks"
 :type: "string"
 The address can be IPv4 or IPv6.
@@ -3607,6 +3668,7 @@ The address can be IPv4 or IPv6.
 
 ```{config:option} bgp.peers.NAME.asn network-physical-network-conf
 :condition: "BGP server"
+:scope: "global"
 :shortdesc: "Peer AS number for use by `ovn` downstream networks"
 :type: "integer"
 
@@ -3616,6 +3678,7 @@ The address can be IPv4 or IPv6.
 :condition: "BGP server"
 :defaultdesc: "`180`"
 :required: "no"
+:scope: "global"
 :shortdesc: "Peer session hold time"
 :type: "integer"
 Specify the peer session hold time in seconds.
@@ -3625,6 +3688,7 @@ Specify the peer session hold time in seconds.
 :condition: "BGP server"
 :defaultdesc: "(no password)"
 :required: "no"
+:scope: "global"
 :shortdesc: "Peer session password for use by `ovn` downstream networks"
 :type: "string"
 
@@ -3632,6 +3696,7 @@ Specify the peer session hold time in seconds.
 
 ```{config:option} dns.nameservers network-physical-network-conf
 :condition: "standard mode"
+:scope: "global"
 :shortdesc: "DNS server IPs on physical network"
 :type: "string"
 Specify a list of DNS server IPs.
@@ -3639,6 +3704,7 @@ Specify a list of DNS server IPs.
 
 ```{config:option} gvrp network-physical-network-conf
 :defaultdesc: "`false`"
+:scope: "global"
 :shortdesc: "Whether to use GARP VLAN Registration Protocol"
 :type: "bool"
 This option specifies whether to register the VLAN using the GARP VLAN Registration Protocol.
@@ -3646,12 +3712,14 @@ This option specifies whether to register the VLAN using the GARP VLAN Registrat
 
 ```{config:option} ipv4.gateway network-physical-network-conf
 :condition: "standard mode"
+:scope: "global"
 :shortdesc: "IPv4 address for the gateway and network"
 :type: "string"
 Use CIDR notation.
 ```
 
 ```{config:option} ipv4.ovn.ranges network-physical-network-conf
+:scope: "global"
 :shortdesc: "IPv4 ranges to use for child OVN network routers"
 :type: "string"
 Specify a comma-separated list of IPv4 ranges in FIRST-LAST format.
@@ -3659,6 +3727,7 @@ Specify a comma-separated list of IPv4 ranges in FIRST-LAST format.
 
 ```{config:option} ipv4.routes network-physical-network-conf
 :condition: "IPv4 address"
+:scope: "global"
 :shortdesc: "Additional IPv4 CIDR subnets"
 :type: "string"
 Specify a comma-separated list of IPv4 CIDR subnets that can be used with child OVN network forwarders, load-balancers and {config:option}`device-nic-ovn-device-conf:ipv4.routes.external` setting.
@@ -3667,6 +3736,7 @@ Specify a comma-separated list of IPv4 CIDR subnets that can be used with child 
 ```{config:option} ipv4.routes.anycast network-physical-network-conf
 :condition: "IPv4 address"
 :defaultdesc: "`false`"
+:scope: "global"
 :shortdesc: "Whether to allow IPv4 routes on multiple networks/NICs"
 :type: "bool"
 If set to `true`, this option allows the overlapping routes to be used on multiple networks/NICs at the same time.
@@ -3674,12 +3744,14 @@ If set to `true`, this option allows the overlapping routes to be used on multip
 
 ```{config:option} ipv6.gateway network-physical-network-conf
 :condition: "standard mode"
+:scope: "global"
 :shortdesc: "IPv6 address for the gateway and network"
 :type: "string"
 Use CIDR notation.
 ```
 
 ```{config:option} ipv6.ovn.ranges network-physical-network-conf
+:scope: "global"
 :shortdesc: "IPv6 ranges to use for child OVN network routers"
 :type: "string"
 Specify a comma-separated list of IPv6 ranges in FIRST-LAST format.
@@ -3687,6 +3759,7 @@ Specify a comma-separated list of IPv6 ranges in FIRST-LAST format.
 
 ```{config:option} ipv6.routes network-physical-network-conf
 :condition: "IPv6 address"
+:scope: "global"
 :shortdesc: "Additional IPv6 CIDR subnets"
 :type: "string"
 Specify a comma-separated list of IPv6 CIDR subnets that can be used with child OVN network forwarders, load-balancers and {config:option}`device-nic-ovn-device-conf:ipv6.routes.external` setting.
@@ -3695,6 +3768,7 @@ Specify a comma-separated list of IPv6 CIDR subnets that can be used with child 
 ```{config:option} ipv6.routes.anycast network-physical-network-conf
 :condition: "IPv6 address"
 :defaultdesc: "`false`"
+:scope: "global"
 :shortdesc: "Whether to allow IPv6 routes on multiple networks/NICs"
 :type: "bool"
 If set to `true`, this option allows the overlapping routes to be used on multiple networks/NICs at the same time.
@@ -3702,6 +3776,7 @@ If set to `true`, this option allows the overlapping routes to be used on multip
 
 ```{config:option} maas.subnet.ipv4 network-physical-network-conf
 :condition: "IPv4 address; using the `network` property on the NIC"
+:scope: "global"
 :shortdesc: "MAAS IPv4 subnet to register instances in"
 :type: "string"
 
@@ -3709,12 +3784,14 @@ If set to `true`, this option allows the overlapping routes to be used on multip
 
 ```{config:option} maas.subnet.ipv6 network-physical-network-conf
 :condition: "IPv6 address; using the `network` property on the NIC"
+:scope: "global"
 :shortdesc: "MAAS IPv6 subnet to register instances in"
 :type: "string"
 
 ```
 
 ```{config:option} mtu network-physical-network-conf
+:scope: "global"
 :shortdesc: "MTU of the new interface"
 :type: "integer"
 
@@ -3723,24 +3800,28 @@ If set to `true`, this option allows the overlapping routes to be used on multip
 ```{config:option} ovn.ingress_mode network-physical-network-conf
 :condition: "standard mode"
 :defaultdesc: "`l2proxy`"
+:scope: "global"
 :shortdesc: "How OVN NIC external IPs are advertised on uplink network"
 :type: "string"
 Possible values are `l2proxy` (proxy ARP/NDP) and `routed`.
 ```
 
 ```{config:option} parent network-physical-network-conf
+:scope: "local"
 :shortdesc: "Existing interface to use for network"
 :type: "string"
 
 ```
 
 ```{config:option} user.* network-physical-network-conf
+:scope: "global"
 :shortdesc: "User-provided free-form key/value pairs"
 :type: "string"
 
 ```
 
 ```{config:option} vlan network-physical-network-conf
+:scope: "global"
 :shortdesc: "VLAN ID to attach to"
 :type: "integer"
 
@@ -3750,6 +3831,7 @@ Possible values are `l2proxy` (proxy ARP/NDP) and `routed`.
 <!-- config group network-sriov-network-conf start -->
 ```{config:option} maas.subnet.ipv4 network-sriov-network-conf
 :condition: "IPv4 address; using the `network` property on the NIC"
+:scope: "global"
 :shortdesc: "MAAS IPv4 subnet to register instances in"
 :type: "string"
 
@@ -3757,30 +3839,35 @@ Possible values are `l2proxy` (proxy ARP/NDP) and `routed`.
 
 ```{config:option} maas.subnet.ipv6 network-sriov-network-conf
 :condition: "IPv6 address; using the `network` property on the NIC"
+:scope: "global"
 :shortdesc: "MAAS IPv6 subnet to register instances in"
 :type: "string"
 
 ```
 
 ```{config:option} mtu network-sriov-network-conf
+:scope: "global"
 :shortdesc: "MTU of the new interface"
 :type: "integer"
 
 ```
 
 ```{config:option} parent network-sriov-network-conf
+:scope: "local"
 :shortdesc: "Parent interface to create `sriov` NICs on"
 :type: "string"
 
 ```
 
 ```{config:option} user.* network-sriov-network-conf
+:scope: "global"
 :shortdesc: "User-provided free-form key/value pairs"
 :type: "string"
 
 ```
 
 ```{config:option} vlan network-sriov-network-conf
+:scope: "global"
 :shortdesc: "VLAN ID to attach to"
 :type: "integer"
 
@@ -4734,6 +4821,7 @@ for automatic access control.
 ```{config:option} size storage-btrfs-bucket-conf
 :condition: "appropriate driver"
 :defaultdesc: "same as `volume.size`"
+:scope: "local"
 :shortdesc: "Size/quota of the storage bucket"
 :type: "string"
 
@@ -4743,6 +4831,7 @@ for automatic access control.
 <!-- config group storage-btrfs-pool-conf start -->
 ```{config:option} btrfs.mount_options storage-btrfs-pool-conf
 :defaultdesc: "`user_subvol_rm_allowed`"
+:scope: "global"
 :shortdesc: "Mount options for block devices"
 :type: "string"
 
@@ -4750,6 +4839,7 @@ for automatic access control.
 
 ```{config:option} size storage-btrfs-pool-conf
 :defaultdesc: "auto (20% of free disk space, >= 5 GiB and <= 30 GiB)"
+:scope: "local"
 :shortdesc: "Size of the storage pool (for loop-based pools)"
 :type: "string"
 When creating loop-based pools, specify the size in bytes ({ref}`suffixes <instances-limit-units>` are supported).
@@ -4760,6 +4850,7 @@ with a minimum of 5 GiB and a maximum of 30 GiB.
 ```
 
 ```{config:option} source storage-btrfs-pool-conf
+:scope: "local"
 :shortdesc: "Path to an existing block device, loop file, or Btrfs subvolume"
 :type: "string"
 
@@ -4767,6 +4858,7 @@ with a minimum of 5 GiB and a maximum of 30 GiB.
 
 ```{config:option} source.wipe storage-btrfs-pool-conf
 :defaultdesc: "`false`"
+:scope: "local"
 :shortdesc: "Whether to wipe the block device before creating the pool"
 :type: "bool"
 Set this option to `true` to wipe the block device specified in `source`
@@ -4778,6 +4870,7 @@ prior to creating the storage pool.
 ```{config:option} security.shared storage-btrfs-volume-conf
 :condition: "custom block volume"
 :defaultdesc: "same as `volume.security.shared` or `false`"
+:scope: "global"
 :shortdesc: "Enable volume sharing"
 :type: "bool"
 Enabling this option allows sharing the volume across multiple instances despite the possibility of data loss.
@@ -4787,6 +4880,7 @@ Enabling this option allows sharing the volume across multiple instances despite
 ```{config:option} security.shifted storage-btrfs-volume-conf
 :condition: "custom volume"
 :defaultdesc: "same as `volume.security.shifted` or `false`"
+:scope: "global"
 :shortdesc: "Enable ID shifting overlay"
 :type: "bool"
 Enabling this option allows attaching the volume to multiple isolated instances.
@@ -4795,6 +4889,7 @@ Enabling this option allows attaching the volume to multiple isolated instances.
 ```{config:option} security.unmapped storage-btrfs-volume-conf
 :condition: "custom volume"
 :defaultdesc: "same as `volume.security.unmappped` or `false`"
+:scope: "global"
 :shortdesc: "Disable ID mapping for the volume"
 :type: "bool"
 
@@ -4803,6 +4898,7 @@ Enabling this option allows attaching the volume to multiple isolated instances.
 ```{config:option} size storage-btrfs-volume-conf
 :condition: "appropriate driver"
 :defaultdesc: "same as `volume.size`"
+:scope: "local"
 :shortdesc: "Size/quota of the storage volume"
 :type: "string"
 
@@ -4811,6 +4907,7 @@ Enabling this option allows attaching the volume to multiple isolated instances.
 ```{config:option} snapshots.expiry storage-btrfs-volume-conf
 :condition: "custom volume"
 :defaultdesc: "same as `volume.snapshots.expiry`"
+:scope: "global"
 :shortdesc: "When snapshots are to be deleted"
 :type: "string"
 Specify an expression like `1M 2H 3d 4w 5m 6y`.
@@ -4819,6 +4916,7 @@ Specify an expression like `1M 2H 3d 4w 5m 6y`.
 ```{config:option} snapshots.pattern storage-btrfs-volume-conf
 :condition: "custom volume"
 :defaultdesc: "same as `volume.snapshots.pattern` or `snap%d`"
+:scope: "global"
 :shortdesc: "Template for the snapshot name"
 :type: "string"
 You can specify a naming template that is used for scheduled snapshots and unnamed snapshots.
@@ -4838,6 +4936,7 @@ This number is then incremented by one for the new name.
 ```{config:option} snapshots.schedule storage-btrfs-volume-conf
 :condition: "custom volume"
 :defaultdesc: "same as `snapshots.schedule`"
+:scope: "global"
 :shortdesc: "Schedule for automatic volume snapshots"
 :type: "string"
 Specify either a cron expression (`<minute> <hour> <dom> <month> <dow>`), a comma-separated list of schedule aliases (`@hourly`, `@daily`, `@midnight`, `@weekly`, `@monthly`, `@annually`, `@yearly`), or leave empty to disable automatic snapshots (the default).
@@ -4845,6 +4944,7 @@ Specify either a cron expression (`<minute> <hour> <dom> <month> <dow>`), a comm
 
 ```{config:option} volatile.uuid storage-btrfs-volume-conf
 :defaultdesc: "random UUID"
+:scope: "global"
 :shortdesc: "The volume's UUID"
 :type: "string"
 
@@ -4854,12 +4954,14 @@ Specify either a cron expression (`<minute> <hour> <dom> <month> <dow>`), a comm
 <!-- config group storage-ceph-pool-conf start -->
 ```{config:option} ceph.cluster_name storage-ceph-pool-conf
 :defaultdesc: "`ceph`"
+:scope: "global"
 :shortdesc: "Name of the Ceph cluster in which to create new storage pools"
 :type: "string"
 
 ```
 
 ```{config:option} ceph.osd.data_pool_name storage-ceph-pool-conf
+:scope: "global"
 :shortdesc: "Name of the OSD data pool"
 :type: "string"
 
@@ -4867,6 +4969,7 @@ Specify either a cron expression (`<minute> <hour> <dom> <month> <dow>`), a comm
 
 ```{config:option} ceph.osd.pg_num storage-ceph-pool-conf
 :defaultdesc: "`32`"
+:scope: "global"
 :shortdesc: "Number of placement groups for the OSD storage pool"
 :type: "string"
 
@@ -4874,6 +4977,7 @@ Specify either a cron expression (`<minute> <hour> <dom> <month> <dow>`), a comm
 
 ```{config:option} ceph.osd.pool_name storage-ceph-pool-conf
 :defaultdesc: "name of the pool"
+:scope: "global"
 :shortdesc: "Name of the OSD storage pool"
 :type: "string"
 
@@ -4881,6 +4985,7 @@ Specify either a cron expression (`<minute> <hour> <dom> <month> <dow>`), a comm
 
 ```{config:option} ceph.rbd.clone_copy storage-ceph-pool-conf
 :defaultdesc: "`true`"
+:scope: "global"
 :shortdesc: "Whether to use RBD lightweight clones"
 :type: "bool"
 Enable this option to use RBD lightweight clones rather than full dataset copies.
@@ -4888,6 +4993,7 @@ Enable this option to use RBD lightweight clones rather than full dataset copies
 
 ```{config:option} ceph.rbd.du storage-ceph-pool-conf
 :defaultdesc: "`true`"
+:scope: "global"
 :shortdesc: "Whether to use RBD `du`"
 :type: "bool"
 This option specifies whether to use RBD `du` to obtain disk usage data for stopped instances.
@@ -4895,6 +5001,7 @@ This option specifies whether to use RBD `du` to obtain disk usage data for stop
 
 ```{config:option} ceph.rbd.features storage-ceph-pool-conf
 :defaultdesc: "`layering`"
+:scope: "global"
 :shortdesc: "Comma-separated list of RBD features to enable on the volumes"
 :type: "string"
 
@@ -4902,12 +5009,14 @@ This option specifies whether to use RBD `du` to obtain disk usage data for stop
 
 ```{config:option} ceph.user.name storage-ceph-pool-conf
 :defaultdesc: "`admin`"
+:scope: "global"
 :shortdesc: "The Ceph user to use when creating storage pools and volumes"
 :type: "string"
 
 ```
 
 ```{config:option} source storage-ceph-pool-conf
+:scope: "local"
 :shortdesc: "Existing OSD storage pool to use"
 :type: "string"
 
@@ -4915,6 +5024,7 @@ This option specifies whether to use RBD `du` to obtain disk usage data for stop
 
 ```{config:option} volatile.pool.pristine storage-ceph-pool-conf
 :defaultdesc: "`true`"
+:scope: "global"
 :shortdesc: "Whether the pool was empty on creation time"
 :type: "string"
 
@@ -4925,6 +5035,7 @@ This option specifies whether to use RBD `du` to obtain disk usage data for stop
 ```{config:option} block.filesystem storage-ceph-volume-conf
 :condition: "block-based volume with content type `filesystem`"
 :defaultdesc: "same as `volume.block.filesystem`"
+:scope: "global"
 :shortdesc: "File system of the storage volume"
 :type: "string"
 Valid options are: `btrfs`, `ext4`, `xfs`
@@ -4934,6 +5045,7 @@ If not set, `ext4` is assumed.
 ```{config:option} block.mount_options storage-ceph-volume-conf
 :condition: "block-based volume with content type `filesystem`"
 :defaultdesc: "same as `volume.block.mount_options`"
+:scope: "global"
 :shortdesc: "Mount options for block-backed file system volumes"
 :type: "string"
 
@@ -4942,6 +5054,7 @@ If not set, `ext4` is assumed.
 ```{config:option} security.shared storage-ceph-volume-conf
 :condition: "custom block volume"
 :defaultdesc: "same as `volume.security.shared` or `false`"
+:scope: "global"
 :shortdesc: "Enable volume sharing"
 :type: "bool"
 Enabling this option allows sharing the volume across multiple instances despite the possibility of data loss.
@@ -4951,6 +5064,7 @@ Enabling this option allows sharing the volume across multiple instances despite
 ```{config:option} security.shifted storage-ceph-volume-conf
 :condition: "custom volume"
 :defaultdesc: "same as `volume.security.shifted` or `false`"
+:scope: "global"
 :shortdesc: "Enable ID shifting overlay"
 :type: "bool"
 Enabling this option allows attaching the volume to multiple isolated instances.
@@ -4959,6 +5073,7 @@ Enabling this option allows attaching the volume to multiple isolated instances.
 ```{config:option} security.unmapped storage-ceph-volume-conf
 :condition: "custom volume"
 :defaultdesc: "same as `volume.security.unmappped` or `false`"
+:scope: "global"
 :shortdesc: "Disable ID mapping for the volume"
 :type: "bool"
 
@@ -4967,6 +5082,7 @@ Enabling this option allows attaching the volume to multiple isolated instances.
 ```{config:option} size storage-ceph-volume-conf
 :condition: "appropriate driver"
 :defaultdesc: "same as `volume.size`"
+:scope: "local"
 :shortdesc: "Size/quota of the storage volume"
 :type: "string"
 
@@ -4975,6 +5091,7 @@ Enabling this option allows attaching the volume to multiple isolated instances.
 ```{config:option} snapshots.expiry storage-ceph-volume-conf
 :condition: "custom volume"
 :defaultdesc: "same as `volume.snapshots.expiry`"
+:scope: "global"
 :shortdesc: "When snapshots are to be deleted"
 :type: "string"
 Specify an expression like `1M 2H 3d 4w 5m 6y`.
@@ -4983,6 +5100,7 @@ Specify an expression like `1M 2H 3d 4w 5m 6y`.
 ```{config:option} snapshots.pattern storage-ceph-volume-conf
 :condition: "custom volume"
 :defaultdesc: "same as `volume.snapshots.pattern` or `snap%d`"
+:scope: "global"
 :shortdesc: "Template for the snapshot name"
 :type: "string"
 You can specify a naming template that is used for scheduled snapshots and unnamed snapshots.
@@ -5002,6 +5120,7 @@ This number is then incremented by one for the new name.
 ```{config:option} snapshots.schedule storage-ceph-volume-conf
 :condition: "custom volume"
 :defaultdesc: "same as `snapshots.schedule`"
+:scope: "global"
 :shortdesc: "Schedule for automatic volume snapshots"
 :type: "string"
 Specify either a cron expression (`<minute> <hour> <dom> <month> <dow>`), a comma-separated list of schedule aliases (`@hourly`, `@daily`, `@midnight`, `@weekly`, `@monthly`, `@annually`, `@yearly`), or leave empty to disable automatic snapshots (the default).
@@ -5009,6 +5128,7 @@ Specify either a cron expression (`<minute> <hour> <dom> <month> <dow>`), a comm
 
 ```{config:option} volatile.uuid storage-ceph-volume-conf
 :defaultdesc: "random UUID"
+:scope: "global"
 :shortdesc: "The volume's UUID"
 :type: "string"
 
@@ -5018,6 +5138,7 @@ Specify either a cron expression (`<minute> <hour> <dom> <month> <dow>`), a comm
 <!-- config group storage-cephfs-pool-conf start -->
 ```{config:option} cephfs.cluster_name storage-cephfs-pool-conf
 :defaultdesc: "`ceph`"
+:scope: "global"
 :shortdesc: "Name of the Ceph cluster that contains the CephFS file system"
 :type: "string"
 
@@ -5025,6 +5146,7 @@ Specify either a cron expression (`<minute> <hour> <dom> <month> <dow>`), a comm
 
 ```{config:option} cephfs.create_missing storage-cephfs-pool-conf
 :defaultdesc: "`false`"
+:scope: "global"
 :shortdesc: "Automatically create the CephFS file system"
 :type: "bool"
 Use this option if the CephFS file system does not exist yet.
@@ -5032,6 +5154,7 @@ LXD will then automatically create the file system and the missing data and meta
 ```
 
 ```{config:option} cephfs.data_pool storage-cephfs-pool-conf
+:scope: "global"
 :shortdesc: "Data OSD pool name"
 :type: "string"
 This option specifies the name for the data OSD pool that should be used when creating
@@ -5040,12 +5163,14 @@ a file system automatically.
 
 ```{config:option} cephfs.fscache storage-cephfs-pool-conf
 :defaultdesc: "`false`"
+:scope: "global"
 :shortdesc: "Enable use of kernel `fscache` and `cachefilesd`"
 :type: "bool"
 
 ```
 
 ```{config:option} cephfs.meta_pool storage-cephfs-pool-conf
+:scope: "global"
 :shortdesc: "Metadata OSD pool name"
 :type: "string"
 This option specifies the name for the file metadata OSD pool that should be used when
@@ -5053,6 +5178,7 @@ creating a file system automatically.
 ```
 
 ```{config:option} cephfs.osd_pg_num storage-cephfs-pool-conf
+:scope: "global"
 :shortdesc: "Number of placement groups when creating missing OSD pools"
 :type: "string"
 This option specifies the number of OSD pool placement groups (`pg_num`) to use
@@ -5061,6 +5187,7 @@ when creating a missing OSD pool.
 
 ```{config:option} cephfs.path storage-cephfs-pool-conf
 :defaultdesc: "`/`"
+:scope: "global"
 :shortdesc: "The base path for the CephFS mount"
 :type: "string"
 
@@ -5068,12 +5195,14 @@ when creating a missing OSD pool.
 
 ```{config:option} cephfs.user.name storage-cephfs-pool-conf
 :defaultdesc: "`admin`"
+:scope: "global"
 :shortdesc: "The Ceph user to use"
 :type: "string"
 
 ```
 
 ```{config:option} source storage-cephfs-pool-conf
+:scope: "local"
 :shortdesc: "Existing CephFS file system or file system path to use"
 :type: "string"
 
@@ -5081,6 +5210,7 @@ when creating a missing OSD pool.
 
 ```{config:option} volatile.pool.pristine storage-cephfs-pool-conf
 :defaultdesc: "`true`"
+:scope: "global"
 :shortdesc: "Whether the CephFS file system was empty on creation time"
 :type: "string"
 
@@ -5091,6 +5221,7 @@ when creating a missing OSD pool.
 ```{config:option} security.shifted storage-cephfs-volume-conf
 :condition: "custom volume"
 :defaultdesc: "same as `volume.security.shifted` or `false`"
+:scope: "global"
 :shortdesc: "Enable ID shifting overlay"
 :type: "bool"
 Enabling this option allows attaching the volume to multiple isolated instances.
@@ -5099,6 +5230,7 @@ Enabling this option allows attaching the volume to multiple isolated instances.
 ```{config:option} security.unmapped storage-cephfs-volume-conf
 :condition: "custom volume"
 :defaultdesc: "same as `volume.security.unmappped` or `false`"
+:scope: "global"
 :shortdesc: "Disable ID mapping for the volume"
 :type: "bool"
 
@@ -5107,6 +5239,7 @@ Enabling this option allows attaching the volume to multiple isolated instances.
 ```{config:option} size storage-cephfs-volume-conf
 :condition: "appropriate driver"
 :defaultdesc: "same as `volume.size`"
+:scope: "local"
 :shortdesc: "Size/quota of the storage volume"
 :type: "string"
 
@@ -5115,6 +5248,7 @@ Enabling this option allows attaching the volume to multiple isolated instances.
 ```{config:option} snapshots.expiry storage-cephfs-volume-conf
 :condition: "custom volume"
 :defaultdesc: "same as `volume.snapshots.expiry`"
+:scope: "global"
 :shortdesc: "When snapshots are to be deleted"
 :type: "string"
 Specify an expression like `1M 2H 3d 4w 5m 6y`.
@@ -5123,6 +5257,7 @@ Specify an expression like `1M 2H 3d 4w 5m 6y`.
 ```{config:option} snapshots.pattern storage-cephfs-volume-conf
 :condition: "custom volume"
 :defaultdesc: "same as `volume.snapshots.pattern` or `snap%d`"
+:scope: "global"
 :shortdesc: "Template for the snapshot name"
 :type: "string"
 You can specify a naming template that is used for scheduled snapshots and unnamed snapshots.
@@ -5142,6 +5277,7 @@ This number is then incremented by one for the new name.
 ```{config:option} snapshots.schedule storage-cephfs-volume-conf
 :condition: "custom volume"
 :defaultdesc: "same as `snapshots.schedule`"
+:scope: "global"
 :shortdesc: "Schedule for automatic volume snapshots"
 :type: "string"
 Specify either a cron expression (`<minute> <hour> <dom> <month> <dow>`), a comma-separated list of schedule aliases (`@hourly`, `@daily`, `@midnight`, `@weekly`, `@monthly`, `@annually`, `@yearly`), or leave empty to disable automatic snapshots (the default).
@@ -5149,6 +5285,7 @@ Specify either a cron expression (`<minute> <hour> <dom> <month> <dow>`), a comm
 
 ```{config:option} volatile.uuid storage-cephfs-volume-conf
 :defaultdesc: "random UUID"
+:scope: "global"
 :shortdesc: "The volume's UUID"
 :type: "string"
 
@@ -5157,6 +5294,7 @@ Specify either a cron expression (`<minute> <hour> <dom> <month> <dow>`), a comm
 <!-- config group storage-cephfs-volume-conf end -->
 <!-- config group storage-cephobject-bucket-conf start -->
 ```{config:option} size storage-cephobject-bucket-conf
+:scope: "local"
 :shortdesc: "Quota of the storage bucket"
 :type: "string"
 
@@ -5165,24 +5303,28 @@ Specify either a cron expression (`<minute> <hour> <dom> <month> <dow>`), a comm
 <!-- config group storage-cephobject-bucket-conf end -->
 <!-- config group storage-cephobject-pool-conf start -->
 ```{config:option} cephobject.bucket.name_prefix storage-cephobject-pool-conf
+:scope: "global"
 :shortdesc: "Prefix to add to bucket names in Ceph"
 :type: "string"
 
 ```
 
 ```{config:option} cephobject.cluster_name storage-cephobject-pool-conf
+:scope: "global"
 :shortdesc: "The Ceph cluster to use"
 :type: "string"
 
 ```
 
 ```{config:option} cephobject.radosgw.endpoint storage-cephobject-pool-conf
+:scope: "global"
 :shortdesc: "URL of the `radosgw` gateway process"
 :type: "string"
 
 ```
 
 ```{config:option} cephobject.radosgw.endpoint_cert_file storage-cephobject-pool-conf
+:scope: "global"
 :shortdesc: "TLS client certificate to use for endpoint communication"
 :type: "string"
 Specify the path to the file that contains the TLS client certificate.
@@ -5190,6 +5332,7 @@ Specify the path to the file that contains the TLS client certificate.
 
 ```{config:option} cephobject.user.name storage-cephobject-pool-conf
 :defaultdesc: "`admin`"
+:scope: "global"
 :shortdesc: "The Ceph user to use"
 :type: "string"
 
@@ -5197,6 +5340,7 @@ Specify the path to the file that contains the TLS client certificate.
 
 ```{config:option} volatile.pool.pristine storage-cephobject-pool-conf
 :defaultdesc: "`true`"
+:scope: "global"
 :shortdesc: "Whether the `radosgw` `lxd-admin` user existed at creation time"
 :type: "string"
 
@@ -5206,6 +5350,7 @@ Specify the path to the file that contains the TLS client certificate.
 <!-- config group storage-dir-pool-conf start -->
 ```{config:option} rsync.bwlimit storage-dir-pool-conf
 :defaultdesc: "`0` (no limit)"
+:scope: "global"
 :shortdesc: "Upper limit on the socket I/O for `rsync`"
 :type: "string"
 When `rsync` must be used to transfer storage entities, this option specifies the upper limit
@@ -5214,12 +5359,14 @@ to be placed on the socket I/O.
 
 ```{config:option} rsync.compression storage-dir-pool-conf
 :defaultdesc: "`true`"
+:scope: "global"
 :shortdesc: "Whether to use compression while migrating storage pools"
 :type: "bool"
 
 ```
 
 ```{config:option} source storage-dir-pool-conf
+:scope: "local"
 :shortdesc: "Path to an existing directory"
 :type: "string"
 
@@ -5230,6 +5377,7 @@ to be placed on the socket I/O.
 ```{config:option} security.shared storage-dir-volume-conf
 :condition: "custom block volume"
 :defaultdesc: "same as `volume.security.shared` or `false`"
+:scope: "global"
 :shortdesc: "Enable volume sharing"
 :type: "bool"
 Enabling this option allows sharing the volume across multiple instances despite the possibility of data loss.
@@ -5239,6 +5387,7 @@ Enabling this option allows sharing the volume across multiple instances despite
 ```{config:option} security.shifted storage-dir-volume-conf
 :condition: "custom volume"
 :defaultdesc: "same as `volume.security.shifted` or `false`"
+:scope: "global"
 :shortdesc: "Enable ID shifting overlay"
 :type: "bool"
 Enabling this option allows attaching the volume to multiple isolated instances.
@@ -5247,6 +5396,7 @@ Enabling this option allows attaching the volume to multiple isolated instances.
 ```{config:option} security.unmapped storage-dir-volume-conf
 :condition: "custom volume"
 :defaultdesc: "same as `volume.security.unmappped` or `false`"
+:scope: "global"
 :shortdesc: "Disable ID mapping for the volume"
 :type: "bool"
 
@@ -5255,6 +5405,7 @@ Enabling this option allows attaching the volume to multiple isolated instances.
 ```{config:option} size storage-dir-volume-conf
 :condition: "appropriate driver"
 :defaultdesc: "same as `volume.size`"
+:scope: "local"
 :shortdesc: "Size/quota of the storage volume"
 :type: "string"
 
@@ -5263,6 +5414,7 @@ Enabling this option allows attaching the volume to multiple isolated instances.
 ```{config:option} snapshots.expiry storage-dir-volume-conf
 :condition: "custom volume"
 :defaultdesc: "same as `volume.snapshots.expiry`"
+:scope: "global"
 :shortdesc: "When snapshots are to be deleted"
 :type: "string"
 Specify an expression like `1M 2H 3d 4w 5m 6y`.
@@ -5271,6 +5423,7 @@ Specify an expression like `1M 2H 3d 4w 5m 6y`.
 ```{config:option} snapshots.pattern storage-dir-volume-conf
 :condition: "custom volume"
 :defaultdesc: "same as `volume.snapshots.pattern` or `snap%d`"
+:scope: "global"
 :shortdesc: "Template for the snapshot name"
 :type: "string"
 You can specify a naming template that is used for scheduled snapshots and unnamed snapshots.
@@ -5290,6 +5443,7 @@ This number is then incremented by one for the new name.
 ```{config:option} snapshots.schedule storage-dir-volume-conf
 :condition: "custom volume"
 :defaultdesc: "same as `snapshots.schedule`"
+:scope: "global"
 :shortdesc: "Schedule for automatic volume snapshots"
 :type: "string"
 Specify either a cron expression (`<minute> <hour> <dom> <month> <dow>`), a comma-separated list of schedule aliases (`@hourly`, `@daily`, `@midnight`, `@weekly`, `@monthly`, `@annually`, `@yearly`), or leave empty to disable automatic snapshots (the default).
@@ -5297,6 +5451,7 @@ Specify either a cron expression (`<minute> <hour> <dom> <month> <dow>`), a comm
 
 ```{config:option} volatile.uuid storage-dir-volume-conf
 :defaultdesc: "random UUID"
+:scope: "global"
 :shortdesc: "The volume's UUID"
 :type: "string"
 
@@ -5307,6 +5462,7 @@ Specify either a cron expression (`<minute> <hour> <dom> <month> <dow>`), a comm
 ```{config:option} size storage-lvm-bucket-conf
 :condition: "appropriate driver"
 :defaultdesc: "same as `volume.size`"
+:scope: "local"
 :shortdesc: "Size/quota of the storage bucket"
 :type: "string"
 
@@ -5316,6 +5472,7 @@ Specify either a cron expression (`<minute> <hour> <dom> <month> <dow>`), a comm
 <!-- config group storage-lvm-pool-conf start -->
 ```{config:option} lvm.thinpool_metadata_size storage-lvm-pool-conf
 :defaultdesc: "`0` (auto)"
+:scope: "global"
 :shortdesc: "The size of the thin pool metadata volume"
 :type: "string"
 By default, LVM calculates an appropriate size.
@@ -5323,6 +5480,7 @@ By default, LVM calculates an appropriate size.
 
 ```{config:option} lvm.thinpool_name storage-lvm-pool-conf
 :defaultdesc: "`LXDThinPool`"
+:scope: "local"
 :shortdesc: "Thin pool where volumes are created"
 :type: "string"
 
@@ -5330,6 +5488,7 @@ By default, LVM calculates an appropriate size.
 
 ```{config:option} lvm.use_thinpool storage-lvm-pool-conf
 :defaultdesc: "`true`"
+:scope: "global"
 :shortdesc: "Whether the storage pool uses a thin pool for logical volumes"
 :type: "bool"
 
@@ -5337,6 +5496,7 @@ By default, LVM calculates an appropriate size.
 
 ```{config:option} lvm.vg.force_reuse storage-lvm-pool-conf
 :defaultdesc: "`false`"
+:scope: "global"
 :shortdesc: "Force using an existing non-empty volume group"
 :type: "bool"
 
@@ -5344,6 +5504,7 @@ By default, LVM calculates an appropriate size.
 
 ```{config:option} lvm.vg_name storage-lvm-pool-conf
 :defaultdesc: "name of the pool"
+:scope: "local"
 :shortdesc: "Name of the volume group to create"
 :type: "string"
 
@@ -5351,6 +5512,7 @@ By default, LVM calculates an appropriate size.
 
 ```{config:option} rsync.bwlimit storage-lvm-pool-conf
 :defaultdesc: "`0` (no limit)"
+:scope: "global"
 :shortdesc: "Upper limit on the socket I/O for `rsync`"
 :type: "string"
 When `rsync` must be used to transfer storage entities, this option specifies the upper limit
@@ -5359,6 +5521,7 @@ to be placed on the socket I/O.
 
 ```{config:option} rsync.compression storage-lvm-pool-conf
 :defaultdesc: "`true`"
+:scope: "global"
 :shortdesc: "Whether to use compression while migrating storage pools"
 :type: "bool"
 
@@ -5366,6 +5529,7 @@ to be placed on the socket I/O.
 
 ```{config:option} size storage-lvm-pool-conf
 :defaultdesc: "auto (20% of free disk space, >= 5 GiB and <= 30 GiB)"
+:scope: "local"
 :shortdesc: "Size of the storage pool (for loop-based pools)"
 :type: "string"
 When creating loop-based pools, specify the size in bytes ({ref}`suffixes <instances-limit-units>` are supported).
@@ -5376,6 +5540,7 @@ with a minimum of 5 GiB and a maximum of 30 GiB.
 ```
 
 ```{config:option} source storage-lvm-pool-conf
+:scope: "local"
 :shortdesc: "Path to an existing block device, loop file, or LVM volume group"
 :type: "string"
 
@@ -5383,6 +5548,7 @@ with a minimum of 5 GiB and a maximum of 30 GiB.
 
 ```{config:option} source.wipe storage-lvm-pool-conf
 :defaultdesc: "`false`"
+:scope: "local"
 :shortdesc: "Whether to wipe the block device before creating the pool"
 :type: "bool"
 Set this option to `true` to wipe the block device specified in `source`
@@ -5394,6 +5560,7 @@ prior to creating the storage pool.
 ```{config:option} block.filesystem storage-lvm-volume-conf
 :condition: "block-based volume with content type `filesystem`"
 :defaultdesc: "same as `volume.block.filesystem`"
+:scope: "global"
 :shortdesc: "File system of the storage volume"
 :type: "string"
 Valid options are: `btrfs`, `ext4`, `xfs`
@@ -5403,6 +5570,7 @@ If not set, `ext4` is assumed.
 ```{config:option} block.mount_options storage-lvm-volume-conf
 :condition: "block-based volume with content type `filesystem`"
 :defaultdesc: "same as `volume.block.mount_options`"
+:scope: "global"
 :shortdesc: "Mount options for block-backed file system volumes"
 :type: "string"
 
@@ -5410,6 +5578,7 @@ If not set, `ext4` is assumed.
 
 ```{config:option} lvm.stripes storage-lvm-volume-conf
 :defaultdesc: "same as `volume.lvm.stripes`"
+:scope: "global"
 :shortdesc: "Number of stripes to use for new volumes (or thin pool volume)"
 :type: "string"
 
@@ -5417,6 +5586,7 @@ If not set, `ext4` is assumed.
 
 ```{config:option} lvm.stripes.size storage-lvm-volume-conf
 :defaultdesc: "same as `volume.lvm.stripes.size`"
+:scope: "global"
 :shortdesc: "Size of stripes to use"
 :type: "string"
 The size must be at least 4096 bytes, and a multiple of 512 bytes.
@@ -5425,6 +5595,7 @@ The size must be at least 4096 bytes, and a multiple of 512 bytes.
 ```{config:option} security.shared storage-lvm-volume-conf
 :condition: "custom block volume"
 :defaultdesc: "same as `volume.security.shared` or `false`"
+:scope: "global"
 :shortdesc: "Enable volume sharing"
 :type: "bool"
 Enabling this option allows sharing the volume across multiple instances despite the possibility of data loss.
@@ -5434,6 +5605,7 @@ Enabling this option allows sharing the volume across multiple instances despite
 ```{config:option} security.shifted storage-lvm-volume-conf
 :condition: "custom volume"
 :defaultdesc: "same as `volume.security.shifted` or `false`"
+:scope: "global"
 :shortdesc: "Enable ID shifting overlay"
 :type: "bool"
 Enabling this option allows attaching the volume to multiple isolated instances.
@@ -5442,6 +5614,7 @@ Enabling this option allows attaching the volume to multiple isolated instances.
 ```{config:option} security.unmapped storage-lvm-volume-conf
 :condition: "custom volume"
 :defaultdesc: "same as `volume.security.unmappped` or `false`"
+:scope: "global"
 :shortdesc: "Disable ID mapping for the volume"
 :type: "bool"
 
@@ -5450,6 +5623,7 @@ Enabling this option allows attaching the volume to multiple isolated instances.
 ```{config:option} size storage-lvm-volume-conf
 :condition: "appropriate driver"
 :defaultdesc: "same as `volume.size`"
+:scope: "local"
 :shortdesc: "Size/quota of the storage volume"
 :type: "string"
 
@@ -5458,6 +5632,7 @@ Enabling this option allows attaching the volume to multiple isolated instances.
 ```{config:option} snapshots.expiry storage-lvm-volume-conf
 :condition: "custom volume"
 :defaultdesc: "same as `volume.snapshots.expiry`"
+:scope: "global"
 :shortdesc: "When snapshots are to be deleted"
 :type: "string"
 Specify an expression like `1M 2H 3d 4w 5m 6y`.
@@ -5466,6 +5641,7 @@ Specify an expression like `1M 2H 3d 4w 5m 6y`.
 ```{config:option} snapshots.pattern storage-lvm-volume-conf
 :condition: "custom volume"
 :defaultdesc: "same as `volume.snapshots.pattern` or `snap%d`"
+:scope: "global"
 :shortdesc: "Template for the snapshot name"
 :type: "string"
 You can specify a naming template that is used for scheduled snapshots and unnamed snapshots.
@@ -5485,6 +5661,7 @@ This number is then incremented by one for the new name.
 ```{config:option} snapshots.schedule storage-lvm-volume-conf
 :condition: "custom volume"
 :defaultdesc: "same as `snapshots.schedule`"
+:scope: "global"
 :shortdesc: "Schedule for automatic volume snapshots"
 :type: "string"
 Specify either a cron expression (`<minute> <hour> <dom> <month> <dow>`), a comma-separated list of schedule aliases (`@hourly`, `@daily`, `@midnight`, `@weekly`, `@monthly`, `@annually`, `@yearly`), or leave empty to disable automatic snapshots (the default).
@@ -5492,6 +5669,7 @@ Specify either a cron expression (`<minute> <hour> <dom> <month> <dow>`), a comm
 
 ```{config:option} volatile.uuid storage-lvm-volume-conf
 :defaultdesc: "random UUID"
+:scope: "global"
 :shortdesc: "The volume's UUID"
 :type: "string"
 
@@ -5501,6 +5679,7 @@ Specify either a cron expression (`<minute> <hour> <dom> <month> <dow>`), a comm
 <!-- config group storage-powerflex-pool-conf start -->
 ```{config:option} powerflex.clone_copy storage-powerflex-pool-conf
 :defaultdesc: "`true`"
+:scope: "global"
 :shortdesc: "Whether to use non-sparse copies for snapshots"
 :type: "bool"
 If this option is set to `true`, PowerFlex makes a non-sparse copy when creating a snapshot of an instance or custom volume.
@@ -5508,12 +5687,14 @@ See {ref}`storage-powerflex-limitations` for more information.
 ```
 
 ```{config:option} powerflex.domain storage-powerflex-pool-conf
+:scope: "global"
 :shortdesc: "Name of the PowerFlex protection domain"
 :type: "string"
 This option is required only if {config:option}`storage-powerflex-pool-conf:powerflex.pool` is specified using its name.
 ```
 
 ```{config:option} powerflex.gateway storage-powerflex-pool-conf
+:scope: "global"
 :shortdesc: "Address of the PowerFlex Gateway"
 :type: "string"
 
@@ -5521,6 +5702,7 @@ This option is required only if {config:option}`storage-powerflex-pool-conf:powe
 
 ```{config:option} powerflex.gateway.verify storage-powerflex-pool-conf
 :defaultdesc: "`true`"
+:scope: "global"
 :shortdesc: "Whether to verify the PowerFlex Gateway's certificate"
 :type: "bool"
 
@@ -5528,6 +5710,7 @@ This option is required only if {config:option}`storage-powerflex-pool-conf:powe
 
 ```{config:option} powerflex.mode storage-powerflex-pool-conf
 :defaultdesc: "the discovered mode"
+:scope: "global"
 :shortdesc: "How volumes are mapped to the local server"
 :type: "string"
 The mode gets discovered automatically if the system provides the necessary kernel modules.
@@ -5535,6 +5718,7 @@ This can be either `nvme` or `sdc`.
 ```
 
 ```{config:option} powerflex.pool storage-powerflex-pool-conf
+:scope: "global"
 :shortdesc: "ID of the PowerFlex storage pool"
 :type: "string"
 If you want to specify the storage pool via its name, also set {config:option}`storage-powerflex-pool-conf:powerflex.domain`.
@@ -5542,6 +5726,7 @@ If you want to specify the storage pool via its name, also set {config:option}`s
 
 ```{config:option} powerflex.sdt storage-powerflex-pool-conf
 :defaultdesc: "one of the SDT"
+:scope: "global"
 :shortdesc: "PowerFlex NVMe/TCP SDT"
 :type: "string"
 
@@ -5549,12 +5734,14 @@ If you want to specify the storage pool via its name, also set {config:option}`s
 
 ```{config:option} powerflex.user.name storage-powerflex-pool-conf
 :defaultdesc: "`admin`"
+:scope: "global"
 :shortdesc: "User for PowerFlex Gateway authentication"
 :type: "string"
 
 ```
 
 ```{config:option} powerflex.user.password storage-powerflex-pool-conf
+:scope: "global"
 :shortdesc: "Password for PowerFlex Gateway authentication"
 :type: "string"
 
@@ -5562,6 +5749,7 @@ If you want to specify the storage pool via its name, also set {config:option}`s
 
 ```{config:option} rsync.bwlimit storage-powerflex-pool-conf
 :defaultdesc: "`0` (no limit)"
+:scope: "global"
 :shortdesc: "Upper limit on the socket I/O for `rsync`"
 :type: "string"
 When `rsync` must be used to transfer storage entities, this option specifies the upper limit
@@ -5570,6 +5758,7 @@ to be placed on the socket I/O.
 
 ```{config:option} rsync.compression storage-powerflex-pool-conf
 :defaultdesc: "`true`"
+:scope: "global"
 :shortdesc: "Whether to use compression while migrating storage pools"
 :type: "bool"
 
@@ -5577,6 +5766,7 @@ to be placed on the socket I/O.
 
 ```{config:option} volume.size storage-powerflex-pool-conf
 :defaultdesc: "`8GiB`"
+:scope: "global"
 :shortdesc: "Size/quota of the storage volume"
 :type: "string"
 The size must be in multiples of 8 GiB.
@@ -5588,6 +5778,7 @@ See {ref}`storage-powerflex-limitations` for more information.
 ```{config:option} block.filesystem storage-powerflex-volume-conf
 :condition: "block-based volume with content type `filesystem`"
 :defaultdesc: "same as `volume.block.filesystem`"
+:scope: "global"
 :shortdesc: "File system of the storage volume"
 :type: "string"
 Valid options are: `btrfs`, `ext4`, `xfs`
@@ -5597,6 +5788,7 @@ If not set, `ext4` is assumed.
 ```{config:option} block.mount_options storage-powerflex-volume-conf
 :condition: "block-based volume with content type `filesystem`"
 :defaultdesc: "same as `volume.block.mount_options`"
+:scope: "global"
 :shortdesc: "Mount options for block-backed file system volumes"
 :type: "string"
 
@@ -5604,6 +5796,7 @@ If not set, `ext4` is assumed.
 
 ```{config:option} block.type storage-powerflex-volume-conf
 :defaultdesc: "same as `volume.block.type` or `thick`"
+:scope: "global"
 :shortdesc: "Whether to create a `thin` or `thick` provisioned volume"
 :type: "string"
 
@@ -5612,6 +5805,7 @@ If not set, `ext4` is assumed.
 ```{config:option} security.shared storage-powerflex-volume-conf
 :condition: "custom block volume"
 :defaultdesc: "same as `volume.security.shared` or `false`"
+:scope: "global"
 :shortdesc: "Enable volume sharing"
 :type: "bool"
 Enabling this option allows sharing the volume across multiple instances despite the possibility of data loss.
@@ -5621,6 +5815,7 @@ Enabling this option allows sharing the volume across multiple instances despite
 ```{config:option} security.shifted storage-powerflex-volume-conf
 :condition: "custom volume"
 :defaultdesc: "same as `volume.security.shifted` or `false`"
+:scope: "global"
 :shortdesc: "Enable ID shifting overlay"
 :type: "bool"
 Enabling this option allows attaching the volume to multiple isolated instances.
@@ -5629,6 +5824,7 @@ Enabling this option allows attaching the volume to multiple isolated instances.
 ```{config:option} security.unmapped storage-powerflex-volume-conf
 :condition: "custom volume"
 :defaultdesc: "same as `volume.security.unmappped` or `false`"
+:scope: "global"
 :shortdesc: "Disable ID mapping for the volume"
 :type: "bool"
 
@@ -5636,6 +5832,7 @@ Enabling this option allows attaching the volume to multiple isolated instances.
 
 ```{config:option} size storage-powerflex-volume-conf
 :defaultdesc: "same as `volume.size`"
+:scope: "global"
 :shortdesc: "Size/quota of the storage volume"
 :type: "string"
 The size must be in multiples of 8 GiB.
@@ -5645,6 +5842,7 @@ See {ref}`storage-powerflex-limitations` for more information.
 ```{config:option} snapshots.expiry storage-powerflex-volume-conf
 :condition: "custom volume"
 :defaultdesc: "same as `volume.snapshots.expiry`"
+:scope: "global"
 :shortdesc: "When snapshots are to be deleted"
 :type: "string"
 Specify an expression like `1M 2H 3d 4w 5m 6y`.
@@ -5653,6 +5851,7 @@ Specify an expression like `1M 2H 3d 4w 5m 6y`.
 ```{config:option} snapshots.pattern storage-powerflex-volume-conf
 :condition: "custom volume"
 :defaultdesc: "same as `volume.snapshots.pattern` or `snap%d`"
+:scope: "global"
 :shortdesc: "Template for the snapshot name"
 :type: "string"
 You can specify a naming template that is used for scheduled snapshots and unnamed snapshots.
@@ -5672,6 +5871,7 @@ This number is then incremented by one for the new name.
 ```{config:option} snapshots.schedule storage-powerflex-volume-conf
 :condition: "custom volume"
 :defaultdesc: "same as `snapshots.schedule`"
+:scope: "global"
 :shortdesc: "Schedule for automatic volume snapshots"
 :type: "string"
 Specify either a cron expression (`<minute> <hour> <dom> <month> <dow>`), a comma-separated list of schedule aliases (`@hourly`, `@daily`, `@midnight`, `@weekly`, `@monthly`, `@annually`, `@yearly`), or leave empty to disable automatic snapshots (the default).
@@ -5679,6 +5879,7 @@ Specify either a cron expression (`<minute> <hour> <dom> <month> <dow>`), a comm
 
 ```{config:option} volatile.uuid storage-powerflex-volume-conf
 :defaultdesc: "random UUID"
+:scope: "global"
 :shortdesc: "The volume's UUID"
 :type: "string"
 
@@ -5689,6 +5890,7 @@ Specify either a cron expression (`<minute> <hour> <dom> <month> <dow>`), a comm
 ```{config:option} size storage-zfs-bucket-conf
 :condition: "appropriate driver"
 :defaultdesc: "same as `volume.size`"
+:scope: "local"
 :shortdesc: "Size/quota of the storage bucket"
 :type: "string"
 
@@ -5698,6 +5900,7 @@ Specify either a cron expression (`<minute> <hour> <dom> <month> <dow>`), a comm
 <!-- config group storage-zfs-pool-conf start -->
 ```{config:option} size storage-zfs-pool-conf
 :defaultdesc: "auto (20% of free disk space, >= 5 GiB and <= 30 GiB)"
+:scope: "local"
 :shortdesc: "Size of the storage pool (for loop-based pools)"
 :type: "string"
 When creating loop-based pools, specify the size in bytes ({ref}`suffixes <instances-limit-units>` are supported).
@@ -5708,6 +5911,7 @@ with a minimum of 5 GiB and a maximum of 30 GiB.
 ```
 
 ```{config:option} source storage-zfs-pool-conf
+:scope: "local"
 :shortdesc: "Path to an existing block device, loop file, or ZFS dataset/pool"
 :type: "string"
 
@@ -5715,6 +5919,7 @@ with a minimum of 5 GiB and a maximum of 30 GiB.
 
 ```{config:option} source.wipe storage-zfs-pool-conf
 :defaultdesc: "`false`"
+:scope: "local"
 :shortdesc: "Whether to wipe the block device before creating the pool"
 :type: "bool"
 Set this option to `true` to wipe the block device specified in `source`
@@ -5723,6 +5928,7 @@ prior to creating the storage pool.
 
 ```{config:option} zfs.clone_copy storage-zfs-pool-conf
 :defaultdesc: "`true`"
+:scope: "global"
 :shortdesc: "Whether to use ZFS lightweight clones"
 :type: "string"
 Set this option to `true` or `false` to enable or disable using ZFS lightweight clones rather
@@ -5732,6 +5938,7 @@ Set the option to `rebase` to copy based on the initial image.
 
 ```{config:option} zfs.export storage-zfs-pool-conf
 :defaultdesc: "`true`"
+:scope: "global"
 :shortdesc: "Disable zpool export while an unmount is being performed"
 :type: "bool"
 
@@ -5739,6 +5946,7 @@ Set the option to `rebase` to copy based on the initial image.
 
 ```{config:option} zfs.pool_name storage-zfs-pool-conf
 :defaultdesc: "name of the pool"
+:scope: "local"
 :shortdesc: "Name of the zpool"
 :type: "string"
 
@@ -5749,6 +5957,7 @@ Set the option to `rebase` to copy based on the initial image.
 ```{config:option} block.filesystem storage-zfs-volume-conf
 :condition: "block-based volume with content type `filesystem` (`zfs.block_mode` enabled)"
 :defaultdesc: "same as `volume.block.filesystem`"
+:scope: "global"
 :shortdesc: "File system of the storage volume"
 :type: "string"
 Valid options are: `btrfs`, `ext4`, `xfs`
@@ -5758,6 +5967,7 @@ If not set, `ext4` is assumed.
 ```{config:option} block.mount_options storage-zfs-volume-conf
 :condition: "block-based volume with content type `filesystem` (`zfs.block_mode` enabled)"
 :defaultdesc: "same as `volume.block.mount_options`"
+:scope: "global"
 :shortdesc: "Mount options for block-backed file system volumes"
 :type: "string"
 
@@ -5766,6 +5976,7 @@ If not set, `ext4` is assumed.
 ```{config:option} security.shared storage-zfs-volume-conf
 :condition: "custom block volume"
 :defaultdesc: "same as `volume.security.shared` or `false`"
+:scope: "global"
 :shortdesc: "Enable volume sharing"
 :type: "bool"
 Enabling this option allows sharing the volume across multiple instances despite the possibility of data loss.
@@ -5775,6 +5986,7 @@ Enabling this option allows sharing the volume across multiple instances despite
 ```{config:option} security.shifted storage-zfs-volume-conf
 :condition: "custom volume"
 :defaultdesc: "same as `volume.security.shifted` or `false`"
+:scope: "global"
 :shortdesc: "Enable ID shifting overlay"
 :type: "bool"
 Enabling this option allows attaching the volume to multiple isolated instances.
@@ -5783,6 +5995,7 @@ Enabling this option allows attaching the volume to multiple isolated instances.
 ```{config:option} security.unmapped storage-zfs-volume-conf
 :condition: "custom volume"
 :defaultdesc: "same as `volume.security.unmappped` or `false`"
+:scope: "global"
 :shortdesc: "Disable ID mapping for the volume"
 :type: "bool"
 
@@ -5791,6 +6004,7 @@ Enabling this option allows attaching the volume to multiple isolated instances.
 ```{config:option} size storage-zfs-volume-conf
 :condition: "appropriate driver"
 :defaultdesc: "same as `volume.size`"
+:scope: "local"
 :shortdesc: "Size/quota of the storage volume"
 :type: "string"
 
@@ -5799,6 +6013,7 @@ Enabling this option allows attaching the volume to multiple isolated instances.
 ```{config:option} snapshots.expiry storage-zfs-volume-conf
 :condition: "custom volume"
 :defaultdesc: "same as `volume.snapshots.expiry`"
+:scope: "global"
 :shortdesc: "When snapshots are to be deleted"
 :type: "string"
 Specify an expression like `1M 2H 3d 4w 5m 6y`.
@@ -5807,6 +6022,7 @@ Specify an expression like `1M 2H 3d 4w 5m 6y`.
 ```{config:option} snapshots.pattern storage-zfs-volume-conf
 :condition: "custom volume"
 :defaultdesc: "same as `volume.snapshots.pattern` or `snap%d`"
+:scope: "global"
 :shortdesc: "Template for the snapshot name"
 :type: "string"
 You can specify a naming template that is used for scheduled snapshots and unnamed snapshots.
@@ -5826,6 +6042,7 @@ This number is then incremented by one for the new name.
 ```{config:option} snapshots.schedule storage-zfs-volume-conf
 :condition: "custom volume"
 :defaultdesc: "same as `snapshots.schedule`"
+:scope: "global"
 :shortdesc: "Schedule for automatic volume snapshots"
 :type: "string"
 Specify either a cron expression (`<minute> <hour> <dom> <month> <dow>`), a comma-separated list of schedule aliases (`@hourly`, `@daily`, `@midnight`, `@weekly`, `@monthly`, `@annually`, `@yearly`), or leave empty to disable automatic snapshots (the default).
@@ -5833,6 +6050,7 @@ Specify either a cron expression (`<minute> <hour> <dom> <month> <dow>`), a comm
 
 ```{config:option} volatile.uuid storage-zfs-volume-conf
 :defaultdesc: "random UUID"
+:scope: "global"
 :shortdesc: "The volume's UUID"
 :type: "string"
 
@@ -5840,6 +6058,7 @@ Specify either a cron expression (`<minute> <hour> <dom> <month> <dow>`), a comm
 
 ```{config:option} zfs.block_mode storage-zfs-volume-conf
 :defaultdesc: "same as `volume.zfs.block_mode`"
+:scope: "global"
 :shortdesc: "Whether to use a formatted `zvol` rather than a dataset"
 :type: "bool"
 `zfs.block_mode` can be set only for custom storage volumes.
@@ -5849,6 +6068,7 @@ use `volume.zfs.block_mode`.
 
 ```{config:option} zfs.blocksize storage-zfs-volume-conf
 :defaultdesc: "same as `volume.zfs.blocksize`"
+:scope: "global"
 :shortdesc: "Size of the ZFS block"
 :type: "string"
 The size must be between 512 bytes and 16 MiB and must be a power of 2.
@@ -5861,6 +6081,7 @@ the specified size is used to set either `volblocksize` or `recordsize` in ZFS.
 ```{config:option} zfs.delegate storage-zfs-volume-conf
 :condition: "ZFS 2.2 or higher"
 :defaultdesc: "same as `volume.zfs.delegate`"
+:scope: "global"
 :shortdesc: "Whether to delegate the ZFS dataset"
 :type: "bool"
 This option controls whether to delegate the ZFS dataset and anything underneath it to the
@@ -5869,6 +6090,7 @@ container or containers that use it. This allows using the `zfs` command in the 
 
 ```{config:option} zfs.remove_snapshots storage-zfs-volume-conf
 :defaultdesc: "same as `volume.zfs.remove_snapshots` or `false`"
+:scope: "global"
 :shortdesc: "Remove snapshots as needed"
 :type: "bool"
 
@@ -5876,6 +6098,7 @@ container or containers that use it. This allows using the `zfs` command in the 
 
 ```{config:option} zfs.reserve_space storage-zfs-volume-conf
 :defaultdesc: "same as `volume.zfs.reserve_space` or `false`"
+:scope: "global"
 :shortdesc: "Use `reservation`/`refreservation` along with `quota`/`refquota`"
 :type: "bool"
 
@@ -5883,6 +6106,7 @@ container or containers that use it. This allows using the `zfs` command in the 
 
 ```{config:option} zfs.use_refquota storage-zfs-volume-conf
 :defaultdesc: "same as `volume.zfs.use_refquota` or `false`"
+:scope: "global"
 :shortdesc: "Use `refquota` instead of `quota` for space"
 :type: "bool"
 

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -2891,6 +2891,11 @@ definitions:
                 example: On device creation.
                 type: string
                 x-go-name: Required
+            scope:
+                description: Scope describes the cluster member specificity of a configuration key. Options marked with a `global` scope are applied to all cluster members. Options marked with a `local` scope are set on a per-member basis.
+                example: global
+                type: string
+                x-go-name: Scope
             shortdesc:
                 description: ShortDescription contains a short-form description of the configuration key.
                 example: A key for doing X.

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -3051,6 +3051,7 @@
 							"condition": "BGP server",
 							"defaultdesc": "local address",
 							"longdesc": "",
+							"scope": "local",
 							"shortdesc": "Override the IPv4 next-hop for advertised prefixes",
 							"type": "string"
 						}
@@ -3060,6 +3061,7 @@
 							"condition": "BGP server",
 							"defaultdesc": "local address",
 							"longdesc": "",
+							"scope": "local",
 							"shortdesc": "Override the IPv6 next-hop for advertised prefixes",
 							"type": "string"
 						}
@@ -3068,6 +3070,7 @@
 						"bgp.peers.NAME.address": {
 							"condition": "BGP server",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "Peer address (IPv4 or IPv6)",
 							"type": "string"
 						}
@@ -3076,6 +3079,7 @@
 						"bgp.peers.NAME.asn": {
 							"condition": "BGP server",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "Peer AS number",
 							"type": "integer"
 						}
@@ -3086,6 +3090,7 @@
 							"defaultdesc": "`180`",
 							"longdesc": "Specify the hold time in seconds.",
 							"required": "no",
+							"scope": "global",
 							"shortdesc": "Peer session hold time",
 							"type": "integer"
 						}
@@ -3096,6 +3101,7 @@
 							"defaultdesc": "(no password)",
 							"longdesc": "",
 							"required": "no",
+							"scope": "global",
 							"shortdesc": "Peer session password",
 							"type": "string"
 						}
@@ -3104,6 +3110,7 @@
 						"bridge.driver": {
 							"defaultdesc": "`native`",
 							"longdesc": "Possible values are `native` and `openvswitch`.",
+							"scope": "global",
 							"shortdesc": "Bridge driver",
 							"type": "string"
 						}
@@ -3111,6 +3118,7 @@
 					{
 						"bridge.external_interfaces": {
 							"longdesc": "Specify a comma-separated list of unconfigured network interfaces to include in the bridge.",
+							"scope": "local",
 							"shortdesc": "Unconfigured network interfaces to include in the bridge",
 							"type": "string"
 						}
@@ -3118,6 +3126,7 @@
 					{
 						"bridge.hwaddr": {
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "MAC address for the bridge",
 							"type": "string"
 						}
@@ -3126,6 +3135,7 @@
 						"bridge.mode": {
 							"defaultdesc": "`standard`",
 							"longdesc": "Possible values are `standard` and `fan`.",
+							"scope": "global",
 							"shortdesc": "Bridge operation mode",
 							"type": "string"
 						}
@@ -3134,6 +3144,7 @@
 						"bridge.mtu": {
 							"defaultdesc": "`1500` if `bridge.mode=standard`, `1480` if `bridge.mode=fan` and `fan.type=ipip`, or `1450` if `bridge.mode=fan` and `fan.type=vxlan`",
 							"longdesc": "The default value varies depending on whether the bridge uses a tunnel or a fan setup.",
+							"scope": "global",
 							"shortdesc": "Bridge MTU",
 							"type": "integer"
 						}
@@ -3142,6 +3153,7 @@
 						"dns.domain": {
 							"defaultdesc": "`lxd`",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "Domain to advertise to DHCP clients and use for DNS resolution",
 							"type": "string"
 						}
@@ -3150,6 +3162,7 @@
 						"dns.mode": {
 							"defaultdesc": "`managed`",
 							"longdesc": "Possible values are `none` for no DNS record, `managed` for LXD-generated static records, and `dynamic` for client-generated records.",
+							"scope": "global",
 							"shortdesc": "DNS registration mode",
 							"type": "string"
 						}
@@ -3158,6 +3171,7 @@
 						"dns.search": {
 							"defaultdesc": "`dns.domain` value",
 							"longdesc": "Specify a comma-separated list of domains.",
+							"scope": "global",
 							"shortdesc": "Full domain search list",
 							"type": "string"
 						}
@@ -3165,6 +3179,7 @@
 					{
 						"dns.zone.forward": {
 							"longdesc": "Specify a comma-separated list of DNS zone names.",
+							"scope": "global",
 							"shortdesc": "DNS zone names for forward DNS records",
 							"type": "string"
 						}
@@ -3172,6 +3187,7 @@
 					{
 						"dns.zone.reverse.ipv4": {
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "DNS zone name for IPv4 reverse DNS records",
 							"type": "string"
 						}
@@ -3179,6 +3195,7 @@
 					{
 						"dns.zone.reverse.ipv6": {
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "DNS zone name for IPv6 reverse DNS records",
 							"type": "string"
 						}
@@ -3188,6 +3205,7 @@
 							"condition": "fan mode",
 							"defaultdesc": "`240.0.0.0/8`",
 							"longdesc": "Use CIDR notation.",
+							"scope": "global",
 							"shortdesc": "Subnet to use as the overlay for the FAN",
 							"type": "string"
 						}
@@ -3197,6 +3215,7 @@
 							"condition": "fan mode",
 							"defaultdesc": "`vxlan`",
 							"longdesc": "Possible values are `vxlan` and `ipip`.",
+							"scope": "global",
 							"shortdesc": "Tunneling type for the FAN",
 							"type": "string"
 						}
@@ -3206,6 +3225,7 @@
 							"condition": "fan mode",
 							"defaultdesc": "initial value on creation: `auto`",
 							"longdesc": "Use CIDR notation.\n\nYou can set the option to `auto` to use the default gateway subnet.",
+							"scope": "global",
 							"shortdesc": "Subnet to use as the underlay for the FAN",
 							"type": "string"
 						}
@@ -3215,6 +3235,7 @@
 							"condition": "standard mode",
 							"defaultdesc": "initial value on creation: `auto`",
 							"longdesc": "Use CIDR notation.\n\nYou can set the option to `none` to turn off IPv4, or to `auto` to generate a new random unused subnet.",
+							"scope": "global",
 							"shortdesc": "IPv4 address for the bridge",
 							"type": "string"
 						}
@@ -3224,6 +3245,7 @@
 							"condition": "IPv4 address",
 							"defaultdesc": "`true`",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "Whether to allocate IPv4 addresses using DHCP",
 							"type": "bool"
 						}
@@ -3233,6 +3255,7 @@
 							"condition": "IPv4 DHCP",
 							"defaultdesc": "`1h`",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "When to expire DHCP leases",
 							"type": "string"
 						}
@@ -3242,6 +3265,7 @@
 							"condition": "IPv4 DHCP",
 							"defaultdesc": "IPv4 address",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "Address of the gateway for the IPv4 subnet",
 							"type": "string"
 						}
@@ -3251,6 +3275,7 @@
 							"condition": "IPv4 DHCP",
 							"defaultdesc": "all addresses",
 							"longdesc": "Specify a comma-separated list of IPv4 ranges in FIRST-LAST format.",
+							"scope": "global",
 							"shortdesc": "IPv4 ranges to use for DHCP",
 							"type": "string"
 						}
@@ -3260,6 +3285,7 @@
 							"condition": "IPv4 address",
 							"defaultdesc": "`true`",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "Whether to generate filtering firewall rules for this network",
 							"type": "bool"
 						}
@@ -3269,6 +3295,7 @@
 							"condition": "IPv4 address",
 							"defaultdesc": "`false` (initial value on creation if `ipv4.address` is set to `auto`: `true`)",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "Whether to use NAT for IPv4",
 							"type": "bool"
 						}
@@ -3277,6 +3304,7 @@
 						"ipv4.nat.address": {
 							"condition": "IPv4 address",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "Source address used for outbound traffic from the bridge",
 							"type": "string"
 						}
@@ -3286,6 +3314,7 @@
 							"condition": "IPv4 address",
 							"defaultdesc": "`before`",
 							"longdesc": "Set this option to `before` to add the NAT rules before any pre-existing rules, or to `after` to add them after the pre-existing rules.",
+							"scope": "global",
 							"shortdesc": "Where to add the required NAT rules",
 							"type": "string"
 						}
@@ -3293,6 +3322,7 @@
 					{
 						"ipv4.ovn.ranges": {
 							"longdesc": "Specify a comma-separated list of IPv4 ranges in FIRST-LAST format.",
+							"scope": "global",
 							"shortdesc": "IPv4 ranges to use for child OVN network routers",
 							"type": "string"
 						}
@@ -3301,6 +3331,7 @@
 						"ipv4.routes": {
 							"condition": "IPv4 address",
 							"longdesc": "Specify a comma-separated list of IPv4 CIDR subnets.",
+							"scope": "global",
 							"shortdesc": "Additional IPv4 CIDR subnets to route to the bridge",
 							"type": "string"
 						}
@@ -3310,6 +3341,7 @@
 							"condition": "IPv4 address",
 							"defaultdesc": "`true`",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "Whether to route IPv4 traffic in and out of the bridge",
 							"type": "bool"
 						}
@@ -3319,6 +3351,7 @@
 							"condition": "standard mode",
 							"defaultdesc": "initial value on creation: `auto`",
 							"longdesc": "Use CIDR notation.\n\nYou can set the option to `none` to turn off IPv6, or to `auto` to generate a new random unused subnet.",
+							"scope": "global",
 							"shortdesc": "IPv6 address for the bridge",
 							"type": "string"
 						}
@@ -3328,6 +3361,7 @@
 							"condition": "IPv6 address",
 							"defaultdesc": "`true`",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "Whether to provide additional network configuration over DHCP",
 							"type": "bool"
 						}
@@ -3337,6 +3371,7 @@
 							"condition": "IPv6 DHCP",
 							"defaultdesc": "`1h`",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "When to expire DHCP leases",
 							"type": "string"
 						}
@@ -3346,6 +3381,7 @@
 							"condition": "IPv6 stateful DHCP",
 							"defaultdesc": "all addresses",
 							"longdesc": "Specify a comma-separated list of IPv6 ranges in FIRST-LAST format.",
+							"scope": "global",
 							"shortdesc": "IPv6 ranges to use for DHCP",
 							"type": "string"
 						}
@@ -3355,6 +3391,7 @@
 							"condition": "IPv6 DHCP",
 							"defaultdesc": "`false`",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "Whether to allocate IPv6 addresses using DHCP",
 							"type": "bool"
 						}
@@ -3364,6 +3401,7 @@
 							"condition": "IPv6 DHCP",
 							"defaultdesc": "`true`",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "Whether to generate filtering firewall rules for this network",
 							"type": "bool"
 						}
@@ -3373,6 +3411,7 @@
 							"condition": "IPv6 address",
 							"defaultdesc": "`false` (initial value on creation if `ipv6.address` is set to `auto`: `true`)",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "Whether to use NAT for IPv6",
 							"type": "bool"
 						}
@@ -3381,6 +3420,7 @@
 						"ipv6.nat.address": {
 							"condition": "IPv6 address",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "Source address used for outbound traffic from the bridge",
 							"type": "string"
 						}
@@ -3390,6 +3430,7 @@
 							"condition": "IPv6 address",
 							"defaultdesc": "`before`",
 							"longdesc": "Set this option to `before` to add the NAT rules before any pre-existing rules, or to `after` to add them after the pre-existing rules.",
+							"scope": "global",
 							"shortdesc": "Where to add the required NAT rules",
 							"type": "string"
 						}
@@ -3397,6 +3438,7 @@
 					{
 						"ipv6.ovn.ranges": {
 							"longdesc": "Specify a comma-separated list of IPv6 ranges in FIRST-LAST format.",
+							"scope": "global",
 							"shortdesc": "IPv6 ranges to use for child OVN network routers",
 							"type": "string"
 						}
@@ -3405,6 +3447,7 @@
 						"ipv6.routes": {
 							"condition": "IPv6 address",
 							"longdesc": "Specify a comma-separated list of IPv6 CIDR subnets.",
+							"scope": "global",
 							"shortdesc": "Additional IPv6 CIDR subnets to route to the bridge",
 							"type": "string"
 						}
@@ -3413,6 +3456,7 @@
 						"ipv6.routing": {
 							"condition": "IPv6 address",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "Whether to route IPv6 traffic in and out of the bridge",
 							"type": "bool"
 						}
@@ -3421,6 +3465,7 @@
 						"maas.subnet.ipv4": {
 							"condition": "IPv4 address; using the `network` property on the NIC",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "MAAS IPv4 subnet to register instances in",
 							"type": "string"
 						}
@@ -3429,6 +3474,7 @@
 						"maas.subnet.ipv6": {
 							"condition": "IPv6 address; using the `network` property on the NIC",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "MAAS IPv6 subnet to register instances in",
 							"type": "string"
 						}
@@ -3436,6 +3482,7 @@
 					{
 						"raw.dnsmasq": {
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "Additional `dnsmasq` configuration to append to the configuration file",
 							"type": "string"
 						}
@@ -3443,6 +3490,7 @@
 					{
 						"security.acls": {
 							"longdesc": "Specify a comma-separated list of network ACLs.\n\nAlso see {ref}`network-acls-bridge-limitations`.",
+							"scope": "global",
 							"shortdesc": "Network ACLs to apply to NICs connected to this network",
 							"type": "string"
 						}
@@ -3451,6 +3499,7 @@
 						"security.acls.default.egress.action": {
 							"condition": "`security.acls`",
 							"longdesc": "The specified action is used for all egress traffic that doesn’t match any ACL rule.",
+							"scope": "global",
 							"shortdesc": "Default action to use for egress traffic",
 							"type": "string"
 						}
@@ -3459,6 +3508,7 @@
 						"security.acls.default.egress.logged": {
 							"condition": "`security.acls`",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "Whether to log egress traffic that doesn’t match any ACL rule",
 							"type": "bool"
 						}
@@ -3467,6 +3517,7 @@
 						"security.acls.default.ingress.action": {
 							"condition": "`security.acls`",
 							"longdesc": "The specified action is used for all ingress traffic that doesn’t match any ACL rule.",
+							"scope": "global",
 							"shortdesc": "Default action to use for ingress traffic",
 							"type": "string"
 						}
@@ -3475,6 +3526,7 @@
 						"security.acls.default.ingress.logged": {
 							"condition": "`security.acls`",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "Whether to log ingress traffic that doesn’t match any ACL rule",
 							"type": "bool"
 						}
@@ -3550,6 +3602,7 @@
 					{
 						"user.*": {
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "User-provided free-form key/value pairs",
 							"type": "string"
 						}
@@ -3766,6 +3819,7 @@
 						"gvrp": {
 							"defaultdesc": "`false`",
 							"longdesc": "This option specifies whether to register the VLAN using the GARP VLAN Registration Protocol.",
+							"scope": "global",
 							"shortdesc": "Whether to use GARP VLAN Registration Protocol",
 							"type": "bool"
 						}
@@ -3774,6 +3828,7 @@
 						"maas.subnet.ipv4": {
 							"condition": "IPv4 address; using the `network` property on the NIC",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "MAAS IPv4 subnet to register instances in",
 							"type": "string"
 						}
@@ -3782,6 +3837,7 @@
 						"maas.subnet.ipv6": {
 							"condition": "IPv4 address; using the `network` property on the NIC",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "MAAS IPv6 subnet to register instances in",
 							"type": "string"
 						}
@@ -3789,6 +3845,7 @@
 					{
 						"mtu": {
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "MTU of the new interface",
 							"type": "integer"
 						}
@@ -3796,6 +3853,7 @@
 					{
 						"parent": {
 							"longdesc": "",
+							"scope": "local",
 							"shortdesc": "Parent interface to create `macvlan` NICs on",
 							"type": "string"
 						}
@@ -3803,6 +3861,7 @@
 					{
 						"user.*": {
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "User-provided free-form key/value pairs",
 							"type": "string"
 						}
@@ -3810,6 +3869,7 @@
 					{
 						"vlan": {
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "VLAN ID to attach to",
 							"type": "integer"
 						}
@@ -4090,6 +4150,7 @@
 						"bgp.peers.NAME.address": {
 							"condition": "BGP server",
 							"longdesc": "The address can be IPv4 or IPv6.",
+							"scope": "global",
 							"shortdesc": "Peer address for use by `ovn` downstream networks",
 							"type": "string"
 						}
@@ -4098,6 +4159,7 @@
 						"bgp.peers.NAME.asn": {
 							"condition": "BGP server",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "Peer AS number for use by `ovn` downstream networks",
 							"type": "integer"
 						}
@@ -4108,6 +4170,7 @@
 							"defaultdesc": "`180`",
 							"longdesc": "Specify the peer session hold time in seconds.",
 							"required": "no",
+							"scope": "global",
 							"shortdesc": "Peer session hold time",
 							"type": "integer"
 						}
@@ -4118,6 +4181,7 @@
 							"defaultdesc": "(no password)",
 							"longdesc": "",
 							"required": "no",
+							"scope": "global",
 							"shortdesc": "Peer session password for use by `ovn` downstream networks",
 							"type": "string"
 						}
@@ -4126,6 +4190,7 @@
 						"dns.nameservers": {
 							"condition": "standard mode",
 							"longdesc": "Specify a list of DNS server IPs.",
+							"scope": "global",
 							"shortdesc": "DNS server IPs on physical network",
 							"type": "string"
 						}
@@ -4134,6 +4199,7 @@
 						"gvrp": {
 							"defaultdesc": "`false`",
 							"longdesc": "This option specifies whether to register the VLAN using the GARP VLAN Registration Protocol.",
+							"scope": "global",
 							"shortdesc": "Whether to use GARP VLAN Registration Protocol",
 							"type": "bool"
 						}
@@ -4142,6 +4208,7 @@
 						"ipv4.gateway": {
 							"condition": "standard mode",
 							"longdesc": "Use CIDR notation.",
+							"scope": "global",
 							"shortdesc": "IPv4 address for the gateway and network",
 							"type": "string"
 						}
@@ -4149,6 +4216,7 @@
 					{
 						"ipv4.ovn.ranges": {
 							"longdesc": "Specify a comma-separated list of IPv4 ranges in FIRST-LAST format.",
+							"scope": "global",
 							"shortdesc": "IPv4 ranges to use for child OVN network routers",
 							"type": "string"
 						}
@@ -4157,6 +4225,7 @@
 						"ipv4.routes": {
 							"condition": "IPv4 address",
 							"longdesc": "Specify a comma-separated list of IPv4 CIDR subnets that can be used with child OVN network forwarders, load-balancers and {config:option}`device-nic-ovn-device-conf:ipv4.routes.external` setting.",
+							"scope": "global",
 							"shortdesc": "Additional IPv4 CIDR subnets",
 							"type": "string"
 						}
@@ -4166,6 +4235,7 @@
 							"condition": "IPv4 address",
 							"defaultdesc": "`false`",
 							"longdesc": "If set to `true`, this option allows the overlapping routes to be used on multiple networks/NICs at the same time.",
+							"scope": "global",
 							"shortdesc": "Whether to allow IPv4 routes on multiple networks/NICs",
 							"type": "bool"
 						}
@@ -4174,6 +4244,7 @@
 						"ipv6.gateway": {
 							"condition": "standard mode",
 							"longdesc": "Use CIDR notation.",
+							"scope": "global",
 							"shortdesc": "IPv6 address for the gateway and network",
 							"type": "string"
 						}
@@ -4181,6 +4252,7 @@
 					{
 						"ipv6.ovn.ranges": {
 							"longdesc": "Specify a comma-separated list of IPv6 ranges in FIRST-LAST format.",
+							"scope": "global",
 							"shortdesc": "IPv6 ranges to use for child OVN network routers",
 							"type": "string"
 						}
@@ -4189,6 +4261,7 @@
 						"ipv6.routes": {
 							"condition": "IPv6 address",
 							"longdesc": "Specify a comma-separated list of IPv6 CIDR subnets that can be used with child OVN network forwarders, load-balancers and {config:option}`device-nic-ovn-device-conf:ipv6.routes.external` setting.",
+							"scope": "global",
 							"shortdesc": "Additional IPv6 CIDR subnets",
 							"type": "string"
 						}
@@ -4198,6 +4271,7 @@
 							"condition": "IPv6 address",
 							"defaultdesc": "`false`",
 							"longdesc": "If set to `true`, this option allows the overlapping routes to be used on multiple networks/NICs at the same time.",
+							"scope": "global",
 							"shortdesc": "Whether to allow IPv6 routes on multiple networks/NICs",
 							"type": "bool"
 						}
@@ -4206,6 +4280,7 @@
 						"maas.subnet.ipv4": {
 							"condition": "IPv4 address; using the `network` property on the NIC",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "MAAS IPv4 subnet to register instances in",
 							"type": "string"
 						}
@@ -4214,6 +4289,7 @@
 						"maas.subnet.ipv6": {
 							"condition": "IPv6 address; using the `network` property on the NIC",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "MAAS IPv6 subnet to register instances in",
 							"type": "string"
 						}
@@ -4221,6 +4297,7 @@
 					{
 						"mtu": {
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "MTU of the new interface",
 							"type": "integer"
 						}
@@ -4230,6 +4307,7 @@
 							"condition": "standard mode",
 							"defaultdesc": "`l2proxy`",
 							"longdesc": "Possible values are `l2proxy` (proxy ARP/NDP) and `routed`.",
+							"scope": "global",
 							"shortdesc": "How OVN NIC external IPs are advertised on uplink network",
 							"type": "string"
 						}
@@ -4237,6 +4315,7 @@
 					{
 						"parent": {
 							"longdesc": "",
+							"scope": "local",
 							"shortdesc": "Existing interface to use for network",
 							"type": "string"
 						}
@@ -4244,6 +4323,7 @@
 					{
 						"user.*": {
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "User-provided free-form key/value pairs",
 							"type": "string"
 						}
@@ -4251,6 +4331,7 @@
 					{
 						"vlan": {
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "VLAN ID to attach to",
 							"type": "integer"
 						}
@@ -4265,6 +4346,7 @@
 						"maas.subnet.ipv4": {
 							"condition": "IPv4 address; using the `network` property on the NIC",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "MAAS IPv4 subnet to register instances in",
 							"type": "string"
 						}
@@ -4273,6 +4355,7 @@
 						"maas.subnet.ipv6": {
 							"condition": "IPv6 address; using the `network` property on the NIC",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "MAAS IPv6 subnet to register instances in",
 							"type": "string"
 						}
@@ -4280,6 +4363,7 @@
 					{
 						"mtu": {
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "MTU of the new interface",
 							"type": "integer"
 						}
@@ -4287,6 +4371,7 @@
 					{
 						"parent": {
 							"longdesc": "",
+							"scope": "local",
 							"shortdesc": "Parent interface to create `sriov` NICs on",
 							"type": "string"
 						}
@@ -4294,6 +4379,7 @@
 					{
 						"user.*": {
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "User-provided free-form key/value pairs",
 							"type": "string"
 						}
@@ -4301,6 +4387,7 @@
 					{
 						"vlan": {
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "VLAN ID to attach to",
 							"type": "integer"
 						}
@@ -5356,6 +5443,7 @@
 							"condition": "appropriate driver",
 							"defaultdesc": "same as `volume.size`",
 							"longdesc": "",
+							"scope": "local",
 							"shortdesc": "Size/quota of the storage bucket",
 							"type": "string"
 						}
@@ -5368,6 +5456,7 @@
 						"btrfs.mount_options": {
 							"defaultdesc": "`user_subvol_rm_allowed`",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "Mount options for block devices",
 							"type": "string"
 						}
@@ -5376,6 +5465,7 @@
 						"size": {
 							"defaultdesc": "auto (20% of free disk space, \u003e= 5 GiB and \u003c= 30 GiB)",
 							"longdesc": "When creating loop-based pools, specify the size in bytes ({ref}`suffixes \u003cinstances-limit-units\u003e` are supported).\nYou can increase the size to grow the storage pool.\n\nThe default (`auto`) creates a storage pool that uses 20% of the free disk space,\nwith a minimum of 5 GiB and a maximum of 30 GiB.",
+							"scope": "local",
 							"shortdesc": "Size of the storage pool (for loop-based pools)",
 							"type": "string"
 						}
@@ -5383,6 +5473,7 @@
 					{
 						"source": {
 							"longdesc": "",
+							"scope": "local",
 							"shortdesc": "Path to an existing block device, loop file, or Btrfs subvolume",
 							"type": "string"
 						}
@@ -5391,6 +5482,7 @@
 						"source.wipe": {
 							"defaultdesc": "`false`",
 							"longdesc": "Set this option to `true` to wipe the block device specified in `source`\nprior to creating the storage pool.",
+							"scope": "local",
 							"shortdesc": "Whether to wipe the block device before creating the pool",
 							"type": "bool"
 						}
@@ -5404,6 +5496,7 @@
 							"condition": "custom block volume",
 							"defaultdesc": "same as `volume.security.shared` or `false`",
 							"longdesc": "Enabling this option allows sharing the volume across multiple instances despite the possibility of data loss.\n",
+							"scope": "global",
 							"shortdesc": "Enable volume sharing",
 							"type": "bool"
 						}
@@ -5413,6 +5506,7 @@
 							"condition": "custom volume",
 							"defaultdesc": "same as `volume.security.shifted` or `false`",
 							"longdesc": "Enabling this option allows attaching the volume to multiple isolated instances.",
+							"scope": "global",
 							"shortdesc": "Enable ID shifting overlay",
 							"type": "bool"
 						}
@@ -5422,6 +5516,7 @@
 							"condition": "custom volume",
 							"defaultdesc": "same as `volume.security.unmappped` or `false`",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "Disable ID mapping for the volume",
 							"type": "bool"
 						}
@@ -5431,6 +5526,7 @@
 							"condition": "appropriate driver",
 							"defaultdesc": "same as `volume.size`",
 							"longdesc": "",
+							"scope": "local",
 							"shortdesc": "Size/quota of the storage volume",
 							"type": "string"
 						}
@@ -5440,6 +5536,7 @@
 							"condition": "custom volume",
 							"defaultdesc": "same as `volume.snapshots.expiry`",
 							"longdesc": "Specify an expression like `1M 2H 3d 4w 5m 6y`.",
+							"scope": "global",
 							"shortdesc": "When snapshots are to be deleted",
 							"type": "string"
 						}
@@ -5449,6 +5546,7 @@
 							"condition": "custom volume",
 							"defaultdesc": "same as `volume.snapshots.pattern` or `snap%d`",
 							"longdesc": "You can specify a naming template that is used for scheduled snapshots and unnamed snapshots.\n\nThe `snapshots.pattern` option takes a Pongo2 template string to format the snapshot name.\n\nTo add a time stamp to the snapshot name, use the Pongo2 context variable `creation_date`.\nMake sure to format the date in your template string to avoid forbidden characters in the snapshot name.\nFor example, set `snapshots.pattern` to `{{ creation_date|date:'2006-01-02_15-04-05' }}` to name the snapshots after their time of creation, down to the precision of a second.\n\nAnother way to avoid name collisions is to use the placeholder `%d` in the pattern.\nFor the first snapshot, the placeholder is replaced with `0`.\nFor subsequent snapshots, the existing snapshot names are taken into account to find the highest number at the placeholder's position.\nThis number is then incremented by one for the new name.",
+							"scope": "global",
 							"shortdesc": "Template for the snapshot name",
 							"type": "string"
 						}
@@ -5458,6 +5556,7 @@
 							"condition": "custom volume",
 							"defaultdesc": "same as `snapshots.schedule`",
 							"longdesc": "Specify either a cron expression (`\u003cminute\u003e \u003chour\u003e \u003cdom\u003e \u003cmonth\u003e \u003cdow\u003e`), a comma-separated list of schedule aliases (`@hourly`, `@daily`, `@midnight`, `@weekly`, `@monthly`, `@annually`, `@yearly`), or leave empty to disable automatic snapshots (the default).",
+							"scope": "global",
 							"shortdesc": "Schedule for automatic volume snapshots",
 							"type": "string"
 						}
@@ -5466,6 +5565,7 @@
 						"volatile.uuid": {
 							"defaultdesc": "random UUID",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "The volume's UUID",
 							"type": "string"
 						}
@@ -5480,6 +5580,7 @@
 						"ceph.cluster_name": {
 							"defaultdesc": "`ceph`",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "Name of the Ceph cluster in which to create new storage pools",
 							"type": "string"
 						}
@@ -5487,6 +5588,7 @@
 					{
 						"ceph.osd.data_pool_name": {
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "Name of the OSD data pool",
 							"type": "string"
 						}
@@ -5495,6 +5597,7 @@
 						"ceph.osd.pg_num": {
 							"defaultdesc": "`32`",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "Number of placement groups for the OSD storage pool",
 							"type": "string"
 						}
@@ -5503,6 +5606,7 @@
 						"ceph.osd.pool_name": {
 							"defaultdesc": "name of the pool",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "Name of the OSD storage pool",
 							"type": "string"
 						}
@@ -5511,6 +5615,7 @@
 						"ceph.rbd.clone_copy": {
 							"defaultdesc": "`true`",
 							"longdesc": "Enable this option to use RBD lightweight clones rather than full dataset copies.",
+							"scope": "global",
 							"shortdesc": "Whether to use RBD lightweight clones",
 							"type": "bool"
 						}
@@ -5519,6 +5624,7 @@
 						"ceph.rbd.du": {
 							"defaultdesc": "`true`",
 							"longdesc": "This option specifies whether to use RBD `du` to obtain disk usage data for stopped instances.",
+							"scope": "global",
 							"shortdesc": "Whether to use RBD `du`",
 							"type": "bool"
 						}
@@ -5527,6 +5633,7 @@
 						"ceph.rbd.features": {
 							"defaultdesc": "`layering`",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "Comma-separated list of RBD features to enable on the volumes",
 							"type": "string"
 						}
@@ -5535,6 +5642,7 @@
 						"ceph.user.name": {
 							"defaultdesc": "`admin`",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "The Ceph user to use when creating storage pools and volumes",
 							"type": "string"
 						}
@@ -5542,6 +5650,7 @@
 					{
 						"source": {
 							"longdesc": "",
+							"scope": "local",
 							"shortdesc": "Existing OSD storage pool to use",
 							"type": "string"
 						}
@@ -5550,6 +5659,7 @@
 						"volatile.pool.pristine": {
 							"defaultdesc": "`true`",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "Whether the pool was empty on creation time",
 							"type": "string"
 						}
@@ -5563,6 +5673,7 @@
 							"condition": "block-based volume with content type `filesystem`",
 							"defaultdesc": "same as `volume.block.filesystem`",
 							"longdesc": "Valid options are: `btrfs`, `ext4`, `xfs`\nIf not set, `ext4` is assumed.",
+							"scope": "global",
 							"shortdesc": "File system of the storage volume",
 							"type": "string"
 						}
@@ -5572,6 +5683,7 @@
 							"condition": "block-based volume with content type `filesystem`",
 							"defaultdesc": "same as `volume.block.mount_options`",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "Mount options for block-backed file system volumes",
 							"type": "string"
 						}
@@ -5581,6 +5693,7 @@
 							"condition": "custom block volume",
 							"defaultdesc": "same as `volume.security.shared` or `false`",
 							"longdesc": "Enabling this option allows sharing the volume across multiple instances despite the possibility of data loss.\n",
+							"scope": "global",
 							"shortdesc": "Enable volume sharing",
 							"type": "bool"
 						}
@@ -5590,6 +5703,7 @@
 							"condition": "custom volume",
 							"defaultdesc": "same as `volume.security.shifted` or `false`",
 							"longdesc": "Enabling this option allows attaching the volume to multiple isolated instances.",
+							"scope": "global",
 							"shortdesc": "Enable ID shifting overlay",
 							"type": "bool"
 						}
@@ -5599,6 +5713,7 @@
 							"condition": "custom volume",
 							"defaultdesc": "same as `volume.security.unmappped` or `false`",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "Disable ID mapping for the volume",
 							"type": "bool"
 						}
@@ -5608,6 +5723,7 @@
 							"condition": "appropriate driver",
 							"defaultdesc": "same as `volume.size`",
 							"longdesc": "",
+							"scope": "local",
 							"shortdesc": "Size/quota of the storage volume",
 							"type": "string"
 						}
@@ -5617,6 +5733,7 @@
 							"condition": "custom volume",
 							"defaultdesc": "same as `volume.snapshots.expiry`",
 							"longdesc": "Specify an expression like `1M 2H 3d 4w 5m 6y`.",
+							"scope": "global",
 							"shortdesc": "When snapshots are to be deleted",
 							"type": "string"
 						}
@@ -5626,6 +5743,7 @@
 							"condition": "custom volume",
 							"defaultdesc": "same as `volume.snapshots.pattern` or `snap%d`",
 							"longdesc": "You can specify a naming template that is used for scheduled snapshots and unnamed snapshots.\n\nThe `snapshots.pattern` option takes a Pongo2 template string to format the snapshot name.\n\nTo add a time stamp to the snapshot name, use the Pongo2 context variable `creation_date`.\nMake sure to format the date in your template string to avoid forbidden characters in the snapshot name.\nFor example, set `snapshots.pattern` to `{{ creation_date|date:'2006-01-02_15-04-05' }}` to name the snapshots after their time of creation, down to the precision of a second.\n\nAnother way to avoid name collisions is to use the placeholder `%d` in the pattern.\nFor the first snapshot, the placeholder is replaced with `0`.\nFor subsequent snapshots, the existing snapshot names are taken into account to find the highest number at the placeholder's position.\nThis number is then incremented by one for the new name.",
+							"scope": "global",
 							"shortdesc": "Template for the snapshot name",
 							"type": "string"
 						}
@@ -5635,6 +5753,7 @@
 							"condition": "custom volume",
 							"defaultdesc": "same as `snapshots.schedule`",
 							"longdesc": "Specify either a cron expression (`\u003cminute\u003e \u003chour\u003e \u003cdom\u003e \u003cmonth\u003e \u003cdow\u003e`), a comma-separated list of schedule aliases (`@hourly`, `@daily`, `@midnight`, `@weekly`, `@monthly`, `@annually`, `@yearly`), or leave empty to disable automatic snapshots (the default).",
+							"scope": "global",
 							"shortdesc": "Schedule for automatic volume snapshots",
 							"type": "string"
 						}
@@ -5643,6 +5762,7 @@
 						"volatile.uuid": {
 							"defaultdesc": "random UUID",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "The volume's UUID",
 							"type": "string"
 						}
@@ -5657,6 +5777,7 @@
 						"cephfs.cluster_name": {
 							"defaultdesc": "`ceph`",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "Name of the Ceph cluster that contains the CephFS file system",
 							"type": "string"
 						}
@@ -5665,6 +5786,7 @@
 						"cephfs.create_missing": {
 							"defaultdesc": "`false`",
 							"longdesc": "Use this option if the CephFS file system does not exist yet.\nLXD will then automatically create the file system and the missing data and metadata OSD pools.",
+							"scope": "global",
 							"shortdesc": "Automatically create the CephFS file system",
 							"type": "bool"
 						}
@@ -5672,6 +5794,7 @@
 					{
 						"cephfs.data_pool": {
 							"longdesc": "This option specifies the name for the data OSD pool that should be used when creating\na file system automatically.",
+							"scope": "global",
 							"shortdesc": "Data OSD pool name",
 							"type": "string"
 						}
@@ -5680,6 +5803,7 @@
 						"cephfs.fscache": {
 							"defaultdesc": "`false`",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "Enable use of kernel `fscache` and `cachefilesd`",
 							"type": "bool"
 						}
@@ -5687,6 +5811,7 @@
 					{
 						"cephfs.meta_pool": {
 							"longdesc": "This option specifies the name for the file metadata OSD pool that should be used when\ncreating a file system automatically.",
+							"scope": "global",
 							"shortdesc": "Metadata OSD pool name",
 							"type": "string"
 						}
@@ -5694,6 +5819,7 @@
 					{
 						"cephfs.osd_pg_num": {
 							"longdesc": "This option specifies the number of OSD pool placement groups (`pg_num`) to use\nwhen creating a missing OSD pool.",
+							"scope": "global",
 							"shortdesc": "Number of placement groups when creating missing OSD pools",
 							"type": "string"
 						}
@@ -5702,6 +5828,7 @@
 						"cephfs.path": {
 							"defaultdesc": "`/`",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "The base path for the CephFS mount",
 							"type": "string"
 						}
@@ -5710,6 +5837,7 @@
 						"cephfs.user.name": {
 							"defaultdesc": "`admin`",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "The Ceph user to use",
 							"type": "string"
 						}
@@ -5717,6 +5845,7 @@
 					{
 						"source": {
 							"longdesc": "",
+							"scope": "local",
 							"shortdesc": "Existing CephFS file system or file system path to use",
 							"type": "string"
 						}
@@ -5725,6 +5854,7 @@
 						"volatile.pool.pristine": {
 							"defaultdesc": "`true`",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "Whether the CephFS file system was empty on creation time",
 							"type": "string"
 						}
@@ -5738,6 +5868,7 @@
 							"condition": "custom volume",
 							"defaultdesc": "same as `volume.security.shifted` or `false`",
 							"longdesc": "Enabling this option allows attaching the volume to multiple isolated instances.",
+							"scope": "global",
 							"shortdesc": "Enable ID shifting overlay",
 							"type": "bool"
 						}
@@ -5747,6 +5878,7 @@
 							"condition": "custom volume",
 							"defaultdesc": "same as `volume.security.unmappped` or `false`",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "Disable ID mapping for the volume",
 							"type": "bool"
 						}
@@ -5756,6 +5888,7 @@
 							"condition": "appropriate driver",
 							"defaultdesc": "same as `volume.size`",
 							"longdesc": "",
+							"scope": "local",
 							"shortdesc": "Size/quota of the storage volume",
 							"type": "string"
 						}
@@ -5765,6 +5898,7 @@
 							"condition": "custom volume",
 							"defaultdesc": "same as `volume.snapshots.expiry`",
 							"longdesc": "Specify an expression like `1M 2H 3d 4w 5m 6y`.",
+							"scope": "global",
 							"shortdesc": "When snapshots are to be deleted",
 							"type": "string"
 						}
@@ -5774,6 +5908,7 @@
 							"condition": "custom volume",
 							"defaultdesc": "same as `volume.snapshots.pattern` or `snap%d`",
 							"longdesc": "You can specify a naming template that is used for scheduled snapshots and unnamed snapshots.\n\nThe `snapshots.pattern` option takes a Pongo2 template string to format the snapshot name.\n\nTo add a time stamp to the snapshot name, use the Pongo2 context variable `creation_date`.\nMake sure to format the date in your template string to avoid forbidden characters in the snapshot name.\nFor example, set `snapshots.pattern` to `{{ creation_date|date:'2006-01-02_15-04-05' }}` to name the snapshots after their time of creation, down to the precision of a second.\n\nAnother way to avoid name collisions is to use the placeholder `%d` in the pattern.\nFor the first snapshot, the placeholder is replaced with `0`.\nFor subsequent snapshots, the existing snapshot names are taken into account to find the highest number at the placeholder's position.\nThis number is then incremented by one for the new name.",
+							"scope": "global",
 							"shortdesc": "Template for the snapshot name",
 							"type": "string"
 						}
@@ -5783,6 +5918,7 @@
 							"condition": "custom volume",
 							"defaultdesc": "same as `snapshots.schedule`",
 							"longdesc": "Specify either a cron expression (`\u003cminute\u003e \u003chour\u003e \u003cdom\u003e \u003cmonth\u003e \u003cdow\u003e`), a comma-separated list of schedule aliases (`@hourly`, `@daily`, `@midnight`, `@weekly`, `@monthly`, `@annually`, `@yearly`), or leave empty to disable automatic snapshots (the default).",
+							"scope": "global",
 							"shortdesc": "Schedule for automatic volume snapshots",
 							"type": "string"
 						}
@@ -5791,6 +5927,7 @@
 						"volatile.uuid": {
 							"defaultdesc": "random UUID",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "The volume's UUID",
 							"type": "string"
 						}
@@ -5804,6 +5941,7 @@
 					{
 						"size": {
 							"longdesc": "",
+							"scope": "local",
 							"shortdesc": "Quota of the storage bucket",
 							"type": "string"
 						}
@@ -5815,6 +5953,7 @@
 					{
 						"cephobject.bucket.name_prefix": {
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "Prefix to add to bucket names in Ceph",
 							"type": "string"
 						}
@@ -5822,6 +5961,7 @@
 					{
 						"cephobject.cluster_name": {
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "The Ceph cluster to use",
 							"type": "string"
 						}
@@ -5829,6 +5969,7 @@
 					{
 						"cephobject.radosgw.endpoint": {
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "URL of the `radosgw` gateway process",
 							"type": "string"
 						}
@@ -5836,6 +5977,7 @@
 					{
 						"cephobject.radosgw.endpoint_cert_file": {
 							"longdesc": "Specify the path to the file that contains the TLS client certificate.",
+							"scope": "global",
 							"shortdesc": "TLS client certificate to use for endpoint communication",
 							"type": "string"
 						}
@@ -5844,6 +5986,7 @@
 						"cephobject.user.name": {
 							"defaultdesc": "`admin`",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "The Ceph user to use",
 							"type": "string"
 						}
@@ -5852,6 +5995,7 @@
 						"volatile.pool.pristine": {
 							"defaultdesc": "`true`",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "Whether the `radosgw` `lxd-admin` user existed at creation time",
 							"type": "string"
 						}
@@ -5866,6 +6010,7 @@
 						"rsync.bwlimit": {
 							"defaultdesc": "`0` (no limit)",
 							"longdesc": "When `rsync` must be used to transfer storage entities, this option specifies the upper limit\nto be placed on the socket I/O.",
+							"scope": "global",
 							"shortdesc": "Upper limit on the socket I/O for `rsync`",
 							"type": "string"
 						}
@@ -5874,6 +6019,7 @@
 						"rsync.compression": {
 							"defaultdesc": "`true`",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "Whether to use compression while migrating storage pools",
 							"type": "bool"
 						}
@@ -5881,6 +6027,7 @@
 					{
 						"source": {
 							"longdesc": "",
+							"scope": "local",
 							"shortdesc": "Path to an existing directory",
 							"type": "string"
 						}
@@ -5894,6 +6041,7 @@
 							"condition": "custom block volume",
 							"defaultdesc": "same as `volume.security.shared` or `false`",
 							"longdesc": "Enabling this option allows sharing the volume across multiple instances despite the possibility of data loss.\n",
+							"scope": "global",
 							"shortdesc": "Enable volume sharing",
 							"type": "bool"
 						}
@@ -5903,6 +6051,7 @@
 							"condition": "custom volume",
 							"defaultdesc": "same as `volume.security.shifted` or `false`",
 							"longdesc": "Enabling this option allows attaching the volume to multiple isolated instances.",
+							"scope": "global",
 							"shortdesc": "Enable ID shifting overlay",
 							"type": "bool"
 						}
@@ -5912,6 +6061,7 @@
 							"condition": "custom volume",
 							"defaultdesc": "same as `volume.security.unmappped` or `false`",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "Disable ID mapping for the volume",
 							"type": "bool"
 						}
@@ -5921,6 +6071,7 @@
 							"condition": "appropriate driver",
 							"defaultdesc": "same as `volume.size`",
 							"longdesc": "",
+							"scope": "local",
 							"shortdesc": "Size/quota of the storage volume",
 							"type": "string"
 						}
@@ -5930,6 +6081,7 @@
 							"condition": "custom volume",
 							"defaultdesc": "same as `volume.snapshots.expiry`",
 							"longdesc": "Specify an expression like `1M 2H 3d 4w 5m 6y`.",
+							"scope": "global",
 							"shortdesc": "When snapshots are to be deleted",
 							"type": "string"
 						}
@@ -5939,6 +6091,7 @@
 							"condition": "custom volume",
 							"defaultdesc": "same as `volume.snapshots.pattern` or `snap%d`",
 							"longdesc": "You can specify a naming template that is used for scheduled snapshots and unnamed snapshots.\n\nThe `snapshots.pattern` option takes a Pongo2 template string to format the snapshot name.\n\nTo add a time stamp to the snapshot name, use the Pongo2 context variable `creation_date`.\nMake sure to format the date in your template string to avoid forbidden characters in the snapshot name.\nFor example, set `snapshots.pattern` to `{{ creation_date|date:'2006-01-02_15-04-05' }}` to name the snapshots after their time of creation, down to the precision of a second.\n\nAnother way to avoid name collisions is to use the placeholder `%d` in the pattern.\nFor the first snapshot, the placeholder is replaced with `0`.\nFor subsequent snapshots, the existing snapshot names are taken into account to find the highest number at the placeholder's position.\nThis number is then incremented by one for the new name.",
+							"scope": "global",
 							"shortdesc": "Template for the snapshot name",
 							"type": "string"
 						}
@@ -5948,6 +6101,7 @@
 							"condition": "custom volume",
 							"defaultdesc": "same as `snapshots.schedule`",
 							"longdesc": "Specify either a cron expression (`\u003cminute\u003e \u003chour\u003e \u003cdom\u003e \u003cmonth\u003e \u003cdow\u003e`), a comma-separated list of schedule aliases (`@hourly`, `@daily`, `@midnight`, `@weekly`, `@monthly`, `@annually`, `@yearly`), or leave empty to disable automatic snapshots (the default).",
+							"scope": "global",
 							"shortdesc": "Schedule for automatic volume snapshots",
 							"type": "string"
 						}
@@ -5956,6 +6110,7 @@
 						"volatile.uuid": {
 							"defaultdesc": "random UUID",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "The volume's UUID",
 							"type": "string"
 						}
@@ -5971,6 +6126,7 @@
 							"condition": "appropriate driver",
 							"defaultdesc": "same as `volume.size`",
 							"longdesc": "",
+							"scope": "local",
 							"shortdesc": "Size/quota of the storage bucket",
 							"type": "string"
 						}
@@ -5983,6 +6139,7 @@
 						"lvm.thinpool_metadata_size": {
 							"defaultdesc": "`0` (auto)",
 							"longdesc": "By default, LVM calculates an appropriate size.",
+							"scope": "global",
 							"shortdesc": "The size of the thin pool metadata volume",
 							"type": "string"
 						}
@@ -5991,6 +6148,7 @@
 						"lvm.thinpool_name": {
 							"defaultdesc": "`LXDThinPool`",
 							"longdesc": "",
+							"scope": "local",
 							"shortdesc": "Thin pool where volumes are created",
 							"type": "string"
 						}
@@ -5999,6 +6157,7 @@
 						"lvm.use_thinpool": {
 							"defaultdesc": "`true`",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "Whether the storage pool uses a thin pool for logical volumes",
 							"type": "bool"
 						}
@@ -6007,6 +6166,7 @@
 						"lvm.vg.force_reuse": {
 							"defaultdesc": "`false`",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "Force using an existing non-empty volume group",
 							"type": "bool"
 						}
@@ -6015,6 +6175,7 @@
 						"lvm.vg_name": {
 							"defaultdesc": "name of the pool",
 							"longdesc": "",
+							"scope": "local",
 							"shortdesc": "Name of the volume group to create",
 							"type": "string"
 						}
@@ -6023,6 +6184,7 @@
 						"rsync.bwlimit": {
 							"defaultdesc": "`0` (no limit)",
 							"longdesc": "When `rsync` must be used to transfer storage entities, this option specifies the upper limit\nto be placed on the socket I/O.",
+							"scope": "global",
 							"shortdesc": "Upper limit on the socket I/O for `rsync`",
 							"type": "string"
 						}
@@ -6031,6 +6193,7 @@
 						"rsync.compression": {
 							"defaultdesc": "`true`",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "Whether to use compression while migrating storage pools",
 							"type": "bool"
 						}
@@ -6039,6 +6202,7 @@
 						"size": {
 							"defaultdesc": "auto (20% of free disk space, \u003e= 5 GiB and \u003c= 30 GiB)",
 							"longdesc": "When creating loop-based pools, specify the size in bytes ({ref}`suffixes \u003cinstances-limit-units\u003e` are supported).\nYou can increase the size to grow the storage pool.\n\nThe default (`auto`) creates a storage pool that uses 20% of the free disk space,\nwith a minimum of 5 GiB and a maximum of 30 GiB.",
+							"scope": "local",
 							"shortdesc": "Size of the storage pool (for loop-based pools)",
 							"type": "string"
 						}
@@ -6046,6 +6210,7 @@
 					{
 						"source": {
 							"longdesc": "",
+							"scope": "local",
 							"shortdesc": "Path to an existing block device, loop file, or LVM volume group",
 							"type": "string"
 						}
@@ -6054,6 +6219,7 @@
 						"source.wipe": {
 							"defaultdesc": "`false`",
 							"longdesc": "Set this option to `true` to wipe the block device specified in `source`\nprior to creating the storage pool.",
+							"scope": "local",
 							"shortdesc": "Whether to wipe the block device before creating the pool",
 							"type": "bool"
 						}
@@ -6067,6 +6233,7 @@
 							"condition": "block-based volume with content type `filesystem`",
 							"defaultdesc": "same as `volume.block.filesystem`",
 							"longdesc": "Valid options are: `btrfs`, `ext4`, `xfs`\nIf not set, `ext4` is assumed.",
+							"scope": "global",
 							"shortdesc": "File system of the storage volume",
 							"type": "string"
 						}
@@ -6076,6 +6243,7 @@
 							"condition": "block-based volume with content type `filesystem`",
 							"defaultdesc": "same as `volume.block.mount_options`",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "Mount options for block-backed file system volumes",
 							"type": "string"
 						}
@@ -6084,6 +6252,7 @@
 						"lvm.stripes": {
 							"defaultdesc": "same as `volume.lvm.stripes`",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "Number of stripes to use for new volumes (or thin pool volume)",
 							"type": "string"
 						}
@@ -6092,6 +6261,7 @@
 						"lvm.stripes.size": {
 							"defaultdesc": "same as `volume.lvm.stripes.size`",
 							"longdesc": "The size must be at least 4096 bytes, and a multiple of 512 bytes.",
+							"scope": "global",
 							"shortdesc": "Size of stripes to use",
 							"type": "string"
 						}
@@ -6101,6 +6271,7 @@
 							"condition": "custom block volume",
 							"defaultdesc": "same as `volume.security.shared` or `false`",
 							"longdesc": "Enabling this option allows sharing the volume across multiple instances despite the possibility of data loss.\n",
+							"scope": "global",
 							"shortdesc": "Enable volume sharing",
 							"type": "bool"
 						}
@@ -6110,6 +6281,7 @@
 							"condition": "custom volume",
 							"defaultdesc": "same as `volume.security.shifted` or `false`",
 							"longdesc": "Enabling this option allows attaching the volume to multiple isolated instances.",
+							"scope": "global",
 							"shortdesc": "Enable ID shifting overlay",
 							"type": "bool"
 						}
@@ -6119,6 +6291,7 @@
 							"condition": "custom volume",
 							"defaultdesc": "same as `volume.security.unmappped` or `false`",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "Disable ID mapping for the volume",
 							"type": "bool"
 						}
@@ -6128,6 +6301,7 @@
 							"condition": "appropriate driver",
 							"defaultdesc": "same as `volume.size`",
 							"longdesc": "",
+							"scope": "local",
 							"shortdesc": "Size/quota of the storage volume",
 							"type": "string"
 						}
@@ -6137,6 +6311,7 @@
 							"condition": "custom volume",
 							"defaultdesc": "same as `volume.snapshots.expiry`",
 							"longdesc": "Specify an expression like `1M 2H 3d 4w 5m 6y`.",
+							"scope": "global",
 							"shortdesc": "When snapshots are to be deleted",
 							"type": "string"
 						}
@@ -6146,6 +6321,7 @@
 							"condition": "custom volume",
 							"defaultdesc": "same as `volume.snapshots.pattern` or `snap%d`",
 							"longdesc": "You can specify a naming template that is used for scheduled snapshots and unnamed snapshots.\n\nThe `snapshots.pattern` option takes a Pongo2 template string to format the snapshot name.\n\nTo add a time stamp to the snapshot name, use the Pongo2 context variable `creation_date`.\nMake sure to format the date in your template string to avoid forbidden characters in the snapshot name.\nFor example, set `snapshots.pattern` to `{{ creation_date|date:'2006-01-02_15-04-05' }}` to name the snapshots after their time of creation, down to the precision of a second.\n\nAnother way to avoid name collisions is to use the placeholder `%d` in the pattern.\nFor the first snapshot, the placeholder is replaced with `0`.\nFor subsequent snapshots, the existing snapshot names are taken into account to find the highest number at the placeholder's position.\nThis number is then incremented by one for the new name.",
+							"scope": "global",
 							"shortdesc": "Template for the snapshot name",
 							"type": "string"
 						}
@@ -6155,6 +6331,7 @@
 							"condition": "custom volume",
 							"defaultdesc": "same as `snapshots.schedule`",
 							"longdesc": "Specify either a cron expression (`\u003cminute\u003e \u003chour\u003e \u003cdom\u003e \u003cmonth\u003e \u003cdow\u003e`), a comma-separated list of schedule aliases (`@hourly`, `@daily`, `@midnight`, `@weekly`, `@monthly`, `@annually`, `@yearly`), or leave empty to disable automatic snapshots (the default).",
+							"scope": "global",
 							"shortdesc": "Schedule for automatic volume snapshots",
 							"type": "string"
 						}
@@ -6163,6 +6340,7 @@
 						"volatile.uuid": {
 							"defaultdesc": "random UUID",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "The volume's UUID",
 							"type": "string"
 						}
@@ -6177,6 +6355,7 @@
 						"powerflex.clone_copy": {
 							"defaultdesc": "`true`",
 							"longdesc": "If this option is set to `true`, PowerFlex makes a non-sparse copy when creating a snapshot of an instance or custom volume.\nSee {ref}`storage-powerflex-limitations` for more information.",
+							"scope": "global",
 							"shortdesc": "Whether to use non-sparse copies for snapshots",
 							"type": "bool"
 						}
@@ -6184,6 +6363,7 @@
 					{
 						"powerflex.domain": {
 							"longdesc": "This option is required only if {config:option}`storage-powerflex-pool-conf:powerflex.pool` is specified using its name.",
+							"scope": "global",
 							"shortdesc": "Name of the PowerFlex protection domain",
 							"type": "string"
 						}
@@ -6191,6 +6371,7 @@
 					{
 						"powerflex.gateway": {
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "Address of the PowerFlex Gateway",
 							"type": "string"
 						}
@@ -6199,6 +6380,7 @@
 						"powerflex.gateway.verify": {
 							"defaultdesc": "`true`",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "Whether to verify the PowerFlex Gateway's certificate",
 							"type": "bool"
 						}
@@ -6207,6 +6389,7 @@
 						"powerflex.mode": {
 							"defaultdesc": "the discovered mode",
 							"longdesc": "The mode gets discovered automatically if the system provides the necessary kernel modules.\nThis can be either `nvme` or `sdc`.",
+							"scope": "global",
 							"shortdesc": "How volumes are mapped to the local server",
 							"type": "string"
 						}
@@ -6214,6 +6397,7 @@
 					{
 						"powerflex.pool": {
 							"longdesc": "If you want to specify the storage pool via its name, also set {config:option}`storage-powerflex-pool-conf:powerflex.domain`.",
+							"scope": "global",
 							"shortdesc": "ID of the PowerFlex storage pool",
 							"type": "string"
 						}
@@ -6222,6 +6406,7 @@
 						"powerflex.sdt": {
 							"defaultdesc": "one of the SDT",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "PowerFlex NVMe/TCP SDT",
 							"type": "string"
 						}
@@ -6230,6 +6415,7 @@
 						"powerflex.user.name": {
 							"defaultdesc": "`admin`",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "User for PowerFlex Gateway authentication",
 							"type": "string"
 						}
@@ -6237,6 +6423,7 @@
 					{
 						"powerflex.user.password": {
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "Password for PowerFlex Gateway authentication",
 							"type": "string"
 						}
@@ -6245,6 +6432,7 @@
 						"rsync.bwlimit": {
 							"defaultdesc": "`0` (no limit)",
 							"longdesc": "When `rsync` must be used to transfer storage entities, this option specifies the upper limit\nto be placed on the socket I/O.",
+							"scope": "global",
 							"shortdesc": "Upper limit on the socket I/O for `rsync`",
 							"type": "string"
 						}
@@ -6253,6 +6441,7 @@
 						"rsync.compression": {
 							"defaultdesc": "`true`",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "Whether to use compression while migrating storage pools",
 							"type": "bool"
 						}
@@ -6261,6 +6450,7 @@
 						"volume.size": {
 							"defaultdesc": "`8GiB`",
 							"longdesc": "The size must be in multiples of 8 GiB.\nSee {ref}`storage-powerflex-limitations` for more information.",
+							"scope": "global",
 							"shortdesc": "Size/quota of the storage volume",
 							"type": "string"
 						}
@@ -6274,6 +6464,7 @@
 							"condition": "block-based volume with content type `filesystem`",
 							"defaultdesc": "same as `volume.block.filesystem`",
 							"longdesc": "Valid options are: `btrfs`, `ext4`, `xfs`\nIf not set, `ext4` is assumed.",
+							"scope": "global",
 							"shortdesc": "File system of the storage volume",
 							"type": "string"
 						}
@@ -6283,6 +6474,7 @@
 							"condition": "block-based volume with content type `filesystem`",
 							"defaultdesc": "same as `volume.block.mount_options`",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "Mount options for block-backed file system volumes",
 							"type": "string"
 						}
@@ -6291,6 +6483,7 @@
 						"block.type": {
 							"defaultdesc": "same as `volume.block.type` or `thick`",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "Whether to create a `thin` or `thick` provisioned volume",
 							"type": "string"
 						}
@@ -6300,6 +6493,7 @@
 							"condition": "custom block volume",
 							"defaultdesc": "same as `volume.security.shared` or `false`",
 							"longdesc": "Enabling this option allows sharing the volume across multiple instances despite the possibility of data loss.\n",
+							"scope": "global",
 							"shortdesc": "Enable volume sharing",
 							"type": "bool"
 						}
@@ -6309,6 +6503,7 @@
 							"condition": "custom volume",
 							"defaultdesc": "same as `volume.security.shifted` or `false`",
 							"longdesc": "Enabling this option allows attaching the volume to multiple isolated instances.",
+							"scope": "global",
 							"shortdesc": "Enable ID shifting overlay",
 							"type": "bool"
 						}
@@ -6318,6 +6513,7 @@
 							"condition": "custom volume",
 							"defaultdesc": "same as `volume.security.unmappped` or `false`",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "Disable ID mapping for the volume",
 							"type": "bool"
 						}
@@ -6326,6 +6522,7 @@
 						"size": {
 							"defaultdesc": "same as `volume.size`",
 							"longdesc": "The size must be in multiples of 8 GiB.\nSee {ref}`storage-powerflex-limitations` for more information.",
+							"scope": "global",
 							"shortdesc": "Size/quota of the storage volume",
 							"type": "string"
 						}
@@ -6335,6 +6532,7 @@
 							"condition": "custom volume",
 							"defaultdesc": "same as `volume.snapshots.expiry`",
 							"longdesc": "Specify an expression like `1M 2H 3d 4w 5m 6y`.",
+							"scope": "global",
 							"shortdesc": "When snapshots are to be deleted",
 							"type": "string"
 						}
@@ -6344,6 +6542,7 @@
 							"condition": "custom volume",
 							"defaultdesc": "same as `volume.snapshots.pattern` or `snap%d`",
 							"longdesc": "You can specify a naming template that is used for scheduled snapshots and unnamed snapshots.\n\nThe `snapshots.pattern` option takes a Pongo2 template string to format the snapshot name.\n\nTo add a time stamp to the snapshot name, use the Pongo2 context variable `creation_date`.\nMake sure to format the date in your template string to avoid forbidden characters in the snapshot name.\nFor example, set `snapshots.pattern` to `{{ creation_date|date:'2006-01-02_15-04-05' }}` to name the snapshots after their time of creation, down to the precision of a second.\n\nAnother way to avoid name collisions is to use the placeholder `%d` in the pattern.\nFor the first snapshot, the placeholder is replaced with `0`.\nFor subsequent snapshots, the existing snapshot names are taken into account to find the highest number at the placeholder's position.\nThis number is then incremented by one for the new name.",
+							"scope": "global",
 							"shortdesc": "Template for the snapshot name",
 							"type": "string"
 						}
@@ -6353,6 +6552,7 @@
 							"condition": "custom volume",
 							"defaultdesc": "same as `snapshots.schedule`",
 							"longdesc": "Specify either a cron expression (`\u003cminute\u003e \u003chour\u003e \u003cdom\u003e \u003cmonth\u003e \u003cdow\u003e`), a comma-separated list of schedule aliases (`@hourly`, `@daily`, `@midnight`, `@weekly`, `@monthly`, `@annually`, `@yearly`), or leave empty to disable automatic snapshots (the default).",
+							"scope": "global",
 							"shortdesc": "Schedule for automatic volume snapshots",
 							"type": "string"
 						}
@@ -6361,6 +6561,7 @@
 						"volatile.uuid": {
 							"defaultdesc": "random UUID",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "The volume's UUID",
 							"type": "string"
 						}
@@ -6376,6 +6577,7 @@
 							"condition": "appropriate driver",
 							"defaultdesc": "same as `volume.size`",
 							"longdesc": "",
+							"scope": "local",
 							"shortdesc": "Size/quota of the storage bucket",
 							"type": "string"
 						}
@@ -6388,6 +6590,7 @@
 						"size": {
 							"defaultdesc": "auto (20% of free disk space, \u003e= 5 GiB and \u003c= 30 GiB)",
 							"longdesc": "When creating loop-based pools, specify the size in bytes ({ref}`suffixes \u003cinstances-limit-units\u003e` are supported).\nYou can increase the size to grow the storage pool.\n\nThe default (`auto`) creates a storage pool that uses 20% of the free disk space,\nwith a minimum of 5 GiB and a maximum of 30 GiB.",
+							"scope": "local",
 							"shortdesc": "Size of the storage pool (for loop-based pools)",
 							"type": "string"
 						}
@@ -6395,6 +6598,7 @@
 					{
 						"source": {
 							"longdesc": "",
+							"scope": "local",
 							"shortdesc": "Path to an existing block device, loop file, or ZFS dataset/pool",
 							"type": "string"
 						}
@@ -6403,6 +6607,7 @@
 						"source.wipe": {
 							"defaultdesc": "`false`",
 							"longdesc": "Set this option to `true` to wipe the block device specified in `source`\nprior to creating the storage pool.",
+							"scope": "local",
 							"shortdesc": "Whether to wipe the block device before creating the pool",
 							"type": "bool"
 						}
@@ -6411,6 +6616,7 @@
 						"zfs.clone_copy": {
 							"defaultdesc": "`true`",
 							"longdesc": "Set this option to `true` or `false` to enable or disable using ZFS lightweight clones rather\nthan full dataset copies.\nSet the option to `rebase` to copy based on the initial image.",
+							"scope": "global",
 							"shortdesc": "Whether to use ZFS lightweight clones",
 							"type": "string"
 						}
@@ -6419,6 +6625,7 @@
 						"zfs.export": {
 							"defaultdesc": "`true`",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "Disable zpool export while an unmount is being performed",
 							"type": "bool"
 						}
@@ -6427,6 +6634,7 @@
 						"zfs.pool_name": {
 							"defaultdesc": "name of the pool",
 							"longdesc": "",
+							"scope": "local",
 							"shortdesc": "Name of the zpool",
 							"type": "string"
 						}
@@ -6440,6 +6648,7 @@
 							"condition": "block-based volume with content type `filesystem` (`zfs.block_mode` enabled)",
 							"defaultdesc": "same as `volume.block.filesystem`",
 							"longdesc": "Valid options are: `btrfs`, `ext4`, `xfs`\nIf not set, `ext4` is assumed.",
+							"scope": "global",
 							"shortdesc": "File system of the storage volume",
 							"type": "string"
 						}
@@ -6449,6 +6658,7 @@
 							"condition": "block-based volume with content type `filesystem` (`zfs.block_mode` enabled)",
 							"defaultdesc": "same as `volume.block.mount_options`",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "Mount options for block-backed file system volumes",
 							"type": "string"
 						}
@@ -6458,6 +6668,7 @@
 							"condition": "custom block volume",
 							"defaultdesc": "same as `volume.security.shared` or `false`",
 							"longdesc": "Enabling this option allows sharing the volume across multiple instances despite the possibility of data loss.\n",
+							"scope": "global",
 							"shortdesc": "Enable volume sharing",
 							"type": "bool"
 						}
@@ -6467,6 +6678,7 @@
 							"condition": "custom volume",
 							"defaultdesc": "same as `volume.security.shifted` or `false`",
 							"longdesc": "Enabling this option allows attaching the volume to multiple isolated instances.",
+							"scope": "global",
 							"shortdesc": "Enable ID shifting overlay",
 							"type": "bool"
 						}
@@ -6476,6 +6688,7 @@
 							"condition": "custom volume",
 							"defaultdesc": "same as `volume.security.unmappped` or `false`",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "Disable ID mapping for the volume",
 							"type": "bool"
 						}
@@ -6485,6 +6698,7 @@
 							"condition": "appropriate driver",
 							"defaultdesc": "same as `volume.size`",
 							"longdesc": "",
+							"scope": "local",
 							"shortdesc": "Size/quota of the storage volume",
 							"type": "string"
 						}
@@ -6494,6 +6708,7 @@
 							"condition": "custom volume",
 							"defaultdesc": "same as `volume.snapshots.expiry`",
 							"longdesc": "Specify an expression like `1M 2H 3d 4w 5m 6y`.",
+							"scope": "global",
 							"shortdesc": "When snapshots are to be deleted",
 							"type": "string"
 						}
@@ -6503,6 +6718,7 @@
 							"condition": "custom volume",
 							"defaultdesc": "same as `volume.snapshots.pattern` or `snap%d`",
 							"longdesc": "You can specify a naming template that is used for scheduled snapshots and unnamed snapshots.\n\nThe `snapshots.pattern` option takes a Pongo2 template string to format the snapshot name.\n\nTo add a time stamp to the snapshot name, use the Pongo2 context variable `creation_date`.\nMake sure to format the date in your template string to avoid forbidden characters in the snapshot name.\nFor example, set `snapshots.pattern` to `{{ creation_date|date:'2006-01-02_15-04-05' }}` to name the snapshots after their time of creation, down to the precision of a second.\n\nAnother way to avoid name collisions is to use the placeholder `%d` in the pattern.\nFor the first snapshot, the placeholder is replaced with `0`.\nFor subsequent snapshots, the existing snapshot names are taken into account to find the highest number at the placeholder's position.\nThis number is then incremented by one for the new name.",
+							"scope": "global",
 							"shortdesc": "Template for the snapshot name",
 							"type": "string"
 						}
@@ -6512,6 +6728,7 @@
 							"condition": "custom volume",
 							"defaultdesc": "same as `snapshots.schedule`",
 							"longdesc": "Specify either a cron expression (`\u003cminute\u003e \u003chour\u003e \u003cdom\u003e \u003cmonth\u003e \u003cdow\u003e`), a comma-separated list of schedule aliases (`@hourly`, `@daily`, `@midnight`, `@weekly`, `@monthly`, `@annually`, `@yearly`), or leave empty to disable automatic snapshots (the default).",
+							"scope": "global",
 							"shortdesc": "Schedule for automatic volume snapshots",
 							"type": "string"
 						}
@@ -6520,6 +6737,7 @@
 						"volatile.uuid": {
 							"defaultdesc": "random UUID",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "The volume's UUID",
 							"type": "string"
 						}
@@ -6528,6 +6746,7 @@
 						"zfs.block_mode": {
 							"defaultdesc": "same as `volume.zfs.block_mode`",
 							"longdesc": "`zfs.block_mode` can be set only for custom storage volumes.\nTo enable ZFS block mode for all storage volumes in the pool, including instance volumes,\nuse `volume.zfs.block_mode`.",
+							"scope": "global",
 							"shortdesc": "Whether to use a formatted `zvol` rather than a dataset",
 							"type": "bool"
 						}
@@ -6536,6 +6755,7 @@
 						"zfs.blocksize": {
 							"defaultdesc": "same as `volume.zfs.blocksize`",
 							"longdesc": "The size must be between 512 bytes and 16 MiB and must be a power of 2.\nFor a block volume, a maximum value of 128 KiB will be used even if a higher value is set.\n\nDepending on the value of {config:option}`storage-zfs-volume-conf:zfs.block_mode`,\nthe specified size is used to set either `volblocksize` or `recordsize` in ZFS.",
+							"scope": "global",
 							"shortdesc": "Size of the ZFS block",
 							"type": "string"
 						}
@@ -6545,6 +6765,7 @@
 							"condition": "ZFS 2.2 or higher",
 							"defaultdesc": "same as `volume.zfs.delegate`",
 							"longdesc": "This option controls whether to delegate the ZFS dataset and anything underneath it to the\ncontainer or containers that use it. This allows using the `zfs` command in the container.",
+							"scope": "global",
 							"shortdesc": "Whether to delegate the ZFS dataset",
 							"type": "bool"
 						}
@@ -6553,6 +6774,7 @@
 						"zfs.remove_snapshots": {
 							"defaultdesc": "same as `volume.zfs.remove_snapshots` or `false`",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "Remove snapshots as needed",
 							"type": "bool"
 						}
@@ -6561,6 +6783,7 @@
 						"zfs.reserve_space": {
 							"defaultdesc": "same as `volume.zfs.reserve_space` or `false`",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "Use `reservation`/`refreservation` along with `quota`/`refquota`",
 							"type": "bool"
 						}
@@ -6569,6 +6792,7 @@
 						"zfs.use_refquota": {
 							"defaultdesc": "same as `volume.zfs.use_refquota` or `false`",
 							"longdesc": "",
+							"scope": "global",
 							"shortdesc": "Use `refquota` instead of `quota` for space",
 							"type": "bool"
 						}

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -203,6 +203,7 @@ func (n *bridge) Validate(config map[string]string) error {
 		//  type: string
 		//  condition: BGP server
 		//  shortdesc: Peer address (IPv4 or IPv6)
+		//  scope: global
 
 		// lxdmeta:generate(entities=network-bridge; group=network-conf; key=bgp.peers.NAME.asn)
 		//
@@ -210,6 +211,7 @@ func (n *bridge) Validate(config map[string]string) error {
 		//  type: integer
 		//  condition: BGP server
 		//  shortdesc: Peer AS number
+		//  scope: global
 
 		// lxdmeta:generate(entities=network-bridge; group=network-conf; key=bgp.peers.NAME.password)
 		//
@@ -219,6 +221,7 @@ func (n *bridge) Validate(config map[string]string) error {
 		//  defaultdesc: (no password)
 		//  required: no
 		//  shortdesc: Peer session password
+		//  scope: global
 
 		// lxdmeta:generate(entities=network-bridge; group=network-conf; key=bgp.peers.NAME.holdtime)
 		// Specify the hold time in seconds.
@@ -228,6 +231,7 @@ func (n *bridge) Validate(config map[string]string) error {
 		//  defaultdesc: `180`
 		//  required: no
 		//  shortdesc: Peer session hold time
+		//  scope: global
 
 		// lxdmeta:generate(entities=network-bridge; group=network-conf; key=bgp.ipv4.nexthop)
 		//
@@ -236,6 +240,7 @@ func (n *bridge) Validate(config map[string]string) error {
 		//  condition: BGP server
 		//  defaultdesc: local address
 		//  shortdesc: Override the IPv4 next-hop for advertised prefixes
+		//  scope: local
 		"bgp.ipv4.nexthop": validate.Optional(validate.IsNetworkAddressV4),
 		// lxdmeta:generate(entities=network-bridge; group=network-conf; key=bgp.ipv6.nexthop)
 		//
@@ -244,6 +249,7 @@ func (n *bridge) Validate(config map[string]string) error {
 		//  condition: BGP server
 		//  defaultdesc: local address
 		//  shortdesc: Override the IPv6 next-hop for advertised prefixes
+		//  scope: local
 		"bgp.ipv6.nexthop": validate.Optional(validate.IsNetworkAddressV6),
 		// lxdmeta:generate(entities=network-bridge; group=network-conf; key=bridge.driver)
 		// Possible values are `native` and `openvswitch`.
@@ -251,12 +257,14 @@ func (n *bridge) Validate(config map[string]string) error {
 		//  type: string
 		//  defaultdesc: `native`
 		//  shortdesc: Bridge driver
+		//  scope: global
 		"bridge.driver": validate.Optional(validate.IsOneOf("native", "openvswitch")),
 		// lxdmeta:generate(entities=network-bridge; group=network-conf; key=bridge.external_interfaces)
 		// Specify a comma-separated list of unconfigured network interfaces to include in the bridge.
 		// ---
 		//  type: string
 		//  shortdesc: Unconfigured network interfaces to include in the bridge
+		//  scope: local
 		"bridge.external_interfaces": validate.Optional(func(value string) error {
 			for _, entry := range strings.Split(value, ",") {
 				entry = strings.TrimSpace(entry)
@@ -273,6 +281,7 @@ func (n *bridge) Validate(config map[string]string) error {
 		// ---
 		//  type: string
 		//  shortdesc: MAC address for the bridge
+		//  scope: global
 		"bridge.hwaddr": validate.Optional(validate.IsNetworkMAC),
 		// lxdmeta:generate(entities=network-bridge; group=network-conf; key=bridge.mtu)
 		// The default value varies depending on whether the bridge uses a tunnel or a fan setup.
@@ -280,6 +289,7 @@ func (n *bridge) Validate(config map[string]string) error {
 		//  type: integer
 		//  defaultdesc: `1500` if `bridge.mode=standard`, `1480` if `bridge.mode=fan` and `fan.type=ipip`, or `1450` if `bridge.mode=fan` and `fan.type=vxlan`
 		//  shortdesc: Bridge MTU
+		//  scope: global
 		"bridge.mtu": validate.Optional(validate.IsNetworkMTU),
 		// lxdmeta:generate(entities=network-bridge; group=network-conf; key=bridge.mode)
 		// Possible values are `standard` and `fan`.
@@ -287,6 +297,7 @@ func (n *bridge) Validate(config map[string]string) error {
 		//  type: string
 		//  defaultdesc: `standard`
 		//  shortdesc: Bridge operation mode
+		//  scope: global
 		"bridge.mode": validate.Optional(validate.IsOneOf("standard", "fan")),
 		// lxdmeta:generate(entities=network-bridge; group=network-conf; key=fan.overlay_subnet)
 		// Use CIDR notation.
@@ -295,6 +306,7 @@ func (n *bridge) Validate(config map[string]string) error {
 		//  condition: fan mode
 		//  defaultdesc: `240.0.0.0/8`
 		//  shortdesc: Subnet to use as the overlay for the FAN
+		//  scope: global
 		"fan.overlay_subnet": validate.Optional(validate.IsNetworkV4),
 		// lxdmeta:generate(entities=network-bridge; group=network-conf; key=fan.underlay_subnet)
 		// Use CIDR notation.
@@ -305,6 +317,7 @@ func (n *bridge) Validate(config map[string]string) error {
 		//  condition: fan mode
 		//  defaultdesc: initial value on creation: `auto`
 		//  shortdesc: Subnet to use as the underlay for the FAN
+		//  scope: global
 		"fan.underlay_subnet": validate.Optional(func(value string) error {
 			if value == "auto" {
 				return nil
@@ -319,6 +332,7 @@ func (n *bridge) Validate(config map[string]string) error {
 		//  condition: fan mode
 		//  defaultdesc: `vxlan`
 		//  shortdesc: Tunneling type for the FAN
+		//  scope: global
 		"fan.type": validate.Optional(validate.IsOneOf("vxlan", "ipip")),
 		// lxdmeta:generate(entities=network-bridge; group=network-conf; key=ipv4.address)
 		// Use CIDR notation.
@@ -329,6 +343,7 @@ func (n *bridge) Validate(config map[string]string) error {
 		//  condition: standard mode
 		//  defaultdesc: initial value on creation: `auto`
 		//  shortdesc: IPv4 address for the bridge
+		//  scope: global
 		"ipv4.address": validate.Optional(func(value string) error {
 			if validate.IsOneOf("none", "auto")(value) == nil {
 				return nil
@@ -343,6 +358,7 @@ func (n *bridge) Validate(config map[string]string) error {
 		//  condition: IPv4 address
 		//  defaultdesc: `true`
 		//  shortdesc: Whether to generate filtering firewall rules for this network
+		//  scope: global
 		"ipv4.firewall": validate.Optional(validate.IsBool),
 		// lxdmeta:generate(entities=network-bridge; group=network-conf; key=ipv4.nat)
 		//
@@ -351,6 +367,7 @@ func (n *bridge) Validate(config map[string]string) error {
 		//  condition: IPv4 address
 		//  defaultdesc: `false` (initial value on creation if `ipv4.address` is set to `auto`: `true`)
 		//  shortdesc: Whether to use NAT for IPv4
+		//  scope: global
 		"ipv4.nat": validate.Optional(validate.IsBool),
 		// lxdmeta:generate(entities=network-bridge; group=network-conf; key=ipv4.nat.order)
 		// Set this option to `before` to add the NAT rules before any pre-existing rules, or to `after` to add them after the pre-existing rules.
@@ -359,6 +376,7 @@ func (n *bridge) Validate(config map[string]string) error {
 		//  condition: IPv4 address
 		//  defaultdesc: `before`
 		//  shortdesc: Where to add the required NAT rules
+		//  scope: global
 		"ipv4.nat.order": validate.Optional(validate.IsOneOf("before", "after")),
 		// lxdmeta:generate(entities=network-bridge; group=network-conf; key=ipv4.nat.address)
 		//
@@ -366,6 +384,7 @@ func (n *bridge) Validate(config map[string]string) error {
 		//  type: string
 		//  condition: IPv4 address
 		//  shortdesc: Source address used for outbound traffic from the bridge
+		//  scope: global
 		"ipv4.nat.address": validate.Optional(validate.IsNetworkAddressV4),
 		// lxdmeta:generate(entities=network-bridge; group=network-conf; key=ipv4.dhcp)
 		//
@@ -374,6 +393,7 @@ func (n *bridge) Validate(config map[string]string) error {
 		//  condition: IPv4 address
 		//  defaultdesc: `true`
 		//  shortdesc: Whether to allocate IPv4 addresses using DHCP
+		//  scope: global
 		"ipv4.dhcp": validate.Optional(validate.IsBool),
 		// lxdmeta:generate(entities=network-bridge; group=network-conf; key=ipv4.dhcp.gateway)
 		//
@@ -382,6 +402,7 @@ func (n *bridge) Validate(config map[string]string) error {
 		//  condition: IPv4 DHCP
 		//  defaultdesc: IPv4 address
 		//  shortdesc: Address of the gateway for the IPv4 subnet
+		//  scope: global
 		"ipv4.dhcp.gateway": validate.Optional(validate.IsNetworkAddressV4),
 		// lxdmeta:generate(entities=network-bridge; group=network-conf; key=ipv4.dhcp.expiry)
 		//
@@ -390,6 +411,7 @@ func (n *bridge) Validate(config map[string]string) error {
 		//  condition: IPv4 DHCP
 		//  defaultdesc: `1h`
 		//  shortdesc: When to expire DHCP leases
+		//  scope: global
 		"ipv4.dhcp.expiry": validate.IsAny,
 		// lxdmeta:generate(entities=network-bridge; group=network-conf; key=ipv4.dhcp.ranges)
 		// Specify a comma-separated list of IPv4 ranges in FIRST-LAST format.
@@ -398,6 +420,7 @@ func (n *bridge) Validate(config map[string]string) error {
 		//  condition: IPv4 DHCP
 		//  defaultdesc: all addresses
 		//  shortdesc: IPv4 ranges to use for DHCP
+		//  scope: global
 		"ipv4.dhcp.ranges": validate.Optional(validate.IsListOf(validate.IsNetworkRangeV4)),
 		// lxdmeta:generate(entities=network-bridge; group=network-conf; key=ipv4.routes)
 		// Specify a comma-separated list of IPv4 CIDR subnets.
@@ -405,6 +428,7 @@ func (n *bridge) Validate(config map[string]string) error {
 		//  type: string
 		//  condition: IPv4 address
 		//  shortdesc: Additional IPv4 CIDR subnets to route to the bridge
+		//  scope: global
 		"ipv4.routes": validate.Optional(validate.IsListOf(validate.IsNetworkV4)),
 		// lxdmeta:generate(entities=network-bridge; group=network-conf; key=ipv4.routing)
 		//
@@ -413,12 +437,14 @@ func (n *bridge) Validate(config map[string]string) error {
 		//  condition: IPv4 address
 		//  defaultdesc: `true`
 		//  shortdesc: Whether to route IPv4 traffic in and out of the bridge
+		//  scope: global
 		"ipv4.routing": validate.Optional(validate.IsBool),
 		// lxdmeta:generate(entities=network-bridge; group=network-conf; key=ipv4.ovn.ranges)
 		// Specify a comma-separated list of IPv4 ranges in FIRST-LAST format.
 		// ---
 		//  type: string
 		//  shortdesc: IPv4 ranges to use for child OVN network routers
+		//  scope: global
 		"ipv4.ovn.ranges": validate.Optional(validate.IsListOf(validate.IsNetworkRangeV4)),
 		// lxdmeta:generate(entities=network-bridge; group=network-conf; key=ipv6.address)
 		// Use CIDR notation.
@@ -429,6 +455,7 @@ func (n *bridge) Validate(config map[string]string) error {
 		//  condition: standard mode
 		//  defaultdesc: initial value on creation: `auto`
 		//  shortdesc: IPv6 address for the bridge
+		//  scope: global
 		"ipv6.address": validate.Optional(func(value string) error {
 			if validate.IsOneOf("none", "auto")(value) == nil {
 				return nil
@@ -443,6 +470,7 @@ func (n *bridge) Validate(config map[string]string) error {
 		//  condition: IPv6 DHCP
 		//  defaultdesc: `true`
 		//  shortdesc: Whether to generate filtering firewall rules for this network
+		//  scope: global
 		"ipv6.firewall": validate.Optional(validate.IsBool),
 		// lxdmeta:generate(entities=network-bridge; group=network-conf; key=ipv6.nat)
 		//
@@ -451,6 +479,7 @@ func (n *bridge) Validate(config map[string]string) error {
 		//  condition: IPv6 address
 		//  defaultdesc: `false` (initial value on creation if `ipv6.address` is set to `auto`: `true`)
 		//  shortdesc: Whether to use NAT for IPv6
+		//  scope: global
 		"ipv6.nat": validate.Optional(validate.IsBool),
 		// lxdmeta:generate(entities=network-bridge; group=network-conf; key=ipv6.nat.order)
 		// Set this option to `before` to add the NAT rules before any pre-existing rules, or to `after` to add them after the pre-existing rules.
@@ -459,6 +488,7 @@ func (n *bridge) Validate(config map[string]string) error {
 		//  condition: IPv6 address
 		//  defaultdesc: `before`
 		//  shortdesc: Where to add the required NAT rules
+		//  scope: global
 		"ipv6.nat.order": validate.Optional(validate.IsOneOf("before", "after")),
 		// lxdmeta:generate(entities=network-bridge; group=network-conf; key=ipv6.nat.address)
 		//
@@ -466,6 +496,7 @@ func (n *bridge) Validate(config map[string]string) error {
 		//  type: string
 		//  condition: IPv6 address
 		//  shortdesc: Source address used for outbound traffic from the bridge
+		//  scope: global
 		"ipv6.nat.address": validate.Optional(validate.IsNetworkAddressV6),
 		// lxdmeta:generate(entities=network-bridge; group=network-conf; key=ipv6.dhcp)
 		//
@@ -474,6 +505,7 @@ func (n *bridge) Validate(config map[string]string) error {
 		//  condition: IPv6 address
 		//  defaultdesc: `true`
 		//  shortdesc: Whether to provide additional network configuration over DHCP
+		//  scope: global
 		"ipv6.dhcp": validate.Optional(validate.IsBool),
 		// lxdmeta:generate(entities=network-bridge; group=network-conf; key=ipv6.dhcp.expiry)
 		//
@@ -482,6 +514,7 @@ func (n *bridge) Validate(config map[string]string) error {
 		//  condition: IPv6 DHCP
 		//  defaultdesc: `1h`
 		//  shortdesc: When to expire DHCP leases
+		//  scope: global
 		"ipv6.dhcp.expiry": validate.IsAny,
 		// lxdmeta:generate(entities=network-bridge; group=network-conf; key=ipv6.dhcp.stateful)
 		//
@@ -490,6 +523,7 @@ func (n *bridge) Validate(config map[string]string) error {
 		//  condition: IPv6 DHCP
 		//  defaultdesc: `false`
 		//  shortdesc: Whether to allocate IPv6 addresses using DHCP
+		//  scope: global
 		"ipv6.dhcp.stateful": validate.Optional(validate.IsBool),
 		// lxdmeta:generate(entities=network-bridge; group=network-conf; key=ipv6.dhcp.ranges)
 		// Specify a comma-separated list of IPv6 ranges in FIRST-LAST format.
@@ -498,6 +532,7 @@ func (n *bridge) Validate(config map[string]string) error {
 		//  condition: IPv6 stateful DHCP
 		//  defaultdesc: all addresses
 		//  shortdesc: IPv6 ranges to use for DHCP
+		//  scope: global
 		"ipv6.dhcp.ranges": validate.Optional(validate.IsListOf(validate.IsNetworkRangeV6)),
 		// lxdmeta:generate(entities=network-bridge; group=network-conf; key=ipv6.routes)
 		// Specify a comma-separated list of IPv6 CIDR subnets.
@@ -505,6 +540,7 @@ func (n *bridge) Validate(config map[string]string) error {
 		//  type: string
 		//  condition: IPv6 address
 		//  shortdesc: Additional IPv6 CIDR subnets to route to the bridge
+		//  scope: global
 		"ipv6.routes": validate.Optional(validate.IsListOf(validate.IsNetworkV6)),
 		// lxdmeta:generate(entities=network-bridge; group=network-conf; key=ipv6.routing)
 		//
@@ -513,12 +549,14 @@ func (n *bridge) Validate(config map[string]string) error {
 		//  condition: IPv6 address
 		//  shortdesc: `true`
 		//  shortdesc: Whether to route IPv6 traffic in and out of the bridge
+		//  scope: global
 		"ipv6.routing": validate.Optional(validate.IsBool),
 		// lxdmeta:generate(entities=network-bridge; group=network-conf; key=ipv6.ovn.ranges)
 		// Specify a comma-separated list of IPv6 ranges in FIRST-LAST format.
 		// ---
 		//  type: string
 		//  shortdesc: IPv6 ranges to use for child OVN network routers
+		//  scope: global
 		"ipv6.ovn.ranges": validate.Optional(validate.IsListOf(validate.IsNetworkRangeV6)),
 		// lxdmeta:generate(entities=network-bridge; group=network-conf; key=dns.domain)
 		//
@@ -526,6 +564,7 @@ func (n *bridge) Validate(config map[string]string) error {
 		//  type: string
 		//  defaultdesc: `lxd`
 		//  shortdesc: Domain to advertise to DHCP clients and use for DNS resolution
+		//  scope: global
 		"dns.domain": validate.IsAny,
 		// lxdmeta:generate(entities=network-bridge; group=network-conf; key=dns.mode)
 		// Possible values are `none` for no DNS record, `managed` for LXD-generated static records, and `dynamic` for client-generated records.
@@ -533,6 +572,7 @@ func (n *bridge) Validate(config map[string]string) error {
 		//  type: string
 		//  defaultdesc: `managed`
 		//  shortdesc: DNS registration mode
+		//  scope: global
 		"dns.mode": validate.Optional(validate.IsOneOf("dynamic", "managed", "none")),
 		// lxdmeta:generate(entities=network-bridge; group=network-conf; key=dns.search)
 		// Specify a comma-separated list of domains.
@@ -540,30 +580,35 @@ func (n *bridge) Validate(config map[string]string) error {
 		//  type: string
 		//  defaultdesc: `dns.domain` value
 		//  shortdesc: Full domain search list
+		//  scope: global
 		"dns.search": validate.IsAny,
 		// lxdmeta:generate(entities=network-bridge; group=network-conf; key=dns.zone.forward)
 		// Specify a comma-separated list of DNS zone names.
 		// ---
 		//  type: string
 		//  shortdesc: DNS zone names for forward DNS records
+		//  scope: global
 		"dns.zone.forward": validate.IsAny,
 		// lxdmeta:generate(entities=network-bridge; group=network-conf; key=dns.zone.reverse.ipv4)
 		//
 		// ---
 		//  type: string
 		//  shortdesc: DNS zone name for IPv4 reverse DNS records
+		//  scope: global
 		"dns.zone.reverse.ipv4": validate.IsAny,
 		// lxdmeta:generate(entities=network-bridge; group=network-conf; key=dns.zone.reverse.ipv6)
 		//
 		// ---
 		//  type: string
 		//  shortdesc: DNS zone name for IPv6 reverse DNS records
+		//  scope: global
 		"dns.zone.reverse.ipv6": validate.IsAny,
 		// lxdmeta:generate(entities=network-bridge; group=network-conf; key=raw.dnsmasq)
 		//
 		// ---
 		//  type: string
 		//  shortdesc: Additional `dnsmasq` configuration to append to the configuration file
+		//  scope: global
 		"raw.dnsmasq": validate.IsAny,
 		// lxdmeta:generate(entities=network-bridge; group=network-conf; key=maas.subnet.ipv4)
 		//
@@ -572,6 +617,7 @@ func (n *bridge) Validate(config map[string]string) error {
 		//  condition: IPv4 address; using the `network` property on the NIC
 		//  shortdesc: `true`
 		//  shortdesc: MAAS IPv4 subnet to register instances in
+		//  scope: global
 		"maas.subnet.ipv4": validate.IsAny,
 		// lxdmeta:generate(entities=network-bridge; group=network-conf; key=maas.subnet.ipv6)
 		//
@@ -580,6 +626,7 @@ func (n *bridge) Validate(config map[string]string) error {
 		//  condition: IPv6 address; using the `network` property on the NIC
 		//  shortdesc: `true`
 		//  shortdesc: MAAS IPv6 subnet to register instances in
+		//  scope: global
 		"maas.subnet.ipv6": validate.IsAny,
 		// lxdmeta:generate(entities=network-bridge; group=network-conf; key=security.acls)
 		// Specify a comma-separated list of network ACLs.
@@ -588,6 +635,7 @@ func (n *bridge) Validate(config map[string]string) error {
 		// ---
 		//  type: string
 		//  shortdesc: Network ACLs to apply to NICs connected to this network
+		//  scope: global
 		"security.acls": validate.IsAny,
 		// lxdmeta:generate(entities=network-bridge; group=network-conf; key=security.acls.default.ingress.action)
 		// The specified action is used for all ingress traffic that doesn’t match any ACL rule.
@@ -596,6 +644,7 @@ func (n *bridge) Validate(config map[string]string) error {
 		//  condition: `security.acls`
 		//  shortdesc: `reject`
 		//  shortdesc: Default action to use for ingress traffic
+		//  scope: global
 		"security.acls.default.ingress.action": validate.Optional(validate.IsOneOf(acl.ValidActions...)),
 		// lxdmeta:generate(entities=network-bridge; group=network-conf; key=security.acls.default.egress.action)
 		// The specified action is used for all egress traffic that doesn’t match any ACL rule.
@@ -604,6 +653,7 @@ func (n *bridge) Validate(config map[string]string) error {
 		//  condition: `security.acls`
 		//  shortdesc: `reject`
 		//  shortdesc: Default action to use for egress traffic
+		//  scope: global
 		"security.acls.default.egress.action": validate.Optional(validate.IsOneOf(acl.ValidActions...)),
 		// lxdmeta:generate(entities=network-bridge; group=network-conf; key=security.acls.default.ingress.logged)
 		//
@@ -612,6 +662,7 @@ func (n *bridge) Validate(config map[string]string) error {
 		//  condition: `security.acls`
 		//  shortdesc: `false`
 		//  shortdesc: Whether to log ingress traffic that doesn’t match any ACL rule
+		//  scope: global
 		"security.acls.default.ingress.logged": validate.Optional(validate.IsBool),
 		// lxdmeta:generate(entities=network-bridge; group=network-conf; key=security.acls.default.egress.logged)
 		//
@@ -620,6 +671,7 @@ func (n *bridge) Validate(config map[string]string) error {
 		//  condition: `security.acls`
 		//  shortdesc: `false`
 		//  shortdesc: Whether to log egress traffic that doesn’t match any ACL rule
+		//  scope: global
 		"security.acls.default.egress.logged": validate.Optional(validate.IsBool),
 
 		// lxdmeta:generate(entities=network-bridge; group=network-conf; key=user.*)
@@ -627,6 +679,7 @@ func (n *bridge) Validate(config map[string]string) error {
 		// ---
 		//  type: string
 		//  shortdesc: User-provided free-form key/value pairs
+		//  scope: global
 	}
 
 	// Add dynamic validation rules.

--- a/lxd/network/driver_macvlan.go
+++ b/lxd/network/driver_macvlan.go
@@ -29,18 +29,21 @@ func (n *macvlan) Validate(config map[string]string) error {
 		// ---
 		//  type: string
 		//  shortdesc: Parent interface to create `macvlan` NICs on
+		//  scope: local
 		"parent": validate.Required(validate.IsNotEmpty, validate.IsInterfaceName),
 		// lxdmeta:generate(entities=network-macvlan; group=network-conf; key=mtu)
 		//
 		// ---
 		//  type: integer
 		//  shortdesc: MTU of the new interface
+		//  scope: global
 		"mtu": validate.Optional(validate.IsNetworkMTU),
 		// lxdmeta:generate(entities=network-macvlan; group=network-conf; key=vlan)
 		//
 		// ---
 		//  type: integer
 		//  shortdesc: VLAN ID to attach to
+		//  scope: global
 		"vlan": validate.Optional(validate.IsNetworkVLAN),
 		// lxdmeta:generate(entities=network-macvlan; group=network-conf; key=gvrp)
 		// This option specifies whether to register the VLAN using the GARP VLAN Registration Protocol.
@@ -48,6 +51,7 @@ func (n *macvlan) Validate(config map[string]string) error {
 		//  type: bool
 		//  defaultdesc: `false`
 		//  shortdesc: Whether to use GARP VLAN Registration Protocol
+		//  scope: global
 		"gvrp": validate.Optional(validate.IsBool),
 		// lxdmeta:generate(entities=network-macvlan; group=network-conf; key=maas.subnet.ipv4)
 		//
@@ -55,6 +59,7 @@ func (n *macvlan) Validate(config map[string]string) error {
 		//  type: string
 		//  condition: IPv4 address; using the `network` property on the NIC
 		//  shortdesc: MAAS IPv4 subnet to register instances in
+		//  scope: global
 		"maas.subnet.ipv4": validate.IsAny,
 		// lxdmeta:generate(entities=network-macvlan; group=network-conf; key=maas.subnet.ipv6)
 		//
@@ -62,6 +67,7 @@ func (n *macvlan) Validate(config map[string]string) error {
 		//  type: string
 		//  condition: IPv4 address; using the `network` property on the NIC
 		//  shortdesc: MAAS IPv6 subnet to register instances in
+		//  scope: global
 		"maas.subnet.ipv6": validate.IsAny,
 
 		// lxdmeta:generate(entities=network-macvlan; group=network-conf; key=user.*)
@@ -69,6 +75,7 @@ func (n *macvlan) Validate(config map[string]string) error {
 		// ---
 		//  type: string
 		//  shortdesc: User-provided free-form key/value pairs
+		//  scope: global
 	}
 
 	err := n.validate(config, rules)

--- a/lxd/network/driver_physical.go
+++ b/lxd/network/driver_physical.go
@@ -35,18 +35,21 @@ func (n *physical) Validate(config map[string]string) error {
 		// ---
 		//  type: string
 		//  shortdesc: Existing interface to use for network
+		//  scope: local
 		"parent": validate.Required(validate.IsNotEmpty, validate.IsInterfaceName),
 		// lxdmeta:generate(entities=network-physical; group=network-conf; key=mtu)
 		//
 		// ---
 		//  type: integer
 		//  shortdesc: MTU of the new interface
+		//  scope: global
 		"mtu": validate.Optional(validate.IsNetworkMTU),
 		// lxdmeta:generate(entities=network-physical; group=network-conf; key=vlan)
 		//
 		// ---
 		//  type: integer
 		//  shortdesc: VLAN ID to attach to
+		//  scope: global
 		"vlan": validate.Optional(validate.IsNetworkVLAN),
 		// lxdmeta:generate(entities=network-physical; group=network-conf; key=gvrp)
 		// This option specifies whether to register the VLAN using the GARP VLAN Registration Protocol.
@@ -54,6 +57,7 @@ func (n *physical) Validate(config map[string]string) error {
 		//  type: bool
 		//  defaultdesc: `false`
 		//  shortdesc: Whether to use GARP VLAN Registration Protocol
+		//  scope: global
 		"gvrp": validate.Optional(validate.IsBool),
 		// lxdmeta:generate(entities=network-physical; group=network-conf; key=maas.subnet.ipv4)
 		//
@@ -61,6 +65,7 @@ func (n *physical) Validate(config map[string]string) error {
 		//  type: string
 		//  condition: IPv4 address; using the `network` property on the NIC
 		//  shortdesc: MAAS IPv4 subnet to register instances in
+		//  scope: global
 		"maas.subnet.ipv4": validate.IsAny,
 		// lxdmeta:generate(entities=network-physical; group=network-conf; key=maas.subnet.ipv6)
 		//
@@ -68,6 +73,7 @@ func (n *physical) Validate(config map[string]string) error {
 		//  type: string
 		//  condition: IPv6 address; using the `network` property on the NIC
 		//  shortdesc: MAAS IPv6 subnet to register instances in
+		//  scope: global
 		"maas.subnet.ipv6": validate.IsAny,
 		// lxdmeta:generate(entities=network-physical; group=network-conf; key=ipv4.gateway)
 		// Use CIDR notation.
@@ -75,6 +81,7 @@ func (n *physical) Validate(config map[string]string) error {
 		//  type: string
 		//  condition: standard mode
 		//  shortdesc: IPv4 address for the gateway and network
+		//  scope: global
 		"ipv4.gateway": validate.Optional(validate.IsNetworkAddressCIDRV4),
 		// lxdmeta:generate(entities=network-physical; group=network-conf; key=ipv6.gateway)
 		// Use CIDR notation.
@@ -82,18 +89,21 @@ func (n *physical) Validate(config map[string]string) error {
 		//  type: string
 		//  condition: standard mode
 		//  shortdesc: IPv6 address for the gateway and network
+		//  scope: global
 		"ipv6.gateway": validate.Optional(validate.IsNetworkAddressCIDRV6),
 		// lxdmeta:generate(entities=network-physical; group=network-conf; key=ipv4.ovn.ranges)
 		// Specify a comma-separated list of IPv4 ranges in FIRST-LAST format.
 		// ---
 		//  type: string
 		//  shortdesc: IPv4 ranges to use for child OVN network routers
+		//  scope: global
 		"ipv4.ovn.ranges": validate.Optional(validate.IsListOf(validate.IsNetworkRangeV4)),
 		// lxdmeta:generate(entities=network-physical; group=network-conf; key=ipv6.ovn.ranges)
 		// Specify a comma-separated list of IPv6 ranges in FIRST-LAST format.
 		// ---
 		//  type: string
 		//  shortdesc: IPv6 ranges to use for child OVN network routers
+		//  scope: global
 		"ipv6.ovn.ranges": validate.Optional(validate.IsListOf(validate.IsNetworkRangeV6)),
 		// lxdmeta:generate(entities=network-physical; group=network-conf; key=ipv4.routes)
 		// Specify a comma-separated list of IPv4 CIDR subnets that can be used with child OVN network forwarders, load-balancers and {config:option}`device-nic-ovn-device-conf:ipv4.routes.external` setting.
@@ -101,6 +111,7 @@ func (n *physical) Validate(config map[string]string) error {
 		//  type: string
 		//  condition: IPv4 address
 		//  shortdesc: Additional IPv4 CIDR subnets
+		//  scope: global
 		"ipv4.routes": validate.Optional(validate.IsListOf(validate.IsNetworkV4)),
 		// lxdmeta:generate(entities=network-physical; group=network-conf; key=ipv4.routes.anycast)
 		// If set to `true`, this option allows the overlapping routes to be used on multiple networks/NICs at the same time.
@@ -109,6 +120,7 @@ func (n *physical) Validate(config map[string]string) error {
 		//  condition: IPv4 address
 		//  defaultdesc: `false`
 		//  shortdesc: Whether to allow IPv4 routes on multiple networks/NICs
+		//  scope: global
 		"ipv4.routes.anycast": validate.Optional(validate.IsBool),
 		// lxdmeta:generate(entities=network-physical; group=network-conf; key=ipv6.routes)
 		// Specify a comma-separated list of IPv6 CIDR subnets that can be used with child OVN network forwarders, load-balancers and {config:option}`device-nic-ovn-device-conf:ipv6.routes.external` setting.
@@ -116,6 +128,7 @@ func (n *physical) Validate(config map[string]string) error {
 		//  type: string
 		//  condition: IPv6 address
 		//  shortdesc: Additional IPv6 CIDR subnets
+		//  scope: global
 		"ipv6.routes": validate.Optional(validate.IsListOf(validate.IsNetworkV6)),
 		// lxdmeta:generate(entities=network-physical; group=network-conf; key=ipv6.routes.anycast)
 		// If set to `true`, this option allows the overlapping routes to be used on multiple networks/NICs at the same time.
@@ -124,6 +137,7 @@ func (n *physical) Validate(config map[string]string) error {
 		//  condition: IPv6 address
 		//  defaultdesc: `false`
 		//  shortdesc: Whether to allow IPv6 routes on multiple networks/NICs
+		//  scope: global
 		"ipv6.routes.anycast": validate.Optional(validate.IsBool),
 		// lxdmeta:generate(entities=network-physical; group=network-conf; key=dns.nameservers)
 		// Specify a list of DNS server IPs.
@@ -131,6 +145,7 @@ func (n *physical) Validate(config map[string]string) error {
 		//  type: string
 		//  condition: standard mode
 		//  shortdesc: DNS server IPs on physical network
+		//  scope: global
 		"dns.nameservers": validate.Optional(validate.IsListOf(validate.IsNetworkAddress)),
 		// lxdmeta:generate(entities=network-physical; group=network-conf; key=ovn.ingress_mode)
 		// Possible values are `l2proxy` (proxy ARP/NDP) and `routed`.
@@ -139,6 +154,7 @@ func (n *physical) Validate(config map[string]string) error {
 		//  condition: standard mode
 		//  defaultdesc: `l2proxy`
 		//  shortdesc: How OVN NIC external IPs are advertised on uplink network
+		//  scope: global
 		"ovn.ingress_mode":            validate.Optional(validate.IsOneOf("l2proxy", "routed")),
 		"volatile.last_state.created": validate.Optional(validate.IsBool),
 
@@ -147,6 +163,7 @@ func (n *physical) Validate(config map[string]string) error {
 		// ---
 		//  type: string
 		//  shortdesc: User-provided free-form key/value pairs
+		//  scope: global
 	}
 
 	// Add the BGP validation rules.
@@ -157,6 +174,7 @@ func (n *physical) Validate(config map[string]string) error {
 	//  type: string
 	//  condition: BGP server
 	//  shortdesc: Peer address for use by `ovn` downstream networks
+	//  scope: global
 
 	// lxdmeta:generate(entities=network-physical; group=network-conf; key=bgp.peers.NAME.asn)
 	//
@@ -164,6 +182,7 @@ func (n *physical) Validate(config map[string]string) error {
 	//  type: integer
 	//  condition: BGP server
 	//  shortdesc: Peer AS number for use by `ovn` downstream networks
+	//  scope: global
 
 	// lxdmeta:generate(entities=network-physical; group=network-conf; key=bgp.peers.NAME.password)
 	//
@@ -173,6 +192,7 @@ func (n *physical) Validate(config map[string]string) error {
 	//  defaultdesc: (no password)
 	//  required: no
 	//  shortdesc: Peer session password for use by `ovn` downstream networks
+	//  scope: global
 
 	// lxdmeta:generate(entities=network-physical; group=network-conf; key=bgp.peers.NAME.holdtime)
 	// Specify the peer session hold time in seconds.
@@ -182,6 +202,7 @@ func (n *physical) Validate(config map[string]string) error {
 	//  defaultdesc: `180`
 	//  required: no
 	//  shortdesc: Peer session hold time
+	//  scope: global
 	bgpRules, err := n.bgpValidationRules(config)
 	if err != nil {
 		return err

--- a/lxd/network/driver_sriov.go
+++ b/lxd/network/driver_sriov.go
@@ -29,18 +29,21 @@ func (n *sriov) Validate(config map[string]string) error {
 		// ---
 		//  type: string
 		//  shortdesc: Parent interface to create `sriov` NICs on
+		//  scope: local
 		"parent": validate.Required(validate.IsNotEmpty, validate.IsInterfaceName),
 		// lxdmeta:generate(entities=network-sriov; group=network-conf; key=mtu)
 		//
 		// ---
 		//  type: integer
 		//  shortdesc: MTU of the new interface
+		//  scope: global
 		"mtu": validate.Optional(validate.IsNetworkMTU),
 		// lxdmeta:generate(entities=network-sriov; group=network-conf; key=vlan)
 		//
 		// ---
 		//  type: integer
 		//  shortdesc: VLAN ID to attach to
+		//  scope: global
 		"vlan": validate.Optional(validate.IsNetworkVLAN),
 		// lxdmeta:generate(entities=network-sriov; group=network-conf; key=maas.subnet.ipv4)
 		//
@@ -48,6 +51,7 @@ func (n *sriov) Validate(config map[string]string) error {
 		//  type: string
 		//  condition: IPv4 address; using the `network` property on the NIC
 		//  shortdesc: MAAS IPv4 subnet to register instances in
+		//  scope: global
 		"maas.subnet.ipv4": validate.IsAny,
 		// lxdmeta:generate(entities=network-sriov; group=network-conf; key=maas.subnet.ipv6)
 		//
@@ -55,6 +59,7 @@ func (n *sriov) Validate(config map[string]string) error {
 		//  type: string
 		//  condition: IPv6 address; using the `network` property on the NIC
 		//  shortdesc: MAAS IPv6 subnet to register instances in
+		//  scope: global
 		"maas.subnet.ipv6": validate.IsAny,
 
 		// lxdmeta:generate(entities=network-sriov; group=network-conf; key=user.*)
@@ -62,6 +67,7 @@ func (n *sriov) Validate(config map[string]string) error {
 		// ---
 		//  type: string
 		//  shortdesc: User-provided free-form key/value pairs
+		//  scope: global
 	}
 
 	err := n.validate(config, rules)

--- a/lxd/storage/drivers/driver_btrfs.go
+++ b/lxd/storage/drivers/driver_btrfs.go
@@ -346,6 +346,7 @@ func (d *btrfs) Validate(config map[string]string) error {
 		//  type: string
 		//  defaultdesc: `user_subvol_rm_allowed`
 		//  shortdesc: Mount options for block devices
+		//  scope: global
 		"btrfs.mount_options": validate.IsAny,
 	}
 

--- a/lxd/storage/drivers/driver_ceph.go
+++ b/lxd/storage/drivers/driver_ceph.go
@@ -294,6 +294,7 @@ func (d *ceph) Validate(config map[string]string) error {
 		//  type: string
 		//  defaultdesc: `ceph`
 		//  shortdesc: Name of the Ceph cluster in which to create new storage pools
+		//  scope: global
 		"ceph.cluster_name":    validate.IsAny,
 		"ceph.osd.force_reuse": validate.Optional(validate.IsBool), // Deprecated, should not be used.
 		// lxdmeta:generate(entities=storage-ceph; group=pool-conf; key=ceph.osd.pg_num)
@@ -302,6 +303,7 @@ func (d *ceph) Validate(config map[string]string) error {
 		//  type: string
 		//  defaultdesc: `32`
 		//  shortdesc: Number of placement groups for the OSD storage pool
+		//  scope: global
 		"ceph.osd.pg_num": validate.IsAny,
 		// lxdmeta:generate(entities=storage-ceph; group=pool-conf; key=ceph.osd.pool_name)
 		//
@@ -309,12 +311,14 @@ func (d *ceph) Validate(config map[string]string) error {
 		//  type: string
 		//  defaultdesc: name of the pool
 		//  shortdesc: Name of the OSD storage pool
+		//  scope: global
 		"ceph.osd.pool_name": validate.IsAny,
 		// lxdmeta:generate(entities=storage-ceph; group=pool-conf; key=ceph.osd.data_pool_name)
 		//
 		// ---
 		//  type: string
 		//  shortdesc: Name of the OSD data pool
+		//  scope: global
 		"ceph.osd.data_pool_name": validate.IsAny,
 		// lxdmeta:generate(entities=storage-ceph; group=pool-conf; key=ceph.rbd.clone_copy)
 		// Enable this option to use RBD lightweight clones rather than full dataset copies.
@@ -322,6 +326,7 @@ func (d *ceph) Validate(config map[string]string) error {
 		//  type: bool
 		//  defaultdesc: `true`
 		//  shortdesc: Whether to use RBD lightweight clones
+		//  scope: global
 		"ceph.rbd.clone_copy": validate.Optional(validate.IsBool),
 		// lxdmeta:generate(entities=storage-ceph; group=pool-conf; key=ceph.rbd.du)
 		// This option specifies whether to use RBD `du` to obtain disk usage data for stopped instances.
@@ -329,6 +334,7 @@ func (d *ceph) Validate(config map[string]string) error {
 		//  type: bool
 		//  defaultdesc: `true`
 		//  shortdesc: Whether to use RBD `du`
+		//  scope: global
 		"ceph.rbd.du": validate.Optional(validate.IsBool),
 		// lxdmeta:generate(entities=storage-ceph; group=pool-conf; key=ceph.rbd.features)
 		//
@@ -336,6 +342,7 @@ func (d *ceph) Validate(config map[string]string) error {
 		//  type: string
 		//  defaultdesc: `layering`
 		//  shortdesc: Comma-separated list of RBD features to enable on the volumes
+		//  scope: global
 		"ceph.rbd.features": validate.IsAny,
 		// lxdmeta:generate(entities=storage-ceph; group=pool-conf; key=ceph.user.name)
 		//
@@ -343,6 +350,7 @@ func (d *ceph) Validate(config map[string]string) error {
 		//  type: string
 		//  defaultdesc: `admin`
 		//  shortdesc: The Ceph user to use when creating storage pools and volumes
+		//  scope: global
 		"ceph.user.name": validate.IsAny,
 		// lxdmeta:generate(entities=storage-ceph; group=pool-conf; key=volatile.pool.pristine)
 		//
@@ -350,6 +358,7 @@ func (d *ceph) Validate(config map[string]string) error {
 		//  type: string
 		//  defaultdesc: `true`
 		//  shortdesc: Whether the pool was empty on creation time
+		//  scope: global
 		"volatile.pool.pristine": validate.IsAny,
 	}
 

--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -1170,6 +1170,7 @@ func (d *ceph) commonVolumeRules() map[string]func(value string) error {
 		//  condition: block-based volume with content type `filesystem`
 		//  defaultdesc: same as `volume.block.filesystem`
 		//  shortdesc: File system of the storage volume
+		//  scope: global
 		"block.filesystem": validate.Optional(validate.IsOneOf(blockBackedAllowedFilesystems...)),
 		// lxdmeta:generate(entities=storage-ceph,storage-lvm; group=volume-conf; key=block.mount_options)
 		//
@@ -1178,6 +1179,7 @@ func (d *ceph) commonVolumeRules() map[string]func(value string) error {
 		//  condition: block-based volume with content type `filesystem`
 		//  defaultdesc: same as `volume.block.mount_options`
 		//  shortdesc: Mount options for block-backed file system volumes
+		//  scope: global
 		"block.mount_options": validate.IsAny,
 	}
 }

--- a/lxd/storage/drivers/driver_cephfs.go
+++ b/lxd/storage/drivers/driver_cephfs.go
@@ -370,6 +370,7 @@ func (d *cephfs) Validate(config map[string]string) error {
 		//  type: string
 		//  defaultdesc: `ceph`
 		//  shortdesc: Name of the Ceph cluster that contains the CephFS file system
+		//  scope: global
 		"cephfs.cluster_name": validate.IsAny,
 		// lxdmeta:generate(entities=storage-cephfs; group=pool-conf; key=cephfs.fscache)
 		//
@@ -377,6 +378,7 @@ func (d *cephfs) Validate(config map[string]string) error {
 		//  type: bool
 		//  defaultdesc: `false`
 		//  shortdesc: Enable use of kernel `fscache` and `cachefilesd`
+		//  scope: global
 		"cephfs.fscache": validate.Optional(validate.IsBool),
 		// lxdmeta:generate(entities=storage-cephfs; group=pool-conf; key=cephfs.path)
 		//
@@ -384,6 +386,7 @@ func (d *cephfs) Validate(config map[string]string) error {
 		//  type: string
 		//  defaultdesc: `/`
 		//  shortdesc: The base path for the CephFS mount
+		//  scope: global
 		"cephfs.path": validate.IsAny,
 		// lxdmeta:generate(entities=storage-cephfs; group=pool-conf; key=cephfs.user.name)
 		//
@@ -391,6 +394,7 @@ func (d *cephfs) Validate(config map[string]string) error {
 		//  type: string
 		//  defaultdesc: `admin`
 		//  shortdesc: The Ceph user to use
+		//  scope: global
 		"cephfs.user.name": validate.IsAny,
 		// lxdmeta:generate(entities=storage-cephfs; group=pool-conf; key=cephfs.create_missing)
 		// Use this option if the CephFS file system does not exist yet.
@@ -399,6 +403,7 @@ func (d *cephfs) Validate(config map[string]string) error {
 		//  type: bool
 		//  defaultdesc: `false`
 		//  shortdesc: Automatically create the CephFS file system
+		//  scope: global
 		"cephfs.create_missing": validate.Optional(validate.IsBool),
 		// lxdmeta:generate(entities=storage-cephfs; group=pool-conf; key=cephfs.osd_pg_num)
 		// This option specifies the number of OSD pool placement groups (`pg_num`) to use
@@ -406,6 +411,7 @@ func (d *cephfs) Validate(config map[string]string) error {
 		// ---
 		//  type: string
 		//  shortdesc: Number of placement groups when creating missing OSD pools
+		//  scope: global
 		"cephfs.osd_pg_num": validate.Optional(validate.IsInt64),
 		// lxdmeta:generate(entities=storage-cephfs; group=pool-conf; key=cephfs.meta_pool)
 		// This option specifies the name for the file metadata OSD pool that should be used when
@@ -413,6 +419,7 @@ func (d *cephfs) Validate(config map[string]string) error {
 		// ---
 		//  type: string
 		//  shortdesc: Metadata OSD pool name
+		//  scope: global
 		"cephfs.meta_pool": validate.IsAny,
 		// lxdmeta:generate(entities=storage-cephfs; group=pool-conf; key=cephfs.data_pool)
 		// This option specifies the name for the data OSD pool that should be used when creating
@@ -420,6 +427,7 @@ func (d *cephfs) Validate(config map[string]string) error {
 		// ---
 		//  type: string
 		//  shortdesc: Data OSD pool name
+		//  scope: global
 		"cephfs.data_pool": validate.IsAny,
 		// lxdmeta:generate(entities=storage-cephfs; group=pool-conf; key=volatile.pool.pristine)
 		//
@@ -427,6 +435,7 @@ func (d *cephfs) Validate(config map[string]string) error {
 		//  type: string
 		//  defaultdesc: `true`
 		//  shortdesc: Whether the CephFS file system was empty on creation time
+		//  scope: global
 		"volatile.pool.pristine": validate.IsAny,
 	}
 

--- a/lxd/storage/drivers/driver_cephobject.go
+++ b/lxd/storage/drivers/driver_cephobject.go
@@ -101,6 +101,7 @@ func (d *cephobject) Validate(config map[string]string) error {
 		// ---
 		//  type: string
 		//  shortdesc: The Ceph cluster to use
+		//  scope: global
 		"cephobject.cluster_name": validate.IsAny,
 		// lxdmeta:generate(entities=storage-cephobject; group=pool-conf; key=cephobject.user.name)
 		//
@@ -108,24 +109,28 @@ func (d *cephobject) Validate(config map[string]string) error {
 		//  type: string
 		//  defaultdesc: `admin`
 		//  shortdesc: The Ceph user to use
+		//  scope: global
 		"cephobject.user.name": validate.IsAny,
 		// lxdmeta:generate(entities=storage-cephobject; group=pool-conf; key=cephobject.radosgw.endpoint)
 		//
 		// ---
 		//  type: string
 		//  shortdesc: URL of the `radosgw` gateway process
+		//  scope: global
 		"cephobject.radosgw.endpoint": validate.Optional(validate.IsRequestURL),
 		// lxdmeta:generate(entities=storage-cephobject; group=pool-conf; key=cephobject.radosgw.endpoint_cert_file)
 		// Specify the path to the file that contains the TLS client certificate.
 		// ---
 		//  type: string
 		//  shortdesc: TLS client certificate to use for endpoint communication
+		//  scope: global
 		"cephobject.radosgw.endpoint_cert_file": validate.Optional(validate.IsAbsFilePath),
 		// lxdmeta:generate(entities=storage-cephobject; group=pool-conf; key=cephobject.bucket.name_prefix)
 		//
 		// ---
 		//  type: string
 		//  shortdesc: Prefix to add to bucket names in Ceph
+		//  scope: global
 		"cephobject.bucket.name_prefix": validate.IsAny,
 		// lxdmeta:generate(entities=storage-cephobject; group=pool-conf; key=volatile.pool.pristine)
 		//
@@ -133,6 +138,7 @@ func (d *cephobject) Validate(config map[string]string) error {
 		//  type: string
 		//  defaultdesc: `true`
 		//  shortdesc: Whether the `radosgw` `lxd-admin` user existed at creation time
+		//  scope: global
 		"volatile.pool.pristine": validate.Optional(validate.IsBool),
 	}
 

--- a/lxd/storage/drivers/driver_lvm.go
+++ b/lxd/storage/drivers/driver_lvm.go
@@ -513,6 +513,7 @@ func (d *lvm) Validate(config map[string]string) error {
 		//  type: string
 		//  defaultdesc: name of the pool
 		//  shortdesc: Name of the volume group to create
+		//  scope: local
 		"lvm.vg_name": validate.IsAny,
 		// lxdmeta:generate(entities=storage-lvm; group=pool-conf; key=lvm.thinpool_name)
 		//
@@ -520,6 +521,7 @@ func (d *lvm) Validate(config map[string]string) error {
 		//  type: string
 		//  defaultdesc: `LXDThinPool`
 		//  shortdesc: Thin pool where volumes are created
+		//  scope: local
 		"lvm.thinpool_name": validate.IsAny,
 		// lxdmeta:generate(entities=storage-lvm; group=pool-conf; key=lvm.thinpool_metadata_size)
 		// By default, LVM calculates an appropriate size.
@@ -527,6 +529,7 @@ func (d *lvm) Validate(config map[string]string) error {
 		//  type: string
 		//  defaultdesc: `0` (auto)
 		//  shortdesc: The size of the thin pool metadata volume
+		//  scope: global
 		"lvm.thinpool_metadata_size": validate.Optional(validate.IsSize),
 		// lxdmeta:generate(entities=storage-lvm; group=pool-conf; key=lvm.use_thinpool)
 		//
@@ -534,6 +537,7 @@ func (d *lvm) Validate(config map[string]string) error {
 		//  type: bool
 		//  defaultdesc: `true`
 		//  shortdesc: Whether the storage pool uses a thin pool for logical volumes
+		//  scope: global
 		"lvm.use_thinpool": validate.Optional(validate.IsBool),
 		// lxdmeta:generate(entities=storage-lvm; group=pool-conf; key=lvm.vg.force_reuse)
 		//
@@ -541,6 +545,7 @@ func (d *lvm) Validate(config map[string]string) error {
 		//  type: bool
 		//  defaultdesc: `false`
 		//  shortdesc: Force using an existing non-empty volume group
+		//  scope: global
 		"lvm.vg.force_reuse": validate.Optional(validate.IsBool),
 	}
 

--- a/lxd/storage/drivers/driver_lvm_volumes.go
+++ b/lxd/storage/drivers/driver_lvm_volumes.go
@@ -313,6 +313,7 @@ func (d *lvm) commonVolumeRules() map[string]func(value string) error {
 		//  type: string
 		//  defaultdesc: same as `volume.lvm.stripes`
 		//  shortdesc: Number of stripes to use for new volumes (or thin pool volume)
+		//  scope: global
 		"lvm.stripes": validate.Optional(validate.IsUint32),
 		// lxdmeta:generate(entities=storage-lvm; group=volume-conf; key=lvm.stripes.size)
 		// The size must be at least 4096 bytes, and a multiple of 512 bytes.
@@ -320,6 +321,7 @@ func (d *lvm) commonVolumeRules() map[string]func(value string) error {
 		//  type: string
 		//  defaultdesc: same as `volume.lvm.stripes.size`
 		//  shortdesc: Size of stripes to use
+		//  scope: global
 		"lvm.stripes.size": validate.Optional(validate.IsSize),
 	}
 }

--- a/lxd/storage/drivers/driver_powerflex.go
+++ b/lxd/storage/drivers/driver_powerflex.go
@@ -199,18 +199,21 @@ func (d *powerflex) Validate(config map[string]string) error {
 		//  type: string
 		//  defaultdesc: `admin`
 		//  shortdesc: User for PowerFlex Gateway authentication
+		//  scope: global
 		"powerflex.user.name": validate.IsAny,
 		// lxdmeta:generate(entities=storage-powerflex; group=pool-conf; key=powerflex.user.password)
 		//
 		// ---
 		//  type: string
 		//  shortdesc: Password for PowerFlex Gateway authentication
+		//  scope: global
 		"powerflex.user.password": validate.IsAny,
 		// lxdmeta:generate(entities=storage-powerflex; group=pool-conf; key=powerflex.gateway)
 		//
 		// ---
 		//  type: string
 		//  shortdesc: Address of the PowerFlex Gateway
+		//  scope: global
 		"powerflex.gateway": validate.Optional(validate.IsRequestURL),
 		// lxdmeta:generate(entities=storage-powerflex; group=pool-conf; key=powerflex.gateway.verify)
 		//
@@ -218,18 +221,21 @@ func (d *powerflex) Validate(config map[string]string) error {
 		//  type: bool
 		//  defaultdesc: `true`
 		//  shortdesc: Whether to verify the PowerFlex Gateway's certificate
+		//  scope: global
 		"powerflex.gateway.verify": validate.Optional(validate.IsBool),
 		// lxdmeta:generate(entities=storage-powerflex; group=pool-conf; key=powerflex.pool)
 		// If you want to specify the storage pool via its name, also set {config:option}`storage-powerflex-pool-conf:powerflex.domain`.
 		// ---
 		//  type: string
 		//  shortdesc: ID of the PowerFlex storage pool
+		//  scope: global
 		"powerflex.pool": validate.IsAny,
 		// lxdmeta:generate(entities=storage-powerflex; group=pool-conf; key=powerflex.domain)
 		// This option is required only if {config:option}`storage-powerflex-pool-conf:powerflex.pool` is specified using its name.
 		// ---
 		//  type: string
 		//  shortdesc: Name of the PowerFlex protection domain
+		//  scope: global
 		"powerflex.domain": validate.IsAny,
 		// lxdmeta:generate(entities=storage-powerflex; group=pool-conf; key=powerflex.mode)
 		// The mode gets discovered automatically if the system provides the necessary kernel modules.
@@ -238,6 +244,7 @@ func (d *powerflex) Validate(config map[string]string) error {
 		//  type: string
 		//  defaultdesc: the discovered mode
 		//  shortdesc: How volumes are mapped to the local server
+		//  scope: global
 		"powerflex.mode": validate.Optional(validate.IsOneOf("nvme", "sdc")),
 		// lxdmeta:generate(entities=storage-powerflex; group=pool-conf; key=powerflex.sdt)
 		//
@@ -245,6 +252,7 @@ func (d *powerflex) Validate(config map[string]string) error {
 		//  type: string
 		//  defaultdesc: one of the SDT
 		//  shortdesc: PowerFlex NVMe/TCP SDT
+		//  scope: global
 		"powerflex.sdt": validate.Optional(validate.IsNetworkAddress),
 		// lxdmeta:generate(entities=storage-powerflex; group=pool-conf; key=powerflex.clone_copy)
 		// If this option is set to `true`, PowerFlex makes a non-sparse copy when creating a snapshot of an instance or custom volume.
@@ -253,6 +261,7 @@ func (d *powerflex) Validate(config map[string]string) error {
 		//  type: bool
 		//  defaultdesc: `true`
 		//  shortdesc: Whether to use non-sparse copies for snapshots
+		//  scope: global
 		"powerflex.clone_copy": validate.Optional(validate.IsBool),
 		// lxdmeta:generate(entities=storage-powerflex; group=pool-conf; key=volume.size)
 		// The size must be in multiples of 8 GiB.
@@ -261,6 +270,7 @@ func (d *powerflex) Validate(config map[string]string) error {
 		//  type: string
 		//  defaultdesc: `8GiB`
 		//  shortdesc: Size/quota of the storage volume
+		//  scope: global
 		"volume.size": validate.Optional(validate.IsMultipleOfUnit("8GiB")),
 	}
 

--- a/lxd/storage/drivers/driver_powerflex_volumes.go
+++ b/lxd/storage/drivers/driver_powerflex_volumes.go
@@ -431,6 +431,7 @@ func (d *powerflex) commonVolumeRules() map[string]func(value string) error {
 		//  condition: block-based volume with content type `filesystem`
 		//  defaultdesc: same as `volume.block.filesystem`
 		//  shortdesc: File system of the storage volume
+		//  scope: global
 		"block.filesystem": validate.Optional(validate.IsOneOf(blockBackedAllowedFilesystems...)),
 		// lxdmeta:generate(entities=storage-powerflex; group=volume-conf; key=block.mount_options)
 		//
@@ -439,6 +440,7 @@ func (d *powerflex) commonVolumeRules() map[string]func(value string) error {
 		//  condition: block-based volume with content type `filesystem`
 		//  defaultdesc: same as `volume.block.mount_options`
 		//  shortdesc: Mount options for block-backed file system volumes
+		//  scope: global
 		"block.mount_options": validate.IsAny,
 		// lxdmeta:generate(entities=storage-powerflex; group=volume-conf; key=block.type)
 		//
@@ -446,6 +448,7 @@ func (d *powerflex) commonVolumeRules() map[string]func(value string) error {
 		//  type: string
 		//  defaultdesc: same as `volume.block.type` or `thick`
 		//  shortdesc: Whether to create a `thin` or `thick` provisioned volume
+		//  scope: global
 		"block.type": validate.Optional(validate.IsOneOf("thin", "thick")),
 		// lxdmeta:generate(entities=storage-powerflex; group=volume-conf; key=size)
 		// The size must be in multiples of 8 GiB.
@@ -454,6 +457,7 @@ func (d *powerflex) commonVolumeRules() map[string]func(value string) error {
 		//  type: string
 		//  defaultdesc: same as `volume.size`
 		//  shortdesc: Size/quota of the storage volume
+		//  scope: global
 		"size": validate.Optional(validate.IsMultipleOfUnit("8GiB")),
 	}
 }

--- a/lxd/storage/drivers/driver_zfs.go
+++ b/lxd/storage/drivers/driver_zfs.go
@@ -451,6 +451,7 @@ func (d *zfs) Validate(config map[string]string) error {
 		//  type: string
 		//  defaultdesc: name of the pool
 		//  shortdesc: Name of the zpool
+		//  scope: local
 		"zfs.pool_name": validate.IsAny,
 		// lxdmeta:generate(entities=storage-zfs; group=pool-conf; key=zfs.clone_copy)
 		// Set this option to `true` or `false` to enable or disable using ZFS lightweight clones rather
@@ -460,6 +461,7 @@ func (d *zfs) Validate(config map[string]string) error {
 		//  type: string
 		//  defaultdesc: `true`
 		//  shortdesc: Whether to use ZFS lightweight clones
+		//  scope: global
 		"zfs.clone_copy": validate.Optional(func(value string) error {
 			if value == "rebase" {
 				return nil
@@ -473,6 +475,7 @@ func (d *zfs) Validate(config map[string]string) error {
 		//  type: bool
 		//  defaultdesc: `true`
 		//  shortdesc: Disable zpool export while an unmount is being performed
+		//  scope: global
 		"zfs.export": validate.Optional(validate.IsBool),
 	}
 

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -1562,6 +1562,7 @@ func (d *zfs) commonVolumeRules() map[string]func(value string) error {
 		//  condition: block-based volume with content type `filesystem` (`zfs.block_mode` enabled)
 		//  defaultdesc: same as `volume.block.filesystem`
 		//  shortdesc: File system of the storage volume
+		//  scope: global
 		"block.filesystem": validate.Optional(validate.IsOneOf(blockBackedAllowedFilesystems...)),
 		// lxdmeta:generate(entities=storage-zfs; group=volume-conf; key=block.mount_options)
 		//
@@ -1570,6 +1571,7 @@ func (d *zfs) commonVolumeRules() map[string]func(value string) error {
 		//  condition: block-based volume with content type `filesystem` (`zfs.block_mode` enabled)
 		//  defaultdesc: same as `volume.block.mount_options`
 		//  shortdesc: Mount options for block-backed file system volumes
+		//  scope: global
 		"block.mount_options": validate.IsAny,
 		// lxdmeta:generate(entities=storage-zfs; group=volume-conf; key=zfs.block_mode)
 		// `zfs.block_mode` can be set only for custom storage volumes.
@@ -1579,6 +1581,7 @@ func (d *zfs) commonVolumeRules() map[string]func(value string) error {
 		//  type: bool
 		//  defaultdesc: same as `volume.zfs.block_mode`
 		//  shortdesc: Whether to use a formatted `zvol` rather than a dataset
+		//  scope: global
 		"zfs.block_mode": validate.Optional(validate.IsBool),
 		// lxdmeta:generate(entities=storage-zfs; group=volume-conf; key=zfs.blocksize)
 		// The size must be between 512 bytes and 16 MiB and must be a power of 2.
@@ -1590,6 +1593,7 @@ func (d *zfs) commonVolumeRules() map[string]func(value string) error {
 		//  type: string
 		//  defaultdesc: same as `volume.zfs.blocksize`
 		//  shortdesc: Size of the ZFS block
+		//  scope: global
 		"zfs.blocksize": validate.Optional(ValidateZfsBlocksize),
 		// lxdmeta:generate(entities=storage-zfs; group=volume-conf; key=zfs.remove_snapshots)
 		//
@@ -1597,6 +1601,7 @@ func (d *zfs) commonVolumeRules() map[string]func(value string) error {
 		//  type: bool
 		//  defaultdesc: same as `volume.zfs.remove_snapshots` or `false`
 		//  shortdesc: Remove snapshots as needed
+		//  scope: global
 		"zfs.remove_snapshots": validate.Optional(validate.IsBool),
 		// lxdmeta:generate(entities=storage-zfs; group=volume-conf; key=zfs.reserve_space)
 		//
@@ -1604,6 +1609,7 @@ func (d *zfs) commonVolumeRules() map[string]func(value string) error {
 		//  type: bool
 		//  defaultdesc: same as `volume.zfs.reserve_space` or `false`
 		//  shortdesc: Use `reservation`/`refreservation` along with `quota`/`refquota`
+		//  scope: global
 		"zfs.reserve_space": validate.Optional(validate.IsBool),
 		// lxdmeta:generate(entities=storage-zfs; group=volume-conf; key=zfs.use_refquota)
 		//
@@ -1611,6 +1617,7 @@ func (d *zfs) commonVolumeRules() map[string]func(value string) error {
 		//  type: bool
 		//  defaultdesc: same as `volume.zfs.use_refquota` or `false`
 		//  shortdesc: Use `refquota` instead of `quota` for space
+		//  scope: global
 		"zfs.use_refquota": validate.Optional(validate.IsBool),
 		// lxdmeta:generate(entities=storage-zfs; group=volume-conf; key=zfs.delegate)
 		// This option controls whether to delegate the ZFS dataset and anything underneath it to the
@@ -1620,6 +1627,7 @@ func (d *zfs) commonVolumeRules() map[string]func(value string) error {
 		//  condition: ZFS 2.2 or higher
 		//  defaultdesc: same as `volume.zfs.delegate`
 		//  shortdesc: Whether to delegate the ZFS dataset
+		//  scope: global
 		"zfs.delegate": validate.Optional(validate.IsBool),
 	}
 }

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -508,6 +508,7 @@ func poolAndVolumeCommonRules(vol *drivers.Volume) map[string]func(string) error
 		//  type: string
 		//  defaultdesc: auto (20% of free disk space, >= 5 GiB and <= 30 GiB)
 		//  shortdesc: Size of the storage pool (for loop-based pools)
+		//  scope: local
 
 		// lxdmeta:generate(entities=storage-btrfs,storage-cephfs,storage-ceph,storage-dir,storage-lvm,storage-zfs; group=volume-conf; key=size)
 		//
@@ -516,12 +517,14 @@ func poolAndVolumeCommonRules(vol *drivers.Volume) map[string]func(string) error
 		//  condition: appropriate driver
 		//  defaultdesc: same as `volume.size`
 		//  shortdesc: Size/quota of the storage volume
+		//  scope: local
 
 		// lxdmeta:generate(entities=storage-cephobject; group=bucket-conf; key=size)
 		//
 		// ---
 		//  type: string
 		//  shortdesc: Quota of the storage bucket
+		//  scope: local
 
 		// lxdmeta:generate(entities=storage-btrfs,storage-lvm,storage-zfs; group=bucket-conf; key=size)
 		//
@@ -530,6 +533,7 @@ func poolAndVolumeCommonRules(vol *drivers.Volume) map[string]func(string) error
 		//  condition: appropriate driver
 		//  defaultdesc: same as `volume.size`
 		//  shortdesc: Size/quota of the storage bucket
+		//  scope: local
 		"size": validate.Optional(validate.IsSize),
 		// lxdmeta:generate(entities=storage-btrfs,storage-cephfs,storage-ceph,storage-dir,storage-lvm,storage-zfs,storage-powerflex; group=volume-conf; key=snapshots.expiry)
 		// Specify an expression like `1M 2H 3d 4w 5m 6y`.
@@ -538,6 +542,7 @@ func poolAndVolumeCommonRules(vol *drivers.Volume) map[string]func(string) error
 		//  condition: custom volume
 		//  defaultdesc: same as `volume.snapshots.expiry`
 		//  shortdesc: When snapshots are to be deleted
+		//  scope: global
 		"snapshots.expiry": func(value string) error {
 			// Validate expression
 			_, err := shared.GetExpiry(time.Time{}, value)
@@ -550,6 +555,7 @@ func poolAndVolumeCommonRules(vol *drivers.Volume) map[string]func(string) error
 		//  condition: custom volume
 		//  defaultdesc: same as `snapshots.schedule`
 		//  shortdesc: Schedule for automatic volume snapshots
+		//  scope: global
 		"snapshots.schedule": validate.Optional(validate.IsCron([]string{"@hourly", "@daily", "@midnight", "@weekly", "@monthly", "@annually", "@yearly"})),
 		// lxdmeta:generate(entities=storage-btrfs,storage-cephfs,storage-ceph,storage-dir,storage-lvm,storage-zfs,storage-powerflex; group=volume-conf; key=snapshots.pattern)
 		// You can specify a naming template that is used for scheduled snapshots and unnamed snapshots.
@@ -560,6 +566,7 @@ func poolAndVolumeCommonRules(vol *drivers.Volume) map[string]func(string) error
 		//  condition: custom volume
 		//  defaultdesc: same as `volume.snapshots.pattern` or `snap%d`
 		//  shortdesc: Template for the snapshot name
+		//  scope: global
 		"snapshots.pattern": validate.IsAny,
 	}
 
@@ -572,6 +579,7 @@ func poolAndVolumeCommonRules(vol *drivers.Volume) map[string]func(string) error
 		//  condition: custom volume
 		//  defaultdesc: same as `volume.security.shifted` or `false`
 		//  shortdesc: Enable ID shifting overlay
+		//  scope: global
 		rules["security.shifted"] = validate.Optional(validate.IsBool)
 		// lxdmeta:generate(entities=storage-btrfs,storage-cephfs,storage-ceph,storage-dir,storage-lvm,storage-zfs,storage-powerflex; group=volume-conf; key=security.unmapped)
 		//
@@ -580,6 +588,7 @@ func poolAndVolumeCommonRules(vol *drivers.Volume) map[string]func(string) error
 		//  condition: custom volume
 		//  defaultdesc: same as `volume.security.unmappped` or `false`
 		//  shortdesc: Disable ID mapping for the volume
+		//  scope: global
 		rules["security.unmapped"] = validate.Optional(validate.IsBool)
 	}
 
@@ -593,6 +602,7 @@ func poolAndVolumeCommonRules(vol *drivers.Volume) map[string]func(string) error
 		//  condition: custom block volume
 		//  defaultdesc: same as `volume.security.shared` or `false`
 		//  shortdesc: Enable volume sharing
+		//  scope: global
 		rules["security.shared"] = validate.Optional(validate.IsBool)
 	}
 
@@ -604,6 +614,7 @@ func poolAndVolumeCommonRules(vol *drivers.Volume) map[string]func(string) error
 		//  type: string
 		//  defaultdesc: random UUID
 		//  shortdesc: The volume's UUID
+		//  scope: global
 		rules["volatile.uuid"] = validate.Optional(validate.IsUUID)
 	}
 
@@ -618,36 +629,42 @@ func validatePoolCommonRules() map[string]func(string) error {
 		// ---
 		//  type: string
 		//  shortdesc: Path to an existing block device, loop file, or Btrfs subvolume
+		//  scope: local
 
 		// lxdmeta:generate(entities=storage-cephfs; group=pool-conf; key=source)
 		//
 		// ---
 		//  type: string
 		//  shortdesc: Existing CephFS file system or file system path to use
+		//  scope: local
 
 		// lxdmeta:generate(entities=storage-ceph; group=pool-conf; key=source)
 		//
 		// ---
 		//  type: string
 		//  shortdesc: Existing OSD storage pool to use
+		//  scope: local
 
 		// lxdmeta:generate(entities=storage-dir; group=pool-conf; key=source)
 		//
 		// ---
 		//  type: string
 		//  shortdesc: Path to an existing directory
+		//  scope: local
 
 		// lxdmeta:generate(entities=storage-lvm; group=pool-conf; key=source)
 		//
 		// ---
 		//  type: string
 		//  shortdesc: Path to an existing block device, loop file, or LVM volume group
+		//  scope: local
 
 		// lxdmeta:generate(entities=storage-zfs; group=pool-conf; key=source)
 		//
 		// ---
 		//  type: string
 		//  shortdesc: Path to an existing block device, loop file, or ZFS dataset/pool
+		//  scope: local
 		"source": validate.IsAny,
 		// lxdmeta:generate(entities=storage-btrfs,storage-lvm,storage-zfs; group=pool-conf; key=source.wipe)
 		// Set this option to `true` to wipe the block device specified in `source`
@@ -656,6 +673,7 @@ func validatePoolCommonRules() map[string]func(string) error {
 		//  type: bool
 		//  defaultdesc: `false`
 		//  shortdesc: Whether to wipe the block device before creating the pool
+		//  scope: local
 		"source.wipe":             validate.Optional(validate.IsBool),
 		"volatile.initial_source": validate.IsAny,
 		// lxdmeta:generate(entities=storage-dir,storage-lvm,storage-powerflex; group=pool-conf; key=rsync.bwlimit)
@@ -665,6 +683,7 @@ func validatePoolCommonRules() map[string]func(string) error {
 		//  type: string
 		//  defaultdesc: `0` (no limit)
 		//  shortdesc: Upper limit on the socket I/O for `rsync`
+		//  scope: global
 		"rsync.bwlimit": validate.Optional(validate.IsSize),
 		// lxdmeta:generate(entities=storage-dir,storage-lvm,storage-powerflex; group=pool-conf; key=rsync.compression)
 		//
@@ -672,6 +691,7 @@ func validatePoolCommonRules() map[string]func(string) error {
 		//  type: bool
 		//  defaultdesc: `true`
 		//  shortdesc: Whether to use compression while migrating storage pools
+		//  scope: global
 		"rsync.compression": validate.Optional(validate.IsBool),
 	}
 

--- a/shared/api/metadata_configuration.go
+++ b/shared/api/metadata_configuration.go
@@ -64,6 +64,12 @@ type MetadataConfigurationConfigKey struct {
 	//
 	// Example: yes.
 	Managed string `json:"managed"`
+
+	// Scope describes the cluster member specificity of a configuration key. Options marked with a `global` scope are applied to all cluster members. Options marked with a `local` scope are set on a per-member basis.
+	//
+	// Example: global
+	// API extension: metadata_configuration_scope
+	Scope string `json:"scope" yaml:"scope"`
 }
 
 // MetadataConfigurationEntity contains metadata about LXD server entities and available entitlements for authorization.

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -424,6 +424,7 @@ var APIExtensions = []string{
 	"vm_limits_cpu_pin_strategy",
 	"gpu_cdi",
 	"images_all_projects",
+	"metadata_configuration_scope",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
Resolves https://github.com/canonical/lxd/issues/14125.

This PR adds `scope` to the metadata configuration API endpoint, `/1.0/metadata/configuration`.

Summary of changes:
- Adds api extension, `metadata_configuration_scope`;
- Adds `Scope` field to `MetadataConfigurationConfigKey` struct;
- Adds `scope` to metadata for member specific config keys in `lxd/network/driver_{bridge/macvlan/physical/sriov}.go`;
- Updates API docs and metadata.