### PR TITLE
Attach VM root volumes as disk devices

### DIFF
--- a/doc/.custom_wordlist.txt
+++ b/doc/.custom_wordlist.txt
@@ -304,6 +304,7 @@ uptime
 URI
 URIs
 userspace
+UUIDs
 vCPU
 vCPUs
 VDPA

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2546,3 +2546,9 @@ Adds optional `target` parameter to `GET /1.0/network`. When target is set, forw
 ## `network_zones_all_projects`
 
 This adds support for listing network zones across all projects using the `all-projects` parameter in `GET /1.0/network-zones` requests.
+
+## `instance_root_volume_attachment`
+
+Adds support for instance root volumes to be attached to other instances as disk
+devices. Introduces the `<type>/<volume>` syntax for the `source` property of
+disk devices.

--- a/doc/explanation/storage.md
+++ b/doc/explanation/storage.md
@@ -120,10 +120,10 @@ Storage volumes can be of the following types:
 
 `container`/`virtual-machine`
 : LXD automatically creates one of these storage volumes when you launch an instance.
-  It is used as the root disk for the instance, and it is destroyed when the instance is deleted.
+  It is used as the root disk for the instance and is destroyed when the instance is deleted.
 
-  This storage volume is created in the storage pool that is specified in the profile used when launching the instance (or the default profile, if no profile is specified).
-  The storage pool can be explicitly specified by providing the `--storage` flag to the launch command.
+  The storage pool can be explicitly specified by providing the `--storage` flag to the {ref}`launch command <lxc_launch.md>`.
+  If no pool or profile is specified, LXD uses the storage pool of the default profile's root disk device.
 
 `image`
 : LXD automatically creates one of these storage volumes when it unpacks an image to launch one or more instances from it.
@@ -157,7 +157,7 @@ Each storage volume uses one of the following content types:
 
   Custom storage volumes of content type `block` can only be attached to virtual machines.
   By default, they can only be attached to one instance at a time, because simultaneous access can lead to data corruption.
-  Sharing a custom storage volumes of content type `block` is made possible through the usage of the `security.shared` configuration key.
+  Sharing custom storage volumes of content type `block` is made possible through the usage of the `security.shared` configuration key.
 
 `iso`
 : This content type is used for custom ISO volumes.

--- a/doc/howto/storage_volumes.md
+++ b/doc/howto/storage_volumes.md
@@ -179,6 +179,34 @@ For example, to set the default volume size for `my-pool`, use the following com
 
     lxc storage set my-pool volume.size=15GiB
 
+## Attach instance root volumes to other instances
+Virtual-machine root volumes can be attached as disk devices to other virtual machines.
+In order to prevent concurrent access, `security.protection.start` must be set on
+an instance before its root volume can be attached to another virtual-machine.
+
+```{caution}
+Because instances created from the same image share the same partition and file system
+UUIDs and labels, booting an instance with two root file systems mounted may result
+in the wrong root file system being used. This may result in unexpected behavior
+or data loss. **It is strongly recommended to only attach virtual-machine root
+volumes to other virtual machines when the target virtual-machine is running.**
+```
+
+Assuming `vm1` is stopped and `vm2` is running, attach the `virtual-machine/vm1` storage
+volume to `vm2`:
+
+    lxc config set vm1 security.protection.start=true
+    lxc storage volume attach my-pool virtual-machine/vm1 vm2
+
+`virtual-machine/vm1` must be detached from `vm2` before `security.protection.start`
+can be unset from `vm1`:
+
+    lxc storage volume detach my-pool virtual-machine/vm1 vm2
+    lxc config unset vm1 security.protection.start
+
+`security.shared` can also be used on `virtual-machine` volumes to enable concurrent
+access. Note that concurrent access to block volumes may result in data loss.
+
 ## Resize a storage volume
 
 If you need more storage in a volume, you can increase the size of your storage volume.

--- a/doc/metadata.txt
+++ b/doc/metadata.txt
@@ -2193,7 +2193,7 @@ See {ref}`container-security` for more information.
 
 ```{config:option} security.protection.delete instance-security
 :defaultdesc: "`false`"
-:liveupdate: "yes"
+:liveupdate: "container"
 :shortdesc: "Whether to prevent the instance from being deleted"
 :type: "bool"
 
@@ -2210,7 +2210,7 @@ Set this option to `true` to prevent the instance's file system from being UID/G
 
 ```{config:option} security.protection.start instance-security
 :defaultdesc: "`false`"
-:liveupdate: "yes"
+:liveupdate: "container"
 :shortdesc: "Whether to prevent the instance from being started"
 :type: "bool"
 
@@ -4881,7 +4881,7 @@ prior to creating the storage pool.
 <!-- config group storage-btrfs-pool-conf end -->
 <!-- config group storage-btrfs-volume-conf start -->
 ```{config:option} security.shared storage-btrfs-volume-conf
-:condition: "custom block volume"
+:condition: "virtual-machine or custom block volume"
 :defaultdesc: "same as `volume.security.shared` or `false`"
 :scope: "global"
 :shortdesc: "Enable volume sharing"
@@ -5073,7 +5073,7 @@ If not set, `ext4` is assumed.
 ```
 
 ```{config:option} security.shared storage-ceph-volume-conf
-:condition: "custom block volume"
+:condition: "virtual-machine or custom block volume"
 :defaultdesc: "same as `volume.security.shared` or `false`"
 :scope: "global"
 :shortdesc: "Enable volume sharing"
@@ -5404,7 +5404,7 @@ to be placed on the socket I/O.
 <!-- config group storage-dir-pool-conf end -->
 <!-- config group storage-dir-volume-conf start -->
 ```{config:option} security.shared storage-dir-volume-conf
-:condition: "custom block volume"
+:condition: "virtual-machine or custom block volume"
 :defaultdesc: "same as `volume.security.shared` or `false`"
 :scope: "global"
 :shortdesc: "Enable volume sharing"
@@ -5622,7 +5622,7 @@ The size must be at least 4096 bytes, and a multiple of 512 bytes.
 ```
 
 ```{config:option} security.shared storage-lvm-volume-conf
-:condition: "custom block volume"
+:condition: "virtual-machine or custom block volume"
 :defaultdesc: "same as `volume.security.shared` or `false`"
 :scope: "global"
 :shortdesc: "Enable volume sharing"
@@ -5832,7 +5832,7 @@ If not set, `ext4` is assumed.
 ```
 
 ```{config:option} security.shared storage-powerflex-volume-conf
-:condition: "custom block volume"
+:condition: "virtual-machine or custom block volume"
 :defaultdesc: "same as `volume.security.shared` or `false`"
 :scope: "global"
 :shortdesc: "Enable volume sharing"
@@ -6003,7 +6003,7 @@ If not set, `ext4` is assumed.
 ```
 
 ```{config:option} security.shared storage-zfs-volume-conf
-:condition: "custom block volume"
+:condition: "virtual-machine or custom block volume"
 :defaultdesc: "same as `volume.security.shared` or `false`"
 :scope: "global"
 :shortdesc: "Enable volume sharing"

--- a/lxc/storage_volume.go
+++ b/lxc/storage_volume.go
@@ -164,10 +164,12 @@ type cmdStorageVolumeAttach struct {
 
 func (c *cmdStorageVolumeAttach) command() *cobra.Command {
 	cmd := &cobra.Command{}
-	cmd.Use = usage("attach", i18n.G("[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"))
+	cmd.Use = usage("attach", i18n.G("[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"))
 	cmd.Short = i18n.G("Attach new storage volumes to instances")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
-		`Attach new storage volumes to instances`))
+		`Attach new storage volumes to instances
+
+<type> must be one of "custom" or "virtual-machine"`))
 
 	cmd.RunE = c.run
 
@@ -210,8 +212,8 @@ func (c *cmdStorageVolumeAttach) run(cmd *cobra.Command, args []string) error {
 	}
 
 	volName, volType := parseVolume("custom", args[1])
-	if volType != "custom" {
-		return errors.New(i18n.G("Only \"custom\" volumes can be attached to instances"))
+	if volType != "custom" && volType != "virtual-machine" {
+		return errors.New(i18n.G(`Only "custom" and "virtual-machine" volumes can be attached to instances`))
 	}
 
 	// Attach the volume
@@ -257,7 +259,7 @@ func (c *cmdStorageVolumeAttach) run(cmd *cobra.Command, args []string) error {
 	device := map[string]string{
 		"type":   "disk",
 		"pool":   resource.name,
-		"source": volName,
+		"source": args[1],
 		"path":   devPath,
 	}
 
@@ -279,10 +281,12 @@ type cmdStorageVolumeAttachProfile struct {
 
 func (c *cmdStorageVolumeAttachProfile) command() *cobra.Command {
 	cmd := &cobra.Command{}
-	cmd.Use = usage("attach-profile", i18n.G("[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"))
+	cmd.Use = usage("attach-profile", i18n.G("[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"))
 	cmd.Short = i18n.G("Attach new storage volumes to profiles")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
-		`Attach new storage volumes to profiles`))
+		`Attach new storage volumes to profiles
+
+<type> must be one of "custom" or "virtual-machine"`))
 
 	cmd.RunE = c.run
 
@@ -340,8 +344,8 @@ func (c *cmdStorageVolumeAttachProfile) run(cmd *cobra.Command, args []string) e
 	}
 
 	volName, volType := parseVolume("custom", args[1])
-	if volType != "custom" {
-		return errors.New(i18n.G("Only \"custom\" volumes can be attached to instances"))
+	if volType != "custom" && volType != "virtual-machine" {
+		return errors.New(i18n.G(`Only "custom" and "virtual-machine" volumes can be attached to profiles`))
 	}
 
 	// Check if the requested storage volume actually exists
@@ -354,7 +358,7 @@ func (c *cmdStorageVolumeAttachProfile) run(cmd *cobra.Command, args []string) e
 	device := map[string]string{
 		"type":   "disk",
 		"pool":   resource.name,
-		"source": vol.Name,
+		"source": args[1],
 	}
 
 	// Ignore path for block volumes

--- a/lxc/storage_volume.go
+++ b/lxc/storage_volume.go
@@ -807,7 +807,7 @@ type cmdStorageVolumeDetach struct {
 
 func (c *cmdStorageVolumeDetach) command() *cobra.Command {
 	cmd := &cobra.Command{}
-	cmd.Use = usage("detach", i18n.G("[<remote>:]<pool> <volume> <instance> [<device name>]"))
+	cmd.Use = usage("detach", i18n.G("[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"))
 	cmd.Short = i18n.G("Detach storage volumes from instances")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Detach storage volumes from instances`))
@@ -865,14 +865,13 @@ func (c *cmdStorageVolumeDetach) run(cmd *cobra.Command, args []string) error {
 	}
 
 	volName, volType := parseVolume("custom", args[1])
-	if volType != "custom" {
-		return errors.New(i18n.G(`Only "custom" volumes can be attached to instances`))
-	}
 
 	// Find the device
 	if devName == "" {
 		for n, d := range inst.Devices {
-			if d["type"] == "disk" && d["pool"] == resource.name && d["source"] == volName {
+			sourceName, sourceType := parseVolume("custom", d["source"])
+
+			if d["type"] == "disk" && d["pool"] == resource.name && volType == sourceType && volName == sourceName {
 				if devName != "" {
 					return errors.New(i18n.G("More than one device matches, specify the device name"))
 				}
@@ -910,7 +909,7 @@ type cmdStorageVolumeDetachProfile struct {
 
 func (c *cmdStorageVolumeDetachProfile) command() *cobra.Command {
 	cmd := &cobra.Command{}
-	cmd.Use = usage("detach-profile", i18n.G("[<remote:>]<pool> <volume> <profile> [<device name>]"))
+	cmd.Use = usage("detach-profile", i18n.G("[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"))
 	cmd.Short = i18n.G("Detach storage volumes from profiles")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Detach storage volumes from profiles`))
@@ -967,14 +966,13 @@ func (c *cmdStorageVolumeDetachProfile) run(cmd *cobra.Command, args []string) e
 	}
 
 	volName, volType := parseVolume("custom", args[1])
-	if volType != "custom" {
-		return errors.New(i18n.G(`Only "custom" volumes can be attached to instances`))
-	}
 
 	// Find the device
 	if devName == "" {
 		for n, d := range profile.Devices {
-			if d["type"] == "disk" && d["pool"] == resource.name && d["source"] == volName {
+			sourceName, sourceType := parseVolume("custom", d["source"])
+
+			if d["type"] == "disk" && d["pool"] == resource.name && volType == sourceType && volName == sourceName {
 				if devName != "" {
 					return errors.New(i18n.G("More than one device matches, specify the device name"))
 				}

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -480,6 +480,17 @@ func (d *disk) validateConfig(instConf instance.ConfigReader) error {
 					return err
 				}
 
+				if d.inst != nil {
+					instVolType, err := storagePools.InstanceTypeToVolumeType(d.inst.Type())
+					if err != nil {
+						return err
+					}
+
+					if instVolType == volumeType && d.inst.Name() == volumeName {
+						return errors.New("Instance root device cannot be attached to itself")
+					}
+				}
+
 				// Derive the effective storage project name from the instance config's project.
 				storageProjectName, err = project.StorageVolumeProject(d.state.DB.Cluster, instConf.Project().Name, dbVolumeType)
 				if err != nil {

--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -1697,6 +1697,55 @@ func (d *common) deleteSnapshots(deleteFunc func(snapInst instance.Instance) err
 	return nil
 }
 
+// checkRootVolumeNotInUse fails if the instance's root volume is in use on
+// another instance.
+func (d *common) checkRootVolumeNotInUse() error {
+	// Make sure that the instance's root volume is not attached to another instance
+	storagePool, err := d.getStoragePool()
+	if err != nil {
+		return err
+	}
+
+	rootVolumeType, err := storagePools.InstanceTypeToVolumeType(d.Type())
+	if err != nil {
+		return err
+	}
+
+	rootVolumeDBType, err := storagePools.VolumeTypeToDBType(rootVolumeType)
+	if err != nil {
+		return err
+	}
+
+	var rootVolume *db.StorageVolume
+	err = d.state.DB.Cluster.Transaction(d.state.ShutdownCtx, func(ctx context.Context, tx *db.ClusterTx) error {
+		rootVolume, err = tx.GetStoragePoolVolume(ctx, storagePool.ID(), d.Project().Name, rootVolumeDBType, d.Name(), true)
+		return err
+	})
+	if err != nil {
+		return err
+	}
+
+	err = storagePools.VolumeUsedByProfileDevices(d.state, storagePool.Name(), d.Project().Name, &rootVolume.StorageVolume, func(profileID int64, profile api.Profile, p api.Project, usedByDevices []string) error {
+		return fmt.Errorf(`"%s/%s" is attached to a profile`, rootVolume.Type, rootVolume.Name)
+	})
+	if err != nil {
+		return err
+	}
+
+	err = storagePools.VolumeUsedByInstanceDevices(d.state, storagePool.Name(), d.Project().Name, &rootVolume.StorageVolume, false, func(inst db.InstanceArgs, p api.Project, usedByDevices []string) error {
+		if inst.Name == d.Name() && inst.Project == d.Project().Name {
+			return nil
+		}
+
+		return fmt.Errorf(`"%s/%s" is attached to another instance`, rootVolume.Type, rootVolume.Name)
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // removeUnixDevices reads the devices path and remove all unix devices.
 func (d *common) removeUnixDevices() error {
 	// Check that we indeed have devices to remove

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -5190,6 +5190,11 @@ func (d *qemu) Rename(newName string, applyTemplateTrigger bool) error {
 		return err
 	}
 
+	err = d.checkRootVolumeNotInUse()
+	if err != nil {
+		return err
+	}
+
 	if d.IsRunning() {
 		return fmt.Errorf("Renaming of running instance not allowed")
 	}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -6121,8 +6121,13 @@ func (d *qemu) delete(force bool) error {
 		return fmt.Errorf("Instance is protected from being deleted")
 	}
 
+	err := d.checkRootVolumeNotInUse()
+	if err != nil {
+		return err
+	}
+
 	// Delete any persistent warnings for instance.
-	err := d.warningsDelete()
+	err = d.warningsDelete()
 	if err != nil {
 		return err
 	}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -5347,6 +5347,47 @@ func (d *qemu) Rename(newName string, applyTemplateTrigger bool) error {
 	return nil
 }
 
+// allowRemoveSecurityProtectionStart: security.protection.start can be removed
+// from a VM when the root disk device has security.shared=true OR it is not
+// attached to any other VMs.
+func allowRemoveSecurityProtectionStart(state *state.State, poolName string, volumeName string, proj *api.Project) error {
+	pool, err := storagePools.LoadByName(state, poolName)
+	if err != nil {
+		return err
+	}
+
+	volumeType := dbCluster.StoragePoolVolumeTypeVM
+	volumeProject := project.StorageVolumeProjectFromRecord(proj, volumeType)
+
+	var dbVolume *db.StorageVolume
+	err = state.DB.Cluster.Transaction(state.ShutdownCtx, func(ctx context.Context, tx *db.ClusterTx) error {
+		dbVolume, err = tx.GetStoragePoolVolume(ctx, pool.ID(), volumeProject, volumeType, volumeName, true)
+		return err
+	})
+	if err != nil {
+		volumeTypeName := dbCluster.StoragePoolVolumeTypeNames[volumeType]
+		return fmt.Errorf(`Failed loading "%s/%s" from project %q: %w`, volumeTypeName, volumeName, volumeProject, err)
+	}
+
+	if shared.IsFalseOrEmpty(dbVolume.Config["security.shared"]) {
+		// Only check instances here, as a VM root volume cannot be part of a profile
+		// when not using security.shared
+		err := storagePools.VolumeUsedByInstanceDevices(state, pool.Name(), volumeProject, &dbVolume.StorageVolume, true, func(inst db.InstanceArgs, project api.Project, usedByDevices []string) error {
+			// The volume is always attached to its instance
+			if proj.Name == inst.Project && volumeName == inst.Name {
+				return nil
+			}
+
+			return fmt.Errorf("Cannot unset security.protection.start while the root device is attached to another instance")
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // Update the instance config.
 func (d *qemu) Update(args db.InstanceArgs, userRequested bool) error {
 	unlock, err := d.updateBackupFileLock(context.Background())
@@ -5597,6 +5638,15 @@ func (d *qemu) Update(args db.InstanceArgs, userRequested bool) error {
 		// Ensure the instance has a root disk.
 		if newErr != nil {
 			return fmt.Errorf("Invalid root disk device: %w", newErr)
+		}
+
+		// If security.protection.start is being removed, we need to make sure that
+		// our root disk device is not attached to another instance.
+		if shared.IsTrue(oldExpandedConfig["security.protection.start"]) && shared.IsFalseOrEmpty(d.expandedConfig["security.protection.start"]) {
+			err := allowRemoveSecurityProtectionStart(d.state, newRootDev["pool"], d.common.name, &d.common.project)
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/lxd/instance/instancetype/instance.go
+++ b/lxd/instance/instancetype/instance.go
@@ -351,7 +351,7 @@ var InstanceConfigKeysAny = map[string]func(value string) error{
 	// ---
 	//  type: bool
 	//  defaultdesc: `false`
-	//  liveupdate: yes
+	//  liveupdate: container
 	//  shortdesc: Whether to prevent the instance from being deleted
 	"security.protection.delete": validate.Optional(validate.IsBool),
 
@@ -360,7 +360,7 @@ var InstanceConfigKeysAny = map[string]func(value string) error{
 	// ---
 	//  type: bool
 	//  defaultdesc: `false`
-	//  liveupdate: yes
+	//  liveupdate: container
 	//  shortdesc: Whether to prevent the instance from being started
 	"security.protection.start": validate.Optional(validate.IsBool),
 

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -2473,7 +2473,7 @@
 					{
 						"security.protection.delete": {
 							"defaultdesc": "`false`",
-							"liveupdate": "yes",
+							"liveupdate": "container",
 							"longdesc": "",
 							"shortdesc": "Whether to prevent the instance from being deleted",
 							"type": "bool"
@@ -2492,7 +2492,7 @@
 					{
 						"security.protection.start": {
 							"defaultdesc": "`false`",
-							"liveupdate": "yes",
+							"liveupdate": "container",
 							"longdesc": "",
 							"shortdesc": "Whether to prevent the instance from being started",
 							"type": "bool"
@@ -5508,7 +5508,7 @@
 				"keys": [
 					{
 						"security.shared": {
-							"condition": "custom block volume",
+							"condition": "virtual-machine or custom block volume",
 							"defaultdesc": "same as `volume.security.shared` or `false`",
 							"longdesc": "Enabling this option allows sharing the volume across multiple instances despite the possibility of data loss.\n",
 							"scope": "global",
@@ -5713,7 +5713,7 @@
 					},
 					{
 						"security.shared": {
-							"condition": "custom block volume",
+							"condition": "virtual-machine or custom block volume",
 							"defaultdesc": "same as `volume.security.shared` or `false`",
 							"longdesc": "Enabling this option allows sharing the volume across multiple instances despite the possibility of data loss.\n",
 							"scope": "global",
@@ -6069,7 +6069,7 @@
 				"keys": [
 					{
 						"security.shared": {
-							"condition": "custom block volume",
+							"condition": "virtual-machine or custom block volume",
 							"defaultdesc": "same as `volume.security.shared` or `false`",
 							"longdesc": "Enabling this option allows sharing the volume across multiple instances despite the possibility of data loss.\n",
 							"scope": "global",
@@ -6299,7 +6299,7 @@
 					},
 					{
 						"security.shared": {
-							"condition": "custom block volume",
+							"condition": "virtual-machine or custom block volume",
 							"defaultdesc": "same as `volume.security.shared` or `false`",
 							"longdesc": "Enabling this option allows sharing the volume across multiple instances despite the possibility of data loss.\n",
 							"scope": "global",
@@ -6521,7 +6521,7 @@
 					},
 					{
 						"security.shared": {
-							"condition": "custom block volume",
+							"condition": "virtual-machine or custom block volume",
 							"defaultdesc": "same as `volume.security.shared` or `false`",
 							"longdesc": "Enabling this option allows sharing the volume across multiple instances despite the possibility of data loss.\n",
 							"scope": "global",
@@ -6696,7 +6696,7 @@
 					},
 					{
 						"security.shared": {
-							"condition": "custom block volume",
+							"condition": "virtual-machine or custom block volume",
 							"defaultdesc": "same as `volume.security.shared` or `false`",
 							"longdesc": "Enabling this option allows sharing the volume across multiple instances despite the possibility of data loss.\n",
 							"scope": "global",

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -5951,6 +5951,32 @@ func (b *lxdBackend) detectChangedConfig(curConfig, newConfig map[string]string)
 	return changedConfig, userOnly
 }
 
+func allowRemoveSecurityShared(s *state.State, projectName string, volume *api.StorageVolume) error {
+	err := VolumeUsedByProfileDevices(s, volume.Pool, projectName, volume, func(profileID int64, profile api.Profile, project api.Project, usedByDevices []string) error {
+		return fmt.Errorf("Cannot disable security.shared on custom storage block volume as it is attached to profile(s)")
+	})
+	if err != nil {
+		return err
+	}
+
+	usedByInstances := 0
+
+	err = VolumeUsedByInstanceDevices(s, volume.Pool, projectName, volume, true, func(inst db.InstanceArgs, project api.Project, usedByDevices []string) error {
+		usedByInstances += 1
+
+		if usedByInstances > 1 {
+			return fmt.Errorf("Cannot disable security.shared on custom storage block volume as it is attached to more than one instance")
+		}
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // UpdateCustomVolume applies the supplied config to the custom volume.
 func (b *lxdBackend) UpdateCustomVolume(projectName string, volName string, newDesc string, newConfig map[string]string, op *operations.Operation) error {
 	l := b.logger.AddContext(logger.Ctx{"project": projectName, "volName": volName, "newDesc": newDesc, "newConfig": newConfig})
@@ -6028,38 +6054,9 @@ func (b *lxdBackend) UpdateCustomVolume(projectName string, volName string, newD
 
 		sharedVolume, ok := changedConfig["security.shared"]
 		if ok && shared.IsFalseOrEmpty(sharedVolume) && curVol.ContentType == cluster.StoragePoolVolumeContentTypeNameBlock {
-			usedByProfile := false
-
-			err = VolumeUsedByProfileDevices(b.state, b.name, projectName, &curVol.StorageVolume, func(profileID int64, profile api.Profile, project api.Project, usedByDevices []string) error {
-				usedByProfile = true
-
-				return db.ErrListStop
-			})
-			if err != nil && err != db.ErrListStop {
+			err = allowRemoveSecurityShared(b.state, projectName, &curVol.StorageVolume)
+			if err != nil {
 				return err
-			}
-
-			if usedByProfile {
-				return fmt.Errorf("Cannot disable security.shared on custom storage block volume as it is attached to profile(s)")
-			}
-
-			var usedByInstanceDevices []string
-
-			err = VolumeUsedByInstanceDevices(b.state, b.name, projectName, &curVol.StorageVolume, true, func(inst db.InstanceArgs, project api.Project, usedByDevices []string) error {
-				usedByInstanceDevices = append(usedByInstanceDevices, inst.Name)
-
-				if len(usedByInstanceDevices) > 1 {
-					return db.ErrListStop
-				}
-
-				return nil
-			})
-			if err != nil && err != db.ErrListStop {
-				return err
-			}
-
-			if len(usedByInstanceDevices) > 1 {
-				return fmt.Errorf("Cannot disable security.shared on custom storage block volume as it is attached to more than one instance")
 			}
 		}
 

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -201,16 +201,14 @@ func DiskVolumeSourceParse(source string) (volType drivers.VolumeType, dbVolType
 		volName = source
 	}
 
-	// Check volume type name is custom.
+	// Check volume type can be attached as a disk device.
 	switch volTypeName {
 	case cluster.StoragePoolVolumeTypeNameContainer:
 		err = errors.New("Using container storage volumes is not supported")
-	case cluster.StoragePoolVolumeTypeNameVM:
-		err = errors.New("Using virtual-machine storage volumes is not supported")
+	case cluster.StoragePoolVolumeTypeNameVM, cluster.StoragePoolVolumeTypeNameCustom:
 	case "":
 		// We simply received the name of a custom storage volume.
 		volTypeName = cluster.StoragePoolVolumeTypeNameCustom
-	case cluster.StoragePoolVolumeTypeNameCustom:
 	case cluster.StoragePoolVolumeTypeNameImage:
 		err = errors.New("Using image storage volumes is not supported")
 	default:

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -592,14 +592,14 @@ func poolAndVolumeCommonRules(vol *drivers.Volume) map[string]func(string) error
 		rules["security.unmapped"] = validate.Optional(validate.IsBool)
 	}
 
-	// security.shared is only relevant for custom block volumes.
-	if vol == nil || (vol.Type() == drivers.VolumeTypeCustom && vol.ContentType() == drivers.ContentTypeBlock) {
+	// security.shared guards virtual-machine and custom block volumes.
+	if vol == nil || ((vol.Type() == drivers.VolumeTypeCustom || vol.Type() == drivers.VolumeTypeVM) && vol.ContentType() == drivers.ContentTypeBlock) {
 		// lxdmeta:generate(entities=storage-btrfs,storage-ceph,storage-dir,storage-lvm,storage-zfs,storage-powerflex; group=volume-conf; key=security.shared)
 		// Enabling this option allows sharing the volume across multiple instances despite the possibility of data loss.
 		//
 		// ---
 		//  type: bool
-		//  condition: custom block volume
+		//  condition: virtual-machine or custom block volume
 		//  defaultdesc: same as `volume.security.shared` or `false`
 		//  shortdesc: Enable volume sharing
 		//  scope: global

--- a/lxd/storage_volumes_utils.go
+++ b/lxd/storage_volumes_utils.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"slices"
 	"strings"
 
 	"github.com/canonical/lxd/lxd/backup"
@@ -138,8 +139,7 @@ func storagePoolVolumeUpdateUsers(s *state.State, projectName string, oldPoolNam
 
 // storagePoolVolumeUsedByGet returns a list of URL resources that use the volume.
 func storagePoolVolumeUsedByGet(s *state.State, requestProjectName string, vol *db.StorageVolume) ([]string, error) {
-	// Handle instance volumes.
-	if vol.Type == cluster.StoragePoolVolumeTypeNameContainer || vol.Type == cluster.StoragePoolVolumeTypeNameVM {
+	if vol.Type == cluster.StoragePoolVolumeTypeNameContainer {
 		volName, snapName, isSnap := api.GetParentAndSnapshotName(vol.Name)
 		if isSnap {
 			return []string{api.NewURL().Path(version.APIVersion, "instances", volName, "snapshots", snapName).Project(vol.Project).String()}, nil
@@ -182,6 +182,24 @@ func storagePoolVolumeUsedByGet(s *state.State, requestProjectName string, vol *
 	})
 	if err != nil {
 		return []string{}, err
+	}
+
+	// Handle instance volumes.
+	if vol.Type == cluster.StoragePoolVolumeTypeNameVM {
+		volName, snapName, isSnap := api.GetParentAndSnapshotName(vol.Name)
+		if isSnap {
+			return []string{api.NewURL().Path(version.APIVersion, "instances", volName, "snapshots", snapName).Project(vol.Project).String()}, nil
+		}
+
+		// VolumeUsedByInstanceDevices will find virtual-machine/container volumes
+		// when they are a root disk device in an instance's unexpanded devices,
+		// but not in a profile's devices.
+		// Since every virtual-machine/container volume is always in use by its
+		// corresponding instance, this ensures that it is reported.
+		instancePath := api.NewURL().Path(version.APIVersion, "instances", volName).Project(vol.Project).String()
+		if !slices.Contains(volumeUsedBy, instancePath) {
+			volumeUsedBy = append(volumeUsedBy, instancePath)
+		}
 	}
 
 	return volumeUsedBy, nil

--- a/po/ar.po
+++ b/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-07 15:11-0700\n"
+"POT-Creation-Date: 2025-01-10 14:44-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -46,7 +46,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1041
+#: lxc/storage_volume.go:1043
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -251,7 +251,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:667
+#: lxc/network_forward.go:675
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -427,12 +427,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1157
+#: lxc/file.go:1177
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1047
+#: lxc/file.go:1067
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -468,7 +468,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:65
+#: lxc/init.go:146 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -521,7 +521,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:687
+#: lxc/file.go:700
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -538,7 +538,7 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
@@ -669,7 +669,7 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:888 lxc/network_forward.go:889
+#: lxc/network_forward.go:896 lxc/network_forward.go:897
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -719,7 +719,7 @@ msgstr ""
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
+#: lxc/image_alias.go:101 lxc/image_alias.go:156 lxc/image_alias.go:320
 msgid "Alias name missing"
 msgstr ""
 
@@ -732,7 +732,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1607
+#: lxc/storage_volume.go:1609
 msgid "All projects"
 msgstr ""
 
@@ -763,7 +763,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -787,12 +787,26 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168 lxc/storage_volume.go:169
+#: lxc/storage_volume.go:168
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:169
+msgid ""
+"Attach new storage volumes to instances\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
+msgstr ""
+
+#: lxc/storage_volume.go:285
 msgid "Attach new storage volumes to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:286
+msgid ""
+"Attach new storage volumes to profiles\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
 #: lxc/console.go:39
@@ -843,16 +857,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2719
+#: lxc/storage_volume.go:2721
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2796
+#: lxc/export.go:192 lxc/storage_volume.go:2798
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1538
+#: lxc/info.go:666 lxc/storage_volume.go:1540
 msgid "Backups:"
 msgstr ""
 
@@ -861,19 +875,19 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
+#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:326
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -916,7 +930,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1752
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -968,7 +982,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -976,7 +990,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:562
+#: lxc/file.go:575
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1001,11 +1015,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:768
+#: lxc/file.go:790
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1018,12 +1032,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:493
+#: lxc/storage_volume.go:497
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:447
+#: lxc/storage_volume.go:451
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1129,9 +1143,9 @@ msgstr ""
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:497 lxc/network_forward.go:649
-#: lxc/network_forward.go:803 lxc/network_forward.go:892
-#: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
+#: lxc/network_forward.go:505 lxc/network_forward.go:657
+#: lxc/network_forward.go:811 lxc/network_forward.go:900
+#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
 #: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
 #: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
@@ -1143,14 +1157,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
-#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
-#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
-#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
+#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
 msgid "Cluster member name"
 msgstr ""
 
@@ -1166,7 +1180,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1608
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1206,21 +1220,21 @@ msgstr ""
 #: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
-#: lxc/network_acl.go:698 lxc/network_forward.go:767
+#: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
-#: lxc/storage_volume.go:1199
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
+#: lxc/storage_volume.go:1201
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:620
+#: lxc/storage_volume.go:624
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1478
+#: lxc/storage_volume.go:1480
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1282,7 +1296,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1290,12 +1304,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1308,7 +1322,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1403,7 +1417,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:462 lxc/file.go:696
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1443,7 +1457,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1495,12 +1509,12 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:182
+#: lxc/init.go:186
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1510,7 +1524,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 msgid "Creating the instance"
 msgstr ""
 
@@ -1524,13 +1538,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1749
+#: lxc/storage_volume.go:1751
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1550,7 +1564,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2653
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1582,7 +1596,7 @@ msgstr ""
 msgid "Delete identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:106 lxc/image_alias.go:107
+#: lxc/image_alias.go:123 lxc/image_alias.go:124
 msgid "Delete image aliases"
 msgstr ""
 
@@ -1606,7 +1620,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:799 lxc/network_forward.go:800
+#: lxc/network_forward.go:807 lxc/network_forward.go:808
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1646,7 +1660,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
+#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1688,13 +1702,13 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
-#: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
-#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
+#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
+#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
+#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
@@ -1708,10 +1722,10 @@ msgstr ""
 #: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:404 lxc/network_forward.go:489
-#: lxc/network_forward.go:599 lxc/network_forward.go:646
-#: lxc/network_forward.go:800 lxc/network_forward.go:874
-#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_forward.go:412 lxc/network_forward.go:497
+#: lxc/network_forward.go:607 lxc/network_forward.go:654
+#: lxc/network_forward.go:808 lxc/network_forward.go:882
+#: lxc/network_forward.go:897 lxc/network_forward.go:982
 #: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
 #: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
 #: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
@@ -1751,27 +1765,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
-#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
-#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
-#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
-#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
-#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
-#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
-#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1465
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1783,11 +1797,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
+#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1837,7 +1851,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:403
+#: lxc/init.go:407
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1849,7 +1863,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1216
+#: lxc/file.go:1236
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1945,7 +1959,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:377 lxc/file.go:378
+#: lxc/file.go:381 lxc/file.go:382
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1985,7 +1999,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:653 lxc/network_forward.go:654
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -2025,7 +2039,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2033,7 +2047,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1785
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2087,11 +2101,11 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
-#: lxc/network_acl.go:524 lxc/network_forward.go:572
+#: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
+#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2102,11 +2116,11 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
-#: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
+#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
-#: lxc/storage_volume.go:2210
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
+#: lxc/storage_volume.go:2212
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2148,8 +2162,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
+#: lxc/storage_volume.go:1577
 msgid "Expires at"
 msgstr ""
 
@@ -2173,7 +2187,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2185,11 +2199,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2650
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2779
+#: lxc/export.go:152 lxc/storage_volume.go:2781
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2208,7 +2222,7 @@ msgid "FILENAME"
 msgstr ""
 
 #: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
-#: lxc/image_alias.go:235
+#: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2216,12 +2230,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1467
+#: lxc/file.go:1491
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1490
+#: lxc/file.go:1514
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2236,12 +2250,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1517
+#: lxc/file.go:1541
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1326
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2271,7 +2285,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1423
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2286,7 +2300,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1428
+#: lxc/file.go:1452
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2296,12 +2310,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1352
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1455
+#: lxc/file.go:1479
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2315,7 +2329,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:304 lxc/move.go:380
+#: lxc/move.go:309 lxc/move.go:385
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2340,7 +2354,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1440
+#: lxc/file.go:1464
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2355,7 +2369,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1042
+#: lxc/file.go:1062
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2442,14 +2456,14 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1625 lxc/warning.go:94
+#: lxc/storage_volume.go:1627 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2517,7 +2531,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1602
+#: lxc/image.go:1602 lxc/image.go:1603
 msgid "Get image properties"
 msgstr ""
 
@@ -2533,7 +2547,7 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:414
 msgid "Get the key as a network forward property"
 msgstr ""
 
@@ -2573,7 +2587,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1249
+#: lxc/storage_volume.go:1251
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2601,7 +2615,7 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:403 lxc/network_forward.go:404
+#: lxc/network_forward.go:411 lxc/network_forward.go:412
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
@@ -2637,11 +2651,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:476
+#: lxc/storage_volume.go:480
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2681,22 +2695,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1540
+#: lxc/file.go:1564
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1529
+#: lxc/file.go:1553
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1376
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1362
+#: lxc/file.go:1386
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2769,11 +2783,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:415
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2783,7 +2797,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2437
+#: lxc/storage_volume.go:2439
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2795,7 +2809,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1517
+#: lxc/image.go:1518
 msgid "Image already up to date."
 msgstr ""
 
@@ -2811,11 +2825,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1472
+#: lxc/image.go:364 lxc/image.go:1473
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1698
+#: lxc/image.go:444 lxc/image.go:1699
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2825,7 +2839,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1515
+#: lxc/image.go:1516
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2833,7 +2847,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2815
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2841,7 +2855,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2814
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2863,11 +2877,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2822
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2894
+#: lxc/storage_volume.go:2896
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2893,11 +2907,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1378
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1531
+#: lxc/file.go:1555
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2906,7 +2920,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:414
+#: lxc/init.go:418
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2915,7 +2929,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1298
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2967,7 +2981,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1293
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2993,23 +3007,23 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2023
+#: lxc/move.go:153 lxc/storage_volume.go:2025
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:144
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2019
+#: lxc/storage_volume.go:2021
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:509
+#: lxc/main.go:518
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:353
+#: lxc/file.go:357
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3019,18 +3033,18 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
-#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
+#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:535
+#: lxc/file.go:548
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:717
+#: lxc/file.go:185 lxc/file.go:739
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3067,7 +3081,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3098,12 +3112,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:176
+#: lxc/init.go:180
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:174
+#: lxc/init.go:178
 msgid "Launching the instance"
 msgstr ""
 
@@ -3201,11 +3215,11 @@ msgstr ""
 msgid "List identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:151
+#: lxc/image_alias.go:176
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:177
 msgid ""
 "List image aliases\n"
 "\n"
@@ -3372,11 +3386,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1605
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1610
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3435,7 +3449,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1481
+#: lxc/info.go:489 lxc/storage_volume.go:1483
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3621,7 +3635,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:873 lxc/network_forward.go:874
+#: lxc/network_forward.go:881 lxc/network_forward.go:882
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -3767,12 +3781,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:322 lxc/move.go:435
+#: lxc/move.go:327 lxc/move.go:440
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:347 lxc/move.go:440
+#: lxc/move.go:352 lxc/move.go:445
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3837,10 +3851,10 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:449
-#: lxc/network_forward.go:534 lxc/network_forward.go:709
-#: lxc/network_forward.go:840 lxc/network_forward.go:933
-#: lxc/network_forward.go:1015 lxc/network_load_balancer.go:221
+#: lxc/network_forward.go:219 lxc/network_forward.go:457
+#: lxc/network_forward.go:542 lxc/network_forward.go:717
+#: lxc/network_forward.go:848 lxc/network_forward.go:945
+#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
 #: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
 #: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
 #: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
@@ -3865,10 +3879,10 @@ msgstr ""
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
 #: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
 #: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:284 lxc/network_forward.go:445
-#: lxc/network_forward.go:530 lxc/network_forward.go:705
-#: lxc/network_forward.go:836 lxc/network_forward.go:929
-#: lxc/network_forward.go:1011 lxc/network_load_balancer.go:131
+#: lxc/network_forward.go:292 lxc/network_forward.go:453
+#: lxc/network_forward.go:538 lxc/network_forward.go:713
+#: lxc/network_forward.go:844 lxc/network_forward.go:941
+#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
 #: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
 #: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
 #: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
@@ -3904,13 +3918,13 @@ msgstr ""
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
-#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
-#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
-#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
+#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
+#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
+#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
+#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
 msgid "Missing pool name"
 msgstr ""
 
@@ -3929,15 +3943,15 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
+#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1411
+#: lxc/storage_volume.go:1413
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:820
+#: lxc/file.go:842
 msgid "Missing target directory"
 msgstr ""
 
@@ -3970,16 +3984,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
-#: lxc/storage_volume.go:975
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
+#: lxc/storage_volume.go:977
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:507
+#: lxc/file.go:520
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1207 lxc/file.go:1208
+#: lxc/file.go:1227 lxc/file.go:1228
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4008,7 +4022,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4016,16 +4030,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1869
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1059 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4047,7 +4061,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
 msgid "NAME"
 msgstr ""
 
@@ -4099,8 +4113,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
-#: lxc/storage_volume.go:1573
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Name"
 msgstr ""
 
@@ -4108,7 +4122,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4163,12 +4177,12 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:386
+#: lxc/network_forward.go:394
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:857
+#: lxc/network_forward.go:865
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -4252,7 +4266,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
+#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4260,7 +4274,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1070 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4272,11 +4286,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4290,7 +4304,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2035
+#: lxc/storage_volume.go:2037
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4298,16 +4312,21 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
-#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
-msgid "Only \"custom\" volumes can be attached to instances"
+#: lxc/storage_volume.go:216
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2701
+#: lxc/storage_volume.go:348
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:2703
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2500
+#: lxc/storage_volume.go:2502
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4319,7 +4338,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1431
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4332,7 +4351,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1577
+#: lxc/info.go:705 lxc/storage_volume.go:1579
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4362,7 +4381,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1767
+#: lxc/storage_volume.go:1769
 msgid "POOL"
 msgstr ""
 
@@ -4379,7 +4398,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167
-#: lxc/storage_volume.go:1773 lxc/warning.go:213
+#: lxc/storage_volume.go:1775 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4403,7 +4422,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:367
+#: lxc/main.go:376
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4441,7 +4460,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1332
+#: lxc/file.go:1356
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4449,12 +4468,12 @@ msgstr ""
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
-#: lxc/network_acl.go:699 lxc/network_forward.go:768
+#: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
-#: lxc/storage_volume.go:1200
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
+#: lxc/storage_volume.go:1202
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4567,11 +4586,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1649
+#: lxc/image.go:1650
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4585,7 +4604,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1238
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4601,7 +4620,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4622,7 +4641,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1017
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4631,7 +4650,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2094
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4644,7 +4663,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2370
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4675,20 +4694,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:455 lxc/file.go:456
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:638 lxc/file.go:989
+#: lxc/file.go:651 lxc/file.go:1009
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:688 lxc/file.go:689
+#: lxc/file.go:701 lxc/file.go:702
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:923 lxc/file.go:1089
+#: lxc/file.go:943 lxc/file.go:1109
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4697,7 +4716,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4726,15 +4745,15 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:463 lxc/file.go:695
+#: lxc/file.go:475 lxc/file.go:708
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1444 lxc/image.go:1445
+#: lxc/image.go:1445 lxc/image.go:1446
 msgid "Refresh images"
 msgstr ""
 
@@ -4743,7 +4762,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1481
+#: lxc/image.go:1482
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4820,7 +4839,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:971 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4856,7 +4875,7 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:969 lxc/network_forward.go:970
+#: lxc/network_forward.go:981 lxc/network_forward.go:982
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -4892,8 +4911,8 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
-#: lxc/image_alias.go:255
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:287
+#: lxc/image_alias.go:288
 msgid "Rename aliases"
 msgstr ""
 
@@ -4929,15 +4948,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1962
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
+#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4989,7 +5008,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5006,7 +5025,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:361
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5055,12 +5074,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1460
+#: lxc/file.go:1484
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1461
+#: lxc/file.go:1485
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5136,7 +5155,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1217
+#: lxc/file.go:1237
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5162,7 +5181,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1665 lxc/image.go:1666
+#: lxc/image.go:1666 lxc/image.go:1667
 msgid "Set image properties"
 msgstr ""
 
@@ -5205,11 +5224,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:488
+#: lxc/network_forward.go:496
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:489
+#: lxc/network_forward.go:497
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5313,11 +5332,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2088
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2089
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5334,7 +5353,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:698
+#: lxc/file.go:711
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5342,7 +5361,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:699
+#: lxc/file.go:712
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5350,7 +5369,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:710
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5362,7 +5381,7 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:504
 msgid "Set the key as a network forward property"
 msgstr ""
 
@@ -5402,7 +5421,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2105
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5410,7 +5429,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1215
+#: lxc/file.go:1235
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5467,7 +5486,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1535 lxc/image.go:1536
+#: lxc/image.go:1536 lxc/image.go:1537
 msgid "Show image properties"
 msgstr ""
 
@@ -5487,7 +5506,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:271 lxc/main.go:272
+#: lxc/main.go:280 lxc/main.go:281
 msgid "Show less common commands"
 msgstr ""
 
@@ -5551,11 +5570,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5623,15 +5642,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2190
+#: lxc/storage_volume.go:2192
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1502
+#: lxc/info.go:619 lxc/storage_volume.go:1504
 msgid "Snapshots:"
 msgstr ""
 
@@ -5736,21 +5755,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:703
+#: lxc/storage_volume.go:707
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:791
+#: lxc/storage_volume.go:795
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:516
+#: lxc/storage_volume.go:520
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:524
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5812,21 +5831,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1747 lxc/warning.go:216
+#: lxc/storage_volume.go:1749 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1262
+#: lxc/file.go:1286
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1256
+#: lxc/file.go:1280
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5836,15 +5855,15 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:181
+#: lxc/move.go:186
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:219 lxc/move.go:240
+#: lxc/move.go:224 lxc/move.go:245
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:193
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5852,15 +5871,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:185
+#: lxc/move.go:190
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:189
+#: lxc/move.go:194
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:210
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5882,7 +5901,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:439
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5935,7 +5954,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:462
+#: lxc/network_forward.go:470
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -5975,12 +5994,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1340
+#: lxc/storage_volume.go:1342
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1317
+#: lxc/storage_volume.go:1319
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -5995,12 +6014,12 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:309
+#: lxc/move.go:314
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
-#: lxc/storage_volume.go:989
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
+#: lxc/storage_volume.go:991
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6028,7 +6047,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:298
+#: lxc/main.go:307
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6052,11 +6071,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:437
+#: lxc/init.go:441
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:440
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6064,7 +6083,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:412
+#: lxc/main.go:421
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6075,7 +6094,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1489
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6090,7 +6109,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1864
+#: lxc/storage_volume.go:1866
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6098,7 +6117,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6115,7 +6134,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:327
+#: lxc/copy.go:382 lxc/move.go:332
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6157,7 +6176,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1472
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6179,13 +6198,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1752
+#: lxc/project.go:995 lxc/storage_volume.go:1754
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1751
+#: lxc/storage.go:724 lxc/storage_volume.go:1753
 msgid "USED BY"
 msgstr ""
 
@@ -6198,7 +6217,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:411
+#: lxc/file.go:423
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6212,12 +6231,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1483
+#: lxc/file.go:1507
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1791
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6228,7 +6247,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1029
+#: lxc/file.go:1049
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6259,7 +6278,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1728 lxc/image.go:1729
+#: lxc/image.go:1729 lxc/image.go:1730
 msgid "Unset image properties"
 msgstr ""
 
@@ -6275,11 +6294,11 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:598
+#: lxc/network_forward.go:606
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:599
+#: lxc/network_forward.go:607
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -6323,7 +6342,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6335,7 +6354,7 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:602
+#: lxc/network_forward.go:610
 msgid "Unset the key as a network forward property"
 msgstr ""
 
@@ -6375,7 +6394,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2381
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6383,7 +6402,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:248
+#: lxc/storage_volume.go:250
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6419,12 +6438,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1485
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2652
+#: lxc/export.go:42 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6491,7 +6510,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1576
+#: lxc/storage_volume.go:1578
 msgid "Volume Only"
 msgstr ""
 
@@ -6542,7 +6561,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:293 lxc/move.go:369
+#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6550,12 +6569,12 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:909
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:912
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:282
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:284
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
@@ -6587,7 +6606,7 @@ msgstr ""
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:174
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
@@ -6640,7 +6659,7 @@ msgstr ""
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: lxc/image_alias.go:104
+#: lxc/image_alias.go:121
 msgid "[<remote>:]<alias>"
 msgstr ""
 
@@ -6648,7 +6667,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/image_alias.go:252
+#: lxc/image_alias.go:285
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
@@ -6702,15 +6721,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1600 lxc/image.go:1727
+#: lxc/image.go:1601 lxc/image.go:1728
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1664
+#: lxc/image.go:1665
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6730,7 +6749,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1443
+#: lxc/image.go:334 lxc/image.go:1444
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6801,7 +6820,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:376
+#: lxc/file.go:380
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -6813,12 +6832,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:454
+#: lxc/file.go:466
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1226
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6886,8 +6905,8 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:644
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:179
+#: lxc/network_forward.go:177 lxc/network_forward.go:652
+#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
 #: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
@@ -6902,12 +6921,12 @@ msgid ""
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:402 lxc/network_forward.go:597
+#: lxc/network_forward.go:410 lxc/network_forward.go:605
 #: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
@@ -6917,13 +6936,13 @@ msgid ""
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:887
+#: lxc/network_forward.go:895
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:968 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -6978,7 +6997,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2811
+#: lxc/storage_volume.go:2813
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7013,65 +7032,65 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1958
+#: lxc/storage_volume.go:1960
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:806
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:167
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
-msgstr ""
-
-#: lxc/storage_volume.go:2562
+#: lxc/storage_volume.go:2564
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2645
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2428
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:610
+#: lxc/storage_volume.go:614
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:718
+#: lxc/storage_volume.go:722
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2364
+#: lxc/storage_volume.go:810
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
+msgstr ""
+
+#: lxc/storage_volume.go:167
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
+msgstr ""
+
+#: lxc/storage_volume.go:2366
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2087
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2245
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1234
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1858
+#: lxc/storage_volume.go:1860
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7177,7 +7196,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1603
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7339,20 +7358,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1230
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:470
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:691
+#: lxc/file.go:704
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7653,7 +7672,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:618
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7661,13 +7680,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2817
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2432
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7701,16 +7720,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1396
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1331
+#: lxc/file.go:1355
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1284
+#: lxc/file.go:1308
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-07 15:11-0700\n"
+"POT-Creation-Date: 2025-01-10 14:44-0600\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1041
+#: lxc/storage_volume.go:1043
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:667
+#: lxc/network_forward.go:675
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,12 +430,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1157
+#: lxc/file.go:1177
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1047
+#: lxc/file.go:1067
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -471,7 +471,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:65
+#: lxc/init.go:146 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:687
+#: lxc/file.go:700
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -541,7 +541,7 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
@@ -672,7 +672,7 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:888 lxc/network_forward.go:889
+#: lxc/network_forward.go:896 lxc/network_forward.go:897
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -722,7 +722,7 @@ msgstr ""
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
+#: lxc/image_alias.go:101 lxc/image_alias.go:156 lxc/image_alias.go:320
 msgid "Alias name missing"
 msgstr ""
 
@@ -735,7 +735,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1607
+#: lxc/storage_volume.go:1609
 msgid "All projects"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -790,12 +790,26 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168 lxc/storage_volume.go:169
+#: lxc/storage_volume.go:168
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:169
+msgid ""
+"Attach new storage volumes to instances\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
+msgstr ""
+
+#: lxc/storage_volume.go:285
 msgid "Attach new storage volumes to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:286
+msgid ""
+"Attach new storage volumes to profiles\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
 #: lxc/console.go:39
@@ -846,16 +860,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2719
+#: lxc/storage_volume.go:2721
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2796
+#: lxc/export.go:192 lxc/storage_volume.go:2798
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1538
+#: lxc/info.go:666 lxc/storage_volume.go:1540
 msgid "Backups:"
 msgstr ""
 
@@ -864,19 +878,19 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
+#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:326
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -919,7 +933,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1752
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -971,7 +985,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -979,7 +993,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:562
+#: lxc/file.go:575
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1004,11 +1018,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:768
+#: lxc/file.go:790
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1021,12 +1035,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:493
+#: lxc/storage_volume.go:497
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:447
+#: lxc/storage_volume.go:451
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1132,9 +1146,9 @@ msgstr ""
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:497 lxc/network_forward.go:649
-#: lxc/network_forward.go:803 lxc/network_forward.go:892
-#: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
+#: lxc/network_forward.go:505 lxc/network_forward.go:657
+#: lxc/network_forward.go:811 lxc/network_forward.go:900
+#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
 #: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
 #: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
@@ -1146,14 +1160,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
-#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
-#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
-#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
+#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
 msgid "Cluster member name"
 msgstr ""
 
@@ -1169,7 +1183,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1608
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1209,21 +1223,21 @@ msgstr ""
 #: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
-#: lxc/network_acl.go:698 lxc/network_forward.go:767
+#: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
-#: lxc/storage_volume.go:1199
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
+#: lxc/storage_volume.go:1201
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:620
+#: lxc/storage_volume.go:624
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1478
+#: lxc/storage_volume.go:1480
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1285,7 +1299,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1293,12 +1307,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1311,7 +1325,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1406,7 +1420,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:462 lxc/file.go:696
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1446,7 +1460,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1498,12 +1512,12 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:182
+#: lxc/init.go:186
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1513,7 +1527,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 msgid "Creating the instance"
 msgstr ""
 
@@ -1527,13 +1541,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1749
+#: lxc/storage_volume.go:1751
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1553,7 +1567,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2653
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1585,7 +1599,7 @@ msgstr ""
 msgid "Delete identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:106 lxc/image_alias.go:107
+#: lxc/image_alias.go:123 lxc/image_alias.go:124
 msgid "Delete image aliases"
 msgstr ""
 
@@ -1609,7 +1623,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:799 lxc/network_forward.go:800
+#: lxc/network_forward.go:807 lxc/network_forward.go:808
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1649,7 +1663,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
+#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1691,13 +1705,13 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
-#: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
-#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
+#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
+#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
+#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
@@ -1711,10 +1725,10 @@ msgstr ""
 #: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:404 lxc/network_forward.go:489
-#: lxc/network_forward.go:599 lxc/network_forward.go:646
-#: lxc/network_forward.go:800 lxc/network_forward.go:874
-#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_forward.go:412 lxc/network_forward.go:497
+#: lxc/network_forward.go:607 lxc/network_forward.go:654
+#: lxc/network_forward.go:808 lxc/network_forward.go:882
+#: lxc/network_forward.go:897 lxc/network_forward.go:982
 #: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
 #: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
 #: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
@@ -1754,27 +1768,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
-#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
-#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
-#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
-#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
-#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
-#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
-#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1465
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1786,11 +1800,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
+#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1840,7 +1854,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:403
+#: lxc/init.go:407
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1852,7 +1866,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1216
+#: lxc/file.go:1236
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1948,7 +1962,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:377 lxc/file.go:378
+#: lxc/file.go:381 lxc/file.go:382
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1988,7 +2002,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:653 lxc/network_forward.go:654
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -2028,7 +2042,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2036,7 +2050,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1785
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2090,11 +2104,11 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
-#: lxc/network_acl.go:524 lxc/network_forward.go:572
+#: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
+#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2105,11 +2119,11 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
-#: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
+#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
-#: lxc/storage_volume.go:2210
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
+#: lxc/storage_volume.go:2212
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2151,8 +2165,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
+#: lxc/storage_volume.go:1577
 msgid "Expires at"
 msgstr ""
 
@@ -2176,7 +2190,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2188,11 +2202,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2650
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2779
+#: lxc/export.go:152 lxc/storage_volume.go:2781
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2211,7 +2225,7 @@ msgid "FILENAME"
 msgstr ""
 
 #: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
-#: lxc/image_alias.go:235
+#: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2219,12 +2233,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1467
+#: lxc/file.go:1491
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1490
+#: lxc/file.go:1514
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2239,12 +2253,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1517
+#: lxc/file.go:1541
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1326
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2274,7 +2288,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1423
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2289,7 +2303,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1428
+#: lxc/file.go:1452
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2299,12 +2313,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1352
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1455
+#: lxc/file.go:1479
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2318,7 +2332,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:304 lxc/move.go:380
+#: lxc/move.go:309 lxc/move.go:385
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2343,7 +2357,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1440
+#: lxc/file.go:1464
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2358,7 +2372,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1042
+#: lxc/file.go:1062
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2445,14 +2459,14 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1625 lxc/warning.go:94
+#: lxc/storage_volume.go:1627 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2520,7 +2534,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1602
+#: lxc/image.go:1602 lxc/image.go:1603
 msgid "Get image properties"
 msgstr ""
 
@@ -2536,7 +2550,7 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:414
 msgid "Get the key as a network forward property"
 msgstr ""
 
@@ -2576,7 +2590,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1249
+#: lxc/storage_volume.go:1251
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2604,7 +2618,7 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:403 lxc/network_forward.go:404
+#: lxc/network_forward.go:411 lxc/network_forward.go:412
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
@@ -2640,11 +2654,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:476
+#: lxc/storage_volume.go:480
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2684,22 +2698,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1540
+#: lxc/file.go:1564
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1529
+#: lxc/file.go:1553
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1376
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1362
+#: lxc/file.go:1386
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2772,11 +2786,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:415
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2786,7 +2800,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2437
+#: lxc/storage_volume.go:2439
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2798,7 +2812,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1517
+#: lxc/image.go:1518
 msgid "Image already up to date."
 msgstr ""
 
@@ -2814,11 +2828,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1472
+#: lxc/image.go:364 lxc/image.go:1473
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1698
+#: lxc/image.go:444 lxc/image.go:1699
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2828,7 +2842,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1515
+#: lxc/image.go:1516
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2836,7 +2850,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2815
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2844,7 +2858,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2814
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2866,11 +2880,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2822
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2894
+#: lxc/storage_volume.go:2896
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2896,11 +2910,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1378
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1531
+#: lxc/file.go:1555
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2909,7 +2923,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:414
+#: lxc/init.go:418
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2918,7 +2932,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1298
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2970,7 +2984,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1293
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2996,23 +3010,23 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2023
+#: lxc/move.go:153 lxc/storage_volume.go:2025
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:144
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2019
+#: lxc/storage_volume.go:2021
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:509
+#: lxc/main.go:518
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:353
+#: lxc/file.go:357
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3022,18 +3036,18 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
-#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
+#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:535
+#: lxc/file.go:548
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:717
+#: lxc/file.go:185 lxc/file.go:739
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3070,7 +3084,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3101,12 +3115,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:176
+#: lxc/init.go:180
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:174
+#: lxc/init.go:178
 msgid "Launching the instance"
 msgstr ""
 
@@ -3204,11 +3218,11 @@ msgstr ""
 msgid "List identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:151
+#: lxc/image_alias.go:176
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:177
 msgid ""
 "List image aliases\n"
 "\n"
@@ -3375,11 +3389,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1605
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1610
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3438,7 +3452,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1481
+#: lxc/info.go:489 lxc/storage_volume.go:1483
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3624,7 +3638,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:873 lxc/network_forward.go:874
+#: lxc/network_forward.go:881 lxc/network_forward.go:882
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -3770,12 +3784,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:322 lxc/move.go:435
+#: lxc/move.go:327 lxc/move.go:440
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:347 lxc/move.go:440
+#: lxc/move.go:352 lxc/move.go:445
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3840,10 +3854,10 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:449
-#: lxc/network_forward.go:534 lxc/network_forward.go:709
-#: lxc/network_forward.go:840 lxc/network_forward.go:933
-#: lxc/network_forward.go:1015 lxc/network_load_balancer.go:221
+#: lxc/network_forward.go:219 lxc/network_forward.go:457
+#: lxc/network_forward.go:542 lxc/network_forward.go:717
+#: lxc/network_forward.go:848 lxc/network_forward.go:945
+#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
 #: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
 #: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
 #: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
@@ -3868,10 +3882,10 @@ msgstr ""
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
 #: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
 #: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:284 lxc/network_forward.go:445
-#: lxc/network_forward.go:530 lxc/network_forward.go:705
-#: lxc/network_forward.go:836 lxc/network_forward.go:929
-#: lxc/network_forward.go:1011 lxc/network_load_balancer.go:131
+#: lxc/network_forward.go:292 lxc/network_forward.go:453
+#: lxc/network_forward.go:538 lxc/network_forward.go:713
+#: lxc/network_forward.go:844 lxc/network_forward.go:941
+#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
 #: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
 #: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
 #: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
@@ -3907,13 +3921,13 @@ msgstr ""
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
-#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
-#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
-#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
+#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
+#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
+#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
+#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
 msgid "Missing pool name"
 msgstr ""
 
@@ -3932,15 +3946,15 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
+#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1411
+#: lxc/storage_volume.go:1413
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:820
+#: lxc/file.go:842
 msgid "Missing target directory"
 msgstr ""
 
@@ -3973,16 +3987,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
-#: lxc/storage_volume.go:975
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
+#: lxc/storage_volume.go:977
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:507
+#: lxc/file.go:520
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1207 lxc/file.go:1208
+#: lxc/file.go:1227 lxc/file.go:1228
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4011,7 +4025,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4019,16 +4033,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1869
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1059 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4050,7 +4064,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
 msgid "NAME"
 msgstr ""
 
@@ -4102,8 +4116,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
-#: lxc/storage_volume.go:1573
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Name"
 msgstr ""
 
@@ -4111,7 +4125,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4166,12 +4180,12 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:386
+#: lxc/network_forward.go:394
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:857
+#: lxc/network_forward.go:865
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -4255,7 +4269,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
+#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4263,7 +4277,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1070 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4275,11 +4289,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4293,7 +4307,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2035
+#: lxc/storage_volume.go:2037
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4301,16 +4315,21 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
-#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
-msgid "Only \"custom\" volumes can be attached to instances"
+#: lxc/storage_volume.go:216
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2701
+#: lxc/storage_volume.go:348
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:2703
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2500
+#: lxc/storage_volume.go:2502
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4322,7 +4341,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1431
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4335,7 +4354,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1577
+#: lxc/info.go:705 lxc/storage_volume.go:1579
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4365,7 +4384,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1767
+#: lxc/storage_volume.go:1769
 msgid "POOL"
 msgstr ""
 
@@ -4382,7 +4401,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167
-#: lxc/storage_volume.go:1773 lxc/warning.go:213
+#: lxc/storage_volume.go:1775 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4406,7 +4425,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:367
+#: lxc/main.go:376
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4444,7 +4463,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1332
+#: lxc/file.go:1356
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4452,12 +4471,12 @@ msgstr ""
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
-#: lxc/network_acl.go:699 lxc/network_forward.go:768
+#: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
-#: lxc/storage_volume.go:1200
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
+#: lxc/storage_volume.go:1202
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4570,11 +4589,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1649
+#: lxc/image.go:1650
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4588,7 +4607,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1238
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4604,7 +4623,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4625,7 +4644,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1017
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4634,7 +4653,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2094
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4647,7 +4666,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2370
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4678,20 +4697,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:455 lxc/file.go:456
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:638 lxc/file.go:989
+#: lxc/file.go:651 lxc/file.go:1009
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:688 lxc/file.go:689
+#: lxc/file.go:701 lxc/file.go:702
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:923 lxc/file.go:1089
+#: lxc/file.go:943 lxc/file.go:1109
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4700,7 +4719,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4729,15 +4748,15 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:463 lxc/file.go:695
+#: lxc/file.go:475 lxc/file.go:708
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1444 lxc/image.go:1445
+#: lxc/image.go:1445 lxc/image.go:1446
 msgid "Refresh images"
 msgstr ""
 
@@ -4746,7 +4765,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1481
+#: lxc/image.go:1482
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4823,7 +4842,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:971 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4859,7 +4878,7 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:969 lxc/network_forward.go:970
+#: lxc/network_forward.go:981 lxc/network_forward.go:982
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -4895,8 +4914,8 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
-#: lxc/image_alias.go:255
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:287
+#: lxc/image_alias.go:288
 msgid "Rename aliases"
 msgstr ""
 
@@ -4932,15 +4951,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1962
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
+#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4992,7 +5011,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5009,7 +5028,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:361
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5058,12 +5077,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1460
+#: lxc/file.go:1484
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1461
+#: lxc/file.go:1485
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5139,7 +5158,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1217
+#: lxc/file.go:1237
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5165,7 +5184,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1665 lxc/image.go:1666
+#: lxc/image.go:1666 lxc/image.go:1667
 msgid "Set image properties"
 msgstr ""
 
@@ -5208,11 +5227,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:488
+#: lxc/network_forward.go:496
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:489
+#: lxc/network_forward.go:497
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5316,11 +5335,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2088
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2089
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5337,7 +5356,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:698
+#: lxc/file.go:711
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5345,7 +5364,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:699
+#: lxc/file.go:712
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5353,7 +5372,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:710
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5365,7 +5384,7 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:504
 msgid "Set the key as a network forward property"
 msgstr ""
 
@@ -5405,7 +5424,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2105
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5413,7 +5432,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1215
+#: lxc/file.go:1235
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5470,7 +5489,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1535 lxc/image.go:1536
+#: lxc/image.go:1536 lxc/image.go:1537
 msgid "Show image properties"
 msgstr ""
 
@@ -5490,7 +5509,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:271 lxc/main.go:272
+#: lxc/main.go:280 lxc/main.go:281
 msgid "Show less common commands"
 msgstr ""
 
@@ -5554,11 +5573,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5626,15 +5645,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2190
+#: lxc/storage_volume.go:2192
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1502
+#: lxc/info.go:619 lxc/storage_volume.go:1504
 msgid "Snapshots:"
 msgstr ""
 
@@ -5739,21 +5758,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:703
+#: lxc/storage_volume.go:707
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:791
+#: lxc/storage_volume.go:795
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:516
+#: lxc/storage_volume.go:520
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:524
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5815,21 +5834,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1747 lxc/warning.go:216
+#: lxc/storage_volume.go:1749 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1262
+#: lxc/file.go:1286
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1256
+#: lxc/file.go:1280
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5839,15 +5858,15 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:181
+#: lxc/move.go:186
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:219 lxc/move.go:240
+#: lxc/move.go:224 lxc/move.go:245
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:193
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5855,15 +5874,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:185
+#: lxc/move.go:190
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:189
+#: lxc/move.go:194
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:210
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5885,7 +5904,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:439
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5938,7 +5957,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:462
+#: lxc/network_forward.go:470
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -5978,12 +5997,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1340
+#: lxc/storage_volume.go:1342
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1317
+#: lxc/storage_volume.go:1319
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -5998,12 +6017,12 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:309
+#: lxc/move.go:314
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
-#: lxc/storage_volume.go:989
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
+#: lxc/storage_volume.go:991
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6031,7 +6050,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:298
+#: lxc/main.go:307
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6055,11 +6074,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:437
+#: lxc/init.go:441
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:440
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6067,7 +6086,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:412
+#: lxc/main.go:421
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6078,7 +6097,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1489
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6093,7 +6112,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1864
+#: lxc/storage_volume.go:1866
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6101,7 +6120,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6118,7 +6137,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:327
+#: lxc/copy.go:382 lxc/move.go:332
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6160,7 +6179,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1472
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6182,13 +6201,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1752
+#: lxc/project.go:995 lxc/storage_volume.go:1754
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1751
+#: lxc/storage.go:724 lxc/storage_volume.go:1753
 msgid "USED BY"
 msgstr ""
 
@@ -6201,7 +6220,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:411
+#: lxc/file.go:423
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6215,12 +6234,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1483
+#: lxc/file.go:1507
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1791
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6231,7 +6250,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1029
+#: lxc/file.go:1049
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6262,7 +6281,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1728 lxc/image.go:1729
+#: lxc/image.go:1729 lxc/image.go:1730
 msgid "Unset image properties"
 msgstr ""
 
@@ -6278,11 +6297,11 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:598
+#: lxc/network_forward.go:606
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:599
+#: lxc/network_forward.go:607
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -6326,7 +6345,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6338,7 +6357,7 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:602
+#: lxc/network_forward.go:610
 msgid "Unset the key as a network forward property"
 msgstr ""
 
@@ -6378,7 +6397,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2381
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6386,7 +6405,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:248
+#: lxc/storage_volume.go:250
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6422,12 +6441,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1485
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2652
+#: lxc/export.go:42 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6494,7 +6513,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1576
+#: lxc/storage_volume.go:1578
 msgid "Volume Only"
 msgstr ""
 
@@ -6545,7 +6564,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:293 lxc/move.go:369
+#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6553,12 +6572,12 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:909
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:912
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:282
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:284
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
@@ -6590,7 +6609,7 @@ msgstr ""
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:174
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
@@ -6643,7 +6662,7 @@ msgstr ""
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: lxc/image_alias.go:104
+#: lxc/image_alias.go:121
 msgid "[<remote>:]<alias>"
 msgstr ""
 
@@ -6651,7 +6670,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/image_alias.go:252
+#: lxc/image_alias.go:285
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
@@ -6705,15 +6724,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1600 lxc/image.go:1727
+#: lxc/image.go:1601 lxc/image.go:1728
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1664
+#: lxc/image.go:1665
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6733,7 +6752,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1443
+#: lxc/image.go:334 lxc/image.go:1444
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6804,7 +6823,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:376
+#: lxc/file.go:380
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -6816,12 +6835,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:454
+#: lxc/file.go:466
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1226
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6889,8 +6908,8 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:644
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:179
+#: lxc/network_forward.go:177 lxc/network_forward.go:652
+#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
 #: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
@@ -6905,12 +6924,12 @@ msgid ""
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:402 lxc/network_forward.go:597
+#: lxc/network_forward.go:410 lxc/network_forward.go:605
 #: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
@@ -6920,13 +6939,13 @@ msgid ""
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:887
+#: lxc/network_forward.go:895
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:968 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -6981,7 +7000,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2811
+#: lxc/storage_volume.go:2813
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7016,65 +7035,65 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1958
+#: lxc/storage_volume.go:1960
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:806
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:167
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
-msgstr ""
-
-#: lxc/storage_volume.go:2562
+#: lxc/storage_volume.go:2564
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2645
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2428
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:610
+#: lxc/storage_volume.go:614
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:718
+#: lxc/storage_volume.go:722
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2364
+#: lxc/storage_volume.go:810
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
+msgstr ""
+
+#: lxc/storage_volume.go:167
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
+msgstr ""
+
+#: lxc/storage_volume.go:2366
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2087
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2245
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1234
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1858
+#: lxc/storage_volume.go:1860
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7180,7 +7199,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1603
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7342,20 +7361,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1230
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:470
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:691
+#: lxc/file.go:704
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7656,7 +7675,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:618
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7664,13 +7683,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2817
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2432
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7704,16 +7723,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1396
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1331
+#: lxc/file.go:1355
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1284
+#: lxc/file.go:1308
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-07 15:11-0700\n"
+"POT-Creation-Date: 2025-01-10 14:44-0600\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1041
+#: lxc/storage_volume.go:1043
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:667
+#: lxc/network_forward.go:675
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,12 +430,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1157
+#: lxc/file.go:1177
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1047
+#: lxc/file.go:1067
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -471,7 +471,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:65
+#: lxc/init.go:146 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:687
+#: lxc/file.go:700
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -541,7 +541,7 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
@@ -672,7 +672,7 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:888 lxc/network_forward.go:889
+#: lxc/network_forward.go:896 lxc/network_forward.go:897
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -722,7 +722,7 @@ msgstr ""
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
+#: lxc/image_alias.go:101 lxc/image_alias.go:156 lxc/image_alias.go:320
 msgid "Alias name missing"
 msgstr ""
 
@@ -735,7 +735,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1607
+#: lxc/storage_volume.go:1609
 msgid "All projects"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -790,12 +790,26 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168 lxc/storage_volume.go:169
+#: lxc/storage_volume.go:168
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:169
+msgid ""
+"Attach new storage volumes to instances\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
+msgstr ""
+
+#: lxc/storage_volume.go:285
 msgid "Attach new storage volumes to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:286
+msgid ""
+"Attach new storage volumes to profiles\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
 #: lxc/console.go:39
@@ -846,16 +860,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2719
+#: lxc/storage_volume.go:2721
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2796
+#: lxc/export.go:192 lxc/storage_volume.go:2798
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1538
+#: lxc/info.go:666 lxc/storage_volume.go:1540
 msgid "Backups:"
 msgstr ""
 
@@ -864,19 +878,19 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
+#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:326
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -919,7 +933,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1752
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -971,7 +985,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -979,7 +993,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:562
+#: lxc/file.go:575
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1004,11 +1018,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:768
+#: lxc/file.go:790
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1021,12 +1035,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:493
+#: lxc/storage_volume.go:497
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:447
+#: lxc/storage_volume.go:451
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1132,9 +1146,9 @@ msgstr ""
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:497 lxc/network_forward.go:649
-#: lxc/network_forward.go:803 lxc/network_forward.go:892
-#: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
+#: lxc/network_forward.go:505 lxc/network_forward.go:657
+#: lxc/network_forward.go:811 lxc/network_forward.go:900
+#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
 #: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
 #: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
@@ -1146,14 +1160,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
-#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
-#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
-#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
+#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
 msgid "Cluster member name"
 msgstr ""
 
@@ -1169,7 +1183,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1608
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1209,21 +1223,21 @@ msgstr ""
 #: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
-#: lxc/network_acl.go:698 lxc/network_forward.go:767
+#: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
-#: lxc/storage_volume.go:1199
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
+#: lxc/storage_volume.go:1201
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:620
+#: lxc/storage_volume.go:624
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1478
+#: lxc/storage_volume.go:1480
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1285,7 +1299,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1293,12 +1307,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1311,7 +1325,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1406,7 +1420,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:462 lxc/file.go:696
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1446,7 +1460,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1498,12 +1512,12 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:182
+#: lxc/init.go:186
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1513,7 +1527,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 msgid "Creating the instance"
 msgstr ""
 
@@ -1527,13 +1541,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1749
+#: lxc/storage_volume.go:1751
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1553,7 +1567,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2653
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1585,7 +1599,7 @@ msgstr ""
 msgid "Delete identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:106 lxc/image_alias.go:107
+#: lxc/image_alias.go:123 lxc/image_alias.go:124
 msgid "Delete image aliases"
 msgstr ""
 
@@ -1609,7 +1623,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:799 lxc/network_forward.go:800
+#: lxc/network_forward.go:807 lxc/network_forward.go:808
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1649,7 +1663,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
+#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1691,13 +1705,13 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
-#: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
-#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
+#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
+#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
+#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
@@ -1711,10 +1725,10 @@ msgstr ""
 #: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:404 lxc/network_forward.go:489
-#: lxc/network_forward.go:599 lxc/network_forward.go:646
-#: lxc/network_forward.go:800 lxc/network_forward.go:874
-#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_forward.go:412 lxc/network_forward.go:497
+#: lxc/network_forward.go:607 lxc/network_forward.go:654
+#: lxc/network_forward.go:808 lxc/network_forward.go:882
+#: lxc/network_forward.go:897 lxc/network_forward.go:982
 #: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
 #: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
 #: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
@@ -1754,27 +1768,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
-#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
-#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
-#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
-#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
-#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
-#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
-#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1465
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1786,11 +1800,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
+#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1840,7 +1854,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:403
+#: lxc/init.go:407
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1852,7 +1866,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1216
+#: lxc/file.go:1236
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1948,7 +1962,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:377 lxc/file.go:378
+#: lxc/file.go:381 lxc/file.go:382
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1988,7 +2002,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:653 lxc/network_forward.go:654
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -2028,7 +2042,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2036,7 +2050,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1785
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2090,11 +2104,11 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
-#: lxc/network_acl.go:524 lxc/network_forward.go:572
+#: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
+#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2105,11 +2119,11 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
-#: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
+#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
-#: lxc/storage_volume.go:2210
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
+#: lxc/storage_volume.go:2212
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2151,8 +2165,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
+#: lxc/storage_volume.go:1577
 msgid "Expires at"
 msgstr ""
 
@@ -2176,7 +2190,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2188,11 +2202,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2650
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2779
+#: lxc/export.go:152 lxc/storage_volume.go:2781
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2211,7 +2225,7 @@ msgid "FILENAME"
 msgstr ""
 
 #: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
-#: lxc/image_alias.go:235
+#: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2219,12 +2233,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1467
+#: lxc/file.go:1491
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1490
+#: lxc/file.go:1514
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2239,12 +2253,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1517
+#: lxc/file.go:1541
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1326
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2274,7 +2288,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1423
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2289,7 +2303,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1428
+#: lxc/file.go:1452
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2299,12 +2313,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1352
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1455
+#: lxc/file.go:1479
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2318,7 +2332,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:304 lxc/move.go:380
+#: lxc/move.go:309 lxc/move.go:385
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2343,7 +2357,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1440
+#: lxc/file.go:1464
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2358,7 +2372,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1042
+#: lxc/file.go:1062
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2445,14 +2459,14 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1625 lxc/warning.go:94
+#: lxc/storage_volume.go:1627 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2520,7 +2534,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1602
+#: lxc/image.go:1602 lxc/image.go:1603
 msgid "Get image properties"
 msgstr ""
 
@@ -2536,7 +2550,7 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:414
 msgid "Get the key as a network forward property"
 msgstr ""
 
@@ -2576,7 +2590,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1249
+#: lxc/storage_volume.go:1251
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2604,7 +2618,7 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:403 lxc/network_forward.go:404
+#: lxc/network_forward.go:411 lxc/network_forward.go:412
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
@@ -2640,11 +2654,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:476
+#: lxc/storage_volume.go:480
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2684,22 +2698,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1540
+#: lxc/file.go:1564
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1529
+#: lxc/file.go:1553
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1376
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1362
+#: lxc/file.go:1386
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2772,11 +2786,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:415
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2786,7 +2800,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2437
+#: lxc/storage_volume.go:2439
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2798,7 +2812,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1517
+#: lxc/image.go:1518
 msgid "Image already up to date."
 msgstr ""
 
@@ -2814,11 +2828,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1472
+#: lxc/image.go:364 lxc/image.go:1473
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1698
+#: lxc/image.go:444 lxc/image.go:1699
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2828,7 +2842,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1515
+#: lxc/image.go:1516
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2836,7 +2850,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2815
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2844,7 +2858,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2814
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2866,11 +2880,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2822
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2894
+#: lxc/storage_volume.go:2896
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2896,11 +2910,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1378
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1531
+#: lxc/file.go:1555
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2909,7 +2923,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:414
+#: lxc/init.go:418
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2918,7 +2932,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1298
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2970,7 +2984,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1293
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2996,23 +3010,23 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2023
+#: lxc/move.go:153 lxc/storage_volume.go:2025
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:144
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2019
+#: lxc/storage_volume.go:2021
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:509
+#: lxc/main.go:518
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:353
+#: lxc/file.go:357
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3022,18 +3036,18 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
-#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
+#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:535
+#: lxc/file.go:548
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:717
+#: lxc/file.go:185 lxc/file.go:739
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3070,7 +3084,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3101,12 +3115,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:176
+#: lxc/init.go:180
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:174
+#: lxc/init.go:178
 msgid "Launching the instance"
 msgstr ""
 
@@ -3204,11 +3218,11 @@ msgstr ""
 msgid "List identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:151
+#: lxc/image_alias.go:176
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:177
 msgid ""
 "List image aliases\n"
 "\n"
@@ -3375,11 +3389,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1605
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1610
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3438,7 +3452,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1481
+#: lxc/info.go:489 lxc/storage_volume.go:1483
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3624,7 +3638,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:873 lxc/network_forward.go:874
+#: lxc/network_forward.go:881 lxc/network_forward.go:882
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -3770,12 +3784,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:322 lxc/move.go:435
+#: lxc/move.go:327 lxc/move.go:440
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:347 lxc/move.go:440
+#: lxc/move.go:352 lxc/move.go:445
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3840,10 +3854,10 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:449
-#: lxc/network_forward.go:534 lxc/network_forward.go:709
-#: lxc/network_forward.go:840 lxc/network_forward.go:933
-#: lxc/network_forward.go:1015 lxc/network_load_balancer.go:221
+#: lxc/network_forward.go:219 lxc/network_forward.go:457
+#: lxc/network_forward.go:542 lxc/network_forward.go:717
+#: lxc/network_forward.go:848 lxc/network_forward.go:945
+#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
 #: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
 #: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
 #: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
@@ -3868,10 +3882,10 @@ msgstr ""
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
 #: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
 #: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:284 lxc/network_forward.go:445
-#: lxc/network_forward.go:530 lxc/network_forward.go:705
-#: lxc/network_forward.go:836 lxc/network_forward.go:929
-#: lxc/network_forward.go:1011 lxc/network_load_balancer.go:131
+#: lxc/network_forward.go:292 lxc/network_forward.go:453
+#: lxc/network_forward.go:538 lxc/network_forward.go:713
+#: lxc/network_forward.go:844 lxc/network_forward.go:941
+#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
 #: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
 #: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
 #: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
@@ -3907,13 +3921,13 @@ msgstr ""
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
-#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
-#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
-#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
+#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
+#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
+#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
+#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
 msgid "Missing pool name"
 msgstr ""
 
@@ -3932,15 +3946,15 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
+#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1411
+#: lxc/storage_volume.go:1413
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:820
+#: lxc/file.go:842
 msgid "Missing target directory"
 msgstr ""
 
@@ -3973,16 +3987,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
-#: lxc/storage_volume.go:975
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
+#: lxc/storage_volume.go:977
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:507
+#: lxc/file.go:520
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1207 lxc/file.go:1208
+#: lxc/file.go:1227 lxc/file.go:1228
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4011,7 +4025,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4019,16 +4033,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1869
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1059 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4050,7 +4064,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
 msgid "NAME"
 msgstr ""
 
@@ -4102,8 +4116,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
-#: lxc/storage_volume.go:1573
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Name"
 msgstr ""
 
@@ -4111,7 +4125,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4166,12 +4180,12 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:386
+#: lxc/network_forward.go:394
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:857
+#: lxc/network_forward.go:865
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -4255,7 +4269,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
+#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4263,7 +4277,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1070 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4275,11 +4289,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4293,7 +4307,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2035
+#: lxc/storage_volume.go:2037
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4301,16 +4315,21 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
-#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
-msgid "Only \"custom\" volumes can be attached to instances"
+#: lxc/storage_volume.go:216
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2701
+#: lxc/storage_volume.go:348
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:2703
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2500
+#: lxc/storage_volume.go:2502
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4322,7 +4341,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1431
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4335,7 +4354,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1577
+#: lxc/info.go:705 lxc/storage_volume.go:1579
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4365,7 +4384,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1767
+#: lxc/storage_volume.go:1769
 msgid "POOL"
 msgstr ""
 
@@ -4382,7 +4401,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167
-#: lxc/storage_volume.go:1773 lxc/warning.go:213
+#: lxc/storage_volume.go:1775 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4406,7 +4425,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:367
+#: lxc/main.go:376
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4444,7 +4463,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1332
+#: lxc/file.go:1356
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4452,12 +4471,12 @@ msgstr ""
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
-#: lxc/network_acl.go:699 lxc/network_forward.go:768
+#: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
-#: lxc/storage_volume.go:1200
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
+#: lxc/storage_volume.go:1202
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4570,11 +4589,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1649
+#: lxc/image.go:1650
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4588,7 +4607,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1238
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4604,7 +4623,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4625,7 +4644,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1017
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4634,7 +4653,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2094
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4647,7 +4666,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2370
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4678,20 +4697,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:455 lxc/file.go:456
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:638 lxc/file.go:989
+#: lxc/file.go:651 lxc/file.go:1009
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:688 lxc/file.go:689
+#: lxc/file.go:701 lxc/file.go:702
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:923 lxc/file.go:1089
+#: lxc/file.go:943 lxc/file.go:1109
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4700,7 +4719,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4729,15 +4748,15 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:463 lxc/file.go:695
+#: lxc/file.go:475 lxc/file.go:708
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1444 lxc/image.go:1445
+#: lxc/image.go:1445 lxc/image.go:1446
 msgid "Refresh images"
 msgstr ""
 
@@ -4746,7 +4765,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1481
+#: lxc/image.go:1482
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4823,7 +4842,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:971 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4859,7 +4878,7 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:969 lxc/network_forward.go:970
+#: lxc/network_forward.go:981 lxc/network_forward.go:982
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -4895,8 +4914,8 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
-#: lxc/image_alias.go:255
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:287
+#: lxc/image_alias.go:288
 msgid "Rename aliases"
 msgstr ""
 
@@ -4932,15 +4951,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1962
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
+#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4992,7 +5011,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5009,7 +5028,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:361
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5058,12 +5077,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1460
+#: lxc/file.go:1484
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1461
+#: lxc/file.go:1485
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5139,7 +5158,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1217
+#: lxc/file.go:1237
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5165,7 +5184,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1665 lxc/image.go:1666
+#: lxc/image.go:1666 lxc/image.go:1667
 msgid "Set image properties"
 msgstr ""
 
@@ -5208,11 +5227,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:488
+#: lxc/network_forward.go:496
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:489
+#: lxc/network_forward.go:497
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5316,11 +5335,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2088
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2089
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5337,7 +5356,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:698
+#: lxc/file.go:711
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5345,7 +5364,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:699
+#: lxc/file.go:712
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5353,7 +5372,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:710
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5365,7 +5384,7 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:504
 msgid "Set the key as a network forward property"
 msgstr ""
 
@@ -5405,7 +5424,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2105
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5413,7 +5432,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1215
+#: lxc/file.go:1235
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5470,7 +5489,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1535 lxc/image.go:1536
+#: lxc/image.go:1536 lxc/image.go:1537
 msgid "Show image properties"
 msgstr ""
 
@@ -5490,7 +5509,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:271 lxc/main.go:272
+#: lxc/main.go:280 lxc/main.go:281
 msgid "Show less common commands"
 msgstr ""
 
@@ -5554,11 +5573,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5626,15 +5645,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2190
+#: lxc/storage_volume.go:2192
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1502
+#: lxc/info.go:619 lxc/storage_volume.go:1504
 msgid "Snapshots:"
 msgstr ""
 
@@ -5739,21 +5758,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:703
+#: lxc/storage_volume.go:707
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:791
+#: lxc/storage_volume.go:795
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:516
+#: lxc/storage_volume.go:520
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:524
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5815,21 +5834,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1747 lxc/warning.go:216
+#: lxc/storage_volume.go:1749 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1262
+#: lxc/file.go:1286
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1256
+#: lxc/file.go:1280
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5839,15 +5858,15 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:181
+#: lxc/move.go:186
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:219 lxc/move.go:240
+#: lxc/move.go:224 lxc/move.go:245
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:193
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5855,15 +5874,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:185
+#: lxc/move.go:190
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:189
+#: lxc/move.go:194
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:210
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5885,7 +5904,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:439
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5938,7 +5957,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:462
+#: lxc/network_forward.go:470
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -5978,12 +5997,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1340
+#: lxc/storage_volume.go:1342
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1317
+#: lxc/storage_volume.go:1319
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -5998,12 +6017,12 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:309
+#: lxc/move.go:314
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
-#: lxc/storage_volume.go:989
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
+#: lxc/storage_volume.go:991
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6031,7 +6050,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:298
+#: lxc/main.go:307
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6055,11 +6074,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:437
+#: lxc/init.go:441
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:440
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6067,7 +6086,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:412
+#: lxc/main.go:421
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6078,7 +6097,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1489
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6093,7 +6112,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1864
+#: lxc/storage_volume.go:1866
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6101,7 +6120,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6118,7 +6137,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:327
+#: lxc/copy.go:382 lxc/move.go:332
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6160,7 +6179,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1472
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6182,13 +6201,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1752
+#: lxc/project.go:995 lxc/storage_volume.go:1754
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1751
+#: lxc/storage.go:724 lxc/storage_volume.go:1753
 msgid "USED BY"
 msgstr ""
 
@@ -6201,7 +6220,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:411
+#: lxc/file.go:423
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6215,12 +6234,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1483
+#: lxc/file.go:1507
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1791
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6231,7 +6250,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1029
+#: lxc/file.go:1049
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6262,7 +6281,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1728 lxc/image.go:1729
+#: lxc/image.go:1729 lxc/image.go:1730
 msgid "Unset image properties"
 msgstr ""
 
@@ -6278,11 +6297,11 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:598
+#: lxc/network_forward.go:606
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:599
+#: lxc/network_forward.go:607
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -6326,7 +6345,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6338,7 +6357,7 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:602
+#: lxc/network_forward.go:610
 msgid "Unset the key as a network forward property"
 msgstr ""
 
@@ -6378,7 +6397,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2381
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6386,7 +6405,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:248
+#: lxc/storage_volume.go:250
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6422,12 +6441,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1485
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2652
+#: lxc/export.go:42 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6494,7 +6513,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1576
+#: lxc/storage_volume.go:1578
 msgid "Volume Only"
 msgstr ""
 
@@ -6545,7 +6564,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:293 lxc/move.go:369
+#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6553,12 +6572,12 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:909
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:912
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:282
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:284
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
@@ -6590,7 +6609,7 @@ msgstr ""
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:174
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
@@ -6643,7 +6662,7 @@ msgstr ""
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: lxc/image_alias.go:104
+#: lxc/image_alias.go:121
 msgid "[<remote>:]<alias>"
 msgstr ""
 
@@ -6651,7 +6670,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/image_alias.go:252
+#: lxc/image_alias.go:285
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
@@ -6705,15 +6724,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1600 lxc/image.go:1727
+#: lxc/image.go:1601 lxc/image.go:1728
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1664
+#: lxc/image.go:1665
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6733,7 +6752,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1443
+#: lxc/image.go:334 lxc/image.go:1444
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6804,7 +6823,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:376
+#: lxc/file.go:380
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -6816,12 +6835,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:454
+#: lxc/file.go:466
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1226
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6889,8 +6908,8 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:644
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:179
+#: lxc/network_forward.go:177 lxc/network_forward.go:652
+#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
 #: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
@@ -6905,12 +6924,12 @@ msgid ""
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:402 lxc/network_forward.go:597
+#: lxc/network_forward.go:410 lxc/network_forward.go:605
 #: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
@@ -6920,13 +6939,13 @@ msgid ""
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:887
+#: lxc/network_forward.go:895
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:968 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -6981,7 +7000,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2811
+#: lxc/storage_volume.go:2813
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7016,65 +7035,65 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1958
+#: lxc/storage_volume.go:1960
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:806
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:167
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
-msgstr ""
-
-#: lxc/storage_volume.go:2562
+#: lxc/storage_volume.go:2564
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2645
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2428
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:610
+#: lxc/storage_volume.go:614
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:718
+#: lxc/storage_volume.go:722
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2364
+#: lxc/storage_volume.go:810
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
+msgstr ""
+
+#: lxc/storage_volume.go:167
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
+msgstr ""
+
+#: lxc/storage_volume.go:2366
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2087
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2245
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1234
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1858
+#: lxc/storage_volume.go:1860
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7180,7 +7199,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1603
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7342,20 +7361,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1230
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:470
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:691
+#: lxc/file.go:704
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7656,7 +7675,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:618
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7664,13 +7683,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2817
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2432
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7704,16 +7723,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1396
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1331
+#: lxc/file.go:1355
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1284
+#: lxc/file.go:1308
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-07 15:11-0700\n"
+"POT-Creation-Date: 2025-01-10 14:44-0600\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1041
+#: lxc/storage_volume.go:1043
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:667
+#: lxc/network_forward.go:675
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,12 +430,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1157
+#: lxc/file.go:1177
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1047
+#: lxc/file.go:1067
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -471,7 +471,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:65
+#: lxc/init.go:146 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:687
+#: lxc/file.go:700
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -541,7 +541,7 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
@@ -672,7 +672,7 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:888 lxc/network_forward.go:889
+#: lxc/network_forward.go:896 lxc/network_forward.go:897
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -722,7 +722,7 @@ msgstr ""
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
+#: lxc/image_alias.go:101 lxc/image_alias.go:156 lxc/image_alias.go:320
 msgid "Alias name missing"
 msgstr ""
 
@@ -735,7 +735,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1607
+#: lxc/storage_volume.go:1609
 msgid "All projects"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -790,12 +790,26 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168 lxc/storage_volume.go:169
+#: lxc/storage_volume.go:168
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:169
+msgid ""
+"Attach new storage volumes to instances\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
+msgstr ""
+
+#: lxc/storage_volume.go:285
 msgid "Attach new storage volumes to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:286
+msgid ""
+"Attach new storage volumes to profiles\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
 #: lxc/console.go:39
@@ -846,16 +860,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2719
+#: lxc/storage_volume.go:2721
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2796
+#: lxc/export.go:192 lxc/storage_volume.go:2798
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1538
+#: lxc/info.go:666 lxc/storage_volume.go:1540
 msgid "Backups:"
 msgstr ""
 
@@ -864,19 +878,19 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
+#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:326
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -919,7 +933,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1752
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -971,7 +985,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -979,7 +993,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:562
+#: lxc/file.go:575
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1004,11 +1018,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:768
+#: lxc/file.go:790
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1021,12 +1035,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:493
+#: lxc/storage_volume.go:497
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:447
+#: lxc/storage_volume.go:451
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1132,9 +1146,9 @@ msgstr ""
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:497 lxc/network_forward.go:649
-#: lxc/network_forward.go:803 lxc/network_forward.go:892
-#: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
+#: lxc/network_forward.go:505 lxc/network_forward.go:657
+#: lxc/network_forward.go:811 lxc/network_forward.go:900
+#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
 #: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
 #: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
@@ -1146,14 +1160,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
-#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
-#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
-#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
+#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
 msgid "Cluster member name"
 msgstr ""
 
@@ -1169,7 +1183,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1608
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1209,21 +1223,21 @@ msgstr ""
 #: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
-#: lxc/network_acl.go:698 lxc/network_forward.go:767
+#: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
-#: lxc/storage_volume.go:1199
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
+#: lxc/storage_volume.go:1201
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:620
+#: lxc/storage_volume.go:624
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1478
+#: lxc/storage_volume.go:1480
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1285,7 +1299,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1293,12 +1307,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1311,7 +1325,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1406,7 +1420,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:462 lxc/file.go:696
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1446,7 +1460,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1498,12 +1512,12 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:182
+#: lxc/init.go:186
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1513,7 +1527,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 msgid "Creating the instance"
 msgstr ""
 
@@ -1527,13 +1541,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1749
+#: lxc/storage_volume.go:1751
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1553,7 +1567,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2653
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1585,7 +1599,7 @@ msgstr ""
 msgid "Delete identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:106 lxc/image_alias.go:107
+#: lxc/image_alias.go:123 lxc/image_alias.go:124
 msgid "Delete image aliases"
 msgstr ""
 
@@ -1609,7 +1623,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:799 lxc/network_forward.go:800
+#: lxc/network_forward.go:807 lxc/network_forward.go:808
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1649,7 +1663,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
+#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1691,13 +1705,13 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
-#: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
-#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
+#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
+#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
+#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
@@ -1711,10 +1725,10 @@ msgstr ""
 #: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:404 lxc/network_forward.go:489
-#: lxc/network_forward.go:599 lxc/network_forward.go:646
-#: lxc/network_forward.go:800 lxc/network_forward.go:874
-#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_forward.go:412 lxc/network_forward.go:497
+#: lxc/network_forward.go:607 lxc/network_forward.go:654
+#: lxc/network_forward.go:808 lxc/network_forward.go:882
+#: lxc/network_forward.go:897 lxc/network_forward.go:982
 #: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
 #: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
 #: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
@@ -1754,27 +1768,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
-#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
-#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
-#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
-#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
-#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
-#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
-#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1465
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1786,11 +1800,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
+#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1840,7 +1854,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:403
+#: lxc/init.go:407
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1852,7 +1866,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1216
+#: lxc/file.go:1236
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1948,7 +1962,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:377 lxc/file.go:378
+#: lxc/file.go:381 lxc/file.go:382
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1988,7 +2002,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:653 lxc/network_forward.go:654
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -2028,7 +2042,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2036,7 +2050,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1785
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2090,11 +2104,11 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
-#: lxc/network_acl.go:524 lxc/network_forward.go:572
+#: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
+#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2105,11 +2119,11 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
-#: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
+#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
-#: lxc/storage_volume.go:2210
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
+#: lxc/storage_volume.go:2212
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2151,8 +2165,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
+#: lxc/storage_volume.go:1577
 msgid "Expires at"
 msgstr ""
 
@@ -2176,7 +2190,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2188,11 +2202,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2650
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2779
+#: lxc/export.go:152 lxc/storage_volume.go:2781
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2211,7 +2225,7 @@ msgid "FILENAME"
 msgstr ""
 
 #: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
-#: lxc/image_alias.go:235
+#: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2219,12 +2233,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1467
+#: lxc/file.go:1491
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1490
+#: lxc/file.go:1514
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2239,12 +2253,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1517
+#: lxc/file.go:1541
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1326
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2274,7 +2288,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1423
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2289,7 +2303,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1428
+#: lxc/file.go:1452
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2299,12 +2313,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1352
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1455
+#: lxc/file.go:1479
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2318,7 +2332,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:304 lxc/move.go:380
+#: lxc/move.go:309 lxc/move.go:385
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2343,7 +2357,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1440
+#: lxc/file.go:1464
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2358,7 +2372,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1042
+#: lxc/file.go:1062
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2445,14 +2459,14 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1625 lxc/warning.go:94
+#: lxc/storage_volume.go:1627 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2520,7 +2534,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1602
+#: lxc/image.go:1602 lxc/image.go:1603
 msgid "Get image properties"
 msgstr ""
 
@@ -2536,7 +2550,7 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:414
 msgid "Get the key as a network forward property"
 msgstr ""
 
@@ -2576,7 +2590,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1249
+#: lxc/storage_volume.go:1251
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2604,7 +2618,7 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:403 lxc/network_forward.go:404
+#: lxc/network_forward.go:411 lxc/network_forward.go:412
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
@@ -2640,11 +2654,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:476
+#: lxc/storage_volume.go:480
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2684,22 +2698,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1540
+#: lxc/file.go:1564
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1529
+#: lxc/file.go:1553
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1376
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1362
+#: lxc/file.go:1386
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2772,11 +2786,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:415
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2786,7 +2800,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2437
+#: lxc/storage_volume.go:2439
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2798,7 +2812,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1517
+#: lxc/image.go:1518
 msgid "Image already up to date."
 msgstr ""
 
@@ -2814,11 +2828,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1472
+#: lxc/image.go:364 lxc/image.go:1473
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1698
+#: lxc/image.go:444 lxc/image.go:1699
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2828,7 +2842,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1515
+#: lxc/image.go:1516
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2836,7 +2850,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2815
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2844,7 +2858,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2814
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2866,11 +2880,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2822
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2894
+#: lxc/storage_volume.go:2896
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2896,11 +2910,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1378
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1531
+#: lxc/file.go:1555
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2909,7 +2923,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:414
+#: lxc/init.go:418
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2918,7 +2932,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1298
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2970,7 +2984,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1293
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2996,23 +3010,23 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2023
+#: lxc/move.go:153 lxc/storage_volume.go:2025
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:144
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2019
+#: lxc/storage_volume.go:2021
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:509
+#: lxc/main.go:518
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:353
+#: lxc/file.go:357
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3022,18 +3036,18 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
-#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
+#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:535
+#: lxc/file.go:548
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:717
+#: lxc/file.go:185 lxc/file.go:739
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3070,7 +3084,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3101,12 +3115,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:176
+#: lxc/init.go:180
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:174
+#: lxc/init.go:178
 msgid "Launching the instance"
 msgstr ""
 
@@ -3204,11 +3218,11 @@ msgstr ""
 msgid "List identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:151
+#: lxc/image_alias.go:176
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:177
 msgid ""
 "List image aliases\n"
 "\n"
@@ -3375,11 +3389,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1605
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1610
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3438,7 +3452,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1481
+#: lxc/info.go:489 lxc/storage_volume.go:1483
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3624,7 +3638,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:873 lxc/network_forward.go:874
+#: lxc/network_forward.go:881 lxc/network_forward.go:882
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -3770,12 +3784,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:322 lxc/move.go:435
+#: lxc/move.go:327 lxc/move.go:440
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:347 lxc/move.go:440
+#: lxc/move.go:352 lxc/move.go:445
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3840,10 +3854,10 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:449
-#: lxc/network_forward.go:534 lxc/network_forward.go:709
-#: lxc/network_forward.go:840 lxc/network_forward.go:933
-#: lxc/network_forward.go:1015 lxc/network_load_balancer.go:221
+#: lxc/network_forward.go:219 lxc/network_forward.go:457
+#: lxc/network_forward.go:542 lxc/network_forward.go:717
+#: lxc/network_forward.go:848 lxc/network_forward.go:945
+#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
 #: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
 #: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
 #: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
@@ -3868,10 +3882,10 @@ msgstr ""
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
 #: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
 #: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:284 lxc/network_forward.go:445
-#: lxc/network_forward.go:530 lxc/network_forward.go:705
-#: lxc/network_forward.go:836 lxc/network_forward.go:929
-#: lxc/network_forward.go:1011 lxc/network_load_balancer.go:131
+#: lxc/network_forward.go:292 lxc/network_forward.go:453
+#: lxc/network_forward.go:538 lxc/network_forward.go:713
+#: lxc/network_forward.go:844 lxc/network_forward.go:941
+#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
 #: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
 #: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
 #: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
@@ -3907,13 +3921,13 @@ msgstr ""
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
-#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
-#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
-#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
+#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
+#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
+#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
+#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
 msgid "Missing pool name"
 msgstr ""
 
@@ -3932,15 +3946,15 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
+#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1411
+#: lxc/storage_volume.go:1413
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:820
+#: lxc/file.go:842
 msgid "Missing target directory"
 msgstr ""
 
@@ -3973,16 +3987,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
-#: lxc/storage_volume.go:975
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
+#: lxc/storage_volume.go:977
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:507
+#: lxc/file.go:520
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1207 lxc/file.go:1208
+#: lxc/file.go:1227 lxc/file.go:1228
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4011,7 +4025,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4019,16 +4033,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1869
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1059 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4050,7 +4064,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
 msgid "NAME"
 msgstr ""
 
@@ -4102,8 +4116,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
-#: lxc/storage_volume.go:1573
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Name"
 msgstr ""
 
@@ -4111,7 +4125,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4166,12 +4180,12 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:386
+#: lxc/network_forward.go:394
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:857
+#: lxc/network_forward.go:865
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -4255,7 +4269,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
+#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4263,7 +4277,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1070 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4275,11 +4289,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4293,7 +4307,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2035
+#: lxc/storage_volume.go:2037
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4301,16 +4315,21 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
-#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
-msgid "Only \"custom\" volumes can be attached to instances"
+#: lxc/storage_volume.go:216
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2701
+#: lxc/storage_volume.go:348
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:2703
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2500
+#: lxc/storage_volume.go:2502
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4322,7 +4341,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1431
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4335,7 +4354,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1577
+#: lxc/info.go:705 lxc/storage_volume.go:1579
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4365,7 +4384,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1767
+#: lxc/storage_volume.go:1769
 msgid "POOL"
 msgstr ""
 
@@ -4382,7 +4401,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167
-#: lxc/storage_volume.go:1773 lxc/warning.go:213
+#: lxc/storage_volume.go:1775 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4406,7 +4425,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:367
+#: lxc/main.go:376
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4444,7 +4463,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1332
+#: lxc/file.go:1356
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4452,12 +4471,12 @@ msgstr ""
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
-#: lxc/network_acl.go:699 lxc/network_forward.go:768
+#: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
-#: lxc/storage_volume.go:1200
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
+#: lxc/storage_volume.go:1202
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4570,11 +4589,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1649
+#: lxc/image.go:1650
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4588,7 +4607,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1238
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4604,7 +4623,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4625,7 +4644,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1017
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4634,7 +4653,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2094
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4647,7 +4666,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2370
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4678,20 +4697,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:455 lxc/file.go:456
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:638 lxc/file.go:989
+#: lxc/file.go:651 lxc/file.go:1009
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:688 lxc/file.go:689
+#: lxc/file.go:701 lxc/file.go:702
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:923 lxc/file.go:1089
+#: lxc/file.go:943 lxc/file.go:1109
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4700,7 +4719,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4729,15 +4748,15 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:463 lxc/file.go:695
+#: lxc/file.go:475 lxc/file.go:708
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1444 lxc/image.go:1445
+#: lxc/image.go:1445 lxc/image.go:1446
 msgid "Refresh images"
 msgstr ""
 
@@ -4746,7 +4765,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1481
+#: lxc/image.go:1482
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4823,7 +4842,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:971 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4859,7 +4878,7 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:969 lxc/network_forward.go:970
+#: lxc/network_forward.go:981 lxc/network_forward.go:982
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -4895,8 +4914,8 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
-#: lxc/image_alias.go:255
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:287
+#: lxc/image_alias.go:288
 msgid "Rename aliases"
 msgstr ""
 
@@ -4932,15 +4951,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1962
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
+#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4992,7 +5011,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5009,7 +5028,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:361
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5058,12 +5077,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1460
+#: lxc/file.go:1484
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1461
+#: lxc/file.go:1485
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5139,7 +5158,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1217
+#: lxc/file.go:1237
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5165,7 +5184,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1665 lxc/image.go:1666
+#: lxc/image.go:1666 lxc/image.go:1667
 msgid "Set image properties"
 msgstr ""
 
@@ -5208,11 +5227,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:488
+#: lxc/network_forward.go:496
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:489
+#: lxc/network_forward.go:497
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5316,11 +5335,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2088
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2089
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5337,7 +5356,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:698
+#: lxc/file.go:711
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5345,7 +5364,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:699
+#: lxc/file.go:712
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5353,7 +5372,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:710
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5365,7 +5384,7 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:504
 msgid "Set the key as a network forward property"
 msgstr ""
 
@@ -5405,7 +5424,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2105
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5413,7 +5432,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1215
+#: lxc/file.go:1235
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5470,7 +5489,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1535 lxc/image.go:1536
+#: lxc/image.go:1536 lxc/image.go:1537
 msgid "Show image properties"
 msgstr ""
 
@@ -5490,7 +5509,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:271 lxc/main.go:272
+#: lxc/main.go:280 lxc/main.go:281
 msgid "Show less common commands"
 msgstr ""
 
@@ -5554,11 +5573,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5626,15 +5645,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2190
+#: lxc/storage_volume.go:2192
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1502
+#: lxc/info.go:619 lxc/storage_volume.go:1504
 msgid "Snapshots:"
 msgstr ""
 
@@ -5739,21 +5758,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:703
+#: lxc/storage_volume.go:707
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:791
+#: lxc/storage_volume.go:795
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:516
+#: lxc/storage_volume.go:520
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:524
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5815,21 +5834,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1747 lxc/warning.go:216
+#: lxc/storage_volume.go:1749 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1262
+#: lxc/file.go:1286
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1256
+#: lxc/file.go:1280
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5839,15 +5858,15 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:181
+#: lxc/move.go:186
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:219 lxc/move.go:240
+#: lxc/move.go:224 lxc/move.go:245
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:193
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5855,15 +5874,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:185
+#: lxc/move.go:190
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:189
+#: lxc/move.go:194
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:210
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5885,7 +5904,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:439
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5938,7 +5957,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:462
+#: lxc/network_forward.go:470
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -5978,12 +5997,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1340
+#: lxc/storage_volume.go:1342
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1317
+#: lxc/storage_volume.go:1319
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -5998,12 +6017,12 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:309
+#: lxc/move.go:314
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
-#: lxc/storage_volume.go:989
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
+#: lxc/storage_volume.go:991
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6031,7 +6050,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:298
+#: lxc/main.go:307
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6055,11 +6074,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:437
+#: lxc/init.go:441
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:440
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6067,7 +6086,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:412
+#: lxc/main.go:421
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6078,7 +6097,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1489
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6093,7 +6112,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1864
+#: lxc/storage_volume.go:1866
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6101,7 +6120,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6118,7 +6137,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:327
+#: lxc/copy.go:382 lxc/move.go:332
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6160,7 +6179,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1472
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6182,13 +6201,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1752
+#: lxc/project.go:995 lxc/storage_volume.go:1754
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1751
+#: lxc/storage.go:724 lxc/storage_volume.go:1753
 msgid "USED BY"
 msgstr ""
 
@@ -6201,7 +6220,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:411
+#: lxc/file.go:423
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6215,12 +6234,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1483
+#: lxc/file.go:1507
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1791
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6231,7 +6250,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1029
+#: lxc/file.go:1049
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6262,7 +6281,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1728 lxc/image.go:1729
+#: lxc/image.go:1729 lxc/image.go:1730
 msgid "Unset image properties"
 msgstr ""
 
@@ -6278,11 +6297,11 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:598
+#: lxc/network_forward.go:606
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:599
+#: lxc/network_forward.go:607
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -6326,7 +6345,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6338,7 +6357,7 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:602
+#: lxc/network_forward.go:610
 msgid "Unset the key as a network forward property"
 msgstr ""
 
@@ -6378,7 +6397,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2381
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6386,7 +6405,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:248
+#: lxc/storage_volume.go:250
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6422,12 +6441,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1485
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2652
+#: lxc/export.go:42 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6494,7 +6513,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1576
+#: lxc/storage_volume.go:1578
 msgid "Volume Only"
 msgstr ""
 
@@ -6545,7 +6564,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:293 lxc/move.go:369
+#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6553,12 +6572,12 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:909
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:912
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:282
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:284
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
@@ -6590,7 +6609,7 @@ msgstr ""
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:174
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
@@ -6643,7 +6662,7 @@ msgstr ""
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: lxc/image_alias.go:104
+#: lxc/image_alias.go:121
 msgid "[<remote>:]<alias>"
 msgstr ""
 
@@ -6651,7 +6670,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/image_alias.go:252
+#: lxc/image_alias.go:285
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
@@ -6705,15 +6724,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1600 lxc/image.go:1727
+#: lxc/image.go:1601 lxc/image.go:1728
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1664
+#: lxc/image.go:1665
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6733,7 +6752,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1443
+#: lxc/image.go:334 lxc/image.go:1444
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6804,7 +6823,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:376
+#: lxc/file.go:380
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -6816,12 +6835,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:454
+#: lxc/file.go:466
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1226
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6889,8 +6908,8 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:644
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:179
+#: lxc/network_forward.go:177 lxc/network_forward.go:652
+#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
 #: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
@@ -6905,12 +6924,12 @@ msgid ""
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:402 lxc/network_forward.go:597
+#: lxc/network_forward.go:410 lxc/network_forward.go:605
 #: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
@@ -6920,13 +6939,13 @@ msgid ""
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:887
+#: lxc/network_forward.go:895
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:968 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -6981,7 +7000,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2811
+#: lxc/storage_volume.go:2813
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7016,65 +7035,65 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1958
+#: lxc/storage_volume.go:1960
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:806
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:167
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
-msgstr ""
-
-#: lxc/storage_volume.go:2562
+#: lxc/storage_volume.go:2564
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2645
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2428
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:610
+#: lxc/storage_volume.go:614
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:718
+#: lxc/storage_volume.go:722
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2364
+#: lxc/storage_volume.go:810
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
+msgstr ""
+
+#: lxc/storage_volume.go:167
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
+msgstr ""
+
+#: lxc/storage_volume.go:2366
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2087
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2245
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1234
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1858
+#: lxc/storage_volume.go:1860
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7180,7 +7199,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1603
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7342,20 +7361,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1230
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:470
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:691
+#: lxc/file.go:704
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7656,7 +7675,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:618
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7664,13 +7683,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2817
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2432
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7704,16 +7723,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1396
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1331
+#: lxc/file.go:1355
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1284
+#: lxc/file.go:1308
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-07 15:11-0700\n"
+"POT-Creation-Date: 2025-01-10 14:44-0600\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1041
+#: lxc/storage_volume.go:1043
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:667
+#: lxc/network_forward.go:675
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,12 +430,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1157
+#: lxc/file.go:1177
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1047
+#: lxc/file.go:1067
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -471,7 +471,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:65
+#: lxc/init.go:146 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:687
+#: lxc/file.go:700
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -541,7 +541,7 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
@@ -672,7 +672,7 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:888 lxc/network_forward.go:889
+#: lxc/network_forward.go:896 lxc/network_forward.go:897
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -722,7 +722,7 @@ msgstr ""
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
+#: lxc/image_alias.go:101 lxc/image_alias.go:156 lxc/image_alias.go:320
 msgid "Alias name missing"
 msgstr ""
 
@@ -735,7 +735,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1607
+#: lxc/storage_volume.go:1609
 msgid "All projects"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -790,12 +790,26 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168 lxc/storage_volume.go:169
+#: lxc/storage_volume.go:168
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:169
+msgid ""
+"Attach new storage volumes to instances\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
+msgstr ""
+
+#: lxc/storage_volume.go:285
 msgid "Attach new storage volumes to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:286
+msgid ""
+"Attach new storage volumes to profiles\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
 #: lxc/console.go:39
@@ -846,16 +860,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2719
+#: lxc/storage_volume.go:2721
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2796
+#: lxc/export.go:192 lxc/storage_volume.go:2798
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1538
+#: lxc/info.go:666 lxc/storage_volume.go:1540
 msgid "Backups:"
 msgstr ""
 
@@ -864,19 +878,19 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
+#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:326
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -919,7 +933,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1752
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -971,7 +985,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -979,7 +993,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:562
+#: lxc/file.go:575
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1004,11 +1018,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:768
+#: lxc/file.go:790
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1021,12 +1035,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:493
+#: lxc/storage_volume.go:497
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:447
+#: lxc/storage_volume.go:451
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1132,9 +1146,9 @@ msgstr ""
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:497 lxc/network_forward.go:649
-#: lxc/network_forward.go:803 lxc/network_forward.go:892
-#: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
+#: lxc/network_forward.go:505 lxc/network_forward.go:657
+#: lxc/network_forward.go:811 lxc/network_forward.go:900
+#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
 #: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
 #: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
@@ -1146,14 +1160,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
-#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
-#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
-#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
+#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
 msgid "Cluster member name"
 msgstr ""
 
@@ -1169,7 +1183,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1608
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1209,21 +1223,21 @@ msgstr ""
 #: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
-#: lxc/network_acl.go:698 lxc/network_forward.go:767
+#: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
-#: lxc/storage_volume.go:1199
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
+#: lxc/storage_volume.go:1201
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:620
+#: lxc/storage_volume.go:624
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1478
+#: lxc/storage_volume.go:1480
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1285,7 +1299,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1293,12 +1307,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1311,7 +1325,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1406,7 +1420,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:462 lxc/file.go:696
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1446,7 +1460,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1498,12 +1512,12 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:182
+#: lxc/init.go:186
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1513,7 +1527,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 msgid "Creating the instance"
 msgstr ""
 
@@ -1527,13 +1541,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1749
+#: lxc/storage_volume.go:1751
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1553,7 +1567,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2653
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1585,7 +1599,7 @@ msgstr ""
 msgid "Delete identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:106 lxc/image_alias.go:107
+#: lxc/image_alias.go:123 lxc/image_alias.go:124
 msgid "Delete image aliases"
 msgstr ""
 
@@ -1609,7 +1623,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:799 lxc/network_forward.go:800
+#: lxc/network_forward.go:807 lxc/network_forward.go:808
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1649,7 +1663,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
+#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1691,13 +1705,13 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
-#: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
-#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
+#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
+#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
+#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
@@ -1711,10 +1725,10 @@ msgstr ""
 #: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:404 lxc/network_forward.go:489
-#: lxc/network_forward.go:599 lxc/network_forward.go:646
-#: lxc/network_forward.go:800 lxc/network_forward.go:874
-#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_forward.go:412 lxc/network_forward.go:497
+#: lxc/network_forward.go:607 lxc/network_forward.go:654
+#: lxc/network_forward.go:808 lxc/network_forward.go:882
+#: lxc/network_forward.go:897 lxc/network_forward.go:982
 #: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
 #: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
 #: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
@@ -1754,27 +1768,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
-#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
-#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
-#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
-#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
-#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
-#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
-#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1465
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1786,11 +1800,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
+#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1840,7 +1854,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:403
+#: lxc/init.go:407
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1852,7 +1866,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1216
+#: lxc/file.go:1236
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1948,7 +1962,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:377 lxc/file.go:378
+#: lxc/file.go:381 lxc/file.go:382
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1988,7 +2002,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:653 lxc/network_forward.go:654
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -2028,7 +2042,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2036,7 +2050,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1785
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2090,11 +2104,11 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
-#: lxc/network_acl.go:524 lxc/network_forward.go:572
+#: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
+#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2105,11 +2119,11 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
-#: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
+#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
-#: lxc/storage_volume.go:2210
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
+#: lxc/storage_volume.go:2212
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2151,8 +2165,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
+#: lxc/storage_volume.go:1577
 msgid "Expires at"
 msgstr ""
 
@@ -2176,7 +2190,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2188,11 +2202,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2650
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2779
+#: lxc/export.go:152 lxc/storage_volume.go:2781
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2211,7 +2225,7 @@ msgid "FILENAME"
 msgstr ""
 
 #: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
-#: lxc/image_alias.go:235
+#: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2219,12 +2233,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1467
+#: lxc/file.go:1491
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1490
+#: lxc/file.go:1514
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2239,12 +2253,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1517
+#: lxc/file.go:1541
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1326
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2274,7 +2288,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1423
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2289,7 +2303,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1428
+#: lxc/file.go:1452
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2299,12 +2313,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1352
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1455
+#: lxc/file.go:1479
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2318,7 +2332,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:304 lxc/move.go:380
+#: lxc/move.go:309 lxc/move.go:385
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2343,7 +2357,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1440
+#: lxc/file.go:1464
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2358,7 +2372,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1042
+#: lxc/file.go:1062
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2445,14 +2459,14 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1625 lxc/warning.go:94
+#: lxc/storage_volume.go:1627 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2520,7 +2534,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1602
+#: lxc/image.go:1602 lxc/image.go:1603
 msgid "Get image properties"
 msgstr ""
 
@@ -2536,7 +2550,7 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:414
 msgid "Get the key as a network forward property"
 msgstr ""
 
@@ -2576,7 +2590,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1249
+#: lxc/storage_volume.go:1251
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2604,7 +2618,7 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:403 lxc/network_forward.go:404
+#: lxc/network_forward.go:411 lxc/network_forward.go:412
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
@@ -2640,11 +2654,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:476
+#: lxc/storage_volume.go:480
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2684,22 +2698,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1540
+#: lxc/file.go:1564
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1529
+#: lxc/file.go:1553
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1376
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1362
+#: lxc/file.go:1386
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2772,11 +2786,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:415
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2786,7 +2800,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2437
+#: lxc/storage_volume.go:2439
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2798,7 +2812,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1517
+#: lxc/image.go:1518
 msgid "Image already up to date."
 msgstr ""
 
@@ -2814,11 +2828,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1472
+#: lxc/image.go:364 lxc/image.go:1473
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1698
+#: lxc/image.go:444 lxc/image.go:1699
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2828,7 +2842,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1515
+#: lxc/image.go:1516
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2836,7 +2850,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2815
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2844,7 +2858,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2814
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2866,11 +2880,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2822
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2894
+#: lxc/storage_volume.go:2896
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2896,11 +2910,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1378
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1531
+#: lxc/file.go:1555
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2909,7 +2923,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:414
+#: lxc/init.go:418
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2918,7 +2932,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1298
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2970,7 +2984,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1293
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2996,23 +3010,23 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2023
+#: lxc/move.go:153 lxc/storage_volume.go:2025
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:144
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2019
+#: lxc/storage_volume.go:2021
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:509
+#: lxc/main.go:518
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:353
+#: lxc/file.go:357
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3022,18 +3036,18 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
-#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
+#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:535
+#: lxc/file.go:548
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:717
+#: lxc/file.go:185 lxc/file.go:739
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3070,7 +3084,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3101,12 +3115,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:176
+#: lxc/init.go:180
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:174
+#: lxc/init.go:178
 msgid "Launching the instance"
 msgstr ""
 
@@ -3204,11 +3218,11 @@ msgstr ""
 msgid "List identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:151
+#: lxc/image_alias.go:176
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:177
 msgid ""
 "List image aliases\n"
 "\n"
@@ -3375,11 +3389,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1605
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1610
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3438,7 +3452,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1481
+#: lxc/info.go:489 lxc/storage_volume.go:1483
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3624,7 +3638,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:873 lxc/network_forward.go:874
+#: lxc/network_forward.go:881 lxc/network_forward.go:882
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -3770,12 +3784,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:322 lxc/move.go:435
+#: lxc/move.go:327 lxc/move.go:440
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:347 lxc/move.go:440
+#: lxc/move.go:352 lxc/move.go:445
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3840,10 +3854,10 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:449
-#: lxc/network_forward.go:534 lxc/network_forward.go:709
-#: lxc/network_forward.go:840 lxc/network_forward.go:933
-#: lxc/network_forward.go:1015 lxc/network_load_balancer.go:221
+#: lxc/network_forward.go:219 lxc/network_forward.go:457
+#: lxc/network_forward.go:542 lxc/network_forward.go:717
+#: lxc/network_forward.go:848 lxc/network_forward.go:945
+#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
 #: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
 #: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
 #: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
@@ -3868,10 +3882,10 @@ msgstr ""
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
 #: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
 #: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:284 lxc/network_forward.go:445
-#: lxc/network_forward.go:530 lxc/network_forward.go:705
-#: lxc/network_forward.go:836 lxc/network_forward.go:929
-#: lxc/network_forward.go:1011 lxc/network_load_balancer.go:131
+#: lxc/network_forward.go:292 lxc/network_forward.go:453
+#: lxc/network_forward.go:538 lxc/network_forward.go:713
+#: lxc/network_forward.go:844 lxc/network_forward.go:941
+#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
 #: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
 #: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
 #: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
@@ -3907,13 +3921,13 @@ msgstr ""
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
-#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
-#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
-#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
+#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
+#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
+#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
+#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
 msgid "Missing pool name"
 msgstr ""
 
@@ -3932,15 +3946,15 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
+#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1411
+#: lxc/storage_volume.go:1413
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:820
+#: lxc/file.go:842
 msgid "Missing target directory"
 msgstr ""
 
@@ -3973,16 +3987,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
-#: lxc/storage_volume.go:975
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
+#: lxc/storage_volume.go:977
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:507
+#: lxc/file.go:520
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1207 lxc/file.go:1208
+#: lxc/file.go:1227 lxc/file.go:1228
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4011,7 +4025,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4019,16 +4033,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1869
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1059 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4050,7 +4064,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
 msgid "NAME"
 msgstr ""
 
@@ -4102,8 +4116,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
-#: lxc/storage_volume.go:1573
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Name"
 msgstr ""
 
@@ -4111,7 +4125,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4166,12 +4180,12 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:386
+#: lxc/network_forward.go:394
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:857
+#: lxc/network_forward.go:865
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -4255,7 +4269,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
+#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4263,7 +4277,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1070 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4275,11 +4289,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4293,7 +4307,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2035
+#: lxc/storage_volume.go:2037
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4301,16 +4315,21 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
-#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
-msgid "Only \"custom\" volumes can be attached to instances"
+#: lxc/storage_volume.go:216
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2701
+#: lxc/storage_volume.go:348
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:2703
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2500
+#: lxc/storage_volume.go:2502
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4322,7 +4341,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1431
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4335,7 +4354,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1577
+#: lxc/info.go:705 lxc/storage_volume.go:1579
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4365,7 +4384,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1767
+#: lxc/storage_volume.go:1769
 msgid "POOL"
 msgstr ""
 
@@ -4382,7 +4401,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167
-#: lxc/storage_volume.go:1773 lxc/warning.go:213
+#: lxc/storage_volume.go:1775 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4406,7 +4425,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:367
+#: lxc/main.go:376
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4444,7 +4463,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1332
+#: lxc/file.go:1356
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4452,12 +4471,12 @@ msgstr ""
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
-#: lxc/network_acl.go:699 lxc/network_forward.go:768
+#: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
-#: lxc/storage_volume.go:1200
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
+#: lxc/storage_volume.go:1202
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4570,11 +4589,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1649
+#: lxc/image.go:1650
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4588,7 +4607,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1238
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4604,7 +4623,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4625,7 +4644,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1017
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4634,7 +4653,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2094
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4647,7 +4666,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2370
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4678,20 +4697,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:455 lxc/file.go:456
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:638 lxc/file.go:989
+#: lxc/file.go:651 lxc/file.go:1009
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:688 lxc/file.go:689
+#: lxc/file.go:701 lxc/file.go:702
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:923 lxc/file.go:1089
+#: lxc/file.go:943 lxc/file.go:1109
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4700,7 +4719,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4729,15 +4748,15 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:463 lxc/file.go:695
+#: lxc/file.go:475 lxc/file.go:708
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1444 lxc/image.go:1445
+#: lxc/image.go:1445 lxc/image.go:1446
 msgid "Refresh images"
 msgstr ""
 
@@ -4746,7 +4765,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1481
+#: lxc/image.go:1482
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4823,7 +4842,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:971 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4859,7 +4878,7 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:969 lxc/network_forward.go:970
+#: lxc/network_forward.go:981 lxc/network_forward.go:982
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -4895,8 +4914,8 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
-#: lxc/image_alias.go:255
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:287
+#: lxc/image_alias.go:288
 msgid "Rename aliases"
 msgstr ""
 
@@ -4932,15 +4951,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1962
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
+#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4992,7 +5011,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5009,7 +5028,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:361
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5058,12 +5077,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1460
+#: lxc/file.go:1484
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1461
+#: lxc/file.go:1485
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5139,7 +5158,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1217
+#: lxc/file.go:1237
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5165,7 +5184,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1665 lxc/image.go:1666
+#: lxc/image.go:1666 lxc/image.go:1667
 msgid "Set image properties"
 msgstr ""
 
@@ -5208,11 +5227,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:488
+#: lxc/network_forward.go:496
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:489
+#: lxc/network_forward.go:497
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5316,11 +5335,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2088
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2089
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5337,7 +5356,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:698
+#: lxc/file.go:711
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5345,7 +5364,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:699
+#: lxc/file.go:712
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5353,7 +5372,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:710
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5365,7 +5384,7 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:504
 msgid "Set the key as a network forward property"
 msgstr ""
 
@@ -5405,7 +5424,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2105
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5413,7 +5432,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1215
+#: lxc/file.go:1235
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5470,7 +5489,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1535 lxc/image.go:1536
+#: lxc/image.go:1536 lxc/image.go:1537
 msgid "Show image properties"
 msgstr ""
 
@@ -5490,7 +5509,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:271 lxc/main.go:272
+#: lxc/main.go:280 lxc/main.go:281
 msgid "Show less common commands"
 msgstr ""
 
@@ -5554,11 +5573,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5626,15 +5645,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2190
+#: lxc/storage_volume.go:2192
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1502
+#: lxc/info.go:619 lxc/storage_volume.go:1504
 msgid "Snapshots:"
 msgstr ""
 
@@ -5739,21 +5758,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:703
+#: lxc/storage_volume.go:707
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:791
+#: lxc/storage_volume.go:795
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:516
+#: lxc/storage_volume.go:520
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:524
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5815,21 +5834,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1747 lxc/warning.go:216
+#: lxc/storage_volume.go:1749 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1262
+#: lxc/file.go:1286
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1256
+#: lxc/file.go:1280
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5839,15 +5858,15 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:181
+#: lxc/move.go:186
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:219 lxc/move.go:240
+#: lxc/move.go:224 lxc/move.go:245
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:193
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5855,15 +5874,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:185
+#: lxc/move.go:190
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:189
+#: lxc/move.go:194
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:210
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5885,7 +5904,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:439
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5938,7 +5957,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:462
+#: lxc/network_forward.go:470
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -5978,12 +5997,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1340
+#: lxc/storage_volume.go:1342
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1317
+#: lxc/storage_volume.go:1319
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -5998,12 +6017,12 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:309
+#: lxc/move.go:314
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
-#: lxc/storage_volume.go:989
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
+#: lxc/storage_volume.go:991
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6031,7 +6050,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:298
+#: lxc/main.go:307
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6055,11 +6074,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:437
+#: lxc/init.go:441
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:440
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6067,7 +6086,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:412
+#: lxc/main.go:421
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6078,7 +6097,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1489
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6093,7 +6112,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1864
+#: lxc/storage_volume.go:1866
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6101,7 +6120,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6118,7 +6137,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:327
+#: lxc/copy.go:382 lxc/move.go:332
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6160,7 +6179,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1472
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6182,13 +6201,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1752
+#: lxc/project.go:995 lxc/storage_volume.go:1754
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1751
+#: lxc/storage.go:724 lxc/storage_volume.go:1753
 msgid "USED BY"
 msgstr ""
 
@@ -6201,7 +6220,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:411
+#: lxc/file.go:423
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6215,12 +6234,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1483
+#: lxc/file.go:1507
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1791
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6231,7 +6250,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1029
+#: lxc/file.go:1049
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6262,7 +6281,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1728 lxc/image.go:1729
+#: lxc/image.go:1729 lxc/image.go:1730
 msgid "Unset image properties"
 msgstr ""
 
@@ -6278,11 +6297,11 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:598
+#: lxc/network_forward.go:606
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:599
+#: lxc/network_forward.go:607
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -6326,7 +6345,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6338,7 +6357,7 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:602
+#: lxc/network_forward.go:610
 msgid "Unset the key as a network forward property"
 msgstr ""
 
@@ -6378,7 +6397,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2381
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6386,7 +6405,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:248
+#: lxc/storage_volume.go:250
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6422,12 +6441,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1485
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2652
+#: lxc/export.go:42 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6494,7 +6513,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1576
+#: lxc/storage_volume.go:1578
 msgid "Volume Only"
 msgstr ""
 
@@ -6545,7 +6564,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:293 lxc/move.go:369
+#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6553,12 +6572,12 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:909
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:912
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:282
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:284
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
@@ -6590,7 +6609,7 @@ msgstr ""
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:174
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
@@ -6643,7 +6662,7 @@ msgstr ""
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: lxc/image_alias.go:104
+#: lxc/image_alias.go:121
 msgid "[<remote>:]<alias>"
 msgstr ""
 
@@ -6651,7 +6670,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/image_alias.go:252
+#: lxc/image_alias.go:285
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
@@ -6705,15 +6724,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1600 lxc/image.go:1727
+#: lxc/image.go:1601 lxc/image.go:1728
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1664
+#: lxc/image.go:1665
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6733,7 +6752,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1443
+#: lxc/image.go:334 lxc/image.go:1444
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6804,7 +6823,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:376
+#: lxc/file.go:380
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -6816,12 +6835,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:454
+#: lxc/file.go:466
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1226
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6889,8 +6908,8 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:644
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:179
+#: lxc/network_forward.go:177 lxc/network_forward.go:652
+#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
 #: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
@@ -6905,12 +6924,12 @@ msgid ""
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:402 lxc/network_forward.go:597
+#: lxc/network_forward.go:410 lxc/network_forward.go:605
 #: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
@@ -6920,13 +6939,13 @@ msgid ""
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:887
+#: lxc/network_forward.go:895
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:968 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -6981,7 +7000,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2811
+#: lxc/storage_volume.go:2813
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7016,65 +7035,65 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1958
+#: lxc/storage_volume.go:1960
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:806
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:167
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
-msgstr ""
-
-#: lxc/storage_volume.go:2562
+#: lxc/storage_volume.go:2564
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2645
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2428
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:610
+#: lxc/storage_volume.go:614
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:718
+#: lxc/storage_volume.go:722
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2364
+#: lxc/storage_volume.go:810
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
+msgstr ""
+
+#: lxc/storage_volume.go:167
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
+msgstr ""
+
+#: lxc/storage_volume.go:2366
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2087
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2245
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1234
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1858
+#: lxc/storage_volume.go:1860
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7180,7 +7199,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1603
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7342,20 +7361,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1230
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:470
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:691
+#: lxc/file.go:704
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7656,7 +7675,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:618
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7664,13 +7683,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2817
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2432
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7704,16 +7723,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1396
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1331
+#: lxc/file.go:1355
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1284
+#: lxc/file.go:1308
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-07 15:11-0700\n"
+"POT-Creation-Date: 2025-01-10 14:44-0600\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -74,7 +74,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:1041
+#: lxc/storage_volume.go:1043
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -369,7 +369,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: lxc/network_forward.go:667
+#: lxc/network_forward.go:675
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -679,12 +679,12 @@ msgstr "%s (%d mehr)"
 msgid "%s (%s) (%d available)"
 msgstr "%s (%d mehr)"
 
-#: lxc/file.go:1157
+#: lxc/file.go:1177
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s ist kein Verzeichnis"
 
-#: lxc/file.go:1047
+#: lxc/file.go:1067
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' ist kein unterstützter Dateityp"
@@ -723,7 +723,7 @@ msgstr "--refresh kann nur mit Containern verwendet werden"
 msgid "--console only works with a single instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/init.go:142 lxc/rebuild.go:65
+#: lxc/init.go:146 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -783,7 +783,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:687
+#: lxc/file.go:700
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
@@ -805,7 +805,7 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr "ALIAS"
 
@@ -943,7 +943,7 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:888 lxc/network_forward.go:889
+#: lxc/network_forward.go:896 lxc/network_forward.go:897
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -996,7 +996,7 @@ msgstr "entfernte Instanz %s existiert bereits"
 msgid "Alias %s doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
 
-#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
+#: lxc/image_alias.go:101 lxc/image_alias.go:156 lxc/image_alias.go:320
 msgid "Alias name missing"
 msgstr "Aliasname fehlt"
 
@@ -1010,7 +1010,7 @@ msgstr "entfernte Instanz %s existiert bereits"
 msgid "Aliases:"
 msgstr "Aliasse:\n"
 
-#: lxc/storage_volume.go:1607
+#: lxc/storage_volume.go:1609
 #, fuzzy
 msgid "All projects"
 msgstr "Fehlerhafte Profil URL %s"
@@ -1043,7 +1043,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1071,13 +1071,27 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr "Netzwerkschnittstellen an Container anbinden"
 
-#: lxc/storage_volume.go:168 lxc/storage_volume.go:169
+#: lxc/storage_volume.go:168
 #, fuzzy
 msgid "Attach new storage volumes to instances"
 msgstr "Netzwerkschnittstellen an Container anbinden"
 
-#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:169
+msgid ""
+"Attach new storage volumes to instances\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
+msgstr ""
+
+#: lxc/storage_volume.go:285
 msgid "Attach new storage volumes to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:286
+msgid ""
+"Attach new storage volumes to profiles\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
 #: lxc/console.go:39
@@ -1130,17 +1144,17 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:2719
+#: lxc/storage_volume.go:2721
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/export.go:192 lxc/storage_volume.go:2796
+#: lxc/export.go:192 lxc/storage_volume.go:2798
 #, fuzzy
 msgid "Backup exported successfully!"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/info.go:666 lxc/storage_volume.go:1538
+#: lxc/info.go:666 lxc/storage_volume.go:1540
 msgid "Backups:"
 msgstr ""
 
@@ -1149,19 +1163,19 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
+#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:326
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1204,7 +1218,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1752
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1267,7 +1281,7 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: lxc/move.go:130
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1275,7 +1289,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:562
+#: lxc/file.go:575
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1300,11 +1314,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:768
+#: lxc/file.go:790
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1317,12 +1331,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:493
+#: lxc/storage_volume.go:497
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:447
+#: lxc/storage_volume.go:451
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1434,9 +1448,9 @@ msgstr "Gerät %s wurde von %s entfernt\n"
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:497 lxc/network_forward.go:649
-#: lxc/network_forward.go:803 lxc/network_forward.go:892
-#: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
+#: lxc/network_forward.go:505 lxc/network_forward.go:657
+#: lxc/network_forward.go:811 lxc/network_forward.go:900
+#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
 #: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
 #: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
@@ -1448,14 +1462,14 @@ msgstr "Gerät %s wurde von %s entfernt\n"
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
-#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
-#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
-#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
+#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
 msgid "Cluster member name"
 msgstr ""
 
@@ -1471,7 +1485,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1608
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr "Spalten"
@@ -1514,21 +1528,21 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 #: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
-#: lxc/network_acl.go:698 lxc/network_forward.go:767
+#: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
-#: lxc/storage_volume.go:1199
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
+#: lxc/storage_volume.go:1201
 #, fuzzy, c-format
 msgid "Config parsing error: %s"
 msgstr "YAML Analyse Fehler %v\n"
 
-#: lxc/storage_volume.go:620
+#: lxc/storage_volume.go:624
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1478
+#: lxc/storage_volume.go:1480
 #, fuzzy, c-format
 msgid "Content type: %s"
 msgstr "Erstellt: %s"
@@ -1592,7 +1606,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 #, fuzzy
 msgid "Copy storage volumes"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -1602,13 +1616,13 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Copy the instance without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:401
 #, fuzzy
 msgid "Copy the volume without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1621,7 +1635,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:519
 #, fuzzy, c-format
 msgid "Copying the storage volume: %s"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -1721,7 +1735,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Create and start instances from images"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:143 lxc/file.go:462 lxc/file.go:696
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1768,7 +1782,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Create new custom storage buckets"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
 #, fuzzy
 msgid "Create new custom storage volumes"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -1831,12 +1845,12 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Create the instance with no profiles applied"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
 #, c-format
 msgid "Created: %s"
 msgstr "Erstellt: %s"
 
-#: lxc/init.go:182
+#: lxc/init.go:186
 #, c-format
 msgid "Creating %s"
 msgstr "Erstelle %s"
@@ -1846,7 +1860,7 @@ msgstr "Erstelle %s"
 msgid "Creating %s: %%s"
 msgstr "Erstelle %s"
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 #, fuzzy
 msgid "Creating the instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -1861,13 +1875,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1749
+#: lxc/storage_volume.go:1751
 msgid "DESCRIPTION"
 msgstr "BESCHREIBUNG"
 
@@ -1887,7 +1901,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2653
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1921,7 +1935,7 @@ msgstr "Fehlerhafte Profil URL %s"
 msgid "Delete identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:106 lxc/image_alias.go:107
+#: lxc/image_alias.go:123 lxc/image_alias.go:124
 msgid "Delete image aliases"
 msgstr ""
 
@@ -1948,7 +1962,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:799 lxc/network_forward.go:800
+#: lxc/network_forward.go:807 lxc/network_forward.go:808
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1993,7 +2007,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
+#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
 #, fuzzy
 msgid "Delete storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -2036,13 +2050,13 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
-#: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
-#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
+#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
+#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
+#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
@@ -2056,10 +2070,10 @@ msgstr ""
 #: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:404 lxc/network_forward.go:489
-#: lxc/network_forward.go:599 lxc/network_forward.go:646
-#: lxc/network_forward.go:800 lxc/network_forward.go:874
-#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_forward.go:412 lxc/network_forward.go:497
+#: lxc/network_forward.go:607 lxc/network_forward.go:654
+#: lxc/network_forward.go:808 lxc/network_forward.go:882
+#: lxc/network_forward.go:897 lxc/network_forward.go:982
 #: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
 #: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
 #: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
@@ -2099,27 +2113,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
-#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
-#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
-#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
-#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
-#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
-#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
-#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1465
+#: lxc/storage_volume.go:1467
 #, fuzzy, c-format
 msgid "Description: %s"
 msgstr "Fingerabdruck: %s\n"
 
-#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -2133,12 +2147,12 @@ msgstr "Netzwerkschnittstellen an Container anbinden"
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
 #, fuzzy
 msgid "Detach storage volumes from instances"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
+#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2193,7 +2207,7 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: lxc/init.go:403
+#: lxc/init.go:407
 #, fuzzy
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
@@ -2207,7 +2221,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1216
+#: lxc/file.go:1236
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2312,7 +2326,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/file.go:377 lxc/file.go:378
+#: lxc/file.go:381 lxc/file.go:382
 #, fuzzy
 msgid "Edit files in instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -2360,7 +2374,7 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:653 lxc/network_forward.go:654
 #, fuzzy
 msgid "Edit network forward configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
@@ -2406,7 +2420,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2415,7 +2429,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1785
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2470,11 +2484,11 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
-#: lxc/network_acl.go:524 lxc/network_forward.go:572
+#: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
+#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Fehler beim hinzufügen des Alias %s\n"
@@ -2485,11 +2499,11 @@ msgid "Error unsetting properties: %v"
 msgstr "Fehler beim hinzufügen des Alias %s\n"
 
 #: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
-#: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
+#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
-#: lxc/storage_volume.go:2210
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
+#: lxc/storage_volume.go:2212
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2540,8 +2554,8 @@ msgstr ""
 "\n"
 "lxc exec <Container> [--env EDITOR=/usr/bin/vim]... <Befehl>\n"
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
+#: lxc/storage_volume.go:1577
 msgid "Expires at"
 msgstr ""
 
@@ -2565,7 +2579,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 #, fuzzy
 msgid "Export custom storage volume"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -2580,12 +2594,12 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Export instances as backup tarballs."
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:2650
+#: lxc/storage_volume.go:2652
 #, fuzzy
 msgid "Export the volume without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/export.go:152 lxc/storage_volume.go:2779
+#: lxc/export.go:152 lxc/storage_volume.go:2781
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -2604,7 +2618,7 @@ msgid "FILENAME"
 msgstr ""
 
 #: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
-#: lxc/image_alias.go:235
+#: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr "FINGERABDRUCK"
 
@@ -2612,12 +2626,12 @@ msgstr "FINGERABDRUCK"
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1467
+#: lxc/file.go:1491
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1490
+#: lxc/file.go:1514
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2632,12 +2646,12 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:1517
+#: lxc/file.go:1541
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1326
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -2667,7 +2681,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:1423
+#: lxc/file.go:1447
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -2682,7 +2696,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:1428
+#: lxc/file.go:1452
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -2692,12 +2706,12 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed starting command: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/file.go:1328
+#: lxc/file.go:1352
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/file.go:1455
+#: lxc/file.go:1479
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -2711,7 +2725,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/move.go:304 lxc/move.go:380
+#: lxc/move.go:309 lxc/move.go:385
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -2736,7 +2750,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1440
+#: lxc/file.go:1464
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -2751,7 +2765,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed to remove alias %s: %w"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/file.go:1042
+#: lxc/file.go:1062
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2842,14 +2856,14 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1625 lxc/warning.go:94
+#: lxc/storage_volume.go:1627 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2919,7 +2933,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1602
+#: lxc/image.go:1602 lxc/image.go:1603
 msgid "Get image properties"
 msgstr ""
 
@@ -2935,7 +2949,7 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:414
 #, fuzzy
 msgid "Get the key as a network forward property"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -2982,7 +2996,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Get the key as a storage property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/storage_volume.go:1249
+#: lxc/storage_volume.go:1251
 #, fuzzy
 msgid "Get the key as a storage volume property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -3015,7 +3029,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:403 lxc/network_forward.go:404
+#: lxc/network_forward.go:411 lxc/network_forward.go:412
 #, fuzzy
 msgid "Get values for network forward configuration keys"
 msgstr "Profil %s erstellt\n"
@@ -3058,11 +3072,11 @@ msgstr "Profil %s erstellt\n"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:476
+#: lxc/storage_volume.go:480
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -3103,22 +3117,22 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1540
+#: lxc/file.go:1564
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/file.go:1529
+#: lxc/file.go:1553
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/file.go:1352
+#: lxc/file.go:1376
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/file.go:1362
+#: lxc/file.go:1386
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -3193,11 +3207,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:415
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3207,7 +3221,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2437
+#: lxc/storage_volume.go:2439
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3220,7 +3234,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/image.go:1517
+#: lxc/image.go:1518
 msgid "Image already up to date."
 msgstr ""
 
@@ -3236,11 +3250,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1472
+#: lxc/image.go:364 lxc/image.go:1473
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1698
+#: lxc/image.go:444 lxc/image.go:1699
 #, fuzzy, c-format
 msgid "Image identifier missing: %s"
 msgstr "Abbild mit Fingerabdruck %s importiert\n"
@@ -3250,7 +3264,7 @@ msgstr "Abbild mit Fingerabdruck %s importiert\n"
 msgid "Image imported with fingerprint: %s"
 msgstr "Abbild mit Fingerabdruck %s importiert\n"
 
-#: lxc/image.go:1515
+#: lxc/image.go:1516
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3259,7 +3273,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2815
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3267,7 +3281,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2814
 #, fuzzy
 msgid "Import custom storage volumes"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -3291,11 +3305,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2822
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2894
+#: lxc/storage_volume.go:2896
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -3321,12 +3335,12 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1378
 #, fuzzy
 msgid "Instance disconnected"
 msgstr "Entferntes Administrator Passwort"
 
-#: lxc/file.go:1531
+#: lxc/file.go:1555
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3335,7 +3349,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:414
+#: lxc/init.go:418
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3344,7 +3358,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1298
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3397,7 +3411,7 @@ msgstr "Ungültiges Ziel %s"
 msgid "Invalid instance name: %s"
 msgstr "Ungültige Quelle %s"
 
-#: lxc/file.go:1269
+#: lxc/file.go:1293
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Ungültige Quelle %s"
@@ -3423,25 +3437,25 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2023
+#: lxc/move.go:153 lxc/storage_volume.go:2025
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "'/' ist kein gültiges Zeichen im Namen eines Sicherungspunktes\n"
 
-#: lxc/move.go:144
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2019
+#: lxc/storage_volume.go:2021
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:509
+#: lxc/main.go:518
 #, fuzzy
 msgid "Invalid number of arguments"
 msgstr "ungültiges Argument %s"
 
-#: lxc/file.go:353
+#: lxc/file.go:357
 #, fuzzy, c-format
 msgid "Invalid path %s"
 msgstr "Ungültiges Ziel %s"
@@ -3451,19 +3465,19 @@ msgstr "Ungültiges Ziel %s"
 msgid "Invalid protocol: %s"
 msgstr "Ungültiges Ziel %s"
 
-#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
-#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
+#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Ungültige Quelle %s"
 
-#: lxc/file.go:535
+#: lxc/file.go:548
 #, c-format
 msgid "Invalid source %s"
 msgstr "Ungültige Quelle %s"
 
-#: lxc/file.go:185 lxc/file.go:717
+#: lxc/file.go:185 lxc/file.go:739
 #, c-format
 msgid "Invalid target %s"
 msgstr "Ungültiges Ziel %s"
@@ -3504,7 +3518,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3535,12 +3549,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:176
+#: lxc/init.go:180
 #, fuzzy, c-format
 msgid "Launching %s"
 msgstr "Erstelle %s"
 
-#: lxc/init.go:174
+#: lxc/init.go:178
 #, fuzzy
 msgid "Launching the instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -3647,11 +3661,11 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "List identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:151
+#: lxc/image_alias.go:176
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:177
 msgid ""
 "List image aliases\n"
 "\n"
@@ -3839,12 +3853,12 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "List storage buckets"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1605
 #, fuzzy
 msgid "List storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1610
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3904,7 +3918,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1481
+#: lxc/info.go:489 lxc/storage_volume.go:1483
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4111,7 +4125,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:873 lxc/network_forward.go:874
+#: lxc/network_forward.go:881 lxc/network_forward.go:882
 #, fuzzy
 msgid "Manage network forward ports"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -4278,12 +4292,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:322 lxc/move.go:435
+#: lxc/move.go:327 lxc/move.go:440
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:347 lxc/move.go:440
+#: lxc/move.go:352 lxc/move.go:445
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4358,10 +4372,10 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "Missing key name"
 msgstr "Fehlende Zusammenfassung."
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:449
-#: lxc/network_forward.go:534 lxc/network_forward.go:709
-#: lxc/network_forward.go:840 lxc/network_forward.go:933
-#: lxc/network_forward.go:1015 lxc/network_load_balancer.go:221
+#: lxc/network_forward.go:219 lxc/network_forward.go:457
+#: lxc/network_forward.go:542 lxc/network_forward.go:717
+#: lxc/network_forward.go:848 lxc/network_forward.go:945
+#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
 #: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
 #: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
 #: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
@@ -4389,10 +4403,10 @@ msgstr "Profilname kann nicht geändert werden"
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
 #: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
 #: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:284 lxc/network_forward.go:445
-#: lxc/network_forward.go:530 lxc/network_forward.go:705
-#: lxc/network_forward.go:836 lxc/network_forward.go:929
-#: lxc/network_forward.go:1011 lxc/network_load_balancer.go:131
+#: lxc/network_forward.go:292 lxc/network_forward.go:453
+#: lxc/network_forward.go:538 lxc/network_forward.go:713
+#: lxc/network_forward.go:844 lxc/network_forward.go:941
+#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
 #: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
 #: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
 #: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
@@ -4431,13 +4445,13 @@ msgstr "Fehlende Zusammenfassung."
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
-#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
-#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
-#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
+#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
+#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
+#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
+#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
 #, fuzzy
 msgid "Missing pool name"
 msgstr "Profilname kann nicht geändert werden"
@@ -4458,17 +4472,17 @@ msgstr "Profilname kann nicht geändert werden"
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
+#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
 #, fuzzy
 msgid "Missing source volume name"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:1411
+#: lxc/storage_volume.go:1413
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: lxc/file.go:820
+#: lxc/file.go:842
 msgid "Missing target directory"
 msgstr ""
 
@@ -4502,17 +4516,17 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
-#: lxc/storage_volume.go:975
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
+#: lxc/storage_volume.go:977
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:507
+#: lxc/file.go:520
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "Mehr als eine Datei herunterzuladen, aber das Ziel ist kein Verzeichnis"
 
-#: lxc/file.go:1207 lxc/file.go:1208
+#: lxc/file.go:1227 lxc/file.go:1228
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -4543,7 +4557,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
 #, fuzzy
 msgid "Move storage volumes between pools"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -4553,16 +4567,16 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Move the instance without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1869
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 #, fuzzy, c-format
 msgid "Moving the storage volume: %s"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_forward.go:1059 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4585,7 +4599,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
 msgid "NAME"
 msgstr ""
 
@@ -4637,8 +4651,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
-#: lxc/storage_volume.go:1573
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Name"
 msgstr ""
 
@@ -4646,7 +4660,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4701,12 +4715,12 @@ msgstr "Profil %s erstellt\n"
 msgid "Network Zone %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/network_forward.go:386
+#: lxc/network_forward.go:394
 #, fuzzy, c-format
 msgid "Network forward %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_forward.go:857
+#: lxc/network_forward.go:865
 #, fuzzy, c-format
 msgid "Network forward %s deleted"
 msgstr "Profil %s gelöscht\n"
@@ -4794,7 +4808,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
+#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
 #, fuzzy
 msgid "No device found for this storage volume"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -4803,7 +4817,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1070 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4816,11 +4830,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4834,7 +4848,7 @@ msgstr "kein Wert in %q gefunden\n"
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2035
+#: lxc/storage_volume.go:2037
 #, fuzzy
 msgid "Not a snapshot name"
 msgstr "'/' ist kein gültiges Zeichen im Namen eines Sicherungspunktes\n"
@@ -4843,16 +4857,21 @@ msgstr "'/' ist kein gültiges Zeichen im Namen eines Sicherungspunktes\n"
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
-#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
-msgid "Only \"custom\" volumes can be attached to instances"
+#: lxc/storage_volume.go:216
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2701
+#: lxc/storage_volume.go:348
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:2703
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2500
+#: lxc/storage_volume.go:2502
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4864,7 +4883,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1431
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4877,7 +4896,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/info.go:705 lxc/storage_volume.go:1577
+#: lxc/info.go:705 lxc/storage_volume.go:1579
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4907,7 +4926,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1767
+#: lxc/storage_volume.go:1769
 msgid "POOL"
 msgstr ""
 
@@ -4924,7 +4943,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167
-#: lxc/storage_volume.go:1773 lxc/warning.go:213
+#: lxc/storage_volume.go:1775 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4948,7 +4967,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:367
+#: lxc/main.go:376
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Administrator Passwort für %s: "
@@ -4990,7 +5009,7 @@ msgstr "Erstellt: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1332
+#: lxc/file.go:1356
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4998,12 +5017,12 @@ msgstr ""
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
-#: lxc/network_acl.go:699 lxc/network_forward.go:768
+#: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
-#: lxc/storage_volume.go:1200
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
+#: lxc/storage_volume.go:1202
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -5122,11 +5141,11 @@ msgstr ""
 msgid "Properties:"
 msgstr "Eigenschaften:\n"
 
-#: lxc/image.go:1649
+#: lxc/image.go:1650
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -5140,7 +5159,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1238
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5156,7 +5175,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5177,7 +5196,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1017
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5186,7 +5205,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2094
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5199,7 +5218,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2370
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5231,22 +5250,22 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Publishing instance: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/file.go:455 lxc/file.go:456
+#: lxc/file.go:467 lxc/file.go:468
 #, fuzzy
 msgid "Pull files from instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:638 lxc/file.go:989
+#: lxc/file.go:651 lxc/file.go:1009
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:688 lxc/file.go:689
+#: lxc/file.go:701 lxc/file.go:702
 #, fuzzy
 msgid "Push files into instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:923 lxc/file.go:1089
+#: lxc/file.go:943 lxc/file.go:1109
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5255,7 +5274,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5286,16 +5305,16 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Rebuild instances"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/file.go:463 lxc/file.go:695
+#: lxc/file.go:475 lxc/file.go:708
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:403
 #, fuzzy
 msgid "Refresh and update the existing storage volume copies"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/image.go:1444 lxc/image.go:1445
+#: lxc/image.go:1445 lxc/image.go:1446
 msgid "Refresh images"
 msgstr ""
 
@@ -5304,7 +5323,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/image.go:1481
+#: lxc/image.go:1482
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5385,7 +5404,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Remove aliases"
 msgstr "Entferntes Administrator Passwort"
 
-#: lxc/network_forward.go:971 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -5427,7 +5446,7 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/network_forward.go:969 lxc/network_forward.go:970
+#: lxc/network_forward.go:981 lxc/network_forward.go:982
 #, fuzzy
 msgid "Remove ports from a forward"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -5468,8 +5487,8 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
-#: lxc/image_alias.go:255
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:287
+#: lxc/image_alias.go:288
 msgid "Rename aliases"
 msgstr ""
 
@@ -5510,17 +5529,17 @@ msgstr "Fehlerhafte Profil URL %s"
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1962
 #, fuzzy
 msgid "Rename storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1961
 #, fuzzy
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
+#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5575,7 +5594,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
 #, fuzzy
 msgid "Restore storage volume snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -5594,7 +5613,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/init.go:357
+#: lxc/init.go:361
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5646,12 +5665,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1460
+#: lxc/file.go:1484
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1461
+#: lxc/file.go:1485
 #, fuzzy, c-format
 msgid "SSH client disconnected %q"
 msgstr "Entferntes Administrator Passwort"
@@ -5731,7 +5750,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Set a cluster member's configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/file.go:1217
+#: lxc/file.go:1237
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5758,7 +5777,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1665 lxc/image.go:1666
+#: lxc/image.go:1666 lxc/image.go:1667
 msgid "Set image properties"
 msgstr ""
 
@@ -5803,12 +5822,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:488
+#: lxc/network_forward.go:496
 #, fuzzy
 msgid "Set network forward keys"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network_forward.go:489
+#: lxc/network_forward.go:497
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5919,12 +5938,12 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2088
 #, fuzzy
 msgid "Set storage volume configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2089
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5942,7 +5961,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr "Setzt die gid der Datei beim Übertragen"
 
-#: lxc/file.go:698
+#: lxc/file.go:711
 msgid "Set the file's gid on push"
 msgstr "Setzt die gid der Datei beim Übertragen"
 
@@ -5951,7 +5970,7 @@ msgstr "Setzt die gid der Datei beim Übertragen"
 msgid "Set the file's perms on create"
 msgstr "Setzt die Dateiberechtigungen beim Übertragen"
 
-#: lxc/file.go:699
+#: lxc/file.go:712
 msgid "Set the file's perms on push"
 msgstr "Setzt die Dateiberechtigungen beim Übertragen"
 
@@ -5960,7 +5979,7 @@ msgstr "Setzt die Dateiberechtigungen beim Übertragen"
 msgid "Set the file's uid on create"
 msgstr "Setzt die uid der Datei beim Übertragen"
 
-#: lxc/file.go:697
+#: lxc/file.go:710
 msgid "Set the file's uid on push"
 msgstr "Setzt die uid der Datei beim Übertragen"
 
@@ -5972,7 +5991,7 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:504
 #, fuzzy
 msgid "Set the key as a network forward property"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -6019,7 +6038,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Set the key as a storage property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2105
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -6028,7 +6047,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1215
+#: lxc/file.go:1235
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -6089,7 +6108,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1535 lxc/image.go:1536
+#: lxc/image.go:1536 lxc/image.go:1537
 msgid "Show image properties"
 msgstr ""
 
@@ -6113,7 +6132,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Show instance or server information"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/main.go:271 lxc/main.go:272
+#: lxc/main.go:280 lxc/main.go:281
 msgid "Show less common commands"
 msgstr ""
 
@@ -6187,12 +6206,12 @@ msgstr "Profil %s erstellt\n"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
 #, fuzzy
 msgid "Show storage volume configurations"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
 #, fuzzy
 msgid "Show storage volume state information"
 msgstr "Profil %s erstellt\n"
@@ -6264,16 +6283,16 @@ msgstr "Größe: %.2vMB\n"
 msgid "Size: %s"
 msgstr "Erstellt: %s"
 
-#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
 #, fuzzy
 msgid "Snapshot storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:2190
+#: lxc/storage_volume.go:2192
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1502
+#: lxc/info.go:619 lxc/storage_volume.go:1504
 msgid "Snapshots:"
 msgstr ""
 
@@ -6383,22 +6402,22 @@ msgstr "Profil %s erstellt\n"
 msgid "Storage pool name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: lxc/storage_volume.go:703
+#: lxc/storage_volume.go:707
 #, fuzzy, c-format
 msgid "Storage volume %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_volume.go:791
+#: lxc/storage_volume.go:795
 #, fuzzy, c-format
 msgid "Storage volume %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/storage_volume.go:516
+#: lxc/storage_volume.go:520
 #, fuzzy
 msgid "Storage volume copied successfully!"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:524
 #, fuzzy
 msgid "Storage volume moved successfully!"
 msgstr "Profil %s erstellt\n"
@@ -6462,22 +6481,22 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1747 lxc/warning.go:216
+#: lxc/storage_volume.go:1749 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1262
+#: lxc/file.go:1286
 #, fuzzy
 msgid "Target path and --listen flag cannot be used together"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: lxc/file.go:1256
+#: lxc/file.go:1280
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6487,16 +6506,16 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:181
+#: lxc/move.go:186
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:219 lxc/move.go:240
+#: lxc/move.go:224 lxc/move.go:245
 #, fuzzy
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: lxc/move.go:193
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -6504,17 +6523,17 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:185
+#: lxc/move.go:190
 #, fuzzy
 msgid "The --storage flag can't be used with --target"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: lxc/move.go:189
+#: lxc/move.go:194
 #, fuzzy
 msgid "The --target-project flag can't be used with --target"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: lxc/move.go:205
+#: lxc/move.go:210
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -6537,7 +6556,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:439
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6591,7 +6610,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/network_forward.go:462
+#: lxc/network_forward.go:470
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -6631,12 +6650,12 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/storage_volume.go:1340
+#: lxc/storage_volume.go:1342
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/storage_volume.go:1317
+#: lxc/storage_volume.go:1319
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6651,12 +6670,12 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:309
+#: lxc/move.go:314
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
-#: lxc/storage_volume.go:989
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
+#: lxc/storage_volume.go:991
 #, fuzzy
 msgid "The specified device doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
@@ -6687,7 +6706,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:298
+#: lxc/main.go:307
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6713,11 +6732,11 @@ msgstr "Wartezeit bevor der Container gestoppt wird."
 msgid "Timestamps:"
 msgstr "Zeitstempel:\n"
 
-#: lxc/init.go:437
+#: lxc/init.go:441
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:440
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6725,7 +6744,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:412
+#: lxc/main.go:421
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6736,7 +6755,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1489
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Erstellt: %s"
@@ -6751,7 +6770,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr "unbekannter entfernter Instanz Name: %q"
 
-#: lxc/storage_volume.go:1864
+#: lxc/storage_volume.go:1866
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6759,7 +6778,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6776,7 +6795,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:327
+#: lxc/copy.go:382 lxc/move.go:332
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -6820,7 +6839,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1472
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6842,13 +6861,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1752
+#: lxc/project.go:995 lxc/storage_volume.go:1754
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1751
+#: lxc/storage.go:724 lxc/storage_volume.go:1753
 msgid "USED BY"
 msgstr ""
 
@@ -6861,7 +6880,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:411
+#: lxc/file.go:423
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6876,12 +6895,12 @@ msgstr "Neue entfernte Server hinzufügen"
 msgid "Unknown certificate type %q"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/file.go:1483
+#: lxc/file.go:1507
 #, fuzzy, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1791
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6892,7 +6911,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/file.go:1029
+#: lxc/file.go:1049
 #, fuzzy, c-format
 msgid "Unknown file type '%s'"
 msgstr "Unbekannter Befehl %s für Abbild"
@@ -6927,7 +6946,7 @@ msgstr "nicht alle Profile der Quelle sind am Ziel vorhanden."
 msgid "Unset device configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/image.go:1728 lxc/image.go:1729
+#: lxc/image.go:1729 lxc/image.go:1730
 msgid "Unset image properties"
 msgstr ""
 
@@ -6945,12 +6964,12 @@ msgstr "Profil %s erstellt\n"
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:598
+#: lxc/network_forward.go:606
 #, fuzzy
 msgid "Unset network forward configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network_forward.go:599
+#: lxc/network_forward.go:607
 #, fuzzy
 msgid "Unset network forward keys"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -7003,7 +7022,7 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
 #, fuzzy
 msgid "Unset storage volume configuration keys"
 msgstr "Alternatives config Verzeichnis."
@@ -7016,7 +7035,7 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:602
+#: lxc/network_forward.go:610
 #, fuzzy
 msgid "Unset the key as a network forward property"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -7064,7 +7083,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Unset the key as a storage property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2381
 #, fuzzy
 msgid "Unset the key as a storage volume property"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -7073,7 +7092,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:248
+#: lxc/storage_volume.go:250
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -7111,12 +7130,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/storage_volume.go:1485
+#: lxc/storage_volume.go:1487
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Erstellt: %s"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2652
+#: lxc/export.go:42 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -7187,7 +7206,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1576
+#: lxc/storage_volume.go:1578
 msgid "Volume Only"
 msgstr ""
 
@@ -7245,7 +7264,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "You must specify a destination instance name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/copy.go:98 lxc/move.go:293 lxc/move.go:369
+#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
 #, fuzzy
 msgid "You must specify a source instance name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -7255,17 +7274,17 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "You need to specify an image name or use --empty"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/storage_volume.go:909
+#: lxc/storage_volume.go:912
 #, fuzzy
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 "Ändert den Laufzustand eines Containers in %s.\n"
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:282
+#: lxc/storage_volume.go:284
 #, fuzzy
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 "Ändert den Laufzustand eines Containers in %s.\n"
 "\n"
@@ -7326,7 +7345,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:174
 #, fuzzy
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
@@ -7429,7 +7448,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/image_alias.go:104
+#: lxc/image_alias.go:121
 #, fuzzy
 msgid "[<remote>:]<alias>"
 msgstr ""
@@ -7447,7 +7466,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/image_alias.go:252
+#: lxc/image_alias.go:285
 #, fuzzy
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
@@ -7539,7 +7558,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr ""
@@ -7548,7 +7567,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/image.go:1600 lxc/image.go:1727
+#: lxc/image.go:1601 lxc/image.go:1728
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr ""
@@ -7557,7 +7576,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/image.go:1664
+#: lxc/image.go:1665
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
@@ -7597,7 +7616,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/image.go:334 lxc/image.go:1443
+#: lxc/image.go:334 lxc/image.go:1444
 #, fuzzy
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
@@ -7743,7 +7762,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/file.go:376
+#: lxc/file.go:380
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
@@ -7769,7 +7788,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/file.go:454
+#: lxc/file.go:466
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
@@ -7779,7 +7798,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/file.go:1206
+#: lxc/file.go:1226
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
@@ -7920,8 +7939,8 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:644
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:179
+#: lxc/network_forward.go:177 lxc/network_forward.go:652
+#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
 #: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address>"
@@ -7948,7 +7967,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_forward.go:402 lxc/network_forward.go:597
+#: lxc/network_forward.go:410 lxc/network_forward.go:605
 #: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>"
@@ -7957,7 +7976,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_forward.go:487 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
@@ -7975,13 +7994,13 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network_forward.go:887
+#: lxc/network_forward.go:895
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:968 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
@@ -8088,7 +8107,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:2811
+#: lxc/storage_volume.go:2813
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
@@ -8155,7 +8174,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:1958
+#: lxc/storage_volume.go:1960
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
@@ -8166,23 +8185,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:806
-#, fuzzy
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
-msgstr ""
-"Ändert den Laufzustand eines Containers in %s.\n"
-"\n"
-"lxd %s <Name>\n"
-
-#: lxc/storage_volume.go:167
-#, fuzzy
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
-msgstr ""
-"Ändert den Laufzustand eines Containers in %s.\n"
-"\n"
-"lxd %s <Name>\n"
-
-#: lxc/storage_volume.go:2562
+#: lxc/storage_volume.go:2564
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
@@ -8191,7 +8194,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:2645
+#: lxc/storage_volume.go:2647
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
@@ -8200,7 +8203,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2428
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
@@ -8209,7 +8212,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:610
+#: lxc/storage_volume.go:614
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
@@ -8217,7 +8220,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:718
+#: lxc/storage_volume.go:722
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
@@ -8226,7 +8229,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
@@ -8234,7 +8237,23 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:2364
+#: lxc/storage_volume.go:810
+#, fuzzy
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
+msgstr ""
+"Ändert den Laufzustand eines Containers in %s.\n"
+"\n"
+"lxd %s <Name>\n"
+
+#: lxc/storage_volume.go:167
+#, fuzzy
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
+msgstr ""
+"Ändert den Laufzustand eines Containers in %s.\n"
+"\n"
+"lxd %s <Name>\n"
+
+#: lxc/storage_volume.go:2366
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
@@ -8242,7 +8261,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2087
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
@@ -8250,7 +8269,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2245
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
@@ -8259,7 +8278,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1234
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
@@ -8268,7 +8287,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:1858
+#: lxc/storage_volume.go:1860
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -8276,7 +8295,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:392
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -8490,7 +8509,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1603
 #, fuzzy
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
@@ -8670,20 +8689,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1230
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:470
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:691
+#: lxc/file.go:704
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -8988,7 +9007,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:618
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -8996,13 +9015,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2817
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2432
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -9036,16 +9055,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1396
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1331
+#: lxc/file.go:1355
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1284
+#: lxc/file.go:1308
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-07 15:11-0700\n"
+"POT-Creation-Date: 2025-01-10 14:44-0600\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1041
+#: lxc/storage_volume.go:1043
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:667
+#: lxc/network_forward.go:675
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,12 +430,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1157
+#: lxc/file.go:1177
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1047
+#: lxc/file.go:1067
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -471,7 +471,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:65
+#: lxc/init.go:146 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:687
+#: lxc/file.go:700
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -541,7 +541,7 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
@@ -674,7 +674,7 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:888 lxc/network_forward.go:889
+#: lxc/network_forward.go:896 lxc/network_forward.go:897
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -725,7 +725,7 @@ msgstr ""
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
+#: lxc/image_alias.go:101 lxc/image_alias.go:156 lxc/image_alias.go:320
 msgid "Alias name missing"
 msgstr ""
 
@@ -738,7 +738,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1607
+#: lxc/storage_volume.go:1609
 msgid "All projects"
 msgstr ""
 
@@ -769,7 +769,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -793,12 +793,26 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168 lxc/storage_volume.go:169
+#: lxc/storage_volume.go:168
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:169
+msgid ""
+"Attach new storage volumes to instances\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
+msgstr ""
+
+#: lxc/storage_volume.go:285
 msgid "Attach new storage volumes to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:286
+msgid ""
+"Attach new storage volumes to profiles\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
 #: lxc/console.go:39
@@ -849,16 +863,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2719
+#: lxc/storage_volume.go:2721
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2796
+#: lxc/export.go:192 lxc/storage_volume.go:2798
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1538
+#: lxc/info.go:666 lxc/storage_volume.go:1540
 msgid "Backups:"
 msgstr ""
 
@@ -867,19 +881,19 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
+#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:326
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -922,7 +936,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1752
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -975,7 +989,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -983,7 +997,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:562
+#: lxc/file.go:575
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1008,11 +1022,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:768
+#: lxc/file.go:790
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1025,12 +1039,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:493
+#: lxc/storage_volume.go:497
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:447
+#: lxc/storage_volume.go:451
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1136,9 +1150,9 @@ msgstr ""
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:497 lxc/network_forward.go:649
-#: lxc/network_forward.go:803 lxc/network_forward.go:892
-#: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
+#: lxc/network_forward.go:505 lxc/network_forward.go:657
+#: lxc/network_forward.go:811 lxc/network_forward.go:900
+#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
 #: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
 #: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
@@ -1150,14 +1164,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
-#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
-#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
-#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
+#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
 msgid "Cluster member name"
 msgstr ""
 
@@ -1173,7 +1187,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1608
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1213,21 +1227,21 @@ msgstr ""
 #: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
-#: lxc/network_acl.go:698 lxc/network_forward.go:767
+#: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
-#: lxc/storage_volume.go:1199
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
+#: lxc/storage_volume.go:1201
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:620
+#: lxc/storage_volume.go:624
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1478
+#: lxc/storage_volume.go:1480
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1289,7 +1303,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1297,12 +1311,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1315,7 +1329,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1410,7 +1424,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:462 lxc/file.go:696
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1451,7 +1465,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1505,12 +1519,12 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:182
+#: lxc/init.go:186
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1520,7 +1534,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 msgid "Creating the instance"
 msgstr ""
 
@@ -1534,13 +1548,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1749
+#: lxc/storage_volume.go:1751
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1560,7 +1574,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2653
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1593,7 +1607,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Delete identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:106 lxc/image_alias.go:107
+#: lxc/image_alias.go:123 lxc/image_alias.go:124
 msgid "Delete image aliases"
 msgstr ""
 
@@ -1617,7 +1631,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:799 lxc/network_forward.go:800
+#: lxc/network_forward.go:807 lxc/network_forward.go:808
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1661,7 +1675,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
+#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1703,13 +1717,13 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
-#: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
-#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
+#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
+#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
+#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
@@ -1723,10 +1737,10 @@ msgstr ""
 #: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:404 lxc/network_forward.go:489
-#: lxc/network_forward.go:599 lxc/network_forward.go:646
-#: lxc/network_forward.go:800 lxc/network_forward.go:874
-#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_forward.go:412 lxc/network_forward.go:497
+#: lxc/network_forward.go:607 lxc/network_forward.go:654
+#: lxc/network_forward.go:808 lxc/network_forward.go:882
+#: lxc/network_forward.go:897 lxc/network_forward.go:982
 #: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
 #: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
 #: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
@@ -1766,27 +1780,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
-#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
-#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
-#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
-#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
-#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
-#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
-#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1465
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "  Χρήση δικτύου:"
@@ -1799,11 +1813,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
+#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1853,7 +1867,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:403
+#: lxc/init.go:407
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1865,7 +1879,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1216
+#: lxc/file.go:1236
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1965,7 +1979,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:377 lxc/file.go:378
+#: lxc/file.go:381 lxc/file.go:382
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2006,7 +2020,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:653 lxc/network_forward.go:654
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -2051,7 +2065,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2059,7 +2073,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1785
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2113,11 +2127,11 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
-#: lxc/network_acl.go:524 lxc/network_forward.go:572
+#: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
+#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2128,11 +2142,11 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
-#: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
+#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
-#: lxc/storage_volume.go:2210
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
+#: lxc/storage_volume.go:2212
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2174,8 +2188,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
+#: lxc/storage_volume.go:1577
 msgid "Expires at"
 msgstr ""
 
@@ -2199,7 +2213,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2211,11 +2225,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2650
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2779
+#: lxc/export.go:152 lxc/storage_volume.go:2781
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2234,7 +2248,7 @@ msgid "FILENAME"
 msgstr ""
 
 #: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
-#: lxc/image_alias.go:235
+#: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2242,12 +2256,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1467
+#: lxc/file.go:1491
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1490
+#: lxc/file.go:1514
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2262,12 +2276,12 @@ msgstr "  Χρήση δικτύου:"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/file.go:1517
+#: lxc/file.go:1541
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1326
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "  Χρήση δικτύου:"
@@ -2297,7 +2311,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/file.go:1423
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2312,7 +2326,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/file.go:1428
+#: lxc/file.go:1452
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2322,12 +2336,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1352
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1455
+#: lxc/file.go:1479
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2341,7 +2355,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/move.go:304 lxc/move.go:380
+#: lxc/move.go:309 lxc/move.go:385
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "  Χρήση δικτύου:"
@@ -2366,7 +2380,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1440
+#: lxc/file.go:1464
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2381,7 +2395,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1042
+#: lxc/file.go:1062
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2468,14 +2482,14 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1625 lxc/warning.go:94
+#: lxc/storage_volume.go:1627 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2543,7 +2557,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1602
+#: lxc/image.go:1602 lxc/image.go:1603
 msgid "Get image properties"
 msgstr ""
 
@@ -2559,7 +2573,7 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:414
 #, fuzzy
 msgid "Get the key as a network forward property"
 msgstr "  Χρήση δικτύου:"
@@ -2605,7 +2619,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1249
+#: lxc/storage_volume.go:1251
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2634,7 +2648,7 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:403 lxc/network_forward.go:404
+#: lxc/network_forward.go:411 lxc/network_forward.go:412
 #, fuzzy
 msgid "Get values for network forward configuration keys"
 msgstr "  Χρήση δικτύου:"
@@ -2676,11 +2690,11 @@ msgstr "  Χρήση δικτύου:"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:476
+#: lxc/storage_volume.go:480
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2720,22 +2734,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1540
+#: lxc/file.go:1564
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1529
+#: lxc/file.go:1553
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1376
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1362
+#: lxc/file.go:1386
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2808,11 +2822,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:415
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2822,7 +2836,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2437
+#: lxc/storage_volume.go:2439
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2834,7 +2848,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1517
+#: lxc/image.go:1518
 msgid "Image already up to date."
 msgstr ""
 
@@ -2850,11 +2864,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1472
+#: lxc/image.go:364 lxc/image.go:1473
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1698
+#: lxc/image.go:444 lxc/image.go:1699
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2864,7 +2878,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1515
+#: lxc/image.go:1516
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2872,7 +2886,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2815
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2880,7 +2894,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2814
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2902,11 +2916,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2822
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2894
+#: lxc/storage_volume.go:2896
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2932,11 +2946,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1378
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1531
+#: lxc/file.go:1555
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2945,7 +2959,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:414
+#: lxc/init.go:418
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2954,7 +2968,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1298
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3006,7 +3020,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1293
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3032,23 +3046,23 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2023
+#: lxc/move.go:153 lxc/storage_volume.go:2025
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:144
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2019
+#: lxc/storage_volume.go:2021
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:509
+#: lxc/main.go:518
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:353
+#: lxc/file.go:357
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3058,18 +3072,18 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
-#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
+#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:535
+#: lxc/file.go:548
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:717
+#: lxc/file.go:185 lxc/file.go:739
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3106,7 +3120,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3137,12 +3151,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:176
+#: lxc/init.go:180
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:174
+#: lxc/init.go:178
 msgid "Launching the instance"
 msgstr ""
 
@@ -3242,11 +3256,11 @@ msgstr ""
 msgid "List identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:151
+#: lxc/image_alias.go:176
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:177
 msgid ""
 "List image aliases\n"
 "\n"
@@ -3413,11 +3427,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1605
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1610
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3476,7 +3490,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1481
+#: lxc/info.go:489 lxc/storage_volume.go:1483
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3665,7 +3679,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:873 lxc/network_forward.go:874
+#: lxc/network_forward.go:881 lxc/network_forward.go:882
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -3824,12 +3838,12 @@ msgstr "  Χρήση μνήμης:"
 msgid "Memory:"
 msgstr "  Χρήση μνήμης:"
 
-#: lxc/move.go:322 lxc/move.go:435
+#: lxc/move.go:327 lxc/move.go:440
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:347 lxc/move.go:440
+#: lxc/move.go:352 lxc/move.go:445
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3901,10 +3915,10 @@ msgstr ""
 msgid "Missing key name"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:449
-#: lxc/network_forward.go:534 lxc/network_forward.go:709
-#: lxc/network_forward.go:840 lxc/network_forward.go:933
-#: lxc/network_forward.go:1015 lxc/network_load_balancer.go:221
+#: lxc/network_forward.go:219 lxc/network_forward.go:457
+#: lxc/network_forward.go:542 lxc/network_forward.go:717
+#: lxc/network_forward.go:848 lxc/network_forward.go:945
+#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
 #: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
 #: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
 #: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
@@ -3929,10 +3943,10 @@ msgstr ""
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
 #: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
 #: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:284 lxc/network_forward.go:445
-#: lxc/network_forward.go:530 lxc/network_forward.go:705
-#: lxc/network_forward.go:836 lxc/network_forward.go:929
-#: lxc/network_forward.go:1011 lxc/network_load_balancer.go:131
+#: lxc/network_forward.go:292 lxc/network_forward.go:453
+#: lxc/network_forward.go:538 lxc/network_forward.go:713
+#: lxc/network_forward.go:844 lxc/network_forward.go:941
+#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
 #: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
 #: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
 #: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
@@ -3969,13 +3983,13 @@ msgstr ""
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
-#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
-#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
-#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
+#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
+#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
+#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
+#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
 msgid "Missing pool name"
 msgstr ""
 
@@ -3994,16 +4008,16 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
+#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1411
+#: lxc/storage_volume.go:1413
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/file.go:820
+#: lxc/file.go:842
 msgid "Missing target directory"
 msgstr ""
 
@@ -4036,16 +4050,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
-#: lxc/storage_volume.go:975
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
+#: lxc/storage_volume.go:977
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:507
+#: lxc/file.go:520
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1207 lxc/file.go:1208
+#: lxc/file.go:1227 lxc/file.go:1228
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4074,7 +4088,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4082,16 +4096,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1869
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1059 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4113,7 +4127,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
 msgid "NAME"
 msgstr ""
 
@@ -4165,8 +4179,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
-#: lxc/storage_volume.go:1573
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Name"
 msgstr ""
 
@@ -4174,7 +4188,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4229,12 +4243,12 @@ msgstr "  Χρήση δικτύου:"
 msgid "Network Zone %s deleted"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_forward.go:386
+#: lxc/network_forward.go:394
 #, fuzzy, c-format
 msgid "Network forward %s created"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_forward.go:857
+#: lxc/network_forward.go:865
 #, fuzzy, c-format
 msgid "Network forward %s deleted"
 msgstr "  Χρήση δικτύου:"
@@ -4320,7 +4334,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
+#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4328,7 +4342,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1070 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4340,11 +4354,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4358,7 +4372,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2035
+#: lxc/storage_volume.go:2037
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4366,16 +4380,21 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
-#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
-msgid "Only \"custom\" volumes can be attached to instances"
+#: lxc/storage_volume.go:216
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2701
+#: lxc/storage_volume.go:348
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:2703
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2500
+#: lxc/storage_volume.go:2502
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4387,7 +4406,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1431
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4400,7 +4419,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1577
+#: lxc/info.go:705 lxc/storage_volume.go:1579
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4430,7 +4449,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1767
+#: lxc/storage_volume.go:1769
 msgid "POOL"
 msgstr ""
 
@@ -4447,7 +4466,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167
-#: lxc/storage_volume.go:1773 lxc/warning.go:213
+#: lxc/storage_volume.go:1775 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4471,7 +4490,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:367
+#: lxc/main.go:376
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4510,7 +4529,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1332
+#: lxc/file.go:1356
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4518,12 +4537,12 @@ msgstr ""
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
-#: lxc/network_acl.go:699 lxc/network_forward.go:768
+#: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
-#: lxc/storage_volume.go:1200
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
+#: lxc/storage_volume.go:1202
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4636,11 +4655,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1649
+#: lxc/image.go:1650
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4654,7 +4673,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1238
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4670,7 +4689,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4691,7 +4710,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1017
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4700,7 +4719,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2094
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4713,7 +4732,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2370
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4744,20 +4763,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:455 lxc/file.go:456
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:638 lxc/file.go:989
+#: lxc/file.go:651 lxc/file.go:1009
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:688 lxc/file.go:689
+#: lxc/file.go:701 lxc/file.go:702
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:923 lxc/file.go:1089
+#: lxc/file.go:943 lxc/file.go:1109
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4766,7 +4785,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4795,15 +4814,15 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:463 lxc/file.go:695
+#: lxc/file.go:475 lxc/file.go:708
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1444 lxc/image.go:1445
+#: lxc/image.go:1445 lxc/image.go:1446
 msgid "Refresh images"
 msgstr ""
 
@@ -4812,7 +4831,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1481
+#: lxc/image.go:1482
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4890,7 +4909,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:971 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4928,7 +4947,7 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:969 lxc/network_forward.go:970
+#: lxc/network_forward.go:981 lxc/network_forward.go:982
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -4966,8 +4985,8 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
-#: lxc/image_alias.go:255
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:287
+#: lxc/image_alias.go:288
 msgid "Rename aliases"
 msgstr ""
 
@@ -5003,15 +5022,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1962
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
+#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5063,7 +5082,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5080,7 +5099,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:361
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5130,12 +5149,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1460
+#: lxc/file.go:1484
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1461
+#: lxc/file.go:1485
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5212,7 +5231,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/file.go:1217
+#: lxc/file.go:1237
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5238,7 +5257,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1665 lxc/image.go:1666
+#: lxc/image.go:1666 lxc/image.go:1667
 msgid "Set image properties"
 msgstr ""
 
@@ -5281,12 +5300,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:488
+#: lxc/network_forward.go:496
 #, fuzzy
 msgid "Set network forward keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_forward.go:489
+#: lxc/network_forward.go:497
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5395,11 +5414,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2088
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2089
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5416,7 +5435,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:698
+#: lxc/file.go:711
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5424,7 +5443,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:699
+#: lxc/file.go:712
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5432,7 +5451,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:710
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5444,7 +5463,7 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:504
 #, fuzzy
 msgid "Set the key as a network forward property"
 msgstr "  Χρήση δικτύου:"
@@ -5490,7 +5509,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2105
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5498,7 +5517,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1215
+#: lxc/file.go:1235
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5557,7 +5576,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1535 lxc/image.go:1536
+#: lxc/image.go:1536 lxc/image.go:1537
 msgid "Show image properties"
 msgstr ""
 
@@ -5577,7 +5596,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:271 lxc/main.go:272
+#: lxc/main.go:280 lxc/main.go:281
 msgid "Show less common commands"
 msgstr ""
 
@@ -5649,11 +5668,11 @@ msgstr "  Χρήση δικτύου:"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5722,15 +5741,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2190
+#: lxc/storage_volume.go:2192
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1502
+#: lxc/info.go:619 lxc/storage_volume.go:1504
 msgid "Snapshots:"
 msgstr ""
 
@@ -5835,21 +5854,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:703
+#: lxc/storage_volume.go:707
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:791
+#: lxc/storage_volume.go:795
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:516
+#: lxc/storage_volume.go:520
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:524
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5911,21 +5930,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1747 lxc/warning.go:216
+#: lxc/storage_volume.go:1749 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1262
+#: lxc/file.go:1286
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1256
+#: lxc/file.go:1280
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5935,15 +5954,15 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:181
+#: lxc/move.go:186
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:219 lxc/move.go:240
+#: lxc/move.go:224 lxc/move.go:245
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:193
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5951,15 +5970,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:185
+#: lxc/move.go:190
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:189
+#: lxc/move.go:194
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:210
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5981,7 +6000,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:439
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6034,7 +6053,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_forward.go:462
+#: lxc/network_forward.go:470
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr "  Χρήση δικτύου:"
@@ -6074,12 +6093,12 @@ msgstr "  Χρήση δικτύου:"
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/storage_volume.go:1340
+#: lxc/storage_volume.go:1342
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/storage_volume.go:1317
+#: lxc/storage_volume.go:1319
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6094,12 +6113,12 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:309
+#: lxc/move.go:314
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
-#: lxc/storage_volume.go:989
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
+#: lxc/storage_volume.go:991
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6128,7 +6147,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:298
+#: lxc/main.go:307
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6152,11 +6171,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:437
+#: lxc/init.go:441
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:440
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6164,7 +6183,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:412
+#: lxc/main.go:421
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6175,7 +6194,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1489
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6190,7 +6209,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1864
+#: lxc/storage_volume.go:1866
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6198,7 +6217,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6215,7 +6234,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:327
+#: lxc/copy.go:382 lxc/move.go:332
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6257,7 +6276,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1472
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6279,13 +6298,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1752
+#: lxc/project.go:995 lxc/storage_volume.go:1754
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1751
+#: lxc/storage.go:724 lxc/storage_volume.go:1753
 msgid "USED BY"
 msgstr ""
 
@@ -6298,7 +6317,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:411
+#: lxc/file.go:423
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6312,12 +6331,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1483
+#: lxc/file.go:1507
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1791
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6328,7 +6347,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1029
+#: lxc/file.go:1049
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6360,7 +6379,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1728 lxc/image.go:1729
+#: lxc/image.go:1729 lxc/image.go:1730
 msgid "Unset image properties"
 msgstr ""
 
@@ -6376,12 +6395,12 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:598
+#: lxc/network_forward.go:606
 #, fuzzy
 msgid "Unset network forward configuration keys"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network_forward.go:599
+#: lxc/network_forward.go:607
 #, fuzzy
 msgid "Unset network forward keys"
 msgstr "  Χρήση δικτύου:"
@@ -6433,7 +6452,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6445,7 +6464,7 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:602
+#: lxc/network_forward.go:610
 #, fuzzy
 msgid "Unset the key as a network forward property"
 msgstr "  Χρήση δικτύου:"
@@ -6492,7 +6511,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2381
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6500,7 +6519,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:248
+#: lxc/storage_volume.go:250
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6536,12 +6555,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1485
+#: lxc/storage_volume.go:1487
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "  Χρήση CPU:"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2652
+#: lxc/export.go:42 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6608,7 +6627,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1576
+#: lxc/storage_volume.go:1578
 msgid "Volume Only"
 msgstr ""
 
@@ -6659,7 +6678,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:293 lxc/move.go:369
+#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6667,12 +6686,12 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:909
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:912
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:282
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:284
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
@@ -6704,7 +6723,7 @@ msgstr ""
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:174
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
@@ -6757,7 +6776,7 @@ msgstr ""
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: lxc/image_alias.go:104
+#: lxc/image_alias.go:121
 msgid "[<remote>:]<alias>"
 msgstr ""
 
@@ -6765,7 +6784,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/image_alias.go:252
+#: lxc/image_alias.go:285
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
@@ -6819,15 +6838,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1600 lxc/image.go:1727
+#: lxc/image.go:1601 lxc/image.go:1728
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1664
+#: lxc/image.go:1665
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6847,7 +6866,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1443
+#: lxc/image.go:334 lxc/image.go:1444
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6918,7 +6937,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:376
+#: lxc/file.go:380
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -6930,12 +6949,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:454
+#: lxc/file.go:466
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1226
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7003,8 +7022,8 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:644
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:179
+#: lxc/network_forward.go:177 lxc/network_forward.go:652
+#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
 #: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
@@ -7019,12 +7038,12 @@ msgid ""
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:402 lxc/network_forward.go:597
+#: lxc/network_forward.go:410 lxc/network_forward.go:605
 #: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
@@ -7034,13 +7053,13 @@ msgid ""
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:887
+#: lxc/network_forward.go:895
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:968 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -7095,7 +7114,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2811
+#: lxc/storage_volume.go:2813
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7130,65 +7149,65 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1958
+#: lxc/storage_volume.go:1960
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:806
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:167
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
-msgstr ""
-
-#: lxc/storage_volume.go:2562
+#: lxc/storage_volume.go:2564
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2645
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2428
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:610
+#: lxc/storage_volume.go:614
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:718
+#: lxc/storage_volume.go:722
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2364
+#: lxc/storage_volume.go:810
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
+msgstr ""
+
+#: lxc/storage_volume.go:167
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
+msgstr ""
+
+#: lxc/storage_volume.go:2366
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2087
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2245
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1234
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1858
+#: lxc/storage_volume.go:1860
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7294,7 +7313,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1603
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7456,20 +7475,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1230
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:470
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:691
+#: lxc/file.go:704
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7770,7 +7789,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:618
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7778,13 +7797,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2817
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2432
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7818,16 +7837,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1396
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1331
+#: lxc/file.go:1355
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1284
+#: lxc/file.go:1308
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-07 15:11-0700\n"
+"POT-Creation-Date: 2025-01-10 14:44-0600\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1041
+#: lxc/storage_volume.go:1043
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:667
+#: lxc/network_forward.go:675
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,12 +430,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1157
+#: lxc/file.go:1177
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1047
+#: lxc/file.go:1067
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -471,7 +471,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:65
+#: lxc/init.go:146 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:687
+#: lxc/file.go:700
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -541,7 +541,7 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
@@ -672,7 +672,7 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:888 lxc/network_forward.go:889
+#: lxc/network_forward.go:896 lxc/network_forward.go:897
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -722,7 +722,7 @@ msgstr ""
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
+#: lxc/image_alias.go:101 lxc/image_alias.go:156 lxc/image_alias.go:320
 msgid "Alias name missing"
 msgstr ""
 
@@ -735,7 +735,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1607
+#: lxc/storage_volume.go:1609
 msgid "All projects"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -790,12 +790,26 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168 lxc/storage_volume.go:169
+#: lxc/storage_volume.go:168
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:169
+msgid ""
+"Attach new storage volumes to instances\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
+msgstr ""
+
+#: lxc/storage_volume.go:285
 msgid "Attach new storage volumes to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:286
+msgid ""
+"Attach new storage volumes to profiles\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
 #: lxc/console.go:39
@@ -846,16 +860,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2719
+#: lxc/storage_volume.go:2721
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2796
+#: lxc/export.go:192 lxc/storage_volume.go:2798
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1538
+#: lxc/info.go:666 lxc/storage_volume.go:1540
 msgid "Backups:"
 msgstr ""
 
@@ -864,19 +878,19 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
+#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:326
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -919,7 +933,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1752
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -971,7 +985,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -979,7 +993,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:562
+#: lxc/file.go:575
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1004,11 +1018,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:768
+#: lxc/file.go:790
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1021,12 +1035,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:493
+#: lxc/storage_volume.go:497
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:447
+#: lxc/storage_volume.go:451
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1132,9 +1146,9 @@ msgstr ""
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:497 lxc/network_forward.go:649
-#: lxc/network_forward.go:803 lxc/network_forward.go:892
-#: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
+#: lxc/network_forward.go:505 lxc/network_forward.go:657
+#: lxc/network_forward.go:811 lxc/network_forward.go:900
+#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
 #: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
 #: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
@@ -1146,14 +1160,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
-#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
-#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
-#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
+#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
 msgid "Cluster member name"
 msgstr ""
 
@@ -1169,7 +1183,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1608
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1209,21 +1223,21 @@ msgstr ""
 #: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
-#: lxc/network_acl.go:698 lxc/network_forward.go:767
+#: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
-#: lxc/storage_volume.go:1199
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
+#: lxc/storage_volume.go:1201
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:620
+#: lxc/storage_volume.go:624
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1478
+#: lxc/storage_volume.go:1480
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1285,7 +1299,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1293,12 +1307,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1311,7 +1325,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1406,7 +1420,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:462 lxc/file.go:696
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1446,7 +1460,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1498,12 +1512,12 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:182
+#: lxc/init.go:186
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1513,7 +1527,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 msgid "Creating the instance"
 msgstr ""
 
@@ -1527,13 +1541,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1749
+#: lxc/storage_volume.go:1751
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1553,7 +1567,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2653
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1585,7 +1599,7 @@ msgstr ""
 msgid "Delete identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:106 lxc/image_alias.go:107
+#: lxc/image_alias.go:123 lxc/image_alias.go:124
 msgid "Delete image aliases"
 msgstr ""
 
@@ -1609,7 +1623,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:799 lxc/network_forward.go:800
+#: lxc/network_forward.go:807 lxc/network_forward.go:808
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1649,7 +1663,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
+#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1691,13 +1705,13 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
-#: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
-#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
+#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
+#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
+#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
@@ -1711,10 +1725,10 @@ msgstr ""
 #: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:404 lxc/network_forward.go:489
-#: lxc/network_forward.go:599 lxc/network_forward.go:646
-#: lxc/network_forward.go:800 lxc/network_forward.go:874
-#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_forward.go:412 lxc/network_forward.go:497
+#: lxc/network_forward.go:607 lxc/network_forward.go:654
+#: lxc/network_forward.go:808 lxc/network_forward.go:882
+#: lxc/network_forward.go:897 lxc/network_forward.go:982
 #: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
 #: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
 #: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
@@ -1754,27 +1768,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
-#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
-#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
-#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
-#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
-#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
-#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
-#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1465
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1786,11 +1800,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
+#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1840,7 +1854,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:403
+#: lxc/init.go:407
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1852,7 +1866,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1216
+#: lxc/file.go:1236
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1948,7 +1962,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:377 lxc/file.go:378
+#: lxc/file.go:381 lxc/file.go:382
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1988,7 +2002,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:653 lxc/network_forward.go:654
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -2028,7 +2042,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2036,7 +2050,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1785
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2090,11 +2104,11 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
-#: lxc/network_acl.go:524 lxc/network_forward.go:572
+#: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
+#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2105,11 +2119,11 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
-#: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
+#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
-#: lxc/storage_volume.go:2210
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
+#: lxc/storage_volume.go:2212
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2151,8 +2165,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
+#: lxc/storage_volume.go:1577
 msgid "Expires at"
 msgstr ""
 
@@ -2176,7 +2190,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2188,11 +2202,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2650
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2779
+#: lxc/export.go:152 lxc/storage_volume.go:2781
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2211,7 +2225,7 @@ msgid "FILENAME"
 msgstr ""
 
 #: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
-#: lxc/image_alias.go:235
+#: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2219,12 +2233,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1467
+#: lxc/file.go:1491
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1490
+#: lxc/file.go:1514
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2239,12 +2253,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1517
+#: lxc/file.go:1541
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1326
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2274,7 +2288,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1423
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2289,7 +2303,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1428
+#: lxc/file.go:1452
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2299,12 +2313,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1352
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1455
+#: lxc/file.go:1479
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2318,7 +2332,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:304 lxc/move.go:380
+#: lxc/move.go:309 lxc/move.go:385
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2343,7 +2357,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1440
+#: lxc/file.go:1464
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2358,7 +2372,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1042
+#: lxc/file.go:1062
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2445,14 +2459,14 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1625 lxc/warning.go:94
+#: lxc/storage_volume.go:1627 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2520,7 +2534,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1602
+#: lxc/image.go:1602 lxc/image.go:1603
 msgid "Get image properties"
 msgstr ""
 
@@ -2536,7 +2550,7 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:414
 msgid "Get the key as a network forward property"
 msgstr ""
 
@@ -2576,7 +2590,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1249
+#: lxc/storage_volume.go:1251
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2604,7 +2618,7 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:403 lxc/network_forward.go:404
+#: lxc/network_forward.go:411 lxc/network_forward.go:412
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
@@ -2640,11 +2654,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:476
+#: lxc/storage_volume.go:480
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2684,22 +2698,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1540
+#: lxc/file.go:1564
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1529
+#: lxc/file.go:1553
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1376
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1362
+#: lxc/file.go:1386
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2772,11 +2786,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:415
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2786,7 +2800,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2437
+#: lxc/storage_volume.go:2439
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2798,7 +2812,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1517
+#: lxc/image.go:1518
 msgid "Image already up to date."
 msgstr ""
 
@@ -2814,11 +2828,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1472
+#: lxc/image.go:364 lxc/image.go:1473
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1698
+#: lxc/image.go:444 lxc/image.go:1699
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2828,7 +2842,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1515
+#: lxc/image.go:1516
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2836,7 +2850,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2815
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2844,7 +2858,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2814
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2866,11 +2880,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2822
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2894
+#: lxc/storage_volume.go:2896
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2896,11 +2910,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1378
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1531
+#: lxc/file.go:1555
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2909,7 +2923,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:414
+#: lxc/init.go:418
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2918,7 +2932,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1298
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2970,7 +2984,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1293
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2996,23 +3010,23 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2023
+#: lxc/move.go:153 lxc/storage_volume.go:2025
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:144
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2019
+#: lxc/storage_volume.go:2021
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:509
+#: lxc/main.go:518
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:353
+#: lxc/file.go:357
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3022,18 +3036,18 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
-#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
+#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:535
+#: lxc/file.go:548
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:717
+#: lxc/file.go:185 lxc/file.go:739
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3070,7 +3084,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3101,12 +3115,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:176
+#: lxc/init.go:180
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:174
+#: lxc/init.go:178
 msgid "Launching the instance"
 msgstr ""
 
@@ -3204,11 +3218,11 @@ msgstr ""
 msgid "List identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:151
+#: lxc/image_alias.go:176
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:177
 msgid ""
 "List image aliases\n"
 "\n"
@@ -3375,11 +3389,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1605
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1610
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3438,7 +3452,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1481
+#: lxc/info.go:489 lxc/storage_volume.go:1483
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3624,7 +3638,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:873 lxc/network_forward.go:874
+#: lxc/network_forward.go:881 lxc/network_forward.go:882
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -3770,12 +3784,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:322 lxc/move.go:435
+#: lxc/move.go:327 lxc/move.go:440
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:347 lxc/move.go:440
+#: lxc/move.go:352 lxc/move.go:445
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3840,10 +3854,10 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:449
-#: lxc/network_forward.go:534 lxc/network_forward.go:709
-#: lxc/network_forward.go:840 lxc/network_forward.go:933
-#: lxc/network_forward.go:1015 lxc/network_load_balancer.go:221
+#: lxc/network_forward.go:219 lxc/network_forward.go:457
+#: lxc/network_forward.go:542 lxc/network_forward.go:717
+#: lxc/network_forward.go:848 lxc/network_forward.go:945
+#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
 #: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
 #: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
 #: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
@@ -3868,10 +3882,10 @@ msgstr ""
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
 #: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
 #: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:284 lxc/network_forward.go:445
-#: lxc/network_forward.go:530 lxc/network_forward.go:705
-#: lxc/network_forward.go:836 lxc/network_forward.go:929
-#: lxc/network_forward.go:1011 lxc/network_load_balancer.go:131
+#: lxc/network_forward.go:292 lxc/network_forward.go:453
+#: lxc/network_forward.go:538 lxc/network_forward.go:713
+#: lxc/network_forward.go:844 lxc/network_forward.go:941
+#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
 #: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
 #: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
 #: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
@@ -3907,13 +3921,13 @@ msgstr ""
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
-#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
-#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
-#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
+#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
+#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
+#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
+#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
 msgid "Missing pool name"
 msgstr ""
 
@@ -3932,15 +3946,15 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
+#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1411
+#: lxc/storage_volume.go:1413
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:820
+#: lxc/file.go:842
 msgid "Missing target directory"
 msgstr ""
 
@@ -3973,16 +3987,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
-#: lxc/storage_volume.go:975
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
+#: lxc/storage_volume.go:977
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:507
+#: lxc/file.go:520
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1207 lxc/file.go:1208
+#: lxc/file.go:1227 lxc/file.go:1228
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4011,7 +4025,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4019,16 +4033,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1869
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1059 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4050,7 +4064,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
 msgid "NAME"
 msgstr ""
 
@@ -4102,8 +4116,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
-#: lxc/storage_volume.go:1573
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Name"
 msgstr ""
 
@@ -4111,7 +4125,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4166,12 +4180,12 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:386
+#: lxc/network_forward.go:394
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:857
+#: lxc/network_forward.go:865
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -4255,7 +4269,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
+#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4263,7 +4277,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1070 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4275,11 +4289,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4293,7 +4307,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2035
+#: lxc/storage_volume.go:2037
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4301,16 +4315,21 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
-#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
-msgid "Only \"custom\" volumes can be attached to instances"
+#: lxc/storage_volume.go:216
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2701
+#: lxc/storage_volume.go:348
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:2703
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2500
+#: lxc/storage_volume.go:2502
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4322,7 +4341,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1431
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4335,7 +4354,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1577
+#: lxc/info.go:705 lxc/storage_volume.go:1579
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4365,7 +4384,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1767
+#: lxc/storage_volume.go:1769
 msgid "POOL"
 msgstr ""
 
@@ -4382,7 +4401,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167
-#: lxc/storage_volume.go:1773 lxc/warning.go:213
+#: lxc/storage_volume.go:1775 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4406,7 +4425,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:367
+#: lxc/main.go:376
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4444,7 +4463,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1332
+#: lxc/file.go:1356
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4452,12 +4471,12 @@ msgstr ""
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
-#: lxc/network_acl.go:699 lxc/network_forward.go:768
+#: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
-#: lxc/storage_volume.go:1200
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
+#: lxc/storage_volume.go:1202
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4570,11 +4589,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1649
+#: lxc/image.go:1650
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4588,7 +4607,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1238
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4604,7 +4623,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4625,7 +4644,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1017
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4634,7 +4653,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2094
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4647,7 +4666,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2370
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4678,20 +4697,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:455 lxc/file.go:456
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:638 lxc/file.go:989
+#: lxc/file.go:651 lxc/file.go:1009
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:688 lxc/file.go:689
+#: lxc/file.go:701 lxc/file.go:702
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:923 lxc/file.go:1089
+#: lxc/file.go:943 lxc/file.go:1109
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4700,7 +4719,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4729,15 +4748,15 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:463 lxc/file.go:695
+#: lxc/file.go:475 lxc/file.go:708
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1444 lxc/image.go:1445
+#: lxc/image.go:1445 lxc/image.go:1446
 msgid "Refresh images"
 msgstr ""
 
@@ -4746,7 +4765,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1481
+#: lxc/image.go:1482
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4823,7 +4842,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:971 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4859,7 +4878,7 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:969 lxc/network_forward.go:970
+#: lxc/network_forward.go:981 lxc/network_forward.go:982
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -4895,8 +4914,8 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
-#: lxc/image_alias.go:255
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:287
+#: lxc/image_alias.go:288
 msgid "Rename aliases"
 msgstr ""
 
@@ -4932,15 +4951,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1962
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
+#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4992,7 +5011,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5009,7 +5028,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:361
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5058,12 +5077,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1460
+#: lxc/file.go:1484
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1461
+#: lxc/file.go:1485
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5139,7 +5158,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1217
+#: lxc/file.go:1237
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5165,7 +5184,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1665 lxc/image.go:1666
+#: lxc/image.go:1666 lxc/image.go:1667
 msgid "Set image properties"
 msgstr ""
 
@@ -5208,11 +5227,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:488
+#: lxc/network_forward.go:496
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:489
+#: lxc/network_forward.go:497
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5316,11 +5335,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2088
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2089
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5337,7 +5356,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:698
+#: lxc/file.go:711
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5345,7 +5364,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:699
+#: lxc/file.go:712
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5353,7 +5372,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:710
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5365,7 +5384,7 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:504
 msgid "Set the key as a network forward property"
 msgstr ""
 
@@ -5405,7 +5424,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2105
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5413,7 +5432,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1215
+#: lxc/file.go:1235
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5470,7 +5489,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1535 lxc/image.go:1536
+#: lxc/image.go:1536 lxc/image.go:1537
 msgid "Show image properties"
 msgstr ""
 
@@ -5490,7 +5509,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:271 lxc/main.go:272
+#: lxc/main.go:280 lxc/main.go:281
 msgid "Show less common commands"
 msgstr ""
 
@@ -5554,11 +5573,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5626,15 +5645,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2190
+#: lxc/storage_volume.go:2192
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1502
+#: lxc/info.go:619 lxc/storage_volume.go:1504
 msgid "Snapshots:"
 msgstr ""
 
@@ -5739,21 +5758,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:703
+#: lxc/storage_volume.go:707
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:791
+#: lxc/storage_volume.go:795
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:516
+#: lxc/storage_volume.go:520
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:524
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5815,21 +5834,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1747 lxc/warning.go:216
+#: lxc/storage_volume.go:1749 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1262
+#: lxc/file.go:1286
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1256
+#: lxc/file.go:1280
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5839,15 +5858,15 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:181
+#: lxc/move.go:186
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:219 lxc/move.go:240
+#: lxc/move.go:224 lxc/move.go:245
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:193
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5855,15 +5874,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:185
+#: lxc/move.go:190
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:189
+#: lxc/move.go:194
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:210
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5885,7 +5904,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:439
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5938,7 +5957,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:462
+#: lxc/network_forward.go:470
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -5978,12 +5997,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1340
+#: lxc/storage_volume.go:1342
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1317
+#: lxc/storage_volume.go:1319
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -5998,12 +6017,12 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:309
+#: lxc/move.go:314
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
-#: lxc/storage_volume.go:989
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
+#: lxc/storage_volume.go:991
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6031,7 +6050,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:298
+#: lxc/main.go:307
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6055,11 +6074,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:437
+#: lxc/init.go:441
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:440
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6067,7 +6086,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:412
+#: lxc/main.go:421
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6078,7 +6097,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1489
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6093,7 +6112,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1864
+#: lxc/storage_volume.go:1866
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6101,7 +6120,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6118,7 +6137,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:327
+#: lxc/copy.go:382 lxc/move.go:332
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6160,7 +6179,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1472
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6182,13 +6201,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1752
+#: lxc/project.go:995 lxc/storage_volume.go:1754
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1751
+#: lxc/storage.go:724 lxc/storage_volume.go:1753
 msgid "USED BY"
 msgstr ""
 
@@ -6201,7 +6220,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:411
+#: lxc/file.go:423
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6215,12 +6234,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1483
+#: lxc/file.go:1507
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1791
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6231,7 +6250,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1029
+#: lxc/file.go:1049
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6262,7 +6281,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1728 lxc/image.go:1729
+#: lxc/image.go:1729 lxc/image.go:1730
 msgid "Unset image properties"
 msgstr ""
 
@@ -6278,11 +6297,11 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:598
+#: lxc/network_forward.go:606
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:599
+#: lxc/network_forward.go:607
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -6326,7 +6345,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6338,7 +6357,7 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:602
+#: lxc/network_forward.go:610
 msgid "Unset the key as a network forward property"
 msgstr ""
 
@@ -6378,7 +6397,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2381
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6386,7 +6405,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:248
+#: lxc/storage_volume.go:250
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6422,12 +6441,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1485
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2652
+#: lxc/export.go:42 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6494,7 +6513,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1576
+#: lxc/storage_volume.go:1578
 msgid "Volume Only"
 msgstr ""
 
@@ -6545,7 +6564,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:293 lxc/move.go:369
+#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6553,12 +6572,12 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:909
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:912
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:282
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:284
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
@@ -6590,7 +6609,7 @@ msgstr ""
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:174
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
@@ -6643,7 +6662,7 @@ msgstr ""
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: lxc/image_alias.go:104
+#: lxc/image_alias.go:121
 msgid "[<remote>:]<alias>"
 msgstr ""
 
@@ -6651,7 +6670,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/image_alias.go:252
+#: lxc/image_alias.go:285
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
@@ -6705,15 +6724,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1600 lxc/image.go:1727
+#: lxc/image.go:1601 lxc/image.go:1728
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1664
+#: lxc/image.go:1665
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6733,7 +6752,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1443
+#: lxc/image.go:334 lxc/image.go:1444
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6804,7 +6823,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:376
+#: lxc/file.go:380
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -6816,12 +6835,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:454
+#: lxc/file.go:466
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1226
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6889,8 +6908,8 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:644
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:179
+#: lxc/network_forward.go:177 lxc/network_forward.go:652
+#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
 #: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
@@ -6905,12 +6924,12 @@ msgid ""
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:402 lxc/network_forward.go:597
+#: lxc/network_forward.go:410 lxc/network_forward.go:605
 #: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
@@ -6920,13 +6939,13 @@ msgid ""
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:887
+#: lxc/network_forward.go:895
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:968 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -6981,7 +7000,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2811
+#: lxc/storage_volume.go:2813
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7016,65 +7035,65 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1958
+#: lxc/storage_volume.go:1960
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:806
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:167
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
-msgstr ""
-
-#: lxc/storage_volume.go:2562
+#: lxc/storage_volume.go:2564
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2645
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2428
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:610
+#: lxc/storage_volume.go:614
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:718
+#: lxc/storage_volume.go:722
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2364
+#: lxc/storage_volume.go:810
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
+msgstr ""
+
+#: lxc/storage_volume.go:167
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
+msgstr ""
+
+#: lxc/storage_volume.go:2366
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2087
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2245
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1234
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1858
+#: lxc/storage_volume.go:1860
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7180,7 +7199,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1603
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7342,20 +7361,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1230
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:470
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:691
+#: lxc/file.go:704
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7656,7 +7675,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:618
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7664,13 +7683,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2817
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2432
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7704,16 +7723,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1396
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1331
+#: lxc/file.go:1355
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1284
+#: lxc/file.go:1308
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-07 15:11-0700\n"
+"POT-Creation-Date: 2025-01-10 14:44-0600\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -79,7 +79,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:1041
+#: lxc/storage_volume.go:1043
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -371,7 +371,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network_forward.go:667
+#: lxc/network_forward.go:675
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -667,12 +667,12 @@ msgstr "%s (%d más)"
 msgid "%s (%s) (%d available)"
 msgstr "%s (%d más)"
 
-#: lxc/file.go:1157
+#: lxc/file.go:1177
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s no es un directorio"
 
-#: lxc/file.go:1047
+#: lxc/file.go:1067
 #, fuzzy, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "%s no es un tipo de archivo soportado."
@@ -710,7 +710,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: lxc/init.go:142 lxc/rebuild.go:65
+#: lxc/init.go:146 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:687
+#: lxc/file.go:700
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -784,7 +784,7 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr "ALIAS"
 
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:888 lxc/network_forward.go:889
+#: lxc/network_forward.go:896 lxc/network_forward.go:897
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -969,7 +969,7 @@ msgstr ""
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
+#: lxc/image_alias.go:101 lxc/image_alias.go:156 lxc/image_alias.go:320
 msgid "Alias name missing"
 msgstr ""
 
@@ -982,7 +982,7 @@ msgstr "El dispostivo ya existe: %s"
 msgid "Aliases:"
 msgstr "Aliases:"
 
-#: lxc/storage_volume.go:1607
+#: lxc/storage_volume.go:1609
 msgid "All projects"
 msgstr ""
 
@@ -1014,7 +1014,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1039,12 +1039,26 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168 lxc/storage_volume.go:169
+#: lxc/storage_volume.go:168
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:169
+msgid ""
+"Attach new storage volumes to instances\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
+msgstr ""
+
+#: lxc/storage_volume.go:285
 msgid "Attach new storage volumes to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:286
+msgid ""
+"Attach new storage volumes to profiles\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
 #: lxc/console.go:39
@@ -1095,16 +1109,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2719
+#: lxc/storage_volume.go:2721
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/export.go:192 lxc/storage_volume.go:2796
+#: lxc/export.go:192 lxc/storage_volume.go:2798
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1538
+#: lxc/info.go:666 lxc/storage_volume.go:1540
 msgid "Backups:"
 msgstr ""
 
@@ -1113,19 +1127,19 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
+#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:326
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1169,7 +1183,7 @@ msgstr "CANCELABLE"
 msgid "COMMON NAME"
 msgstr "NOMBRE COMÚN"
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1752
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1222,7 +1236,7 @@ msgstr "Cacheado: %s"
 msgid "Caches:"
 msgstr "Cacheado: %s"
 
-#: lxc/move.go:130
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 "No se puede anular la configuración o los perfiles en el cambio de nombre "
@@ -1232,7 +1246,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr "No se puede proporcionar un nombre para la imagen de destino"
 
-#: lxc/file.go:562
+#: lxc/file.go:575
 msgid "Can't pull a directory without --recursive"
 msgstr "No se puede jalar un directorio sin - recursivo"
 
@@ -1258,11 +1272,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr "No se puede especificar un remote diferente para renombrar."
 
-#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:768
+#: lxc/file.go:790
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1275,12 +1289,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:493
+#: lxc/storage_volume.go:497
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:447
+#: lxc/storage_volume.go:451
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1388,9 +1402,9 @@ msgstr "Perfil %s eliminado de %s"
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:497 lxc/network_forward.go:649
-#: lxc/network_forward.go:803 lxc/network_forward.go:892
-#: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
+#: lxc/network_forward.go:505 lxc/network_forward.go:657
+#: lxc/network_forward.go:811 lxc/network_forward.go:900
+#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
 #: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
 #: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
@@ -1402,14 +1416,14 @@ msgstr "Perfil %s eliminado de %s"
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
-#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
-#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
-#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
+#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
 msgid "Cluster member name"
 msgstr "Nombre del Miembro del Cluster"
 
@@ -1425,7 +1439,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1608
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr "Columnas"
@@ -1467,21 +1481,21 @@ msgstr "Perfil para aplicar al nuevo contenedor"
 #: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
-#: lxc/network_acl.go:698 lxc/network_forward.go:767
+#: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
-#: lxc/storage_volume.go:1199
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
+#: lxc/storage_volume.go:1201
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:620
+#: lxc/storage_volume.go:624
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1478
+#: lxc/storage_volume.go:1480
 #, fuzzy, c-format
 msgid "Content type: %s"
 msgstr "Auto actualización: %s"
@@ -1543,7 +1557,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1551,12 +1565,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1570,7 +1584,7 @@ msgstr "Copiando la imagen: %s"
 msgid "Copying the image: %s"
 msgstr "Copiando la imagen: %s"
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1669,7 +1683,7 @@ msgstr "Creando el contenedor"
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:462 lxc/file.go:696
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1713,7 +1727,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr "Perfil %s creado"
 
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1767,12 +1781,12 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
 #, c-format
 msgid "Created: %s"
 msgstr "Creado: %s"
 
-#: lxc/init.go:182
+#: lxc/init.go:186
 #, c-format
 msgid "Creating %s"
 msgstr "Creando %s"
@@ -1782,7 +1796,7 @@ msgstr "Creando %s"
 msgid "Creating %s: %%s"
 msgstr "Creando %s"
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 #, fuzzy
 msgid "Creating the instance"
 msgstr "Creando el contenedor"
@@ -1797,13 +1811,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1749
+#: lxc/storage_volume.go:1751
 msgid "DESCRIPTION"
 msgstr "DESCRIPCIÓN"
 
@@ -1823,7 +1837,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2653
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1856,7 +1870,7 @@ msgstr "Eliminar imágenes"
 msgid "Delete identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:106 lxc/image_alias.go:107
+#: lxc/image_alias.go:123 lxc/image_alias.go:124
 msgid "Delete image aliases"
 msgstr "Eliminar alias de imagen"
 
@@ -1881,7 +1895,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:799 lxc/network_forward.go:800
+#: lxc/network_forward.go:807 lxc/network_forward.go:808
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1925,7 +1939,7 @@ msgstr "Perfil %s creado"
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
+#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1967,13 +1981,13 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
-#: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
-#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
+#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
+#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
+#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
@@ -1987,10 +2001,10 @@ msgstr ""
 #: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:404 lxc/network_forward.go:489
-#: lxc/network_forward.go:599 lxc/network_forward.go:646
-#: lxc/network_forward.go:800 lxc/network_forward.go:874
-#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_forward.go:412 lxc/network_forward.go:497
+#: lxc/network_forward.go:607 lxc/network_forward.go:654
+#: lxc/network_forward.go:808 lxc/network_forward.go:882
+#: lxc/network_forward.go:897 lxc/network_forward.go:982
 #: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
 #: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
 #: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
@@ -2030,27 +2044,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
-#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
-#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
-#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
-#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
-#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
-#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
-#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr "Descripción"
 
-#: lxc/storage_volume.go:1465
+#: lxc/storage_volume.go:1467
 #, fuzzy, c-format
 msgid "Description: %s"
 msgstr "Huella dactilar: %s"
 
-#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Nombre del Miembro del Cluster"
@@ -2063,11 +2077,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
+#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2118,7 +2132,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr "Dispositivo: %s"
 
-#: lxc/init.go:403
+#: lxc/init.go:407
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2130,7 +2144,7 @@ msgstr "El directorio importado no está disponible en esta plataforma"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1216
+#: lxc/file.go:1236
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2231,7 +2245,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:377 lxc/file.go:378
+#: lxc/file.go:381 lxc/file.go:382
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2272,7 +2286,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:653 lxc/network_forward.go:654
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -2317,7 +2331,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2325,7 +2339,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1785
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2379,11 +2393,11 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
-#: lxc/network_acl.go:524 lxc/network_forward.go:572
+#: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
+#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Error actualizando el archivo de plantilla: %s"
@@ -2394,11 +2408,11 @@ msgid "Error unsetting properties: %v"
 msgstr "Error actualizando el archivo de plantilla: %s"
 
 #: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
-#: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
+#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
-#: lxc/storage_volume.go:2210
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
+#: lxc/storage_volume.go:2212
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2441,8 +2455,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
+#: lxc/storage_volume.go:1577
 #, fuzzy
 msgid "Expires at"
 msgstr "Expira: %s"
@@ -2467,7 +2481,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2481,11 +2495,11 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Export instances as backup tarballs."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2650
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2779
+#: lxc/export.go:152 lxc/storage_volume.go:2781
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -2504,7 +2518,7 @@ msgid "FILENAME"
 msgstr ""
 
 #: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
-#: lxc/image_alias.go:235
+#: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr "HUELLA DIGITAL"
 
@@ -2512,12 +2526,12 @@ msgstr "HUELLA DIGITAL"
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1467
+#: lxc/file.go:1491
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1490
+#: lxc/file.go:1514
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2532,12 +2546,12 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/file.go:1517
+#: lxc/file.go:1541
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1326
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Nombre del Miembro del Cluster"
@@ -2567,7 +2581,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/file.go:1423
+#: lxc/file.go:1447
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Acepta certificado"
@@ -2582,7 +2596,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/file.go:1428
+#: lxc/file.go:1452
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Acepta certificado"
@@ -2592,12 +2606,12 @@ msgstr "Acepta certificado"
 msgid "Failed starting command: %w"
 msgstr "Acepta certificado"
 
-#: lxc/file.go:1328
+#: lxc/file.go:1352
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Acepta certificado"
 
-#: lxc/file.go:1455
+#: lxc/file.go:1479
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Acepta certificado"
@@ -2611,7 +2625,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr "Acepta certificado"
 
-#: lxc/move.go:304 lxc/move.go:380
+#: lxc/move.go:309 lxc/move.go:385
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "Nombre del Miembro del Cluster"
@@ -2636,7 +2650,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1440
+#: lxc/file.go:1464
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Acepta certificado"
@@ -2651,7 +2665,7 @@ msgstr "Perfil para aplicar al nuevo contenedor"
 msgid "Failed to remove alias %s: %w"
 msgstr "Acepta certificado"
 
-#: lxc/file.go:1042
+#: lxc/file.go:1062
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2739,14 +2753,14 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1625 lxc/warning.go:94
+#: lxc/storage_volume.go:1627 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2815,7 +2829,7 @@ msgstr "Aliases:"
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1602
+#: lxc/image.go:1602 lxc/image.go:1603
 msgid "Get image properties"
 msgstr ""
 
@@ -2831,7 +2845,7 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:414
 #, fuzzy
 msgid "Get the key as a network forward property"
 msgstr "Perfil %s creado"
@@ -2877,7 +2891,7 @@ msgstr "Perfil %s creado"
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1249
+#: lxc/storage_volume.go:1251
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2906,7 +2920,7 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:403 lxc/network_forward.go:404
+#: lxc/network_forward.go:411 lxc/network_forward.go:412
 #, fuzzy
 msgid "Get values for network forward configuration keys"
 msgstr "Perfil %s creado"
@@ -2948,11 +2962,11 @@ msgstr "Perfil %s creado"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:476
+#: lxc/storage_volume.go:480
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2993,22 +3007,22 @@ msgstr "Aliases:"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1540
+#: lxc/file.go:1564
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Copiando la imagen: %s"
 
-#: lxc/file.go:1529
+#: lxc/file.go:1553
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Copiando la imagen: %s"
 
-#: lxc/file.go:1352
+#: lxc/file.go:1376
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Dispositivo %s añadido a %s"
 
-#: lxc/file.go:1362
+#: lxc/file.go:1386
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Copiando la imagen: %s"
@@ -3083,11 +3097,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:415
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3097,7 +3111,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2437
+#: lxc/storage_volume.go:2439
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3109,7 +3123,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1517
+#: lxc/image.go:1518
 msgid "Image already up to date."
 msgstr ""
 
@@ -3125,11 +3139,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1472
+#: lxc/image.go:364 lxc/image.go:1473
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1698
+#: lxc/image.go:444 lxc/image.go:1699
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -3139,7 +3153,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1515
+#: lxc/image.go:1516
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3147,7 +3161,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2815
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3155,7 +3169,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2814
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -3178,11 +3192,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2822
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2894
+#: lxc/storage_volume.go:2896
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -3209,11 +3223,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/file.go:1354
+#: lxc/file.go:1378
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1531
+#: lxc/file.go:1555
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3223,7 +3237,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr "Nombre del contenedor es obligatorio"
 
-#: lxc/init.go:414
+#: lxc/init.go:418
 #, fuzzy, c-format
 msgid "Instance name is: %s"
 msgstr "Nombre del contenedor es: %s"
@@ -3233,7 +3247,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Instance name must be specified"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/file.go:1274
+#: lxc/file.go:1298
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3285,7 +3299,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Invalid instance name: %s"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/file.go:1269
+#: lxc/file.go:1293
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Nombre del contenedor es: %s"
@@ -3311,24 +3325,24 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2023
+#: lxc/move.go:153 lxc/storage_volume.go:2025
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/move.go:144
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2019
+#: lxc/storage_volume.go:2021
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:509
+#: lxc/main.go:518
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:353
+#: lxc/file.go:357
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3338,19 +3352,19 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
-#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
+#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/file.go:535
+#: lxc/file.go:548
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:717
+#: lxc/file.go:185 lxc/file.go:739
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3387,7 +3401,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3418,12 +3432,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:176
+#: lxc/init.go:180
 #, fuzzy, c-format
 msgid "Launching %s"
 msgstr "Creando %s"
 
-#: lxc/init.go:174
+#: lxc/init.go:178
 #, fuzzy
 msgid "Launching the instance"
 msgstr "Creando el contenedor"
@@ -3530,11 +3544,11 @@ msgstr "Aliases:"
 msgid "List identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:151
+#: lxc/image_alias.go:176
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:177
 msgid ""
 "List image aliases\n"
 "\n"
@@ -3705,11 +3719,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr "Aliases:"
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1605
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1610
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3769,7 +3783,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1481
+#: lxc/info.go:489 lxc/storage_volume.go:1483
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3959,7 +3973,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:873 lxc/network_forward.go:874
+#: lxc/network_forward.go:881 lxc/network_forward.go:882
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -4117,12 +4131,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:322 lxc/move.go:435
+#: lxc/move.go:327 lxc/move.go:440
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:347 lxc/move.go:440
+#: lxc/move.go:352 lxc/move.go:445
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4197,10 +4211,10 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Missing key name"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:449
-#: lxc/network_forward.go:534 lxc/network_forward.go:709
-#: lxc/network_forward.go:840 lxc/network_forward.go:933
-#: lxc/network_forward.go:1015 lxc/network_load_balancer.go:221
+#: lxc/network_forward.go:219 lxc/network_forward.go:457
+#: lxc/network_forward.go:542 lxc/network_forward.go:717
+#: lxc/network_forward.go:848 lxc/network_forward.go:945
+#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
 #: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
 #: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
 #: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
@@ -4227,10 +4241,10 @@ msgstr "Nombre del contenedor es: %s"
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
 #: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
 #: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:284 lxc/network_forward.go:445
-#: lxc/network_forward.go:530 lxc/network_forward.go:705
-#: lxc/network_forward.go:836 lxc/network_forward.go:929
-#: lxc/network_forward.go:1011 lxc/network_load_balancer.go:131
+#: lxc/network_forward.go:292 lxc/network_forward.go:453
+#: lxc/network_forward.go:538 lxc/network_forward.go:713
+#: lxc/network_forward.go:844 lxc/network_forward.go:941
+#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
 #: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
 #: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
 #: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
@@ -4269,13 +4283,13 @@ msgstr "Nombre del contenedor es: %s"
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
-#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
-#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
-#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
+#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
+#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
+#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
+#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
 msgid "Missing pool name"
 msgstr ""
 
@@ -4295,16 +4309,16 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
+#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1411
+#: lxc/storage_volume.go:1413
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/file.go:820
+#: lxc/file.go:842
 #, fuzzy
 msgid "Missing target directory"
 msgstr "%s no es un directorio"
@@ -4339,16 +4353,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
-#: lxc/storage_volume.go:975
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
+#: lxc/storage_volume.go:977
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:507
+#: lxc/file.go:520
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1207 lxc/file.go:1208
+#: lxc/file.go:1227 lxc/file.go:1228
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Aliases:"
@@ -4378,7 +4392,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4386,16 +4400,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1869
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1059 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4417,7 +4431,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
 msgid "NAME"
 msgstr ""
 
@@ -4469,8 +4483,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
-#: lxc/storage_volume.go:1573
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Name"
 msgstr ""
 
@@ -4478,7 +4492,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4533,12 +4547,12 @@ msgstr "Perfil %s creado"
 msgid "Network Zone %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: lxc/network_forward.go:386
+#: lxc/network_forward.go:394
 #, fuzzy, c-format
 msgid "Network forward %s created"
 msgstr "Perfil %s creado"
 
-#: lxc/network_forward.go:857
+#: lxc/network_forward.go:865
 #, fuzzy, c-format
 msgid "Network forward %s deleted"
 msgstr "Perfil %s eliminado"
@@ -4622,7 +4636,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
+#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4630,7 +4644,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1070 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4642,11 +4656,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4660,7 +4674,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2035
+#: lxc/storage_volume.go:2037
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4668,16 +4682,21 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
-#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
-msgid "Only \"custom\" volumes can be attached to instances"
+#: lxc/storage_volume.go:216
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2701
+#: lxc/storage_volume.go:348
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:2703
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2500
+#: lxc/storage_volume.go:2502
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4689,7 +4708,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1431
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4702,7 +4721,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1577
+#: lxc/info.go:705 lxc/storage_volume.go:1579
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4732,7 +4751,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1767
+#: lxc/storage_volume.go:1769
 msgid "POOL"
 msgstr ""
 
@@ -4749,7 +4768,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167
-#: lxc/storage_volume.go:1773 lxc/warning.go:213
+#: lxc/storage_volume.go:1775 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4773,7 +4792,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:367
+#: lxc/main.go:376
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Contraseña admin para %s:"
@@ -4812,7 +4831,7 @@ msgstr "Auto actualización: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1332
+#: lxc/file.go:1356
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4820,12 +4839,12 @@ msgstr ""
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
-#: lxc/network_acl.go:699 lxc/network_forward.go:768
+#: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
-#: lxc/storage_volume.go:1200
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
+#: lxc/storage_volume.go:1202
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4942,11 +4961,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1649
+#: lxc/image.go:1650
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4960,7 +4979,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1238
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4976,7 +4995,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4997,7 +5016,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1017
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5006,7 +5025,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2094
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5019,7 +5038,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2370
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5050,20 +5069,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/file.go:455 lxc/file.go:456
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:638 lxc/file.go:989
+#: lxc/file.go:651 lxc/file.go:1009
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:688 lxc/file.go:689
+#: lxc/file.go:701 lxc/file.go:702
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:923 lxc/file.go:1089
+#: lxc/file.go:943 lxc/file.go:1109
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5072,7 +5091,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5103,15 +5122,15 @@ msgstr "Creando el contenedor"
 msgid "Rebuild instances"
 msgstr "Aliases:"
 
-#: lxc/file.go:463 lxc/file.go:695
+#: lxc/file.go:475 lxc/file.go:708
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1444 lxc/image.go:1445
+#: lxc/image.go:1445 lxc/image.go:1446
 msgid "Refresh images"
 msgstr ""
 
@@ -5120,7 +5139,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:1481
+#: lxc/image.go:1482
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr "Refrescando la imagen: %s"
@@ -5200,7 +5219,7 @@ msgstr "Perfil %s creado"
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:971 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -5238,7 +5257,7 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:969 lxc/network_forward.go:970
+#: lxc/network_forward.go:981 lxc/network_forward.go:982
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -5276,8 +5295,8 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
-#: lxc/image_alias.go:255
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:287
+#: lxc/image_alias.go:288
 msgid "Rename aliases"
 msgstr ""
 
@@ -5314,15 +5333,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1962
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
+#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5377,7 +5396,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5394,7 +5413,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:361
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5446,12 +5465,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1460
+#: lxc/file.go:1484
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1461
+#: lxc/file.go:1485
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5529,7 +5548,7 @@ msgstr "Aliases:"
 msgid "Set a cluster member's configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/file.go:1217
+#: lxc/file.go:1237
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5555,7 +5574,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1665 lxc/image.go:1666
+#: lxc/image.go:1666 lxc/image.go:1667
 msgid "Set image properties"
 msgstr ""
 
@@ -5598,12 +5617,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:488
+#: lxc/network_forward.go:496
 #, fuzzy
 msgid "Set network forward keys"
 msgstr "Perfil %s creado"
 
-#: lxc/network_forward.go:489
+#: lxc/network_forward.go:497
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5712,11 +5731,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2088
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2089
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5733,7 +5752,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:698
+#: lxc/file.go:711
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5741,7 +5760,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:699
+#: lxc/file.go:712
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5749,7 +5768,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:710
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5761,7 +5780,7 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:504
 #, fuzzy
 msgid "Set the key as a network forward property"
 msgstr "Perfil %s creado"
@@ -5807,7 +5826,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2105
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5815,7 +5834,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1215
+#: lxc/file.go:1235
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5874,7 +5893,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1535 lxc/image.go:1536
+#: lxc/image.go:1536 lxc/image.go:1537
 msgid "Show image properties"
 msgstr ""
 
@@ -5895,7 +5914,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:271 lxc/main.go:272
+#: lxc/main.go:280 lxc/main.go:281
 msgid "Show less common commands"
 msgstr ""
 
@@ -5967,11 +5986,11 @@ msgstr "Perfil %s creado"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -6040,15 +6059,15 @@ msgstr "Auto actualización: %s"
 msgid "Size: %s"
 msgstr "Auto actualización: %s"
 
-#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2190
+#: lxc/storage_volume.go:2192
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1502
+#: lxc/info.go:619 lxc/storage_volume.go:1504
 msgid "Snapshots:"
 msgstr ""
 
@@ -6154,21 +6173,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:703
+#: lxc/storage_volume.go:707
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:791
+#: lxc/storage_volume.go:795
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:516
+#: lxc/storage_volume.go:520
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:524
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -6230,21 +6249,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1747 lxc/warning.go:216
+#: lxc/storage_volume.go:1749 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1262
+#: lxc/file.go:1286
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1256
+#: lxc/file.go:1280
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6254,16 +6273,16 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:181
+#: lxc/move.go:186
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:219 lxc/move.go:240
+#: lxc/move.go:224 lxc/move.go:245
 #, fuzzy
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
 
-#: lxc/move.go:193
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -6271,16 +6290,16 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:185
+#: lxc/move.go:190
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:189
+#: lxc/move.go:194
 #, fuzzy
 msgid "The --target-project flag can't be used with --target"
 msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
 
-#: lxc/move.go:205
+#: lxc/move.go:210
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -6302,7 +6321,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:439
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6355,7 +6374,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/network_forward.go:462
+#: lxc/network_forward.go:470
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr "Nombre del Miembro del Cluster"
@@ -6395,12 +6414,12 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/storage_volume.go:1340
+#: lxc/storage_volume.go:1342
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/storage_volume.go:1317
+#: lxc/storage_volume.go:1319
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6415,12 +6434,12 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:309
+#: lxc/move.go:314
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
-#: lxc/storage_volume.go:989
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
+#: lxc/storage_volume.go:991
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6450,7 +6469,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr "El directorio importado no está disponible en esta plataforma"
 
-#: lxc/main.go:298
+#: lxc/main.go:307
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6474,11 +6493,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:437
+#: lxc/init.go:441
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:440
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6486,7 +6505,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:412
+#: lxc/main.go:421
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6497,7 +6516,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1489
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Auto actualización: %s"
@@ -6512,7 +6531,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1864
+#: lxc/storage_volume.go:1866
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6520,7 +6539,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6537,7 +6556,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:327
+#: lxc/copy.go:382 lxc/move.go:332
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -6581,7 +6600,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1472
+#: lxc/storage_volume.go:1474
 #, fuzzy, c-format
 msgid "Type: %s"
 msgstr "Expira: %s"
@@ -6603,13 +6622,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1752
+#: lxc/project.go:995 lxc/storage_volume.go:1754
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1751
+#: lxc/storage.go:724 lxc/storage_volume.go:1753
 msgid "USED BY"
 msgstr ""
 
@@ -6622,7 +6641,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:411
+#: lxc/file.go:423
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6636,12 +6655,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1483
+#: lxc/file.go:1507
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1791
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6652,7 +6671,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1029
+#: lxc/file.go:1049
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6685,7 +6704,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1728 lxc/image.go:1729
+#: lxc/image.go:1729 lxc/image.go:1730
 msgid "Unset image properties"
 msgstr ""
 
@@ -6701,12 +6720,12 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:598
+#: lxc/network_forward.go:606
 #, fuzzy
 msgid "Unset network forward configuration keys"
 msgstr "Perfil %s creado"
 
-#: lxc/network_forward.go:599
+#: lxc/network_forward.go:607
 #, fuzzy
 msgid "Unset network forward keys"
 msgstr "Perfil %s creado"
@@ -6758,7 +6777,7 @@ msgstr "Perfil %s creado"
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6770,7 +6789,7 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:602
+#: lxc/network_forward.go:610
 #, fuzzy
 msgid "Unset the key as a network forward property"
 msgstr "Perfil %s creado"
@@ -6817,7 +6836,7 @@ msgstr "Perfil %s creado"
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2381
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6825,7 +6844,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:248
+#: lxc/storage_volume.go:250
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6862,12 +6881,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1485
+#: lxc/storage_volume.go:1487
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Auto actualización: %s"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2652
+#: lxc/export.go:42 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6934,7 +6953,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1576
+#: lxc/storage_volume.go:1578
 msgid "Volume Only"
 msgstr ""
 
@@ -6985,7 +7004,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:293 lxc/move.go:369
+#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6993,14 +7012,14 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:909
+#: lxc/storage_volume.go:912
 #, fuzzy
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:282
+#: lxc/storage_volume.go:284
 #, fuzzy
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
@@ -7038,7 +7057,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:] [<filter>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:174
 #, fuzzy
 msgid "[<remote>:] [<filters>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7103,7 +7122,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image_alias.go:104
+#: lxc/image_alias.go:121
 #, fuzzy
 msgid "[<remote>:]<alias>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7113,7 +7132,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image_alias.go:252
+#: lxc/image_alias.go:285
 #, fuzzy
 msgid "[<remote>:]<alias> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7176,17 +7195,17 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:1600 lxc/image.go:1727
+#: lxc/image.go:1601 lxc/image.go:1728
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:1664
+#: lxc/image.go:1665
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7211,7 +7230,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<image> [<target>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:334 lxc/image.go:1443
+#: lxc/image.go:334 lxc/image.go:1444
 #, fuzzy
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7298,7 +7317,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:376
+#: lxc/file.go:380
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7313,13 +7332,13 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/file.go:454
+#: lxc/file.go:466
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/file.go:1206
+#: lxc/file.go:1226
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7403,8 +7422,8 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:644
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:179
+#: lxc/network_forward.go:177 lxc/network_forward.go:652
+#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
 #: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address>"
@@ -7422,13 +7441,13 @@ msgid ""
 "[<target_port(s)>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_forward.go:402 lxc/network_forward.go:597
+#: lxc/network_forward.go:410 lxc/network_forward.go:605
 #: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_forward.go:487 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7440,13 +7459,13 @@ msgid ""
 "<backend_name>[,<backend_name>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network_forward.go:887
+#: lxc/network_forward.go:895
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:968 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7514,7 +7533,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<pool>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2811
+#: lxc/storage_volume.go:2813
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7557,79 +7576,79 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1958
+#: lxc/storage_volume.go:1960
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:806
-#, fuzzy
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
-msgstr "No se puede proveer el nombre del container a la lista"
-
-#: lxc/storage_volume.go:167
-#, fuzzy
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
-msgstr "No se puede proveer el nombre del container a la lista"
-
-#: lxc/storage_volume.go:2562
+#: lxc/storage_volume.go:2564
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2645
+#: lxc/storage_volume.go:2647
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2428
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:610
+#: lxc/storage_volume.go:614
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:718
+#: lxc/storage_volume.go:722
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2364
+#: lxc/storage_volume.go:810
+#, fuzzy
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
+msgstr "No se puede proveer el nombre del container a la lista"
+
+#: lxc/storage_volume.go:167
+#, fuzzy
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
+msgstr "No se puede proveer el nombre del container a la lista"
+
+#: lxc/storage_volume.go:2366
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2087
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2245
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1234
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1858
+#: lxc/storage_volume.go:1860
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:392
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7761,7 +7780,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1603
 #, fuzzy
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7927,20 +7946,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1230
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:470
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:691
+#: lxc/file.go:704
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -8241,7 +8260,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:618
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -8249,13 +8268,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2817
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2432
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -8289,16 +8308,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1396
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1331
+#: lxc/file.go:1355
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1284
+#: lxc/file.go:1308
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-07 15:11-0700\n"
+"POT-Creation-Date: 2025-01-10 14:44-0600\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1041
+#: lxc/storage_volume.go:1043
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:667
+#: lxc/network_forward.go:675
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,12 +430,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1157
+#: lxc/file.go:1177
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1047
+#: lxc/file.go:1067
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -471,7 +471,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:65
+#: lxc/init.go:146 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:687
+#: lxc/file.go:700
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -541,7 +541,7 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
@@ -672,7 +672,7 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:888 lxc/network_forward.go:889
+#: lxc/network_forward.go:896 lxc/network_forward.go:897
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -722,7 +722,7 @@ msgstr ""
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
+#: lxc/image_alias.go:101 lxc/image_alias.go:156 lxc/image_alias.go:320
 msgid "Alias name missing"
 msgstr ""
 
@@ -735,7 +735,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1607
+#: lxc/storage_volume.go:1609
 msgid "All projects"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -790,12 +790,26 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168 lxc/storage_volume.go:169
+#: lxc/storage_volume.go:168
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:169
+msgid ""
+"Attach new storage volumes to instances\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
+msgstr ""
+
+#: lxc/storage_volume.go:285
 msgid "Attach new storage volumes to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:286
+msgid ""
+"Attach new storage volumes to profiles\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
 #: lxc/console.go:39
@@ -846,16 +860,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2719
+#: lxc/storage_volume.go:2721
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2796
+#: lxc/export.go:192 lxc/storage_volume.go:2798
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1538
+#: lxc/info.go:666 lxc/storage_volume.go:1540
 msgid "Backups:"
 msgstr ""
 
@@ -864,19 +878,19 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
+#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:326
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -919,7 +933,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1752
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -971,7 +985,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -979,7 +993,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:562
+#: lxc/file.go:575
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1004,11 +1018,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:768
+#: lxc/file.go:790
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1021,12 +1035,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:493
+#: lxc/storage_volume.go:497
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:447
+#: lxc/storage_volume.go:451
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1132,9 +1146,9 @@ msgstr ""
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:497 lxc/network_forward.go:649
-#: lxc/network_forward.go:803 lxc/network_forward.go:892
-#: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
+#: lxc/network_forward.go:505 lxc/network_forward.go:657
+#: lxc/network_forward.go:811 lxc/network_forward.go:900
+#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
 #: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
 #: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
@@ -1146,14 +1160,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
-#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
-#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
-#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
+#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
 msgid "Cluster member name"
 msgstr ""
 
@@ -1169,7 +1183,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1608
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1209,21 +1223,21 @@ msgstr ""
 #: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
-#: lxc/network_acl.go:698 lxc/network_forward.go:767
+#: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
-#: lxc/storage_volume.go:1199
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
+#: lxc/storage_volume.go:1201
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:620
+#: lxc/storage_volume.go:624
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1478
+#: lxc/storage_volume.go:1480
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1285,7 +1299,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1293,12 +1307,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1311,7 +1325,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1406,7 +1420,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:462 lxc/file.go:696
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1446,7 +1460,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1498,12 +1512,12 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:182
+#: lxc/init.go:186
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1513,7 +1527,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 msgid "Creating the instance"
 msgstr ""
 
@@ -1527,13 +1541,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1749
+#: lxc/storage_volume.go:1751
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1553,7 +1567,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2653
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1585,7 +1599,7 @@ msgstr ""
 msgid "Delete identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:106 lxc/image_alias.go:107
+#: lxc/image_alias.go:123 lxc/image_alias.go:124
 msgid "Delete image aliases"
 msgstr ""
 
@@ -1609,7 +1623,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:799 lxc/network_forward.go:800
+#: lxc/network_forward.go:807 lxc/network_forward.go:808
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1649,7 +1663,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
+#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1691,13 +1705,13 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
-#: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
-#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
+#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
+#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
+#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
@@ -1711,10 +1725,10 @@ msgstr ""
 #: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:404 lxc/network_forward.go:489
-#: lxc/network_forward.go:599 lxc/network_forward.go:646
-#: lxc/network_forward.go:800 lxc/network_forward.go:874
-#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_forward.go:412 lxc/network_forward.go:497
+#: lxc/network_forward.go:607 lxc/network_forward.go:654
+#: lxc/network_forward.go:808 lxc/network_forward.go:882
+#: lxc/network_forward.go:897 lxc/network_forward.go:982
 #: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
 #: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
 #: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
@@ -1754,27 +1768,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
-#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
-#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
-#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
-#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
-#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
-#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
-#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1465
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1786,11 +1800,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
+#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1840,7 +1854,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:403
+#: lxc/init.go:407
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1852,7 +1866,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1216
+#: lxc/file.go:1236
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1948,7 +1962,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:377 lxc/file.go:378
+#: lxc/file.go:381 lxc/file.go:382
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1988,7 +2002,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:653 lxc/network_forward.go:654
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -2028,7 +2042,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2036,7 +2050,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1785
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2090,11 +2104,11 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
-#: lxc/network_acl.go:524 lxc/network_forward.go:572
+#: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
+#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2105,11 +2119,11 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
-#: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
+#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
-#: lxc/storage_volume.go:2210
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
+#: lxc/storage_volume.go:2212
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2151,8 +2165,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
+#: lxc/storage_volume.go:1577
 msgid "Expires at"
 msgstr ""
 
@@ -2176,7 +2190,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2188,11 +2202,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2650
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2779
+#: lxc/export.go:152 lxc/storage_volume.go:2781
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2211,7 +2225,7 @@ msgid "FILENAME"
 msgstr ""
 
 #: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
-#: lxc/image_alias.go:235
+#: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2219,12 +2233,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1467
+#: lxc/file.go:1491
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1490
+#: lxc/file.go:1514
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2239,12 +2253,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1517
+#: lxc/file.go:1541
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1326
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2274,7 +2288,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1423
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2289,7 +2303,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1428
+#: lxc/file.go:1452
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2299,12 +2313,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1352
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1455
+#: lxc/file.go:1479
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2318,7 +2332,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:304 lxc/move.go:380
+#: lxc/move.go:309 lxc/move.go:385
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2343,7 +2357,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1440
+#: lxc/file.go:1464
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2358,7 +2372,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1042
+#: lxc/file.go:1062
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2445,14 +2459,14 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1625 lxc/warning.go:94
+#: lxc/storage_volume.go:1627 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2520,7 +2534,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1602
+#: lxc/image.go:1602 lxc/image.go:1603
 msgid "Get image properties"
 msgstr ""
 
@@ -2536,7 +2550,7 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:414
 msgid "Get the key as a network forward property"
 msgstr ""
 
@@ -2576,7 +2590,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1249
+#: lxc/storage_volume.go:1251
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2604,7 +2618,7 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:403 lxc/network_forward.go:404
+#: lxc/network_forward.go:411 lxc/network_forward.go:412
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
@@ -2640,11 +2654,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:476
+#: lxc/storage_volume.go:480
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2684,22 +2698,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1540
+#: lxc/file.go:1564
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1529
+#: lxc/file.go:1553
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1376
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1362
+#: lxc/file.go:1386
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2772,11 +2786,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:415
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2786,7 +2800,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2437
+#: lxc/storage_volume.go:2439
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2798,7 +2812,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1517
+#: lxc/image.go:1518
 msgid "Image already up to date."
 msgstr ""
 
@@ -2814,11 +2828,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1472
+#: lxc/image.go:364 lxc/image.go:1473
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1698
+#: lxc/image.go:444 lxc/image.go:1699
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2828,7 +2842,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1515
+#: lxc/image.go:1516
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2836,7 +2850,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2815
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2844,7 +2858,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2814
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2866,11 +2880,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2822
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2894
+#: lxc/storage_volume.go:2896
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2896,11 +2910,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1378
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1531
+#: lxc/file.go:1555
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2909,7 +2923,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:414
+#: lxc/init.go:418
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2918,7 +2932,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1298
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2970,7 +2984,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1293
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2996,23 +3010,23 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2023
+#: lxc/move.go:153 lxc/storage_volume.go:2025
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:144
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2019
+#: lxc/storage_volume.go:2021
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:509
+#: lxc/main.go:518
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:353
+#: lxc/file.go:357
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3022,18 +3036,18 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
-#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
+#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:535
+#: lxc/file.go:548
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:717
+#: lxc/file.go:185 lxc/file.go:739
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3070,7 +3084,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3101,12 +3115,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:176
+#: lxc/init.go:180
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:174
+#: lxc/init.go:178
 msgid "Launching the instance"
 msgstr ""
 
@@ -3204,11 +3218,11 @@ msgstr ""
 msgid "List identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:151
+#: lxc/image_alias.go:176
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:177
 msgid ""
 "List image aliases\n"
 "\n"
@@ -3375,11 +3389,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1605
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1610
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3438,7 +3452,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1481
+#: lxc/info.go:489 lxc/storage_volume.go:1483
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3624,7 +3638,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:873 lxc/network_forward.go:874
+#: lxc/network_forward.go:881 lxc/network_forward.go:882
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -3770,12 +3784,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:322 lxc/move.go:435
+#: lxc/move.go:327 lxc/move.go:440
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:347 lxc/move.go:440
+#: lxc/move.go:352 lxc/move.go:445
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3840,10 +3854,10 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:449
-#: lxc/network_forward.go:534 lxc/network_forward.go:709
-#: lxc/network_forward.go:840 lxc/network_forward.go:933
-#: lxc/network_forward.go:1015 lxc/network_load_balancer.go:221
+#: lxc/network_forward.go:219 lxc/network_forward.go:457
+#: lxc/network_forward.go:542 lxc/network_forward.go:717
+#: lxc/network_forward.go:848 lxc/network_forward.go:945
+#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
 #: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
 #: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
 #: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
@@ -3868,10 +3882,10 @@ msgstr ""
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
 #: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
 #: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:284 lxc/network_forward.go:445
-#: lxc/network_forward.go:530 lxc/network_forward.go:705
-#: lxc/network_forward.go:836 lxc/network_forward.go:929
-#: lxc/network_forward.go:1011 lxc/network_load_balancer.go:131
+#: lxc/network_forward.go:292 lxc/network_forward.go:453
+#: lxc/network_forward.go:538 lxc/network_forward.go:713
+#: lxc/network_forward.go:844 lxc/network_forward.go:941
+#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
 #: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
 #: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
 #: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
@@ -3907,13 +3921,13 @@ msgstr ""
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
-#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
-#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
-#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
+#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
+#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
+#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
+#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
 msgid "Missing pool name"
 msgstr ""
 
@@ -3932,15 +3946,15 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
+#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1411
+#: lxc/storage_volume.go:1413
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:820
+#: lxc/file.go:842
 msgid "Missing target directory"
 msgstr ""
 
@@ -3973,16 +3987,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
-#: lxc/storage_volume.go:975
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
+#: lxc/storage_volume.go:977
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:507
+#: lxc/file.go:520
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1207 lxc/file.go:1208
+#: lxc/file.go:1227 lxc/file.go:1228
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4011,7 +4025,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4019,16 +4033,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1869
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1059 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4050,7 +4064,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
 msgid "NAME"
 msgstr ""
 
@@ -4102,8 +4116,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
-#: lxc/storage_volume.go:1573
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Name"
 msgstr ""
 
@@ -4111,7 +4125,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4166,12 +4180,12 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:386
+#: lxc/network_forward.go:394
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:857
+#: lxc/network_forward.go:865
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -4255,7 +4269,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
+#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4263,7 +4277,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1070 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4275,11 +4289,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4293,7 +4307,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2035
+#: lxc/storage_volume.go:2037
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4301,16 +4315,21 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
-#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
-msgid "Only \"custom\" volumes can be attached to instances"
+#: lxc/storage_volume.go:216
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2701
+#: lxc/storage_volume.go:348
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:2703
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2500
+#: lxc/storage_volume.go:2502
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4322,7 +4341,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1431
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4335,7 +4354,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1577
+#: lxc/info.go:705 lxc/storage_volume.go:1579
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4365,7 +4384,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1767
+#: lxc/storage_volume.go:1769
 msgid "POOL"
 msgstr ""
 
@@ -4382,7 +4401,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167
-#: lxc/storage_volume.go:1773 lxc/warning.go:213
+#: lxc/storage_volume.go:1775 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4406,7 +4425,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:367
+#: lxc/main.go:376
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4444,7 +4463,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1332
+#: lxc/file.go:1356
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4452,12 +4471,12 @@ msgstr ""
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
-#: lxc/network_acl.go:699 lxc/network_forward.go:768
+#: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
-#: lxc/storage_volume.go:1200
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
+#: lxc/storage_volume.go:1202
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4570,11 +4589,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1649
+#: lxc/image.go:1650
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4588,7 +4607,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1238
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4604,7 +4623,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4625,7 +4644,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1017
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4634,7 +4653,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2094
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4647,7 +4666,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2370
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4678,20 +4697,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:455 lxc/file.go:456
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:638 lxc/file.go:989
+#: lxc/file.go:651 lxc/file.go:1009
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:688 lxc/file.go:689
+#: lxc/file.go:701 lxc/file.go:702
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:923 lxc/file.go:1089
+#: lxc/file.go:943 lxc/file.go:1109
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4700,7 +4719,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4729,15 +4748,15 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:463 lxc/file.go:695
+#: lxc/file.go:475 lxc/file.go:708
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1444 lxc/image.go:1445
+#: lxc/image.go:1445 lxc/image.go:1446
 msgid "Refresh images"
 msgstr ""
 
@@ -4746,7 +4765,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1481
+#: lxc/image.go:1482
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4823,7 +4842,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:971 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4859,7 +4878,7 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:969 lxc/network_forward.go:970
+#: lxc/network_forward.go:981 lxc/network_forward.go:982
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -4895,8 +4914,8 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
-#: lxc/image_alias.go:255
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:287
+#: lxc/image_alias.go:288
 msgid "Rename aliases"
 msgstr ""
 
@@ -4932,15 +4951,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1962
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
+#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4992,7 +5011,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5009,7 +5028,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:361
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5058,12 +5077,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1460
+#: lxc/file.go:1484
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1461
+#: lxc/file.go:1485
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5139,7 +5158,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1217
+#: lxc/file.go:1237
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5165,7 +5184,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1665 lxc/image.go:1666
+#: lxc/image.go:1666 lxc/image.go:1667
 msgid "Set image properties"
 msgstr ""
 
@@ -5208,11 +5227,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:488
+#: lxc/network_forward.go:496
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:489
+#: lxc/network_forward.go:497
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5316,11 +5335,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2088
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2089
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5337,7 +5356,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:698
+#: lxc/file.go:711
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5345,7 +5364,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:699
+#: lxc/file.go:712
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5353,7 +5372,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:710
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5365,7 +5384,7 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:504
 msgid "Set the key as a network forward property"
 msgstr ""
 
@@ -5405,7 +5424,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2105
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5413,7 +5432,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1215
+#: lxc/file.go:1235
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5470,7 +5489,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1535 lxc/image.go:1536
+#: lxc/image.go:1536 lxc/image.go:1537
 msgid "Show image properties"
 msgstr ""
 
@@ -5490,7 +5509,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:271 lxc/main.go:272
+#: lxc/main.go:280 lxc/main.go:281
 msgid "Show less common commands"
 msgstr ""
 
@@ -5554,11 +5573,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5626,15 +5645,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2190
+#: lxc/storage_volume.go:2192
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1502
+#: lxc/info.go:619 lxc/storage_volume.go:1504
 msgid "Snapshots:"
 msgstr ""
 
@@ -5739,21 +5758,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:703
+#: lxc/storage_volume.go:707
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:791
+#: lxc/storage_volume.go:795
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:516
+#: lxc/storage_volume.go:520
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:524
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5815,21 +5834,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1747 lxc/warning.go:216
+#: lxc/storage_volume.go:1749 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1262
+#: lxc/file.go:1286
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1256
+#: lxc/file.go:1280
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5839,15 +5858,15 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:181
+#: lxc/move.go:186
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:219 lxc/move.go:240
+#: lxc/move.go:224 lxc/move.go:245
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:193
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5855,15 +5874,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:185
+#: lxc/move.go:190
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:189
+#: lxc/move.go:194
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:210
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5885,7 +5904,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:439
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5938,7 +5957,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:462
+#: lxc/network_forward.go:470
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -5978,12 +5997,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1340
+#: lxc/storage_volume.go:1342
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1317
+#: lxc/storage_volume.go:1319
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -5998,12 +6017,12 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:309
+#: lxc/move.go:314
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
-#: lxc/storage_volume.go:989
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
+#: lxc/storage_volume.go:991
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6031,7 +6050,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:298
+#: lxc/main.go:307
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6055,11 +6074,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:437
+#: lxc/init.go:441
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:440
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6067,7 +6086,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:412
+#: lxc/main.go:421
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6078,7 +6097,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1489
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6093,7 +6112,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1864
+#: lxc/storage_volume.go:1866
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6101,7 +6120,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6118,7 +6137,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:327
+#: lxc/copy.go:382 lxc/move.go:332
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6160,7 +6179,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1472
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6182,13 +6201,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1752
+#: lxc/project.go:995 lxc/storage_volume.go:1754
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1751
+#: lxc/storage.go:724 lxc/storage_volume.go:1753
 msgid "USED BY"
 msgstr ""
 
@@ -6201,7 +6220,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:411
+#: lxc/file.go:423
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6215,12 +6234,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1483
+#: lxc/file.go:1507
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1791
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6231,7 +6250,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1029
+#: lxc/file.go:1049
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6262,7 +6281,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1728 lxc/image.go:1729
+#: lxc/image.go:1729 lxc/image.go:1730
 msgid "Unset image properties"
 msgstr ""
 
@@ -6278,11 +6297,11 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:598
+#: lxc/network_forward.go:606
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:599
+#: lxc/network_forward.go:607
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -6326,7 +6345,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6338,7 +6357,7 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:602
+#: lxc/network_forward.go:610
 msgid "Unset the key as a network forward property"
 msgstr ""
 
@@ -6378,7 +6397,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2381
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6386,7 +6405,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:248
+#: lxc/storage_volume.go:250
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6422,12 +6441,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1485
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2652
+#: lxc/export.go:42 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6494,7 +6513,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1576
+#: lxc/storage_volume.go:1578
 msgid "Volume Only"
 msgstr ""
 
@@ -6545,7 +6564,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:293 lxc/move.go:369
+#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6553,12 +6572,12 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:909
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:912
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:282
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:284
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
@@ -6590,7 +6609,7 @@ msgstr ""
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:174
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
@@ -6643,7 +6662,7 @@ msgstr ""
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: lxc/image_alias.go:104
+#: lxc/image_alias.go:121
 msgid "[<remote>:]<alias>"
 msgstr ""
 
@@ -6651,7 +6670,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/image_alias.go:252
+#: lxc/image_alias.go:285
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
@@ -6705,15 +6724,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1600 lxc/image.go:1727
+#: lxc/image.go:1601 lxc/image.go:1728
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1664
+#: lxc/image.go:1665
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6733,7 +6752,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1443
+#: lxc/image.go:334 lxc/image.go:1444
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6804,7 +6823,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:376
+#: lxc/file.go:380
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -6816,12 +6835,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:454
+#: lxc/file.go:466
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1226
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6889,8 +6908,8 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:644
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:179
+#: lxc/network_forward.go:177 lxc/network_forward.go:652
+#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
 #: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
@@ -6905,12 +6924,12 @@ msgid ""
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:402 lxc/network_forward.go:597
+#: lxc/network_forward.go:410 lxc/network_forward.go:605
 #: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
@@ -6920,13 +6939,13 @@ msgid ""
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:887
+#: lxc/network_forward.go:895
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:968 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -6981,7 +7000,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2811
+#: lxc/storage_volume.go:2813
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7016,65 +7035,65 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1958
+#: lxc/storage_volume.go:1960
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:806
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:167
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
-msgstr ""
-
-#: lxc/storage_volume.go:2562
+#: lxc/storage_volume.go:2564
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2645
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2428
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:610
+#: lxc/storage_volume.go:614
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:718
+#: lxc/storage_volume.go:722
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2364
+#: lxc/storage_volume.go:810
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
+msgstr ""
+
+#: lxc/storage_volume.go:167
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
+msgstr ""
+
+#: lxc/storage_volume.go:2366
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2087
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2245
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1234
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1858
+#: lxc/storage_volume.go:1860
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7180,7 +7199,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1603
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7342,20 +7361,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1230
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:470
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:691
+#: lxc/file.go:704
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7656,7 +7675,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:618
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7664,13 +7683,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2817
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2432
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7704,16 +7723,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1396
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1331
+#: lxc/file.go:1355
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1284
+#: lxc/file.go:1308
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-07 15:11-0700\n"
+"POT-Creation-Date: 2025-01-10 14:44-0600\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1041
+#: lxc/storage_volume.go:1043
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:667
+#: lxc/network_forward.go:675
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,12 +430,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1157
+#: lxc/file.go:1177
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1047
+#: lxc/file.go:1067
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -471,7 +471,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:65
+#: lxc/init.go:146 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:687
+#: lxc/file.go:700
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -541,7 +541,7 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
@@ -672,7 +672,7 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:888 lxc/network_forward.go:889
+#: lxc/network_forward.go:896 lxc/network_forward.go:897
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -722,7 +722,7 @@ msgstr ""
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
+#: lxc/image_alias.go:101 lxc/image_alias.go:156 lxc/image_alias.go:320
 msgid "Alias name missing"
 msgstr ""
 
@@ -735,7 +735,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1607
+#: lxc/storage_volume.go:1609
 msgid "All projects"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -790,12 +790,26 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168 lxc/storage_volume.go:169
+#: lxc/storage_volume.go:168
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:169
+msgid ""
+"Attach new storage volumes to instances\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
+msgstr ""
+
+#: lxc/storage_volume.go:285
 msgid "Attach new storage volumes to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:286
+msgid ""
+"Attach new storage volumes to profiles\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
 #: lxc/console.go:39
@@ -846,16 +860,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2719
+#: lxc/storage_volume.go:2721
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2796
+#: lxc/export.go:192 lxc/storage_volume.go:2798
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1538
+#: lxc/info.go:666 lxc/storage_volume.go:1540
 msgid "Backups:"
 msgstr ""
 
@@ -864,19 +878,19 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
+#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:326
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -919,7 +933,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1752
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -971,7 +985,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -979,7 +993,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:562
+#: lxc/file.go:575
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1004,11 +1018,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:768
+#: lxc/file.go:790
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1021,12 +1035,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:493
+#: lxc/storage_volume.go:497
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:447
+#: lxc/storage_volume.go:451
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1132,9 +1146,9 @@ msgstr ""
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:497 lxc/network_forward.go:649
-#: lxc/network_forward.go:803 lxc/network_forward.go:892
-#: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
+#: lxc/network_forward.go:505 lxc/network_forward.go:657
+#: lxc/network_forward.go:811 lxc/network_forward.go:900
+#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
 #: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
 #: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
@@ -1146,14 +1160,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
-#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
-#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
-#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
+#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
 msgid "Cluster member name"
 msgstr ""
 
@@ -1169,7 +1183,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1608
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1209,21 +1223,21 @@ msgstr ""
 #: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
-#: lxc/network_acl.go:698 lxc/network_forward.go:767
+#: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
-#: lxc/storage_volume.go:1199
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
+#: lxc/storage_volume.go:1201
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:620
+#: lxc/storage_volume.go:624
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1478
+#: lxc/storage_volume.go:1480
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1285,7 +1299,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1293,12 +1307,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1311,7 +1325,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1406,7 +1420,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:462 lxc/file.go:696
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1446,7 +1460,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1498,12 +1512,12 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:182
+#: lxc/init.go:186
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1513,7 +1527,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 msgid "Creating the instance"
 msgstr ""
 
@@ -1527,13 +1541,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1749
+#: lxc/storage_volume.go:1751
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1553,7 +1567,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2653
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1585,7 +1599,7 @@ msgstr ""
 msgid "Delete identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:106 lxc/image_alias.go:107
+#: lxc/image_alias.go:123 lxc/image_alias.go:124
 msgid "Delete image aliases"
 msgstr ""
 
@@ -1609,7 +1623,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:799 lxc/network_forward.go:800
+#: lxc/network_forward.go:807 lxc/network_forward.go:808
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1649,7 +1663,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
+#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1691,13 +1705,13 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
-#: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
-#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
+#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
+#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
+#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
@@ -1711,10 +1725,10 @@ msgstr ""
 #: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:404 lxc/network_forward.go:489
-#: lxc/network_forward.go:599 lxc/network_forward.go:646
-#: lxc/network_forward.go:800 lxc/network_forward.go:874
-#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_forward.go:412 lxc/network_forward.go:497
+#: lxc/network_forward.go:607 lxc/network_forward.go:654
+#: lxc/network_forward.go:808 lxc/network_forward.go:882
+#: lxc/network_forward.go:897 lxc/network_forward.go:982
 #: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
 #: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
 #: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
@@ -1754,27 +1768,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
-#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
-#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
-#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
-#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
-#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
-#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
-#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1465
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1786,11 +1800,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
+#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1840,7 +1854,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:403
+#: lxc/init.go:407
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1852,7 +1866,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1216
+#: lxc/file.go:1236
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1948,7 +1962,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:377 lxc/file.go:378
+#: lxc/file.go:381 lxc/file.go:382
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1988,7 +2002,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:653 lxc/network_forward.go:654
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -2028,7 +2042,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2036,7 +2050,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1785
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2090,11 +2104,11 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
-#: lxc/network_acl.go:524 lxc/network_forward.go:572
+#: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
+#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2105,11 +2119,11 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
-#: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
+#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
-#: lxc/storage_volume.go:2210
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
+#: lxc/storage_volume.go:2212
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2151,8 +2165,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
+#: lxc/storage_volume.go:1577
 msgid "Expires at"
 msgstr ""
 
@@ -2176,7 +2190,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2188,11 +2202,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2650
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2779
+#: lxc/export.go:152 lxc/storage_volume.go:2781
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2211,7 +2225,7 @@ msgid "FILENAME"
 msgstr ""
 
 #: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
-#: lxc/image_alias.go:235
+#: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2219,12 +2233,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1467
+#: lxc/file.go:1491
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1490
+#: lxc/file.go:1514
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2239,12 +2253,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1517
+#: lxc/file.go:1541
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1326
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2274,7 +2288,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1423
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2289,7 +2303,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1428
+#: lxc/file.go:1452
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2299,12 +2313,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1352
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1455
+#: lxc/file.go:1479
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2318,7 +2332,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:304 lxc/move.go:380
+#: lxc/move.go:309 lxc/move.go:385
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2343,7 +2357,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1440
+#: lxc/file.go:1464
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2358,7 +2372,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1042
+#: lxc/file.go:1062
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2445,14 +2459,14 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1625 lxc/warning.go:94
+#: lxc/storage_volume.go:1627 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2520,7 +2534,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1602
+#: lxc/image.go:1602 lxc/image.go:1603
 msgid "Get image properties"
 msgstr ""
 
@@ -2536,7 +2550,7 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:414
 msgid "Get the key as a network forward property"
 msgstr ""
 
@@ -2576,7 +2590,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1249
+#: lxc/storage_volume.go:1251
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2604,7 +2618,7 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:403 lxc/network_forward.go:404
+#: lxc/network_forward.go:411 lxc/network_forward.go:412
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
@@ -2640,11 +2654,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:476
+#: lxc/storage_volume.go:480
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2684,22 +2698,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1540
+#: lxc/file.go:1564
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1529
+#: lxc/file.go:1553
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1376
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1362
+#: lxc/file.go:1386
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2772,11 +2786,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:415
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2786,7 +2800,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2437
+#: lxc/storage_volume.go:2439
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2798,7 +2812,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1517
+#: lxc/image.go:1518
 msgid "Image already up to date."
 msgstr ""
 
@@ -2814,11 +2828,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1472
+#: lxc/image.go:364 lxc/image.go:1473
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1698
+#: lxc/image.go:444 lxc/image.go:1699
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2828,7 +2842,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1515
+#: lxc/image.go:1516
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2836,7 +2850,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2815
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2844,7 +2858,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2814
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2866,11 +2880,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2822
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2894
+#: lxc/storage_volume.go:2896
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2896,11 +2910,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1378
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1531
+#: lxc/file.go:1555
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2909,7 +2923,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:414
+#: lxc/init.go:418
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2918,7 +2932,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1298
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2970,7 +2984,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1293
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2996,23 +3010,23 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2023
+#: lxc/move.go:153 lxc/storage_volume.go:2025
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:144
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2019
+#: lxc/storage_volume.go:2021
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:509
+#: lxc/main.go:518
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:353
+#: lxc/file.go:357
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3022,18 +3036,18 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
-#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
+#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:535
+#: lxc/file.go:548
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:717
+#: lxc/file.go:185 lxc/file.go:739
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3070,7 +3084,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3101,12 +3115,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:176
+#: lxc/init.go:180
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:174
+#: lxc/init.go:178
 msgid "Launching the instance"
 msgstr ""
 
@@ -3204,11 +3218,11 @@ msgstr ""
 msgid "List identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:151
+#: lxc/image_alias.go:176
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:177
 msgid ""
 "List image aliases\n"
 "\n"
@@ -3375,11 +3389,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1605
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1610
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3438,7 +3452,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1481
+#: lxc/info.go:489 lxc/storage_volume.go:1483
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3624,7 +3638,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:873 lxc/network_forward.go:874
+#: lxc/network_forward.go:881 lxc/network_forward.go:882
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -3770,12 +3784,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:322 lxc/move.go:435
+#: lxc/move.go:327 lxc/move.go:440
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:347 lxc/move.go:440
+#: lxc/move.go:352 lxc/move.go:445
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3840,10 +3854,10 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:449
-#: lxc/network_forward.go:534 lxc/network_forward.go:709
-#: lxc/network_forward.go:840 lxc/network_forward.go:933
-#: lxc/network_forward.go:1015 lxc/network_load_balancer.go:221
+#: lxc/network_forward.go:219 lxc/network_forward.go:457
+#: lxc/network_forward.go:542 lxc/network_forward.go:717
+#: lxc/network_forward.go:848 lxc/network_forward.go:945
+#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
 #: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
 #: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
 #: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
@@ -3868,10 +3882,10 @@ msgstr ""
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
 #: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
 #: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:284 lxc/network_forward.go:445
-#: lxc/network_forward.go:530 lxc/network_forward.go:705
-#: lxc/network_forward.go:836 lxc/network_forward.go:929
-#: lxc/network_forward.go:1011 lxc/network_load_balancer.go:131
+#: lxc/network_forward.go:292 lxc/network_forward.go:453
+#: lxc/network_forward.go:538 lxc/network_forward.go:713
+#: lxc/network_forward.go:844 lxc/network_forward.go:941
+#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
 #: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
 #: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
 #: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
@@ -3907,13 +3921,13 @@ msgstr ""
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
-#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
-#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
-#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
+#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
+#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
+#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
+#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
 msgid "Missing pool name"
 msgstr ""
 
@@ -3932,15 +3946,15 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
+#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1411
+#: lxc/storage_volume.go:1413
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:820
+#: lxc/file.go:842
 msgid "Missing target directory"
 msgstr ""
 
@@ -3973,16 +3987,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
-#: lxc/storage_volume.go:975
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
+#: lxc/storage_volume.go:977
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:507
+#: lxc/file.go:520
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1207 lxc/file.go:1208
+#: lxc/file.go:1227 lxc/file.go:1228
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4011,7 +4025,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4019,16 +4033,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1869
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1059 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4050,7 +4064,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
 msgid "NAME"
 msgstr ""
 
@@ -4102,8 +4116,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
-#: lxc/storage_volume.go:1573
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Name"
 msgstr ""
 
@@ -4111,7 +4125,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4166,12 +4180,12 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:386
+#: lxc/network_forward.go:394
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:857
+#: lxc/network_forward.go:865
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -4255,7 +4269,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
+#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4263,7 +4277,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1070 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4275,11 +4289,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4293,7 +4307,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2035
+#: lxc/storage_volume.go:2037
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4301,16 +4315,21 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
-#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
-msgid "Only \"custom\" volumes can be attached to instances"
+#: lxc/storage_volume.go:216
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2701
+#: lxc/storage_volume.go:348
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:2703
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2500
+#: lxc/storage_volume.go:2502
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4322,7 +4341,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1431
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4335,7 +4354,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1577
+#: lxc/info.go:705 lxc/storage_volume.go:1579
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4365,7 +4384,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1767
+#: lxc/storage_volume.go:1769
 msgid "POOL"
 msgstr ""
 
@@ -4382,7 +4401,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167
-#: lxc/storage_volume.go:1773 lxc/warning.go:213
+#: lxc/storage_volume.go:1775 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4406,7 +4425,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:367
+#: lxc/main.go:376
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4444,7 +4463,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1332
+#: lxc/file.go:1356
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4452,12 +4471,12 @@ msgstr ""
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
-#: lxc/network_acl.go:699 lxc/network_forward.go:768
+#: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
-#: lxc/storage_volume.go:1200
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
+#: lxc/storage_volume.go:1202
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4570,11 +4589,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1649
+#: lxc/image.go:1650
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4588,7 +4607,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1238
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4604,7 +4623,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4625,7 +4644,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1017
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4634,7 +4653,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2094
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4647,7 +4666,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2370
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4678,20 +4697,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:455 lxc/file.go:456
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:638 lxc/file.go:989
+#: lxc/file.go:651 lxc/file.go:1009
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:688 lxc/file.go:689
+#: lxc/file.go:701 lxc/file.go:702
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:923 lxc/file.go:1089
+#: lxc/file.go:943 lxc/file.go:1109
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4700,7 +4719,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4729,15 +4748,15 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:463 lxc/file.go:695
+#: lxc/file.go:475 lxc/file.go:708
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1444 lxc/image.go:1445
+#: lxc/image.go:1445 lxc/image.go:1446
 msgid "Refresh images"
 msgstr ""
 
@@ -4746,7 +4765,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1481
+#: lxc/image.go:1482
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4823,7 +4842,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:971 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4859,7 +4878,7 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:969 lxc/network_forward.go:970
+#: lxc/network_forward.go:981 lxc/network_forward.go:982
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -4895,8 +4914,8 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
-#: lxc/image_alias.go:255
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:287
+#: lxc/image_alias.go:288
 msgid "Rename aliases"
 msgstr ""
 
@@ -4932,15 +4951,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1962
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
+#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4992,7 +5011,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5009,7 +5028,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:361
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5058,12 +5077,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1460
+#: lxc/file.go:1484
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1461
+#: lxc/file.go:1485
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5139,7 +5158,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1217
+#: lxc/file.go:1237
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5165,7 +5184,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1665 lxc/image.go:1666
+#: lxc/image.go:1666 lxc/image.go:1667
 msgid "Set image properties"
 msgstr ""
 
@@ -5208,11 +5227,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:488
+#: lxc/network_forward.go:496
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:489
+#: lxc/network_forward.go:497
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5316,11 +5335,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2088
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2089
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5337,7 +5356,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:698
+#: lxc/file.go:711
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5345,7 +5364,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:699
+#: lxc/file.go:712
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5353,7 +5372,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:710
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5365,7 +5384,7 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:504
 msgid "Set the key as a network forward property"
 msgstr ""
 
@@ -5405,7 +5424,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2105
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5413,7 +5432,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1215
+#: lxc/file.go:1235
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5470,7 +5489,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1535 lxc/image.go:1536
+#: lxc/image.go:1536 lxc/image.go:1537
 msgid "Show image properties"
 msgstr ""
 
@@ -5490,7 +5509,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:271 lxc/main.go:272
+#: lxc/main.go:280 lxc/main.go:281
 msgid "Show less common commands"
 msgstr ""
 
@@ -5554,11 +5573,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5626,15 +5645,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2190
+#: lxc/storage_volume.go:2192
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1502
+#: lxc/info.go:619 lxc/storage_volume.go:1504
 msgid "Snapshots:"
 msgstr ""
 
@@ -5739,21 +5758,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:703
+#: lxc/storage_volume.go:707
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:791
+#: lxc/storage_volume.go:795
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:516
+#: lxc/storage_volume.go:520
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:524
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5815,21 +5834,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1747 lxc/warning.go:216
+#: lxc/storage_volume.go:1749 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1262
+#: lxc/file.go:1286
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1256
+#: lxc/file.go:1280
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5839,15 +5858,15 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:181
+#: lxc/move.go:186
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:219 lxc/move.go:240
+#: lxc/move.go:224 lxc/move.go:245
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:193
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5855,15 +5874,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:185
+#: lxc/move.go:190
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:189
+#: lxc/move.go:194
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:210
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5885,7 +5904,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:439
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5938,7 +5957,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:462
+#: lxc/network_forward.go:470
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -5978,12 +5997,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1340
+#: lxc/storage_volume.go:1342
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1317
+#: lxc/storage_volume.go:1319
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -5998,12 +6017,12 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:309
+#: lxc/move.go:314
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
-#: lxc/storage_volume.go:989
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
+#: lxc/storage_volume.go:991
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6031,7 +6050,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:298
+#: lxc/main.go:307
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6055,11 +6074,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:437
+#: lxc/init.go:441
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:440
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6067,7 +6086,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:412
+#: lxc/main.go:421
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6078,7 +6097,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1489
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6093,7 +6112,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1864
+#: lxc/storage_volume.go:1866
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6101,7 +6120,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6118,7 +6137,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:327
+#: lxc/copy.go:382 lxc/move.go:332
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6160,7 +6179,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1472
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6182,13 +6201,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1752
+#: lxc/project.go:995 lxc/storage_volume.go:1754
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1751
+#: lxc/storage.go:724 lxc/storage_volume.go:1753
 msgid "USED BY"
 msgstr ""
 
@@ -6201,7 +6220,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:411
+#: lxc/file.go:423
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6215,12 +6234,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1483
+#: lxc/file.go:1507
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1791
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6231,7 +6250,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1029
+#: lxc/file.go:1049
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6262,7 +6281,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1728 lxc/image.go:1729
+#: lxc/image.go:1729 lxc/image.go:1730
 msgid "Unset image properties"
 msgstr ""
 
@@ -6278,11 +6297,11 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:598
+#: lxc/network_forward.go:606
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:599
+#: lxc/network_forward.go:607
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -6326,7 +6345,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6338,7 +6357,7 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:602
+#: lxc/network_forward.go:610
 msgid "Unset the key as a network forward property"
 msgstr ""
 
@@ -6378,7 +6397,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2381
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6386,7 +6405,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:248
+#: lxc/storage_volume.go:250
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6422,12 +6441,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1485
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2652
+#: lxc/export.go:42 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6494,7 +6513,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1576
+#: lxc/storage_volume.go:1578
 msgid "Volume Only"
 msgstr ""
 
@@ -6545,7 +6564,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:293 lxc/move.go:369
+#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6553,12 +6572,12 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:909
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:912
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:282
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:284
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
@@ -6590,7 +6609,7 @@ msgstr ""
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:174
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
@@ -6643,7 +6662,7 @@ msgstr ""
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: lxc/image_alias.go:104
+#: lxc/image_alias.go:121
 msgid "[<remote>:]<alias>"
 msgstr ""
 
@@ -6651,7 +6670,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/image_alias.go:252
+#: lxc/image_alias.go:285
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
@@ -6705,15 +6724,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1600 lxc/image.go:1727
+#: lxc/image.go:1601 lxc/image.go:1728
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1664
+#: lxc/image.go:1665
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6733,7 +6752,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1443
+#: lxc/image.go:334 lxc/image.go:1444
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6804,7 +6823,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:376
+#: lxc/file.go:380
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -6816,12 +6835,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:454
+#: lxc/file.go:466
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1226
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6889,8 +6908,8 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:644
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:179
+#: lxc/network_forward.go:177 lxc/network_forward.go:652
+#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
 #: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
@@ -6905,12 +6924,12 @@ msgid ""
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:402 lxc/network_forward.go:597
+#: lxc/network_forward.go:410 lxc/network_forward.go:605
 #: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
@@ -6920,13 +6939,13 @@ msgid ""
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:887
+#: lxc/network_forward.go:895
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:968 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -6981,7 +7000,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2811
+#: lxc/storage_volume.go:2813
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7016,65 +7035,65 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1958
+#: lxc/storage_volume.go:1960
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:806
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:167
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
-msgstr ""
-
-#: lxc/storage_volume.go:2562
+#: lxc/storage_volume.go:2564
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2645
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2428
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:610
+#: lxc/storage_volume.go:614
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:718
+#: lxc/storage_volume.go:722
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2364
+#: lxc/storage_volume.go:810
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
+msgstr ""
+
+#: lxc/storage_volume.go:167
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
+msgstr ""
+
+#: lxc/storage_volume.go:2366
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2087
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2245
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1234
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1858
+#: lxc/storage_volume.go:1860
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7180,7 +7199,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1603
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7342,20 +7361,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1230
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:470
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:691
+#: lxc/file.go:704
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7656,7 +7675,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:618
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7664,13 +7683,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2817
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2432
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7704,16 +7723,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1396
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1331
+#: lxc/file.go:1355
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1284
+#: lxc/file.go:1308
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-07 15:11-0700\n"
+"POT-Creation-Date: 2025-01-10 14:44-0600\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -75,7 +75,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:1041
+#: lxc/storage_volume.go:1043
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -379,7 +379,7 @@ msgstr ""
 "### Notez que seules les règles d'entrée et de sortie, la description et les "
 "clés de configuration peuvent être modifiées ."
 
-#: lxc/network_forward.go:667
+#: lxc/network_forward.go:675
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -676,12 +676,12 @@ msgstr "%s (%d de plus)"
 msgid "%s (%s) (%d available)"
 msgstr "%s (%d de plus)"
 
-#: lxc/file.go:1157
+#: lxc/file.go:1177
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s n'est pas un répertoire"
 
-#: lxc/file.go:1047
+#: lxc/file.go:1067
 #, fuzzy, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' n'est pas un format de fichier pris en charge."
@@ -718,7 +718,7 @@ msgstr "--console ne peut être utilisé avec --all"
 msgid "--console only works with a single instance"
 msgstr "--console fonctionne seulement avec une instance seule"
 
-#: lxc/init.go:142 lxc/rebuild.go:65
+#: lxc/init.go:146 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr "--empty ne peut être combiné avec le nom d'une image"
 
@@ -775,7 +775,7 @@ msgstr "Serveur distant : %s"
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:687
+#: lxc/file.go:700
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
@@ -801,7 +801,7 @@ msgstr "<cible>"
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr "ALIAS"
 
@@ -948,7 +948,7 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:888 lxc/network_forward.go:889
+#: lxc/network_forward.go:896 lxc/network_forward.go:897
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -1001,7 +1001,7 @@ msgstr "le serveur distant %s existe déjà"
 msgid "Alias %s doesn't exist"
 msgstr "le serveur distant %s n'existe pas"
 
-#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
+#: lxc/image_alias.go:101 lxc/image_alias.go:156 lxc/image_alias.go:320
 msgid "Alias name missing"
 msgstr ""
 
@@ -1014,7 +1014,7 @@ msgstr "le serveur distant %s existe déjà"
 msgid "Aliases:"
 msgstr "Alias :"
 
-#: lxc/storage_volume.go:1607
+#: lxc/storage_volume.go:1609
 #, fuzzy
 msgid "All projects"
 msgstr "Rendre l'image publique"
@@ -1047,7 +1047,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1074,13 +1074,27 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168 lxc/storage_volume.go:169
+#: lxc/storage_volume.go:168
 #, fuzzy
 msgid "Attach new storage volumes to instances"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:169
+msgid ""
+"Attach new storage volumes to instances\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
+msgstr ""
+
+#: lxc/storage_volume.go:285
 msgid "Attach new storage volumes to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:286
+msgid ""
+"Attach new storage volumes to profiles\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
 #: lxc/console.go:39
@@ -1133,17 +1147,17 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/storage_volume.go:2719
+#: lxc/storage_volume.go:2721
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Copie de l'image : %s"
 
-#: lxc/export.go:192 lxc/storage_volume.go:2796
+#: lxc/export.go:192 lxc/storage_volume.go:2798
 #, fuzzy
 msgid "Backup exported successfully!"
 msgstr "Image copiée avec succès !"
 
-#: lxc/info.go:666 lxc/storage_volume.go:1538
+#: lxc/info.go:666 lxc/storage_volume.go:1540
 msgid "Backups:"
 msgstr ""
 
@@ -1152,19 +1166,19 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
+#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:326
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Clé de configuration invalide"
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1207,7 +1221,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr "COMMON NAME"
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1752
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1261,7 +1275,7 @@ msgstr "Créé : %s"
 msgid "Caches:"
 msgstr "Créé : %s"
 
-#: lxc/move.go:130
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1269,7 +1283,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:562
+#: lxc/file.go:575
 #, fuzzy
 msgid "Can't pull a directory without --recursive"
 msgstr "impossible de récupérer un répertoire sans --recursive"
@@ -1296,11 +1310,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:768
+#: lxc/file.go:790
 #, fuzzy
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "impossible de spécifier uid/gid/mode en mode récursif"
@@ -1315,12 +1329,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:493
+#: lxc/storage_volume.go:497
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:447
+#: lxc/storage_volume.go:451
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1428,9 +1442,9 @@ msgstr "Périphérique %s retiré de %s"
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:497 lxc/network_forward.go:649
-#: lxc/network_forward.go:803 lxc/network_forward.go:892
-#: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
+#: lxc/network_forward.go:505 lxc/network_forward.go:657
+#: lxc/network_forward.go:811 lxc/network_forward.go:900
+#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
 #: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
 #: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
@@ -1442,14 +1456,14 @@ msgstr "Périphérique %s retiré de %s"
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
-#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
-#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
-#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
+#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
 msgid "Cluster member name"
 msgstr ""
 
@@ -1465,7 +1479,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1608
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr "Colonnes"
@@ -1516,21 +1530,21 @@ msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 #: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
-#: lxc/network_acl.go:698 lxc/network_forward.go:767
+#: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
-#: lxc/storage_volume.go:1199
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
+#: lxc/storage_volume.go:1201
 #, c-format
 msgid "Config parsing error: %s"
 msgstr "Erreur lors de la lecture de la configuration : %s"
 
-#: lxc/storage_volume.go:620
+#: lxc/storage_volume.go:624
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1478
+#: lxc/storage_volume.go:1480
 #, fuzzy, c-format
 msgid "Content type: %s"
 msgstr "État : %s"
@@ -1594,7 +1608,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 #, fuzzy
 msgid "Copy storage volumes"
 msgstr "Copie de l'image : %s"
@@ -1604,13 +1618,13 @@ msgstr "Copie de l'image : %s"
 msgid "Copy the instance without its snapshots"
 msgstr "Copiez le conteneur sans ses instantanés"
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:401
 #, fuzzy
 msgid "Copy the volume without its snapshots"
 msgstr "Copiez le conteneur sans ses instantanés"
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1624,7 +1638,7 @@ msgstr "Copie de l'image : %s"
 msgid "Copying the image: %s"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:519
 #, fuzzy, c-format
 msgid "Copying the storage volume: %s"
 msgstr "Copie de l'image : %s"
@@ -1725,7 +1739,7 @@ msgstr "Récupération de l'image : %s"
 msgid "Create and start instances from images"
 msgstr "Création du conteneur"
 
-#: lxc/file.go:143 lxc/file.go:462 lxc/file.go:696
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
 msgid "Create any directories necessary"
 msgstr "Créer tous répertoires nécessaires"
 
@@ -1788,7 +1802,7 @@ msgstr "Copie de l'image : %s"
 msgid "Create new custom storage buckets"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
 #, fuzzy
 msgid "Create new custom storage volumes"
 msgstr "Copie de l'image : %s"
@@ -1851,12 +1865,12 @@ msgstr "Copie de l'image : %s"
 msgid "Create the instance with no profiles applied"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
 #, c-format
 msgid "Created: %s"
 msgstr "Créé : %s"
 
-#: lxc/init.go:182
+#: lxc/init.go:186
 #, c-format
 msgid "Creating %s"
 msgstr "Création de %s"
@@ -1866,7 +1880,7 @@ msgstr "Création de %s"
 msgid "Creating %s: %%s"
 msgstr "Création de %s"
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 #, fuzzy
 msgid "Creating the instance"
 msgstr "Création du conteneur"
@@ -1881,13 +1895,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1749
+#: lxc/storage_volume.go:1751
 msgid "DESCRIPTION"
 msgstr "DESCRIPTION"
 
@@ -1907,7 +1921,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2653
+#: lxc/storage_volume.go:2655
 #, fuzzy
 msgid "Define a compression algorithm: for backup or none"
 msgstr "Définir un algorithme de compression : pour image ou aucun"
@@ -1944,7 +1958,7 @@ msgstr "Récupération de l'image : %s"
 msgid "Delete identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:106 lxc/image_alias.go:107
+#: lxc/image_alias.go:123 lxc/image_alias.go:124
 msgid "Delete image aliases"
 msgstr ""
 
@@ -1972,7 +1986,7 @@ msgstr "Copie de l'image : %s"
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:799 lxc/network_forward.go:800
+#: lxc/network_forward.go:807 lxc/network_forward.go:808
 msgid "Delete network forwards"
 msgstr ""
 
@@ -2018,7 +2032,7 @@ msgstr "Copie de l'image : %s"
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
+#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
 #, fuzzy
 msgid "Delete storage volumes"
 msgstr "Copie de l'image : %s"
@@ -2062,13 +2076,13 @@ msgstr "Récupération de l'image : %s"
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
-#: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
-#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
+#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
+#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
+#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
@@ -2082,10 +2096,10 @@ msgstr "Récupération de l'image : %s"
 #: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:404 lxc/network_forward.go:489
-#: lxc/network_forward.go:599 lxc/network_forward.go:646
-#: lxc/network_forward.go:800 lxc/network_forward.go:874
-#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_forward.go:412 lxc/network_forward.go:497
+#: lxc/network_forward.go:607 lxc/network_forward.go:654
+#: lxc/network_forward.go:808 lxc/network_forward.go:882
+#: lxc/network_forward.go:897 lxc/network_forward.go:982
 #: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
 #: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
 #: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
@@ -2125,27 +2139,27 @@ msgstr "Récupération de l'image : %s"
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
-#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
-#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
-#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
-#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
-#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
-#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
-#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1465
+#: lxc/storage_volume.go:1467
 #, fuzzy, c-format
 msgid "Description: %s"
 msgstr "Empreinte : %s"
 
-#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -2158,12 +2172,12 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
 #, fuzzy
 msgid "Detach storage volumes from instances"
 msgstr "Clé de configuration invalide"
 
-#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
+#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2214,7 +2228,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr "Serveur distant : %s"
 
-#: lxc/init.go:403
+#: lxc/init.go:407
 #, fuzzy
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr "pas d'image, conteneur ou instantané affecté sur ce serveur"
@@ -2227,7 +2241,7 @@ msgstr "L'importation de répertoire n'est pas disponible sur cette plateforme"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1216
+#: lxc/file.go:1236
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2333,7 +2347,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/file.go:377 lxc/file.go:378
+#: lxc/file.go:381 lxc/file.go:382
 #, fuzzy
 msgid "Edit files in instances"
 msgstr "Création du conteneur"
@@ -2381,7 +2395,7 @@ msgstr "Clé de configuration invalide"
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:653 lxc/network_forward.go:654
 #, fuzzy
 msgid "Edit network forward configurations as YAML"
 msgstr "Clé de configuration invalide"
@@ -2428,7 +2442,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2437,7 +2451,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1785
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2492,11 +2506,11 @@ msgid "Error retrieving aliases: %w"
 msgstr "Récupération de l'image : %s"
 
 #: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
-#: lxc/network_acl.go:524 lxc/network_forward.go:572
+#: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
+#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Récupération de l'image : %s"
@@ -2507,11 +2521,11 @@ msgid "Error unsetting properties: %v"
 msgstr "Récupération de l'image : %s"
 
 #: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
-#: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
+#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
-#: lxc/storage_volume.go:2210
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
+#: lxc/storage_volume.go:2212
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2570,8 +2584,8 @@ msgstr ""
 "sélectionné si à la fois stdin et stdout sont des terminaux (stderr\n"
 "est ignoré)."
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
+#: lxc/storage_volume.go:1577
 #, fuzzy
 msgid "Expires at"
 msgstr "Expire : %s"
@@ -2597,7 +2611,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 #, fuzzy
 msgid "Export custom storage volume"
 msgstr "Copie de l'image : %s"
@@ -2612,12 +2626,12 @@ msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 msgid "Export instances as backup tarballs."
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: lxc/storage_volume.go:2650
+#: lxc/storage_volume.go:2652
 #, fuzzy
 msgid "Export the volume without its snapshots"
 msgstr "Copiez le conteneur sans ses instantanés"
 
-#: lxc/export.go:152 lxc/storage_volume.go:2779
+#: lxc/export.go:152 lxc/storage_volume.go:2781
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Import de l'image : %s"
@@ -2637,7 +2651,7 @@ msgid "FILENAME"
 msgstr "NOM"
 
 #: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
-#: lxc/image_alias.go:235
+#: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr "EMPREINTE"
 
@@ -2645,12 +2659,12 @@ msgstr "EMPREINTE"
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1467
+#: lxc/file.go:1491
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1490
+#: lxc/file.go:1514
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2665,12 +2679,12 @@ msgstr "Profil à appliquer au nouveau conteneur"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: lxc/file.go:1517
+#: lxc/file.go:1541
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1326
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Profil à appliquer au nouveau conteneur"
@@ -2700,7 +2714,7 @@ msgstr "Profil à appliquer au nouveau conteneur"
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: lxc/file.go:1423
+#: lxc/file.go:1447
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
@@ -2715,7 +2729,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/file.go:1428
+#: lxc/file.go:1452
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
@@ -2725,12 +2739,12 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed starting command: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/file.go:1328
+#: lxc/file.go:1352
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/file.go:1455
+#: lxc/file.go:1479
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Échec lors de la génération de 'lxc.1': %v"
@@ -2745,7 +2759,7 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed to close server cert file %q: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/move.go:304 lxc/move.go:380
+#: lxc/move.go:309 lxc/move.go:385
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "Profil à appliquer au nouveau conteneur"
@@ -2770,7 +2784,7 @@ msgstr "Profil à appliquer au nouveau conteneur"
 msgid "Failed to find project: %w"
 msgstr "Échec lors de la génération de 'lxc.1': %v"
 
-#: lxc/file.go:1440
+#: lxc/file.go:1464
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Échec lors de la génération de 'lxc.1': %v"
@@ -2785,7 +2799,7 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Failed to remove alias %s: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/file.go:1042
+#: lxc/file.go:1062
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2877,14 +2891,14 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1625 lxc/warning.go:94
+#: lxc/storage_volume.go:1627 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2953,7 +2967,7 @@ msgstr "Création du conteneur"
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1602
+#: lxc/image.go:1602 lxc/image.go:1603
 msgid "Get image properties"
 msgstr ""
 
@@ -2969,7 +2983,7 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:414
 #, fuzzy
 msgid "Get the key as a network forward property"
 msgstr "Copie de l'image : %s"
@@ -3016,7 +3030,7 @@ msgstr "Copie de l'image : %s"
 msgid "Get the key as a storage property"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:1249
+#: lxc/storage_volume.go:1251
 #, fuzzy
 msgid "Get the key as a storage volume property"
 msgstr "Copie de l'image : %s"
@@ -3050,7 +3064,7 @@ msgstr "Clé de configuration invalide"
 msgid "Get values for network configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_forward.go:403 lxc/network_forward.go:404
+#: lxc/network_forward.go:411 lxc/network_forward.go:412
 #, fuzzy
 msgid "Get values for network forward configuration keys"
 msgstr "Clé de configuration invalide"
@@ -3094,11 +3108,11 @@ msgstr "Clé de configuration invalide"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:476
+#: lxc/storage_volume.go:480
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -3140,22 +3154,22 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1540
+#: lxc/file.go:1564
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/file.go:1529
+#: lxc/file.go:1553
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/file.go:1352
+#: lxc/file.go:1376
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/file.go:1362
+#: lxc/file.go:1386
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "L'arrêt du conteneur a échoué !"
@@ -3231,11 +3245,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:415
 #, fuzzy
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
@@ -3248,7 +3262,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2437
+#: lxc/storage_volume.go:2439
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3261,7 +3275,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/image.go:1517
+#: lxc/image.go:1518
 msgid "Image already up to date."
 msgstr ""
 
@@ -3278,11 +3292,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr "Image copiée avec succès !"
 
-#: lxc/image.go:364 lxc/image.go:1472
+#: lxc/image.go:364 lxc/image.go:1473
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1698
+#: lxc/image.go:444 lxc/image.go:1699
 #, fuzzy, c-format
 msgid "Image identifier missing: %s"
 msgstr "Image importée avec l'empreinte : %s"
@@ -3292,7 +3306,7 @@ msgstr "Image importée avec l'empreinte : %s"
 msgid "Image imported with fingerprint: %s"
 msgstr "Image importée avec l'empreinte : %s"
 
-#: lxc/image.go:1515
+#: lxc/image.go:1516
 #, fuzzy
 msgid "Image refreshed successfully!"
 msgstr "Image copiée avec succès !"
@@ -3302,7 +3316,7 @@ msgstr "Image copiée avec succès !"
 msgid "Immediately attach to the console"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2815
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3310,7 +3324,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2814
 #, fuzzy
 msgid "Import custom storage volumes"
 msgstr "Copie de l'image : %s"
@@ -3335,11 +3349,11 @@ msgstr "Import de l'image : %s"
 msgid "Import instance backups"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2822
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2894
+#: lxc/storage_volume.go:2896
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
@@ -3366,12 +3380,12 @@ msgstr ""
 msgid "Instance Only"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/file.go:1354
+#: lxc/file.go:1378
 #, fuzzy
 msgid "Instance disconnected"
 msgstr "Mot de passe de l'administrateur distant"
 
-#: lxc/file.go:1531
+#: lxc/file.go:1555
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3381,7 +3395,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr "Le nom du conteneur est obligatoire"
 
-#: lxc/init.go:414
+#: lxc/init.go:418
 #, fuzzy, c-format
 msgid "Instance name is: %s"
 msgstr "Le nom du conteneur est : %s"
@@ -3391,7 +3405,7 @@ msgstr "Le nom du conteneur est : %s"
 msgid "Instance name must be specified"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/file.go:1274
+#: lxc/file.go:1298
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3443,7 +3457,7 @@ msgstr "Cible invalide %s"
 msgid "Invalid instance name: %s"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/file.go:1269
+#: lxc/file.go:1293
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Le nom du conteneur est : %s"
@@ -3469,25 +3483,25 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2023
+#: lxc/move.go:153 lxc/storage_volume.go:2025
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "'/' n'est pas autorisé dans le nom d'un instantané"
 
-#: lxc/move.go:144
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2019
+#: lxc/storage_volume.go:2021
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:509
+#: lxc/main.go:518
 #, fuzzy
 msgid "Invalid number of arguments"
 msgstr "nombre d'arguments incorrect pour la sous-comande"
 
-#: lxc/file.go:353
+#: lxc/file.go:357
 #, fuzzy, c-format
 msgid "Invalid path %s"
 msgstr "Cible invalide %s"
@@ -3497,19 +3511,19 @@ msgstr "Cible invalide %s"
 msgid "Invalid protocol: %s"
 msgstr "Cible invalide %s"
 
-#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
-#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
+#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/file.go:535
+#: lxc/file.go:548
 #, c-format
 msgid "Invalid source %s"
 msgstr "Source invalide %s"
 
-#: lxc/file.go:185 lxc/file.go:717
+#: lxc/file.go:185 lxc/file.go:739
 #, c-format
 msgid "Invalid target %s"
 msgstr "Cible invalide %s"
@@ -3547,7 +3561,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3578,12 +3592,12 @@ msgstr "Dernière utilisation : %s"
 msgid "Last used: never"
 msgstr "Dernière utilisation : jamais"
 
-#: lxc/init.go:176
+#: lxc/init.go:180
 #, fuzzy, c-format
 msgid "Launching %s"
 msgstr "Création de %s"
 
-#: lxc/init.go:174
+#: lxc/init.go:178
 #, fuzzy
 msgid "Launching the instance"
 msgstr "Création du conteneur"
@@ -3690,11 +3704,11 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "List identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:151
+#: lxc/image_alias.go:176
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:177
 msgid ""
 "List image aliases\n"
 "\n"
@@ -3928,12 +3942,12 @@ msgstr "Copie de l'image : %s"
 msgid "List storage buckets"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1605
 #, fuzzy
 msgid "List storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1610
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3993,7 +4007,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1481
+#: lxc/info.go:489 lxc/storage_volume.go:1483
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4196,7 +4210,7 @@ msgstr "Copie de l'image : %s"
 msgid "Manage network ACLs"
 msgstr "Nom du réseau"
 
-#: lxc/network_forward.go:873 lxc/network_forward.go:874
+#: lxc/network_forward.go:881 lxc/network_forward.go:882
 #, fuzzy
 msgid "Manage network forward ports"
 msgstr "Copie de l'image : %s"
@@ -4364,12 +4378,12 @@ msgstr "  Mémoire utilisée :"
 msgid "Memory:"
 msgstr "  Mémoire utilisée :"
 
-#: lxc/move.go:322 lxc/move.go:435
+#: lxc/move.go:327 lxc/move.go:440
 #, fuzzy, c-format
 msgid "Migration API failure: %w"
 msgstr "Échec lors de la migration vers l'hôte source: %s"
 
-#: lxc/move.go:347 lxc/move.go:440
+#: lxc/move.go:352 lxc/move.go:445
 #, fuzzy, c-format
 msgid "Migration operation failure: %w"
 msgstr "Échec lors de la migration vers l'hôte source: %s"
@@ -4444,10 +4458,10 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "Missing key name"
 msgstr "Résumé manquant."
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:449
-#: lxc/network_forward.go:534 lxc/network_forward.go:709
-#: lxc/network_forward.go:840 lxc/network_forward.go:933
-#: lxc/network_forward.go:1015 lxc/network_load_balancer.go:221
+#: lxc/network_forward.go:219 lxc/network_forward.go:457
+#: lxc/network_forward.go:542 lxc/network_forward.go:717
+#: lxc/network_forward.go:848 lxc/network_forward.go:945
+#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
 #: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
 #: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
 #: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
@@ -4475,10 +4489,10 @@ msgstr "Nom du réseau"
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
 #: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
 #: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:284 lxc/network_forward.go:445
-#: lxc/network_forward.go:530 lxc/network_forward.go:705
-#: lxc/network_forward.go:836 lxc/network_forward.go:929
-#: lxc/network_forward.go:1011 lxc/network_load_balancer.go:131
+#: lxc/network_forward.go:292 lxc/network_forward.go:453
+#: lxc/network_forward.go:538 lxc/network_forward.go:713
+#: lxc/network_forward.go:844 lxc/network_forward.go:941
+#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
 #: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
 #: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
 #: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
@@ -4518,13 +4532,13 @@ msgstr "Résumé manquant."
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
-#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
-#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
-#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
+#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
+#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
+#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
+#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
 #, fuzzy
 msgid "Missing pool name"
 msgstr "Nom de l'ensemble de stockage"
@@ -4545,17 +4559,17 @@ msgstr "Nom de l'ensemble de stockage"
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
+#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
 #, fuzzy
 msgid "Missing source volume name"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:1411
+#: lxc/storage_volume.go:1413
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Nom de l'ensemble de stockage"
 
-#: lxc/file.go:820
+#: lxc/file.go:842
 #, fuzzy
 msgid "Missing target directory"
 msgstr "%s n'est pas un répertoire"
@@ -4591,18 +4605,18 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
-#: lxc/storage_volume.go:975
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
+#: lxc/storage_volume.go:977
 #, fuzzy
 msgid "More than one device matches, specify the device name"
 msgstr "Plus d'un périphérique correspond, spécifier le nom du périphérique."
 
-#: lxc/file.go:507
+#: lxc/file.go:520
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "Plusieurs fichiers à télécharger, mais la destination n'est pas un dossier"
 
-#: lxc/file.go:1207 lxc/file.go:1208
+#: lxc/file.go:1227 lxc/file.go:1228
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Création du conteneur"
@@ -4633,7 +4647,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
 #, fuzzy
 msgid "Move storage volumes between pools"
 msgstr "Copie de l'image : %s"
@@ -4643,16 +4657,16 @@ msgstr "Copie de l'image : %s"
 msgid "Move the instance without its snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1869
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 #, fuzzy, c-format
 msgid "Moving the storage volume: %s"
 msgstr "Copie de l'image : %s"
 
-#: lxc/network_forward.go:1059 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4675,7 +4689,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
 msgid "NAME"
 msgstr "NOM"
 
@@ -4727,8 +4741,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
-#: lxc/storage_volume.go:1573
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 #, fuzzy
 msgid "Name"
 msgstr "Nom : %s"
@@ -4737,7 +4751,7 @@ msgstr "Nom : %s"
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
 #, c-format
 msgid "Name: %s"
 msgstr "Nom : %s"
@@ -4792,12 +4806,12 @@ msgstr "Le réseau %s a été créé"
 msgid "Network Zone %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: lxc/network_forward.go:386
+#: lxc/network_forward.go:394
 #, fuzzy, c-format
 msgid "Network forward %s created"
 msgstr "Le réseau %s a été créé"
 
-#: lxc/network_forward.go:857
+#: lxc/network_forward.go:865
 #, fuzzy, c-format
 msgid "Network forward %s deleted"
 msgstr "Le réseau %s a été supprimé"
@@ -4885,7 +4899,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr "Aucun périphérique existant pour ce réseau"
 
-#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
+#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
 #, fuzzy
 msgid "No device found for this storage volume"
 msgstr "Aucun périphérique existant pour ce réseau"
@@ -4894,7 +4908,7 @@ msgstr "Aucun périphérique existant pour ce réseau"
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1070 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4907,11 +4921,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr "vous devez spécifier un nom de conteneur source"
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4925,7 +4939,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2035
+#: lxc/storage_volume.go:2037
 #, fuzzy
 msgid "Not a snapshot name"
 msgstr "'/' n'est pas autorisé dans le nom d'un instantané"
@@ -4934,20 +4948,27 @@ msgstr "'/' n'est pas autorisé dans le nom d'un instantané"
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
-#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
+#: lxc/storage_volume.go:216
 #, fuzzy
-msgid "Only \"custom\" volumes can be attached to instances"
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 "Seuls les volumes \"personnalisés\" peuvent être attachés aux conteneurs."
 
-#: lxc/storage_volume.go:2701
+#: lxc/storage_volume.go:348
+#, fuzzy
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
+msgstr ""
+"Seuls les volumes \"personnalisés\" peuvent être attachés aux conteneurs."
+
+#: lxc/storage_volume.go:2703
 #, fuzzy
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 "Seuls les volumes \"personnalisés\" peuvent être attachés aux conteneurs."
 
-#: lxc/storage_volume.go:2500
+#: lxc/storage_volume.go:2502
 #, fuzzy
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
@@ -4962,7 +4983,7 @@ msgstr "Seules les URLs https sont supportées par simplestreams"
 msgid "Only https:// is supported for remote image import"
 msgstr "Seul https:// est supporté par l'import d'images distantes."
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1431
 #, fuzzy
 msgid "Only instance or custom volumes are supported"
 msgstr ""
@@ -4978,7 +4999,7 @@ msgstr "Seuls les réseaux gérés par LXD peuvent être modifiés."
 msgid "Operation %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: lxc/info.go:705 lxc/storage_volume.go:1577
+#: lxc/info.go:705 lxc/storage_volume.go:1579
 msgid "Optimized Storage"
 msgstr ""
 
@@ -5009,7 +5030,7 @@ msgstr "PID"
 msgid "PID: %d"
 msgstr "Pid : %d"
 
-#: lxc/storage_volume.go:1767
+#: lxc/storage_volume.go:1769
 msgid "POOL"
 msgstr ""
 
@@ -5026,7 +5047,7 @@ msgid "PROFILES"
 msgstr "PROFILS"
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167
-#: lxc/storage_volume.go:1773 lxc/warning.go:213
+#: lxc/storage_volume.go:1775 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -5051,7 +5072,7 @@ msgstr "Paquets émis"
 msgid "Partitions:"
 msgstr "Options :"
 
-#: lxc/main.go:367
+#: lxc/main.go:376
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Mot de passe administrateur pour %s : "
@@ -5093,7 +5114,7 @@ msgstr "État : %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1332
+#: lxc/file.go:1356
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -5101,12 +5122,12 @@ msgstr ""
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
-#: lxc/network_acl.go:699 lxc/network_forward.go:768
+#: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
-#: lxc/storage_volume.go:1200
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
+#: lxc/storage_volume.go:1202
 #, fuzzy
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr "Appuyer sur Entrée pour ouvrir à nouveau l'éditeur"
@@ -5225,11 +5246,11 @@ msgstr ""
 msgid "Properties:"
 msgstr "Propriétés :"
 
-#: lxc/image.go:1649
+#: lxc/image.go:1650
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -5243,7 +5264,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1238
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5259,7 +5280,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5280,7 +5301,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1017
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5289,7 +5310,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2094
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5302,7 +5323,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2370
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5334,22 +5355,22 @@ msgstr "Création du conteneur"
 msgid "Publishing instance: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/file.go:455 lxc/file.go:456
+#: lxc/file.go:467 lxc/file.go:468
 #, fuzzy
 msgid "Pull files from instances"
 msgstr "Création du conteneur"
 
-#: lxc/file.go:638 lxc/file.go:989
+#: lxc/file.go:651 lxc/file.go:1009
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:688 lxc/file.go:689
+#: lxc/file.go:701 lxc/file.go:702
 #, fuzzy
 msgid "Push files into instances"
 msgstr "Création du conteneur"
 
-#: lxc/file.go:923 lxc/file.go:1089
+#: lxc/file.go:943 lxc/file.go:1109
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5358,7 +5379,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5390,17 +5411,17 @@ msgstr "Création du conteneur"
 msgid "Rebuild instances"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/file.go:463 lxc/file.go:695
+#: lxc/file.go:475 lxc/file.go:708
 #, fuzzy
 msgid "Recursively transfer files"
 msgstr "Pousser ou récupérer des fichiers récursivement"
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:403
 #, fuzzy
 msgid "Refresh and update the existing storage volume copies"
 msgstr "Copie de l'image : %s"
 
-#: lxc/image.go:1444 lxc/image.go:1445
+#: lxc/image.go:1445 lxc/image.go:1446
 #, fuzzy
 msgid "Refresh images"
 msgstr "Récupération de l'image : %s"
@@ -5410,7 +5431,7 @@ msgstr "Récupération de l'image : %s"
 msgid "Refreshing instance: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/image.go:1481
+#: lxc/image.go:1482
 #, fuzzy, c-format
 msgid "Refreshing the image: %s"
 msgstr "Récupération de l'image : %s"
@@ -5492,7 +5513,7 @@ msgstr "Clé de configuration invalide"
 msgid "Remove aliases"
 msgstr "Mot de passe de l'administrateur distant"
 
-#: lxc/network_forward.go:971 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -5534,7 +5555,7 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr "Création du conteneur"
 
-#: lxc/network_forward.go:969 lxc/network_forward.go:970
+#: lxc/network_forward.go:981 lxc/network_forward.go:982
 #, fuzzy
 msgid "Remove ports from a forward"
 msgstr "Création du conteneur"
@@ -5576,8 +5597,8 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
-#: lxc/image_alias.go:255
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:287
+#: lxc/image_alias.go:288
 msgid "Rename aliases"
 msgstr ""
 
@@ -5617,17 +5638,17 @@ msgstr "Créé : %s"
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1962
 #, fuzzy
 msgid "Rename storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1961
 #, fuzzy
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
+#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5699,7 +5720,7 @@ msgstr ""
 "Exemple :\n"
 "    lxc snapshot u1 snap0"
 
-#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
 #, fuzzy
 msgid "Restore storage volume snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
@@ -5718,7 +5739,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: lxc/init.go:357
+#: lxc/init.go:361
 #, c-format
 msgid "Retrieving image: %s"
 msgstr "Récupération de l'image : %s"
@@ -5770,12 +5791,12 @@ msgstr "SOURCE"
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1460
+#: lxc/file.go:1484
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1461
+#: lxc/file.go:1485
 #, fuzzy, c-format
 msgid "SSH client disconnected %q"
 msgstr "Mot de passe de l'administrateur distant"
@@ -5858,7 +5879,7 @@ msgstr "Création du conteneur"
 msgid "Set a cluster member's configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/file.go:1217
+#: lxc/file.go:1237
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5885,7 +5906,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1665 lxc/image.go:1666
+#: lxc/image.go:1666 lxc/image.go:1667
 msgid "Set image properties"
 msgstr ""
 
@@ -5931,12 +5952,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:488
+#: lxc/network_forward.go:496
 #, fuzzy
 msgid "Set network forward keys"
 msgstr "Nom du réseau"
 
-#: lxc/network_forward.go:489
+#: lxc/network_forward.go:497
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -6048,12 +6069,12 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2088
 #, fuzzy
 msgid "Set storage volume configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2089
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -6071,7 +6092,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr "Définir le gid du fichier lors de l'envoi"
 
-#: lxc/file.go:698
+#: lxc/file.go:711
 msgid "Set the file's gid on push"
 msgstr "Définir le gid du fichier lors de l'envoi"
 
@@ -6080,7 +6101,7 @@ msgstr "Définir le gid du fichier lors de l'envoi"
 msgid "Set the file's perms on create"
 msgstr "Définir les permissions du fichier lors de l'envoi"
 
-#: lxc/file.go:699
+#: lxc/file.go:712
 msgid "Set the file's perms on push"
 msgstr "Définir les permissions du fichier lors de l'envoi"
 
@@ -6089,7 +6110,7 @@ msgstr "Définir les permissions du fichier lors de l'envoi"
 msgid "Set the file's uid on create"
 msgstr "Définir l'uid du fichier lors de l'envoi"
 
-#: lxc/file.go:697
+#: lxc/file.go:710
 msgid "Set the file's uid on push"
 msgstr "Définir l'uid du fichier lors de l'envoi"
 
@@ -6101,7 +6122,7 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:504
 #, fuzzy
 msgid "Set the key as a network forward property"
 msgstr "Nom du réseau"
@@ -6148,7 +6169,7 @@ msgstr "Copie de l'image : %s"
 msgid "Set the key as a storage property"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2105
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "Copie de l'image : %s"
@@ -6157,7 +6178,7 @@ msgstr "Copie de l'image : %s"
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1215
+#: lxc/file.go:1235
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -6218,7 +6239,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1535 lxc/image.go:1536
+#: lxc/image.go:1536 lxc/image.go:1537
 msgid "Show image properties"
 msgstr ""
 
@@ -6242,7 +6263,7 @@ msgstr "Afficher la configuration étendue"
 msgid "Show instance or server information"
 msgstr "Afficher des informations supplémentaires"
 
-#: lxc/main.go:271 lxc/main.go:272
+#: lxc/main.go:280 lxc/main.go:281
 #, fuzzy
 msgid "Show less common commands"
 msgstr "Afficher les commandes moins communes"
@@ -6321,12 +6342,12 @@ msgstr "Afficher la configuration étendue"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
 #, fuzzy
 msgid "Show storage volume configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
 #, fuzzy
 msgid "Show storage volume state information"
 msgstr "Afficher la configuration étendue"
@@ -6399,16 +6420,16 @@ msgstr "Taille : %.2f Mo"
 msgid "Size: %s"
 msgstr "État : %s"
 
-#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
 #, fuzzy
 msgid "Snapshot storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:2190
+#: lxc/storage_volume.go:2192
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1502
+#: lxc/info.go:619 lxc/storage_volume.go:1504
 msgid "Snapshots:"
 msgstr "Instantanés :"
 
@@ -6519,22 +6540,22 @@ msgstr "Le réseau %s a été créé"
 msgid "Storage pool name"
 msgstr "Nom de l'ensemble de stockage"
 
-#: lxc/storage_volume.go:703
+#: lxc/storage_volume.go:707
 #, fuzzy, c-format
 msgid "Storage volume %s created"
 msgstr "Profil %s créé"
 
-#: lxc/storage_volume.go:791
+#: lxc/storage_volume.go:795
 #, fuzzy, c-format
 msgid "Storage volume %s deleted"
 msgstr "Profil %s supprimé"
 
-#: lxc/storage_volume.go:516
+#: lxc/storage_volume.go:520
 #, fuzzy
 msgid "Storage volume copied successfully!"
 msgstr "Image copiée avec succès !"
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:524
 #, fuzzy
 msgid "Storage volume moved successfully!"
 msgstr "Image copiée avec succès !"
@@ -6600,22 +6621,22 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1747 lxc/warning.go:216
+#: lxc/storage_volume.go:1749 lxc/warning.go:216
 msgid "TYPE"
 msgstr "TYPE"
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
 #, fuzzy
 msgid "Taken at"
 msgstr "pris à %s"
 
-#: lxc/file.go:1262
+#: lxc/file.go:1286
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1256
+#: lxc/file.go:1280
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6625,15 +6646,15 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:181
+#: lxc/move.go:186
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:219 lxc/move.go:240
+#: lxc/move.go:224 lxc/move.go:245
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:193
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -6641,15 +6662,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:185
+#: lxc/move.go:190
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:189
+#: lxc/move.go:194
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:210
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -6677,7 +6698,7 @@ msgstr ""
 "Le conteneur est en cours d'exécution. Utiliser --force pour qu'il soit "
 "arrêté et redémarré."
 
-#: lxc/init.go:435
+#: lxc/init.go:439
 #, fuzzy
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
@@ -6733,7 +6754,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/network_forward.go:462
+#: lxc/network_forward.go:470
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -6773,12 +6794,12 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/storage_volume.go:1340
+#: lxc/storage_volume.go:1342
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/storage_volume.go:1317
+#: lxc/storage_volume.go:1319
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6793,12 +6814,12 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:309
+#: lxc/move.go:314
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
-#: lxc/storage_volume.go:989
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
+#: lxc/storage_volume.go:991
 msgid "The specified device doesn't exist"
 msgstr "Le périphérique indiqué n'existe pas"
 
@@ -6828,7 +6849,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr "L'importation de répertoire n'est pas disponible sur cette plateforme"
 
-#: lxc/main.go:298
+#: lxc/main.go:307
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6853,12 +6874,12 @@ msgstr "Temps d'attente du conteneur avant de le tuer"
 msgid "Timestamps:"
 msgstr "Horodatage :"
 
-#: lxc/init.go:437
+#: lxc/init.go:441
 #, fuzzy
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr "Pour attacher un réseau à un conteneur, utiliser : lxc network attach"
 
-#: lxc/init.go:436
+#: lxc/init.go:440
 msgid "To create a new network, use: lxc network create"
 msgstr "Pour créer un réseau, utiliser : lxc network create"
 
@@ -6866,7 +6887,7 @@ msgstr "Pour créer un réseau, utiliser : lxc network create"
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:412
+#: lxc/main.go:421
 #, fuzzy
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
@@ -6879,7 +6900,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1489
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Publié : %s"
@@ -6894,7 +6915,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr "Transfert de l'image : %s"
 
-#: lxc/storage_volume.go:1864
+#: lxc/storage_volume.go:1866
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6902,7 +6923,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6919,7 +6940,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr "Transfert de l'image : %s"
 
-#: lxc/copy.go:382 lxc/move.go:327
+#: lxc/copy.go:382 lxc/move.go:332
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "Transfert de l'image : %s"
@@ -6964,7 +6985,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1472
+#: lxc/storage_volume.go:1474
 #, fuzzy, c-format
 msgid "Type: %s"
 msgstr "Expire : %s"
@@ -6986,13 +7007,13 @@ msgstr "DATE DE PUBLICATION"
 msgid "URL"
 msgstr "URL"
 
-#: lxc/project.go:995 lxc/storage_volume.go:1752
+#: lxc/project.go:995 lxc/storage_volume.go:1754
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1751
+#: lxc/storage.go:724 lxc/storage_volume.go:1753
 msgid "USED BY"
 msgstr "UTILISÉ PAR"
 
@@ -7005,7 +7026,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:411
+#: lxc/file.go:423
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -7020,12 +7041,12 @@ msgstr "Ajouter de nouveaux serveurs distants"
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1483
+#: lxc/file.go:1507
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1791
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -7036,7 +7057,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1029
+#: lxc/file.go:1049
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -7071,7 +7092,7 @@ msgstr "tous les profils de la source n'existent pas sur la cible"
 msgid "Unset device configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/image.go:1728 lxc/image.go:1729
+#: lxc/image.go:1729 lxc/image.go:1730
 msgid "Unset image properties"
 msgstr ""
 
@@ -7090,12 +7111,12 @@ msgstr "Clé de configuration invalide"
 msgid "Unset network configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_forward.go:598
+#: lxc/network_forward.go:606
 #, fuzzy
 msgid "Unset network forward configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network_forward.go:599
+#: lxc/network_forward.go:607
 #, fuzzy
 msgid "Unset network forward keys"
 msgstr "Nom du réseau"
@@ -7150,7 +7171,7 @@ msgstr "Clé de configuration invalide"
 msgid "Unset storage pool configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
 #, fuzzy
 msgid "Unset storage volume configuration keys"
 msgstr "Clé de configuration invalide"
@@ -7163,7 +7184,7 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:602
+#: lxc/network_forward.go:610
 #, fuzzy
 msgid "Unset the key as a network forward property"
 msgstr "Nom du réseau"
@@ -7211,7 +7232,7 @@ msgstr "Copie de l'image : %s"
 msgid "Unset the key as a storage property"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2381
 #, fuzzy
 msgid "Unset the key as a storage volume property"
 msgstr "Copie de l'image : %s"
@@ -7220,7 +7241,7 @@ msgstr "Copie de l'image : %s"
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:248
+#: lxc/storage_volume.go:250
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -7258,12 +7279,12 @@ msgstr "Publié : %s"
 msgid "Upper devices"
 msgstr "Création du conteneur"
 
-#: lxc/storage_volume.go:1485
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Usage: %s"
 msgstr "Utilisation : %s"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2652
+#: lxc/export.go:42 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -7332,7 +7353,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
-#: lxc/storage_volume.go:1576
+#: lxc/storage_volume.go:1578
 msgid "Volume Only"
 msgstr ""
 
@@ -7390,7 +7411,7 @@ msgstr "impossible de copier vers le même nom de conteneur"
 msgid "You must specify a destination instance name"
 msgstr "vous devez spécifier un nom de conteneur source"
 
-#: lxc/copy.go:98 lxc/move.go:293 lxc/move.go:369
+#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
 #, fuzzy
 msgid "You must specify a source instance name"
 msgstr "vous devez spécifier un nom de conteneur source"
@@ -7400,17 +7421,17 @@ msgstr "vous devez spécifier un nom de conteneur source"
 msgid "You need to specify an image name or use --empty"
 msgstr "vous devez spécifier un nom de conteneur source"
 
-#: lxc/storage_volume.go:909
+#: lxc/storage_volume.go:912
 #, fuzzy
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 "Change l'état d'un ou plusieurs conteneurs à %s.\n"
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:282
+#: lxc/storage_volume.go:284
 #, fuzzy
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 "Change l'état d'un ou plusieurs conteneurs à %s.\n"
 "\n"
@@ -7474,7 +7495,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:174
 #, fuzzy
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
@@ -7580,7 +7601,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image_alias.go:104
+#: lxc/image_alias.go:121
 #, fuzzy
 msgid "[<remote>:]<alias>"
 msgstr ""
@@ -7604,7 +7625,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/image_alias.go:252
+#: lxc/image_alias.go:285
 #, fuzzy
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
@@ -7702,7 +7723,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr ""
@@ -7714,7 +7735,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/image.go:1600 lxc/image.go:1727
+#: lxc/image.go:1601 lxc/image.go:1728
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr ""
@@ -7726,7 +7747,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/image.go:1664
+#: lxc/image.go:1665
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
@@ -7766,7 +7787,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:334 lxc/image.go:1443
+#: lxc/image.go:334 lxc/image.go:1444
 #, fuzzy
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
@@ -7933,7 +7954,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:376
+#: lxc/file.go:380
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
@@ -7965,7 +7986,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:454
+#: lxc/file.go:466
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
@@ -7978,7 +7999,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/file.go:1206
+#: lxc/file.go:1226
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
@@ -8143,8 +8164,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:644
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:179
+#: lxc/network_forward.go:177 lxc/network_forward.go:652
+#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
 #: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address>"
@@ -8171,7 +8192,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:402 lxc/network_forward.go:597
+#: lxc/network_forward.go:410 lxc/network_forward.go:605
 #: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>"
@@ -8180,7 +8201,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:487 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
@@ -8198,13 +8219,13 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:887
+#: lxc/network_forward.go:895
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:968 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
@@ -8311,7 +8332,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2811
+#: lxc/storage_volume.go:2813
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
@@ -8378,7 +8399,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1958
+#: lxc/storage_volume.go:1960
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
@@ -8392,23 +8413,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:806
-#, fuzzy
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
-msgstr ""
-"Change l'état d'un ou plusieurs conteneurs à %s.\n"
-"\n"
-"lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
-
-#: lxc/storage_volume.go:167
-#, fuzzy
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
-msgstr ""
-"Change l'état d'un ou plusieurs conteneurs à %s.\n"
-"\n"
-"lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
-
-#: lxc/storage_volume.go:2562
+#: lxc/storage_volume.go:2564
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
@@ -8420,7 +8425,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:2645
+#: lxc/storage_volume.go:2647
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
@@ -8432,7 +8437,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2428
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
@@ -8444,7 +8449,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:610
+#: lxc/storage_volume.go:614
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
@@ -8452,7 +8457,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:718
+#: lxc/storage_volume.go:722
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
@@ -8464,7 +8469,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
@@ -8472,7 +8477,23 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2364
+#: lxc/storage_volume.go:810
+#, fuzzy
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
+msgstr ""
+"Change l'état d'un ou plusieurs conteneurs à %s.\n"
+"\n"
+"lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
+
+#: lxc/storage_volume.go:167
+#, fuzzy
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
+msgstr ""
+"Change l'état d'un ou plusieurs conteneurs à %s.\n"
+"\n"
+"lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
+
+#: lxc/storage_volume.go:2366
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
@@ -8480,7 +8501,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2087
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
@@ -8488,7 +8509,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2245
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
@@ -8500,7 +8521,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1234
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
@@ -8512,7 +8533,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:1858
+#: lxc/storage_volume.go:1860
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -8520,7 +8541,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:392
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -8746,7 +8767,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1603
 #, fuzzy
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
@@ -8933,20 +8954,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1230
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:470
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:691
+#: lxc/file.go:704
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -9269,7 +9290,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:618
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -9277,13 +9298,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2817
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2432
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -9318,16 +9339,16 @@ msgstr "s'il vous plaît utilisez  `lxc profile`"
 msgid "space used"
 msgstr "espace utilisé"
 
-#: lxc/file.go:1372
+#: lxc/file.go:1396
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1331
+#: lxc/file.go:1355
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1284
+#: lxc/file.go:1308
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-07 15:11-0700\n"
+"POT-Creation-Date: 2025-01-10 14:44-0600\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -50,7 +50,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1041
+#: lxc/storage_volume.go:1043
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -255,7 +255,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:667
+#: lxc/network_forward.go:675
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -431,12 +431,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1157
+#: lxc/file.go:1177
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1047
+#: lxc/file.go:1067
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -472,7 +472,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:65
+#: lxc/init.go:146 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -525,7 +525,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:687
+#: lxc/file.go:700
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -542,7 +542,7 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
@@ -673,7 +673,7 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:888 lxc/network_forward.go:889
+#: lxc/network_forward.go:896 lxc/network_forward.go:897
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
+#: lxc/image_alias.go:101 lxc/image_alias.go:156 lxc/image_alias.go:320
 msgid "Alias name missing"
 msgstr ""
 
@@ -736,7 +736,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1607
+#: lxc/storage_volume.go:1609
 msgid "All projects"
 msgstr ""
 
@@ -767,7 +767,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -791,12 +791,26 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168 lxc/storage_volume.go:169
+#: lxc/storage_volume.go:168
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:169
+msgid ""
+"Attach new storage volumes to instances\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
+msgstr ""
+
+#: lxc/storage_volume.go:285
 msgid "Attach new storage volumes to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:286
+msgid ""
+"Attach new storage volumes to profiles\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
 #: lxc/console.go:39
@@ -847,16 +861,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2719
+#: lxc/storage_volume.go:2721
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2796
+#: lxc/export.go:192 lxc/storage_volume.go:2798
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1538
+#: lxc/info.go:666 lxc/storage_volume.go:1540
 msgid "Backups:"
 msgstr ""
 
@@ -865,19 +879,19 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
+#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:326
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -920,7 +934,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1752
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -972,7 +986,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -980,7 +994,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:562
+#: lxc/file.go:575
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1005,11 +1019,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:768
+#: lxc/file.go:790
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1022,12 +1036,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:493
+#: lxc/storage_volume.go:497
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:447
+#: lxc/storage_volume.go:451
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1133,9 +1147,9 @@ msgstr ""
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:497 lxc/network_forward.go:649
-#: lxc/network_forward.go:803 lxc/network_forward.go:892
-#: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
+#: lxc/network_forward.go:505 lxc/network_forward.go:657
+#: lxc/network_forward.go:811 lxc/network_forward.go:900
+#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
 #: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
 #: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
@@ -1147,14 +1161,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
-#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
-#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
-#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
+#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
 msgid "Cluster member name"
 msgstr ""
 
@@ -1170,7 +1184,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1608
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1210,21 +1224,21 @@ msgstr ""
 #: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
-#: lxc/network_acl.go:698 lxc/network_forward.go:767
+#: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
-#: lxc/storage_volume.go:1199
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
+#: lxc/storage_volume.go:1201
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:620
+#: lxc/storage_volume.go:624
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1478
+#: lxc/storage_volume.go:1480
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1286,7 +1300,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1294,12 +1308,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1312,7 +1326,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1407,7 +1421,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:462 lxc/file.go:696
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1447,7 +1461,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1499,12 +1513,12 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:182
+#: lxc/init.go:186
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1514,7 +1528,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 msgid "Creating the instance"
 msgstr ""
 
@@ -1528,13 +1542,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1749
+#: lxc/storage_volume.go:1751
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1554,7 +1568,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2653
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1586,7 +1600,7 @@ msgstr ""
 msgid "Delete identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:106 lxc/image_alias.go:107
+#: lxc/image_alias.go:123 lxc/image_alias.go:124
 msgid "Delete image aliases"
 msgstr ""
 
@@ -1610,7 +1624,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:799 lxc/network_forward.go:800
+#: lxc/network_forward.go:807 lxc/network_forward.go:808
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1650,7 +1664,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
+#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1692,13 +1706,13 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
-#: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
-#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
+#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
+#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
+#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
@@ -1712,10 +1726,10 @@ msgstr ""
 #: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:404 lxc/network_forward.go:489
-#: lxc/network_forward.go:599 lxc/network_forward.go:646
-#: lxc/network_forward.go:800 lxc/network_forward.go:874
-#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_forward.go:412 lxc/network_forward.go:497
+#: lxc/network_forward.go:607 lxc/network_forward.go:654
+#: lxc/network_forward.go:808 lxc/network_forward.go:882
+#: lxc/network_forward.go:897 lxc/network_forward.go:982
 #: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
 #: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
 #: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
@@ -1755,27 +1769,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
-#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
-#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
-#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
-#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
-#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
-#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
-#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1465
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1787,11 +1801,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
+#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1841,7 +1855,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:403
+#: lxc/init.go:407
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1853,7 +1867,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1216
+#: lxc/file.go:1236
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1949,7 +1963,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:377 lxc/file.go:378
+#: lxc/file.go:381 lxc/file.go:382
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1989,7 +2003,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:653 lxc/network_forward.go:654
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -2029,7 +2043,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2037,7 +2051,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1785
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2091,11 +2105,11 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
-#: lxc/network_acl.go:524 lxc/network_forward.go:572
+#: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
+#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2106,11 +2120,11 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
-#: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
+#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
-#: lxc/storage_volume.go:2210
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
+#: lxc/storage_volume.go:2212
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2152,8 +2166,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
+#: lxc/storage_volume.go:1577
 msgid "Expires at"
 msgstr ""
 
@@ -2177,7 +2191,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2189,11 +2203,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2650
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2779
+#: lxc/export.go:152 lxc/storage_volume.go:2781
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2212,7 +2226,7 @@ msgid "FILENAME"
 msgstr ""
 
 #: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
-#: lxc/image_alias.go:235
+#: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2220,12 +2234,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1467
+#: lxc/file.go:1491
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1490
+#: lxc/file.go:1514
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2240,12 +2254,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1517
+#: lxc/file.go:1541
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1326
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2275,7 +2289,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1423
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2290,7 +2304,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1428
+#: lxc/file.go:1452
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2300,12 +2314,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1352
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1455
+#: lxc/file.go:1479
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2319,7 +2333,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:304 lxc/move.go:380
+#: lxc/move.go:309 lxc/move.go:385
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2344,7 +2358,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1440
+#: lxc/file.go:1464
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2359,7 +2373,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1042
+#: lxc/file.go:1062
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2446,14 +2460,14 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1625 lxc/warning.go:94
+#: lxc/storage_volume.go:1627 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2521,7 +2535,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1602
+#: lxc/image.go:1602 lxc/image.go:1603
 msgid "Get image properties"
 msgstr ""
 
@@ -2537,7 +2551,7 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:414
 msgid "Get the key as a network forward property"
 msgstr ""
 
@@ -2577,7 +2591,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1249
+#: lxc/storage_volume.go:1251
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2605,7 +2619,7 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:403 lxc/network_forward.go:404
+#: lxc/network_forward.go:411 lxc/network_forward.go:412
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
@@ -2641,11 +2655,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:476
+#: lxc/storage_volume.go:480
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2685,22 +2699,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1540
+#: lxc/file.go:1564
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1529
+#: lxc/file.go:1553
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1376
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1362
+#: lxc/file.go:1386
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2773,11 +2787,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:415
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2787,7 +2801,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2437
+#: lxc/storage_volume.go:2439
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2799,7 +2813,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1517
+#: lxc/image.go:1518
 msgid "Image already up to date."
 msgstr ""
 
@@ -2815,11 +2829,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1472
+#: lxc/image.go:364 lxc/image.go:1473
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1698
+#: lxc/image.go:444 lxc/image.go:1699
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2829,7 +2843,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1515
+#: lxc/image.go:1516
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2837,7 +2851,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2815
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2845,7 +2859,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2814
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2867,11 +2881,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2822
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2894
+#: lxc/storage_volume.go:2896
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2897,11 +2911,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1378
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1531
+#: lxc/file.go:1555
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2910,7 +2924,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:414
+#: lxc/init.go:418
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2919,7 +2933,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1298
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2971,7 +2985,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1293
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2997,23 +3011,23 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2023
+#: lxc/move.go:153 lxc/storage_volume.go:2025
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:144
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2019
+#: lxc/storage_volume.go:2021
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:509
+#: lxc/main.go:518
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:353
+#: lxc/file.go:357
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3023,18 +3037,18 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
-#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
+#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:535
+#: lxc/file.go:548
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:717
+#: lxc/file.go:185 lxc/file.go:739
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3071,7 +3085,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3102,12 +3116,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:176
+#: lxc/init.go:180
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:174
+#: lxc/init.go:178
 msgid "Launching the instance"
 msgstr ""
 
@@ -3205,11 +3219,11 @@ msgstr ""
 msgid "List identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:151
+#: lxc/image_alias.go:176
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:177
 msgid ""
 "List image aliases\n"
 "\n"
@@ -3376,11 +3390,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1605
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1610
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3439,7 +3453,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1481
+#: lxc/info.go:489 lxc/storage_volume.go:1483
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3625,7 +3639,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:873 lxc/network_forward.go:874
+#: lxc/network_forward.go:881 lxc/network_forward.go:882
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -3771,12 +3785,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:322 lxc/move.go:435
+#: lxc/move.go:327 lxc/move.go:440
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:347 lxc/move.go:440
+#: lxc/move.go:352 lxc/move.go:445
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3841,10 +3855,10 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:449
-#: lxc/network_forward.go:534 lxc/network_forward.go:709
-#: lxc/network_forward.go:840 lxc/network_forward.go:933
-#: lxc/network_forward.go:1015 lxc/network_load_balancer.go:221
+#: lxc/network_forward.go:219 lxc/network_forward.go:457
+#: lxc/network_forward.go:542 lxc/network_forward.go:717
+#: lxc/network_forward.go:848 lxc/network_forward.go:945
+#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
 #: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
 #: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
 #: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
@@ -3869,10 +3883,10 @@ msgstr ""
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
 #: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
 #: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:284 lxc/network_forward.go:445
-#: lxc/network_forward.go:530 lxc/network_forward.go:705
-#: lxc/network_forward.go:836 lxc/network_forward.go:929
-#: lxc/network_forward.go:1011 lxc/network_load_balancer.go:131
+#: lxc/network_forward.go:292 lxc/network_forward.go:453
+#: lxc/network_forward.go:538 lxc/network_forward.go:713
+#: lxc/network_forward.go:844 lxc/network_forward.go:941
+#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
 #: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
 #: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
 #: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
@@ -3908,13 +3922,13 @@ msgstr ""
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
-#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
-#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
-#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
+#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
+#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
+#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
+#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
 msgid "Missing pool name"
 msgstr ""
 
@@ -3933,15 +3947,15 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
+#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1411
+#: lxc/storage_volume.go:1413
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:820
+#: lxc/file.go:842
 msgid "Missing target directory"
 msgstr ""
 
@@ -3974,16 +3988,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
-#: lxc/storage_volume.go:975
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
+#: lxc/storage_volume.go:977
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:507
+#: lxc/file.go:520
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1207 lxc/file.go:1208
+#: lxc/file.go:1227 lxc/file.go:1228
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4012,7 +4026,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4020,16 +4034,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1869
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1059 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4051,7 +4065,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
 msgid "NAME"
 msgstr ""
 
@@ -4103,8 +4117,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
-#: lxc/storage_volume.go:1573
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Name"
 msgstr ""
 
@@ -4112,7 +4126,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4167,12 +4181,12 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:386
+#: lxc/network_forward.go:394
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:857
+#: lxc/network_forward.go:865
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -4256,7 +4270,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
+#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4264,7 +4278,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1070 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4276,11 +4290,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4294,7 +4308,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2035
+#: lxc/storage_volume.go:2037
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4302,16 +4316,21 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
-#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
-msgid "Only \"custom\" volumes can be attached to instances"
+#: lxc/storage_volume.go:216
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2701
+#: lxc/storage_volume.go:348
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:2703
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2500
+#: lxc/storage_volume.go:2502
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4323,7 +4342,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1431
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4336,7 +4355,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1577
+#: lxc/info.go:705 lxc/storage_volume.go:1579
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4366,7 +4385,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1767
+#: lxc/storage_volume.go:1769
 msgid "POOL"
 msgstr ""
 
@@ -4383,7 +4402,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167
-#: lxc/storage_volume.go:1773 lxc/warning.go:213
+#: lxc/storage_volume.go:1775 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4407,7 +4426,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:367
+#: lxc/main.go:376
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4445,7 +4464,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1332
+#: lxc/file.go:1356
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4453,12 +4472,12 @@ msgstr ""
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
-#: lxc/network_acl.go:699 lxc/network_forward.go:768
+#: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
-#: lxc/storage_volume.go:1200
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
+#: lxc/storage_volume.go:1202
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4571,11 +4590,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1649
+#: lxc/image.go:1650
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4589,7 +4608,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1238
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4605,7 +4624,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4626,7 +4645,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1017
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4635,7 +4654,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2094
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4648,7 +4667,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2370
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4679,20 +4698,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:455 lxc/file.go:456
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:638 lxc/file.go:989
+#: lxc/file.go:651 lxc/file.go:1009
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:688 lxc/file.go:689
+#: lxc/file.go:701 lxc/file.go:702
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:923 lxc/file.go:1089
+#: lxc/file.go:943 lxc/file.go:1109
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4701,7 +4720,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4730,15 +4749,15 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:463 lxc/file.go:695
+#: lxc/file.go:475 lxc/file.go:708
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1444 lxc/image.go:1445
+#: lxc/image.go:1445 lxc/image.go:1446
 msgid "Refresh images"
 msgstr ""
 
@@ -4747,7 +4766,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1481
+#: lxc/image.go:1482
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4824,7 +4843,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:971 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4860,7 +4879,7 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:969 lxc/network_forward.go:970
+#: lxc/network_forward.go:981 lxc/network_forward.go:982
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -4896,8 +4915,8 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
-#: lxc/image_alias.go:255
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:287
+#: lxc/image_alias.go:288
 msgid "Rename aliases"
 msgstr ""
 
@@ -4933,15 +4952,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1962
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
+#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4993,7 +5012,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5010,7 +5029,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:361
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5059,12 +5078,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1460
+#: lxc/file.go:1484
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1461
+#: lxc/file.go:1485
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5140,7 +5159,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1217
+#: lxc/file.go:1237
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5166,7 +5185,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1665 lxc/image.go:1666
+#: lxc/image.go:1666 lxc/image.go:1667
 msgid "Set image properties"
 msgstr ""
 
@@ -5209,11 +5228,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:488
+#: lxc/network_forward.go:496
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:489
+#: lxc/network_forward.go:497
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5317,11 +5336,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2088
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2089
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5338,7 +5357,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:698
+#: lxc/file.go:711
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5346,7 +5365,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:699
+#: lxc/file.go:712
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5354,7 +5373,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:710
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5366,7 +5385,7 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:504
 msgid "Set the key as a network forward property"
 msgstr ""
 
@@ -5406,7 +5425,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2105
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5414,7 +5433,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1215
+#: lxc/file.go:1235
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5471,7 +5490,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1535 lxc/image.go:1536
+#: lxc/image.go:1536 lxc/image.go:1537
 msgid "Show image properties"
 msgstr ""
 
@@ -5491,7 +5510,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:271 lxc/main.go:272
+#: lxc/main.go:280 lxc/main.go:281
 msgid "Show less common commands"
 msgstr ""
 
@@ -5555,11 +5574,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5627,15 +5646,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2190
+#: lxc/storage_volume.go:2192
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1502
+#: lxc/info.go:619 lxc/storage_volume.go:1504
 msgid "Snapshots:"
 msgstr ""
 
@@ -5740,21 +5759,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:703
+#: lxc/storage_volume.go:707
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:791
+#: lxc/storage_volume.go:795
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:516
+#: lxc/storage_volume.go:520
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:524
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5816,21 +5835,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1747 lxc/warning.go:216
+#: lxc/storage_volume.go:1749 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1262
+#: lxc/file.go:1286
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1256
+#: lxc/file.go:1280
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5840,15 +5859,15 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:181
+#: lxc/move.go:186
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:219 lxc/move.go:240
+#: lxc/move.go:224 lxc/move.go:245
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:193
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5856,15 +5875,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:185
+#: lxc/move.go:190
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:189
+#: lxc/move.go:194
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:210
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5886,7 +5905,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:439
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5939,7 +5958,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:462
+#: lxc/network_forward.go:470
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -5979,12 +5998,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1340
+#: lxc/storage_volume.go:1342
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1317
+#: lxc/storage_volume.go:1319
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -5999,12 +6018,12 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:309
+#: lxc/move.go:314
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
-#: lxc/storage_volume.go:989
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
+#: lxc/storage_volume.go:991
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6032,7 +6051,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:298
+#: lxc/main.go:307
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6056,11 +6075,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:437
+#: lxc/init.go:441
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:440
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6068,7 +6087,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:412
+#: lxc/main.go:421
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6079,7 +6098,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1489
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6094,7 +6113,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1864
+#: lxc/storage_volume.go:1866
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6102,7 +6121,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6119,7 +6138,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:327
+#: lxc/copy.go:382 lxc/move.go:332
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6161,7 +6180,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1472
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6183,13 +6202,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1752
+#: lxc/project.go:995 lxc/storage_volume.go:1754
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1751
+#: lxc/storage.go:724 lxc/storage_volume.go:1753
 msgid "USED BY"
 msgstr ""
 
@@ -6202,7 +6221,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:411
+#: lxc/file.go:423
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6216,12 +6235,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1483
+#: lxc/file.go:1507
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1791
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6232,7 +6251,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1029
+#: lxc/file.go:1049
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6263,7 +6282,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1728 lxc/image.go:1729
+#: lxc/image.go:1729 lxc/image.go:1730
 msgid "Unset image properties"
 msgstr ""
 
@@ -6279,11 +6298,11 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:598
+#: lxc/network_forward.go:606
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:599
+#: lxc/network_forward.go:607
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -6327,7 +6346,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6339,7 +6358,7 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:602
+#: lxc/network_forward.go:610
 msgid "Unset the key as a network forward property"
 msgstr ""
 
@@ -6379,7 +6398,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2381
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6387,7 +6406,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:248
+#: lxc/storage_volume.go:250
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6423,12 +6442,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1485
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2652
+#: lxc/export.go:42 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6495,7 +6514,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1576
+#: lxc/storage_volume.go:1578
 msgid "Volume Only"
 msgstr ""
 
@@ -6546,7 +6565,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:293 lxc/move.go:369
+#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6554,12 +6573,12 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:909
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:912
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:282
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:284
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
@@ -6591,7 +6610,7 @@ msgstr ""
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:174
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
@@ -6644,7 +6663,7 @@ msgstr ""
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: lxc/image_alias.go:104
+#: lxc/image_alias.go:121
 msgid "[<remote>:]<alias>"
 msgstr ""
 
@@ -6652,7 +6671,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/image_alias.go:252
+#: lxc/image_alias.go:285
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
@@ -6706,15 +6725,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1600 lxc/image.go:1727
+#: lxc/image.go:1601 lxc/image.go:1728
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1664
+#: lxc/image.go:1665
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6734,7 +6753,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1443
+#: lxc/image.go:334 lxc/image.go:1444
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6805,7 +6824,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:376
+#: lxc/file.go:380
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -6817,12 +6836,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:454
+#: lxc/file.go:466
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1226
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6890,8 +6909,8 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:644
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:179
+#: lxc/network_forward.go:177 lxc/network_forward.go:652
+#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
 #: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
@@ -6906,12 +6925,12 @@ msgid ""
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:402 lxc/network_forward.go:597
+#: lxc/network_forward.go:410 lxc/network_forward.go:605
 #: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
@@ -6921,13 +6940,13 @@ msgid ""
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:887
+#: lxc/network_forward.go:895
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:968 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -6982,7 +7001,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2811
+#: lxc/storage_volume.go:2813
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7017,65 +7036,65 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1958
+#: lxc/storage_volume.go:1960
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:806
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:167
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
-msgstr ""
-
-#: lxc/storage_volume.go:2562
+#: lxc/storage_volume.go:2564
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2645
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2428
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:610
+#: lxc/storage_volume.go:614
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:718
+#: lxc/storage_volume.go:722
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2364
+#: lxc/storage_volume.go:810
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
+msgstr ""
+
+#: lxc/storage_volume.go:167
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
+msgstr ""
+
+#: lxc/storage_volume.go:2366
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2087
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2245
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1234
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1858
+#: lxc/storage_volume.go:1860
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7181,7 +7200,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1603
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7343,20 +7362,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1230
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:470
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:691
+#: lxc/file.go:704
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7657,7 +7676,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:618
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7665,13 +7684,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2817
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2432
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7705,16 +7724,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1396
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1331
+#: lxc/file.go:1355
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1284
+#: lxc/file.go:1308
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-07 15:11-0700\n"
+"POT-Creation-Date: 2025-01-10 14:44-0600\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1041
+#: lxc/storage_volume.go:1043
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:667
+#: lxc/network_forward.go:675
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,12 +430,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1157
+#: lxc/file.go:1177
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1047
+#: lxc/file.go:1067
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -471,7 +471,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:65
+#: lxc/init.go:146 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:687
+#: lxc/file.go:700
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -541,7 +541,7 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
@@ -672,7 +672,7 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:888 lxc/network_forward.go:889
+#: lxc/network_forward.go:896 lxc/network_forward.go:897
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -722,7 +722,7 @@ msgstr ""
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
+#: lxc/image_alias.go:101 lxc/image_alias.go:156 lxc/image_alias.go:320
 msgid "Alias name missing"
 msgstr ""
 
@@ -735,7 +735,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1607
+#: lxc/storage_volume.go:1609
 msgid "All projects"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -790,12 +790,26 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168 lxc/storage_volume.go:169
+#: lxc/storage_volume.go:168
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:169
+msgid ""
+"Attach new storage volumes to instances\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
+msgstr ""
+
+#: lxc/storage_volume.go:285
 msgid "Attach new storage volumes to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:286
+msgid ""
+"Attach new storage volumes to profiles\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
 #: lxc/console.go:39
@@ -846,16 +860,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2719
+#: lxc/storage_volume.go:2721
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2796
+#: lxc/export.go:192 lxc/storage_volume.go:2798
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1538
+#: lxc/info.go:666 lxc/storage_volume.go:1540
 msgid "Backups:"
 msgstr ""
 
@@ -864,19 +878,19 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
+#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:326
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -919,7 +933,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1752
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -971,7 +985,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -979,7 +993,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:562
+#: lxc/file.go:575
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1004,11 +1018,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:768
+#: lxc/file.go:790
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1021,12 +1035,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:493
+#: lxc/storage_volume.go:497
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:447
+#: lxc/storage_volume.go:451
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1132,9 +1146,9 @@ msgstr ""
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:497 lxc/network_forward.go:649
-#: lxc/network_forward.go:803 lxc/network_forward.go:892
-#: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
+#: lxc/network_forward.go:505 lxc/network_forward.go:657
+#: lxc/network_forward.go:811 lxc/network_forward.go:900
+#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
 #: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
 #: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
@@ -1146,14 +1160,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
-#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
-#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
-#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
+#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
 msgid "Cluster member name"
 msgstr ""
 
@@ -1169,7 +1183,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1608
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1209,21 +1223,21 @@ msgstr ""
 #: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
-#: lxc/network_acl.go:698 lxc/network_forward.go:767
+#: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
-#: lxc/storage_volume.go:1199
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
+#: lxc/storage_volume.go:1201
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:620
+#: lxc/storage_volume.go:624
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1478
+#: lxc/storage_volume.go:1480
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1285,7 +1299,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1293,12 +1307,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1311,7 +1325,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1406,7 +1420,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:462 lxc/file.go:696
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1446,7 +1460,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1498,12 +1512,12 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:182
+#: lxc/init.go:186
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1513,7 +1527,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 msgid "Creating the instance"
 msgstr ""
 
@@ -1527,13 +1541,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1749
+#: lxc/storage_volume.go:1751
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1553,7 +1567,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2653
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1585,7 +1599,7 @@ msgstr ""
 msgid "Delete identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:106 lxc/image_alias.go:107
+#: lxc/image_alias.go:123 lxc/image_alias.go:124
 msgid "Delete image aliases"
 msgstr ""
 
@@ -1609,7 +1623,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:799 lxc/network_forward.go:800
+#: lxc/network_forward.go:807 lxc/network_forward.go:808
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1649,7 +1663,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
+#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1691,13 +1705,13 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
-#: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
-#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
+#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
+#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
+#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
@@ -1711,10 +1725,10 @@ msgstr ""
 #: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:404 lxc/network_forward.go:489
-#: lxc/network_forward.go:599 lxc/network_forward.go:646
-#: lxc/network_forward.go:800 lxc/network_forward.go:874
-#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_forward.go:412 lxc/network_forward.go:497
+#: lxc/network_forward.go:607 lxc/network_forward.go:654
+#: lxc/network_forward.go:808 lxc/network_forward.go:882
+#: lxc/network_forward.go:897 lxc/network_forward.go:982
 #: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
 #: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
 #: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
@@ -1754,27 +1768,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
-#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
-#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
-#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
-#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
-#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
-#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
-#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1465
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1786,11 +1800,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
+#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1840,7 +1854,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:403
+#: lxc/init.go:407
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1852,7 +1866,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1216
+#: lxc/file.go:1236
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1948,7 +1962,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:377 lxc/file.go:378
+#: lxc/file.go:381 lxc/file.go:382
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1988,7 +2002,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:653 lxc/network_forward.go:654
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -2028,7 +2042,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2036,7 +2050,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1785
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2090,11 +2104,11 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
-#: lxc/network_acl.go:524 lxc/network_forward.go:572
+#: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
+#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2105,11 +2119,11 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
-#: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
+#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
-#: lxc/storage_volume.go:2210
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
+#: lxc/storage_volume.go:2212
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2151,8 +2165,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
+#: lxc/storage_volume.go:1577
 msgid "Expires at"
 msgstr ""
 
@@ -2176,7 +2190,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2188,11 +2202,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2650
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2779
+#: lxc/export.go:152 lxc/storage_volume.go:2781
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2211,7 +2225,7 @@ msgid "FILENAME"
 msgstr ""
 
 #: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
-#: lxc/image_alias.go:235
+#: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2219,12 +2233,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1467
+#: lxc/file.go:1491
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1490
+#: lxc/file.go:1514
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2239,12 +2253,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1517
+#: lxc/file.go:1541
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1326
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2274,7 +2288,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1423
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2289,7 +2303,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1428
+#: lxc/file.go:1452
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2299,12 +2313,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1352
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1455
+#: lxc/file.go:1479
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2318,7 +2332,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:304 lxc/move.go:380
+#: lxc/move.go:309 lxc/move.go:385
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2343,7 +2357,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1440
+#: lxc/file.go:1464
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2358,7 +2372,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1042
+#: lxc/file.go:1062
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2445,14 +2459,14 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1625 lxc/warning.go:94
+#: lxc/storage_volume.go:1627 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2520,7 +2534,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1602
+#: lxc/image.go:1602 lxc/image.go:1603
 msgid "Get image properties"
 msgstr ""
 
@@ -2536,7 +2550,7 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:414
 msgid "Get the key as a network forward property"
 msgstr ""
 
@@ -2576,7 +2590,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1249
+#: lxc/storage_volume.go:1251
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2604,7 +2618,7 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:403 lxc/network_forward.go:404
+#: lxc/network_forward.go:411 lxc/network_forward.go:412
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
@@ -2640,11 +2654,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:476
+#: lxc/storage_volume.go:480
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2684,22 +2698,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1540
+#: lxc/file.go:1564
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1529
+#: lxc/file.go:1553
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1376
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1362
+#: lxc/file.go:1386
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2772,11 +2786,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:415
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2786,7 +2800,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2437
+#: lxc/storage_volume.go:2439
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2798,7 +2812,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1517
+#: lxc/image.go:1518
 msgid "Image already up to date."
 msgstr ""
 
@@ -2814,11 +2828,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1472
+#: lxc/image.go:364 lxc/image.go:1473
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1698
+#: lxc/image.go:444 lxc/image.go:1699
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2828,7 +2842,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1515
+#: lxc/image.go:1516
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2836,7 +2850,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2815
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2844,7 +2858,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2814
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2866,11 +2880,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2822
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2894
+#: lxc/storage_volume.go:2896
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2896,11 +2910,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1378
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1531
+#: lxc/file.go:1555
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2909,7 +2923,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:414
+#: lxc/init.go:418
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2918,7 +2932,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1298
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2970,7 +2984,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1293
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2996,23 +3010,23 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2023
+#: lxc/move.go:153 lxc/storage_volume.go:2025
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:144
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2019
+#: lxc/storage_volume.go:2021
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:509
+#: lxc/main.go:518
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:353
+#: lxc/file.go:357
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3022,18 +3036,18 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
-#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
+#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:535
+#: lxc/file.go:548
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:717
+#: lxc/file.go:185 lxc/file.go:739
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3070,7 +3084,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3101,12 +3115,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:176
+#: lxc/init.go:180
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:174
+#: lxc/init.go:178
 msgid "Launching the instance"
 msgstr ""
 
@@ -3204,11 +3218,11 @@ msgstr ""
 msgid "List identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:151
+#: lxc/image_alias.go:176
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:177
 msgid ""
 "List image aliases\n"
 "\n"
@@ -3375,11 +3389,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1605
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1610
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3438,7 +3452,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1481
+#: lxc/info.go:489 lxc/storage_volume.go:1483
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3624,7 +3638,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:873 lxc/network_forward.go:874
+#: lxc/network_forward.go:881 lxc/network_forward.go:882
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -3770,12 +3784,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:322 lxc/move.go:435
+#: lxc/move.go:327 lxc/move.go:440
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:347 lxc/move.go:440
+#: lxc/move.go:352 lxc/move.go:445
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3840,10 +3854,10 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:449
-#: lxc/network_forward.go:534 lxc/network_forward.go:709
-#: lxc/network_forward.go:840 lxc/network_forward.go:933
-#: lxc/network_forward.go:1015 lxc/network_load_balancer.go:221
+#: lxc/network_forward.go:219 lxc/network_forward.go:457
+#: lxc/network_forward.go:542 lxc/network_forward.go:717
+#: lxc/network_forward.go:848 lxc/network_forward.go:945
+#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
 #: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
 #: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
 #: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
@@ -3868,10 +3882,10 @@ msgstr ""
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
 #: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
 #: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:284 lxc/network_forward.go:445
-#: lxc/network_forward.go:530 lxc/network_forward.go:705
-#: lxc/network_forward.go:836 lxc/network_forward.go:929
-#: lxc/network_forward.go:1011 lxc/network_load_balancer.go:131
+#: lxc/network_forward.go:292 lxc/network_forward.go:453
+#: lxc/network_forward.go:538 lxc/network_forward.go:713
+#: lxc/network_forward.go:844 lxc/network_forward.go:941
+#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
 #: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
 #: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
 #: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
@@ -3907,13 +3921,13 @@ msgstr ""
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
-#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
-#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
-#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
+#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
+#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
+#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
+#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
 msgid "Missing pool name"
 msgstr ""
 
@@ -3932,15 +3946,15 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
+#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1411
+#: lxc/storage_volume.go:1413
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:820
+#: lxc/file.go:842
 msgid "Missing target directory"
 msgstr ""
 
@@ -3973,16 +3987,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
-#: lxc/storage_volume.go:975
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
+#: lxc/storage_volume.go:977
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:507
+#: lxc/file.go:520
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1207 lxc/file.go:1208
+#: lxc/file.go:1227 lxc/file.go:1228
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4011,7 +4025,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4019,16 +4033,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1869
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1059 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4050,7 +4064,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
 msgid "NAME"
 msgstr ""
 
@@ -4102,8 +4116,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
-#: lxc/storage_volume.go:1573
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Name"
 msgstr ""
 
@@ -4111,7 +4125,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4166,12 +4180,12 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:386
+#: lxc/network_forward.go:394
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:857
+#: lxc/network_forward.go:865
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -4255,7 +4269,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
+#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4263,7 +4277,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1070 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4275,11 +4289,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4293,7 +4307,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2035
+#: lxc/storage_volume.go:2037
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4301,16 +4315,21 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
-#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
-msgid "Only \"custom\" volumes can be attached to instances"
+#: lxc/storage_volume.go:216
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2701
+#: lxc/storage_volume.go:348
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:2703
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2500
+#: lxc/storage_volume.go:2502
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4322,7 +4341,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1431
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4335,7 +4354,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1577
+#: lxc/info.go:705 lxc/storage_volume.go:1579
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4365,7 +4384,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1767
+#: lxc/storage_volume.go:1769
 msgid "POOL"
 msgstr ""
 
@@ -4382,7 +4401,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167
-#: lxc/storage_volume.go:1773 lxc/warning.go:213
+#: lxc/storage_volume.go:1775 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4406,7 +4425,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:367
+#: lxc/main.go:376
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4444,7 +4463,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1332
+#: lxc/file.go:1356
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4452,12 +4471,12 @@ msgstr ""
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
-#: lxc/network_acl.go:699 lxc/network_forward.go:768
+#: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
-#: lxc/storage_volume.go:1200
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
+#: lxc/storage_volume.go:1202
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4570,11 +4589,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1649
+#: lxc/image.go:1650
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4588,7 +4607,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1238
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4604,7 +4623,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4625,7 +4644,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1017
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4634,7 +4653,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2094
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4647,7 +4666,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2370
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4678,20 +4697,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:455 lxc/file.go:456
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:638 lxc/file.go:989
+#: lxc/file.go:651 lxc/file.go:1009
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:688 lxc/file.go:689
+#: lxc/file.go:701 lxc/file.go:702
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:923 lxc/file.go:1089
+#: lxc/file.go:943 lxc/file.go:1109
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4700,7 +4719,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4729,15 +4748,15 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:463 lxc/file.go:695
+#: lxc/file.go:475 lxc/file.go:708
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1444 lxc/image.go:1445
+#: lxc/image.go:1445 lxc/image.go:1446
 msgid "Refresh images"
 msgstr ""
 
@@ -4746,7 +4765,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1481
+#: lxc/image.go:1482
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4823,7 +4842,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:971 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4859,7 +4878,7 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:969 lxc/network_forward.go:970
+#: lxc/network_forward.go:981 lxc/network_forward.go:982
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -4895,8 +4914,8 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
-#: lxc/image_alias.go:255
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:287
+#: lxc/image_alias.go:288
 msgid "Rename aliases"
 msgstr ""
 
@@ -4932,15 +4951,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1962
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
+#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4992,7 +5011,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5009,7 +5028,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:361
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5058,12 +5077,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1460
+#: lxc/file.go:1484
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1461
+#: lxc/file.go:1485
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5139,7 +5158,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1217
+#: lxc/file.go:1237
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5165,7 +5184,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1665 lxc/image.go:1666
+#: lxc/image.go:1666 lxc/image.go:1667
 msgid "Set image properties"
 msgstr ""
 
@@ -5208,11 +5227,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:488
+#: lxc/network_forward.go:496
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:489
+#: lxc/network_forward.go:497
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5316,11 +5335,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2088
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2089
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5337,7 +5356,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:698
+#: lxc/file.go:711
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5345,7 +5364,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:699
+#: lxc/file.go:712
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5353,7 +5372,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:710
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5365,7 +5384,7 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:504
 msgid "Set the key as a network forward property"
 msgstr ""
 
@@ -5405,7 +5424,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2105
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5413,7 +5432,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1215
+#: lxc/file.go:1235
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5470,7 +5489,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1535 lxc/image.go:1536
+#: lxc/image.go:1536 lxc/image.go:1537
 msgid "Show image properties"
 msgstr ""
 
@@ -5490,7 +5509,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:271 lxc/main.go:272
+#: lxc/main.go:280 lxc/main.go:281
 msgid "Show less common commands"
 msgstr ""
 
@@ -5554,11 +5573,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5626,15 +5645,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2190
+#: lxc/storage_volume.go:2192
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1502
+#: lxc/info.go:619 lxc/storage_volume.go:1504
 msgid "Snapshots:"
 msgstr ""
 
@@ -5739,21 +5758,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:703
+#: lxc/storage_volume.go:707
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:791
+#: lxc/storage_volume.go:795
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:516
+#: lxc/storage_volume.go:520
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:524
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5815,21 +5834,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1747 lxc/warning.go:216
+#: lxc/storage_volume.go:1749 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1262
+#: lxc/file.go:1286
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1256
+#: lxc/file.go:1280
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5839,15 +5858,15 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:181
+#: lxc/move.go:186
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:219 lxc/move.go:240
+#: lxc/move.go:224 lxc/move.go:245
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:193
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5855,15 +5874,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:185
+#: lxc/move.go:190
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:189
+#: lxc/move.go:194
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:210
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5885,7 +5904,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:439
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5938,7 +5957,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:462
+#: lxc/network_forward.go:470
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -5978,12 +5997,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1340
+#: lxc/storage_volume.go:1342
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1317
+#: lxc/storage_volume.go:1319
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -5998,12 +6017,12 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:309
+#: lxc/move.go:314
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
-#: lxc/storage_volume.go:989
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
+#: lxc/storage_volume.go:991
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6031,7 +6050,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:298
+#: lxc/main.go:307
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6055,11 +6074,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:437
+#: lxc/init.go:441
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:440
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6067,7 +6086,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:412
+#: lxc/main.go:421
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6078,7 +6097,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1489
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6093,7 +6112,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1864
+#: lxc/storage_volume.go:1866
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6101,7 +6120,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6118,7 +6137,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:327
+#: lxc/copy.go:382 lxc/move.go:332
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6160,7 +6179,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1472
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6182,13 +6201,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1752
+#: lxc/project.go:995 lxc/storage_volume.go:1754
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1751
+#: lxc/storage.go:724 lxc/storage_volume.go:1753
 msgid "USED BY"
 msgstr ""
 
@@ -6201,7 +6220,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:411
+#: lxc/file.go:423
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6215,12 +6234,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1483
+#: lxc/file.go:1507
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1791
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6231,7 +6250,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1029
+#: lxc/file.go:1049
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6262,7 +6281,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1728 lxc/image.go:1729
+#: lxc/image.go:1729 lxc/image.go:1730
 msgid "Unset image properties"
 msgstr ""
 
@@ -6278,11 +6297,11 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:598
+#: lxc/network_forward.go:606
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:599
+#: lxc/network_forward.go:607
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -6326,7 +6345,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6338,7 +6357,7 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:602
+#: lxc/network_forward.go:610
 msgid "Unset the key as a network forward property"
 msgstr ""
 
@@ -6378,7 +6397,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2381
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6386,7 +6405,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:248
+#: lxc/storage_volume.go:250
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6422,12 +6441,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1485
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2652
+#: lxc/export.go:42 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6494,7 +6513,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1576
+#: lxc/storage_volume.go:1578
 msgid "Volume Only"
 msgstr ""
 
@@ -6545,7 +6564,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:293 lxc/move.go:369
+#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6553,12 +6572,12 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:909
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:912
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:282
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:284
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
@@ -6590,7 +6609,7 @@ msgstr ""
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:174
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
@@ -6643,7 +6662,7 @@ msgstr ""
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: lxc/image_alias.go:104
+#: lxc/image_alias.go:121
 msgid "[<remote>:]<alias>"
 msgstr ""
 
@@ -6651,7 +6670,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/image_alias.go:252
+#: lxc/image_alias.go:285
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
@@ -6705,15 +6724,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1600 lxc/image.go:1727
+#: lxc/image.go:1601 lxc/image.go:1728
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1664
+#: lxc/image.go:1665
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6733,7 +6752,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1443
+#: lxc/image.go:334 lxc/image.go:1444
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6804,7 +6823,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:376
+#: lxc/file.go:380
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -6816,12 +6835,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:454
+#: lxc/file.go:466
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1226
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6889,8 +6908,8 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:644
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:179
+#: lxc/network_forward.go:177 lxc/network_forward.go:652
+#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
 #: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
@@ -6905,12 +6924,12 @@ msgid ""
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:402 lxc/network_forward.go:597
+#: lxc/network_forward.go:410 lxc/network_forward.go:605
 #: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
@@ -6920,13 +6939,13 @@ msgid ""
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:887
+#: lxc/network_forward.go:895
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:968 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -6981,7 +7000,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2811
+#: lxc/storage_volume.go:2813
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7016,65 +7035,65 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1958
+#: lxc/storage_volume.go:1960
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:806
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:167
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
-msgstr ""
-
-#: lxc/storage_volume.go:2562
+#: lxc/storage_volume.go:2564
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2645
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2428
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:610
+#: lxc/storage_volume.go:614
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:718
+#: lxc/storage_volume.go:722
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2364
+#: lxc/storage_volume.go:810
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
+msgstr ""
+
+#: lxc/storage_volume.go:167
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
+msgstr ""
+
+#: lxc/storage_volume.go:2366
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2087
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2245
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1234
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1858
+#: lxc/storage_volume.go:1860
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7180,7 +7199,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1603
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7342,20 +7361,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1230
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:470
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:691
+#: lxc/file.go:704
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7656,7 +7675,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:618
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7664,13 +7683,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2817
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2432
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7704,16 +7723,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1396
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1331
+#: lxc/file.go:1355
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1284
+#: lxc/file.go:1308
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-07 15:11-0700\n"
+"POT-Creation-Date: 2025-01-10 14:44-0600\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1041
+#: lxc/storage_volume.go:1043
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:667
+#: lxc/network_forward.go:675
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,12 +430,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1157
+#: lxc/file.go:1177
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1047
+#: lxc/file.go:1067
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -471,7 +471,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:65
+#: lxc/init.go:146 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:687
+#: lxc/file.go:700
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -541,7 +541,7 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
@@ -672,7 +672,7 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:888 lxc/network_forward.go:889
+#: lxc/network_forward.go:896 lxc/network_forward.go:897
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -722,7 +722,7 @@ msgstr ""
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
+#: lxc/image_alias.go:101 lxc/image_alias.go:156 lxc/image_alias.go:320
 msgid "Alias name missing"
 msgstr ""
 
@@ -735,7 +735,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1607
+#: lxc/storage_volume.go:1609
 msgid "All projects"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -790,12 +790,26 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168 lxc/storage_volume.go:169
+#: lxc/storage_volume.go:168
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:169
+msgid ""
+"Attach new storage volumes to instances\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
+msgstr ""
+
+#: lxc/storage_volume.go:285
 msgid "Attach new storage volumes to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:286
+msgid ""
+"Attach new storage volumes to profiles\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
 #: lxc/console.go:39
@@ -846,16 +860,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2719
+#: lxc/storage_volume.go:2721
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2796
+#: lxc/export.go:192 lxc/storage_volume.go:2798
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1538
+#: lxc/info.go:666 lxc/storage_volume.go:1540
 msgid "Backups:"
 msgstr ""
 
@@ -864,19 +878,19 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
+#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:326
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -919,7 +933,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1752
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -971,7 +985,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -979,7 +993,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:562
+#: lxc/file.go:575
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1004,11 +1018,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:768
+#: lxc/file.go:790
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1021,12 +1035,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:493
+#: lxc/storage_volume.go:497
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:447
+#: lxc/storage_volume.go:451
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1132,9 +1146,9 @@ msgstr ""
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:497 lxc/network_forward.go:649
-#: lxc/network_forward.go:803 lxc/network_forward.go:892
-#: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
+#: lxc/network_forward.go:505 lxc/network_forward.go:657
+#: lxc/network_forward.go:811 lxc/network_forward.go:900
+#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
 #: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
 #: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
@@ -1146,14 +1160,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
-#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
-#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
-#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
+#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
 msgid "Cluster member name"
 msgstr ""
 
@@ -1169,7 +1183,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1608
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1209,21 +1223,21 @@ msgstr ""
 #: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
-#: lxc/network_acl.go:698 lxc/network_forward.go:767
+#: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
-#: lxc/storage_volume.go:1199
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
+#: lxc/storage_volume.go:1201
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:620
+#: lxc/storage_volume.go:624
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1478
+#: lxc/storage_volume.go:1480
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1285,7 +1299,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1293,12 +1307,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1311,7 +1325,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1406,7 +1420,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:462 lxc/file.go:696
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1446,7 +1460,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1498,12 +1512,12 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:182
+#: lxc/init.go:186
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1513,7 +1527,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 msgid "Creating the instance"
 msgstr ""
 
@@ -1527,13 +1541,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1749
+#: lxc/storage_volume.go:1751
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1553,7 +1567,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2653
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1585,7 +1599,7 @@ msgstr ""
 msgid "Delete identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:106 lxc/image_alias.go:107
+#: lxc/image_alias.go:123 lxc/image_alias.go:124
 msgid "Delete image aliases"
 msgstr ""
 
@@ -1609,7 +1623,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:799 lxc/network_forward.go:800
+#: lxc/network_forward.go:807 lxc/network_forward.go:808
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1649,7 +1663,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
+#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1691,13 +1705,13 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
-#: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
-#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
+#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
+#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
+#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
@@ -1711,10 +1725,10 @@ msgstr ""
 #: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:404 lxc/network_forward.go:489
-#: lxc/network_forward.go:599 lxc/network_forward.go:646
-#: lxc/network_forward.go:800 lxc/network_forward.go:874
-#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_forward.go:412 lxc/network_forward.go:497
+#: lxc/network_forward.go:607 lxc/network_forward.go:654
+#: lxc/network_forward.go:808 lxc/network_forward.go:882
+#: lxc/network_forward.go:897 lxc/network_forward.go:982
 #: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
 #: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
 #: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
@@ -1754,27 +1768,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
-#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
-#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
-#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
-#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
-#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
-#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
-#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1465
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1786,11 +1800,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
+#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1840,7 +1854,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:403
+#: lxc/init.go:407
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1852,7 +1866,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1216
+#: lxc/file.go:1236
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1948,7 +1962,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:377 lxc/file.go:378
+#: lxc/file.go:381 lxc/file.go:382
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1988,7 +2002,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:653 lxc/network_forward.go:654
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -2028,7 +2042,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2036,7 +2050,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1785
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2090,11 +2104,11 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
-#: lxc/network_acl.go:524 lxc/network_forward.go:572
+#: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
+#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2105,11 +2119,11 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
-#: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
+#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
-#: lxc/storage_volume.go:2210
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
+#: lxc/storage_volume.go:2212
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2151,8 +2165,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
+#: lxc/storage_volume.go:1577
 msgid "Expires at"
 msgstr ""
 
@@ -2176,7 +2190,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2188,11 +2202,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2650
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2779
+#: lxc/export.go:152 lxc/storage_volume.go:2781
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2211,7 +2225,7 @@ msgid "FILENAME"
 msgstr ""
 
 #: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
-#: lxc/image_alias.go:235
+#: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2219,12 +2233,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1467
+#: lxc/file.go:1491
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1490
+#: lxc/file.go:1514
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2239,12 +2253,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1517
+#: lxc/file.go:1541
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1326
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2274,7 +2288,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1423
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2289,7 +2303,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1428
+#: lxc/file.go:1452
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2299,12 +2313,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1352
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1455
+#: lxc/file.go:1479
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2318,7 +2332,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:304 lxc/move.go:380
+#: lxc/move.go:309 lxc/move.go:385
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2343,7 +2357,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1440
+#: lxc/file.go:1464
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2358,7 +2372,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1042
+#: lxc/file.go:1062
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2445,14 +2459,14 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1625 lxc/warning.go:94
+#: lxc/storage_volume.go:1627 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2520,7 +2534,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1602
+#: lxc/image.go:1602 lxc/image.go:1603
 msgid "Get image properties"
 msgstr ""
 
@@ -2536,7 +2550,7 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:414
 msgid "Get the key as a network forward property"
 msgstr ""
 
@@ -2576,7 +2590,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1249
+#: lxc/storage_volume.go:1251
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2604,7 +2618,7 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:403 lxc/network_forward.go:404
+#: lxc/network_forward.go:411 lxc/network_forward.go:412
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
@@ -2640,11 +2654,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:476
+#: lxc/storage_volume.go:480
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2684,22 +2698,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1540
+#: lxc/file.go:1564
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1529
+#: lxc/file.go:1553
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1376
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1362
+#: lxc/file.go:1386
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2772,11 +2786,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:415
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2786,7 +2800,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2437
+#: lxc/storage_volume.go:2439
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2798,7 +2812,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1517
+#: lxc/image.go:1518
 msgid "Image already up to date."
 msgstr ""
 
@@ -2814,11 +2828,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1472
+#: lxc/image.go:364 lxc/image.go:1473
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1698
+#: lxc/image.go:444 lxc/image.go:1699
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2828,7 +2842,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1515
+#: lxc/image.go:1516
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2836,7 +2850,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2815
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2844,7 +2858,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2814
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2866,11 +2880,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2822
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2894
+#: lxc/storage_volume.go:2896
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2896,11 +2910,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1378
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1531
+#: lxc/file.go:1555
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2909,7 +2923,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:414
+#: lxc/init.go:418
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2918,7 +2932,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1298
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2970,7 +2984,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1293
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2996,23 +3010,23 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2023
+#: lxc/move.go:153 lxc/storage_volume.go:2025
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:144
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2019
+#: lxc/storage_volume.go:2021
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:509
+#: lxc/main.go:518
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:353
+#: lxc/file.go:357
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3022,18 +3036,18 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
-#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
+#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:535
+#: lxc/file.go:548
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:717
+#: lxc/file.go:185 lxc/file.go:739
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3070,7 +3084,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3101,12 +3115,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:176
+#: lxc/init.go:180
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:174
+#: lxc/init.go:178
 msgid "Launching the instance"
 msgstr ""
 
@@ -3204,11 +3218,11 @@ msgstr ""
 msgid "List identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:151
+#: lxc/image_alias.go:176
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:177
 msgid ""
 "List image aliases\n"
 "\n"
@@ -3375,11 +3389,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1605
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1610
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3438,7 +3452,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1481
+#: lxc/info.go:489 lxc/storage_volume.go:1483
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3624,7 +3638,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:873 lxc/network_forward.go:874
+#: lxc/network_forward.go:881 lxc/network_forward.go:882
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -3770,12 +3784,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:322 lxc/move.go:435
+#: lxc/move.go:327 lxc/move.go:440
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:347 lxc/move.go:440
+#: lxc/move.go:352 lxc/move.go:445
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3840,10 +3854,10 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:449
-#: lxc/network_forward.go:534 lxc/network_forward.go:709
-#: lxc/network_forward.go:840 lxc/network_forward.go:933
-#: lxc/network_forward.go:1015 lxc/network_load_balancer.go:221
+#: lxc/network_forward.go:219 lxc/network_forward.go:457
+#: lxc/network_forward.go:542 lxc/network_forward.go:717
+#: lxc/network_forward.go:848 lxc/network_forward.go:945
+#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
 #: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
 #: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
 #: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
@@ -3868,10 +3882,10 @@ msgstr ""
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
 #: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
 #: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:284 lxc/network_forward.go:445
-#: lxc/network_forward.go:530 lxc/network_forward.go:705
-#: lxc/network_forward.go:836 lxc/network_forward.go:929
-#: lxc/network_forward.go:1011 lxc/network_load_balancer.go:131
+#: lxc/network_forward.go:292 lxc/network_forward.go:453
+#: lxc/network_forward.go:538 lxc/network_forward.go:713
+#: lxc/network_forward.go:844 lxc/network_forward.go:941
+#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
 #: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
 #: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
 #: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
@@ -3907,13 +3921,13 @@ msgstr ""
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
-#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
-#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
-#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
+#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
+#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
+#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
+#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
 msgid "Missing pool name"
 msgstr ""
 
@@ -3932,15 +3946,15 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
+#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1411
+#: lxc/storage_volume.go:1413
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:820
+#: lxc/file.go:842
 msgid "Missing target directory"
 msgstr ""
 
@@ -3973,16 +3987,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
-#: lxc/storage_volume.go:975
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
+#: lxc/storage_volume.go:977
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:507
+#: lxc/file.go:520
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1207 lxc/file.go:1208
+#: lxc/file.go:1227 lxc/file.go:1228
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4011,7 +4025,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4019,16 +4033,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1869
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1059 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4050,7 +4064,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
 msgid "NAME"
 msgstr ""
 
@@ -4102,8 +4116,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
-#: lxc/storage_volume.go:1573
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Name"
 msgstr ""
 
@@ -4111,7 +4125,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4166,12 +4180,12 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:386
+#: lxc/network_forward.go:394
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:857
+#: lxc/network_forward.go:865
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -4255,7 +4269,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
+#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4263,7 +4277,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1070 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4275,11 +4289,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4293,7 +4307,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2035
+#: lxc/storage_volume.go:2037
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4301,16 +4315,21 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
-#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
-msgid "Only \"custom\" volumes can be attached to instances"
+#: lxc/storage_volume.go:216
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2701
+#: lxc/storage_volume.go:348
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:2703
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2500
+#: lxc/storage_volume.go:2502
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4322,7 +4341,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1431
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4335,7 +4354,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1577
+#: lxc/info.go:705 lxc/storage_volume.go:1579
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4365,7 +4384,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1767
+#: lxc/storage_volume.go:1769
 msgid "POOL"
 msgstr ""
 
@@ -4382,7 +4401,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167
-#: lxc/storage_volume.go:1773 lxc/warning.go:213
+#: lxc/storage_volume.go:1775 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4406,7 +4425,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:367
+#: lxc/main.go:376
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4444,7 +4463,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1332
+#: lxc/file.go:1356
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4452,12 +4471,12 @@ msgstr ""
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
-#: lxc/network_acl.go:699 lxc/network_forward.go:768
+#: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
-#: lxc/storage_volume.go:1200
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
+#: lxc/storage_volume.go:1202
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4570,11 +4589,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1649
+#: lxc/image.go:1650
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4588,7 +4607,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1238
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4604,7 +4623,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4625,7 +4644,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1017
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4634,7 +4653,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2094
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4647,7 +4666,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2370
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4678,20 +4697,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:455 lxc/file.go:456
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:638 lxc/file.go:989
+#: lxc/file.go:651 lxc/file.go:1009
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:688 lxc/file.go:689
+#: lxc/file.go:701 lxc/file.go:702
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:923 lxc/file.go:1089
+#: lxc/file.go:943 lxc/file.go:1109
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4700,7 +4719,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4729,15 +4748,15 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:463 lxc/file.go:695
+#: lxc/file.go:475 lxc/file.go:708
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1444 lxc/image.go:1445
+#: lxc/image.go:1445 lxc/image.go:1446
 msgid "Refresh images"
 msgstr ""
 
@@ -4746,7 +4765,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1481
+#: lxc/image.go:1482
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4823,7 +4842,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:971 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4859,7 +4878,7 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:969 lxc/network_forward.go:970
+#: lxc/network_forward.go:981 lxc/network_forward.go:982
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -4895,8 +4914,8 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
-#: lxc/image_alias.go:255
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:287
+#: lxc/image_alias.go:288
 msgid "Rename aliases"
 msgstr ""
 
@@ -4932,15 +4951,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1962
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
+#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4992,7 +5011,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5009,7 +5028,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:361
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5058,12 +5077,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1460
+#: lxc/file.go:1484
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1461
+#: lxc/file.go:1485
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5139,7 +5158,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1217
+#: lxc/file.go:1237
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5165,7 +5184,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1665 lxc/image.go:1666
+#: lxc/image.go:1666 lxc/image.go:1667
 msgid "Set image properties"
 msgstr ""
 
@@ -5208,11 +5227,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:488
+#: lxc/network_forward.go:496
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:489
+#: lxc/network_forward.go:497
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5316,11 +5335,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2088
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2089
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5337,7 +5356,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:698
+#: lxc/file.go:711
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5345,7 +5364,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:699
+#: lxc/file.go:712
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5353,7 +5372,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:710
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5365,7 +5384,7 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:504
 msgid "Set the key as a network forward property"
 msgstr ""
 
@@ -5405,7 +5424,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2105
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5413,7 +5432,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1215
+#: lxc/file.go:1235
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5470,7 +5489,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1535 lxc/image.go:1536
+#: lxc/image.go:1536 lxc/image.go:1537
 msgid "Show image properties"
 msgstr ""
 
@@ -5490,7 +5509,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:271 lxc/main.go:272
+#: lxc/main.go:280 lxc/main.go:281
 msgid "Show less common commands"
 msgstr ""
 
@@ -5554,11 +5573,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5626,15 +5645,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2190
+#: lxc/storage_volume.go:2192
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1502
+#: lxc/info.go:619 lxc/storage_volume.go:1504
 msgid "Snapshots:"
 msgstr ""
 
@@ -5739,21 +5758,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:703
+#: lxc/storage_volume.go:707
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:791
+#: lxc/storage_volume.go:795
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:516
+#: lxc/storage_volume.go:520
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:524
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5815,21 +5834,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1747 lxc/warning.go:216
+#: lxc/storage_volume.go:1749 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1262
+#: lxc/file.go:1286
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1256
+#: lxc/file.go:1280
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5839,15 +5858,15 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:181
+#: lxc/move.go:186
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:219 lxc/move.go:240
+#: lxc/move.go:224 lxc/move.go:245
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:193
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5855,15 +5874,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:185
+#: lxc/move.go:190
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:189
+#: lxc/move.go:194
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:210
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5885,7 +5904,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:439
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5938,7 +5957,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:462
+#: lxc/network_forward.go:470
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -5978,12 +5997,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1340
+#: lxc/storage_volume.go:1342
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1317
+#: lxc/storage_volume.go:1319
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -5998,12 +6017,12 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:309
+#: lxc/move.go:314
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
-#: lxc/storage_volume.go:989
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
+#: lxc/storage_volume.go:991
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6031,7 +6050,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:298
+#: lxc/main.go:307
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6055,11 +6074,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:437
+#: lxc/init.go:441
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:440
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6067,7 +6086,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:412
+#: lxc/main.go:421
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6078,7 +6097,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1489
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6093,7 +6112,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1864
+#: lxc/storage_volume.go:1866
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6101,7 +6120,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6118,7 +6137,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:327
+#: lxc/copy.go:382 lxc/move.go:332
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6160,7 +6179,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1472
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6182,13 +6201,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1752
+#: lxc/project.go:995 lxc/storage_volume.go:1754
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1751
+#: lxc/storage.go:724 lxc/storage_volume.go:1753
 msgid "USED BY"
 msgstr ""
 
@@ -6201,7 +6220,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:411
+#: lxc/file.go:423
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6215,12 +6234,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1483
+#: lxc/file.go:1507
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1791
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6231,7 +6250,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1029
+#: lxc/file.go:1049
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6262,7 +6281,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1728 lxc/image.go:1729
+#: lxc/image.go:1729 lxc/image.go:1730
 msgid "Unset image properties"
 msgstr ""
 
@@ -6278,11 +6297,11 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:598
+#: lxc/network_forward.go:606
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:599
+#: lxc/network_forward.go:607
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -6326,7 +6345,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6338,7 +6357,7 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:602
+#: lxc/network_forward.go:610
 msgid "Unset the key as a network forward property"
 msgstr ""
 
@@ -6378,7 +6397,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2381
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6386,7 +6405,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:248
+#: lxc/storage_volume.go:250
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6422,12 +6441,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1485
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2652
+#: lxc/export.go:42 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6494,7 +6513,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1576
+#: lxc/storage_volume.go:1578
 msgid "Volume Only"
 msgstr ""
 
@@ -6545,7 +6564,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:293 lxc/move.go:369
+#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6553,12 +6572,12 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:909
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:912
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:282
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:284
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
@@ -6590,7 +6609,7 @@ msgstr ""
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:174
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
@@ -6643,7 +6662,7 @@ msgstr ""
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: lxc/image_alias.go:104
+#: lxc/image_alias.go:121
 msgid "[<remote>:]<alias>"
 msgstr ""
 
@@ -6651,7 +6670,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/image_alias.go:252
+#: lxc/image_alias.go:285
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
@@ -6705,15 +6724,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1600 lxc/image.go:1727
+#: lxc/image.go:1601 lxc/image.go:1728
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1664
+#: lxc/image.go:1665
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6733,7 +6752,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1443
+#: lxc/image.go:334 lxc/image.go:1444
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6804,7 +6823,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:376
+#: lxc/file.go:380
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -6816,12 +6835,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:454
+#: lxc/file.go:466
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1226
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6889,8 +6908,8 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:644
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:179
+#: lxc/network_forward.go:177 lxc/network_forward.go:652
+#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
 #: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
@@ -6905,12 +6924,12 @@ msgid ""
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:402 lxc/network_forward.go:597
+#: lxc/network_forward.go:410 lxc/network_forward.go:605
 #: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
@@ -6920,13 +6939,13 @@ msgid ""
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:887
+#: lxc/network_forward.go:895
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:968 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -6981,7 +7000,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2811
+#: lxc/storage_volume.go:2813
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7016,65 +7035,65 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1958
+#: lxc/storage_volume.go:1960
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:806
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:167
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
-msgstr ""
-
-#: lxc/storage_volume.go:2562
+#: lxc/storage_volume.go:2564
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2645
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2428
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:610
+#: lxc/storage_volume.go:614
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:718
+#: lxc/storage_volume.go:722
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2364
+#: lxc/storage_volume.go:810
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
+msgstr ""
+
+#: lxc/storage_volume.go:167
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
+msgstr ""
+
+#: lxc/storage_volume.go:2366
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2087
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2245
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1234
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1858
+#: lxc/storage_volume.go:1860
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7180,7 +7199,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1603
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7342,20 +7361,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1230
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:470
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:691
+#: lxc/file.go:704
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7656,7 +7675,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:618
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7664,13 +7683,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2817
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2432
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7704,16 +7723,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1396
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1331
+#: lxc/file.go:1355
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1284
+#: lxc/file.go:1308
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-07 15:11-0700\n"
+"POT-Creation-Date: 2025-01-10 14:44-0600\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -79,7 +79,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:1041
+#: lxc/storage_volume.go:1043
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -376,7 +376,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network_forward.go:667
+#: lxc/network_forward.go:675
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -672,12 +672,12 @@ msgstr "%s (altri %d)"
 msgid "%s (%s) (%d available)"
 msgstr "%s (altri %d)"
 
-#: lxc/file.go:1157
+#: lxc/file.go:1177
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s non è una directory"
 
-#: lxc/file.go:1047
+#: lxc/file.go:1067
 #, fuzzy, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' non è un tipo di file supportato."
@@ -714,7 +714,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr "non tutti i profili dell'origine esistono nella destinazione"
 
-#: lxc/init.go:142 lxc/rebuild.go:65
+#: lxc/init.go:146 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -768,7 +768,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:687
+#: lxc/file.go:700
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "Creazione del container in corso"
@@ -786,7 +786,7 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr "ALIAS"
 
@@ -920,7 +920,7 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:888 lxc/network_forward.go:889
+#: lxc/network_forward.go:896 lxc/network_forward.go:897
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -971,7 +971,7 @@ msgstr "il remote %s esiste già"
 msgid "Alias %s doesn't exist"
 msgstr "il remote %s non esiste"
 
-#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
+#: lxc/image_alias.go:101 lxc/image_alias.go:156 lxc/image_alias.go:320
 msgid "Alias name missing"
 msgstr "Nome dell'alias mancante"
 
@@ -984,7 +984,7 @@ msgstr "il remote %s esiste già"
 msgid "Aliases:"
 msgstr "Alias:"
 
-#: lxc/storage_volume.go:1607
+#: lxc/storage_volume.go:1609
 msgid "All projects"
 msgstr ""
 
@@ -1016,7 +1016,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1041,12 +1041,26 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168 lxc/storage_volume.go:169
+#: lxc/storage_volume.go:168
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:169
+msgid ""
+"Attach new storage volumes to instances\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
+msgstr ""
+
+#: lxc/storage_volume.go:285
 msgid "Attach new storage volumes to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:286
+msgid ""
+"Attach new storage volumes to profiles\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
 #: lxc/console.go:39
@@ -1097,16 +1111,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2719
+#: lxc/storage_volume.go:2721
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/export.go:192 lxc/storage_volume.go:2796
+#: lxc/export.go:192 lxc/storage_volume.go:2798
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1538
+#: lxc/info.go:666 lxc/storage_volume.go:1540
 msgid "Backups:"
 msgstr ""
 
@@ -1115,19 +1129,19 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
+#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:326
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Proprietà errata: %s"
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1170,7 +1184,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr "NOME COMUNE"
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1752
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1223,7 +1237,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1231,7 +1245,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:562
+#: lxc/file.go:575
 msgid "Can't pull a directory without --recursive"
 msgstr "Impossibile effettuare il pull di una directory senza --recursive"
 
@@ -1256,11 +1270,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:768
+#: lxc/file.go:790
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1273,12 +1287,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:493
+#: lxc/storage_volume.go:497
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:447
+#: lxc/storage_volume.go:451
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1386,9 +1400,9 @@ msgstr ""
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:497 lxc/network_forward.go:649
-#: lxc/network_forward.go:803 lxc/network_forward.go:892
-#: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
+#: lxc/network_forward.go:505 lxc/network_forward.go:657
+#: lxc/network_forward.go:811 lxc/network_forward.go:900
+#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
 #: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
 #: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
@@ -1400,14 +1414,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
-#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
-#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
-#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
+#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
 msgid "Cluster member name"
 msgstr ""
 
@@ -1423,7 +1437,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1608
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr "Colonne"
@@ -1463,21 +1477,21 @@ msgstr ""
 #: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
-#: lxc/network_acl.go:698 lxc/network_forward.go:767
+#: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
-#: lxc/storage_volume.go:1199
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
+#: lxc/storage_volume.go:1201
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:620
+#: lxc/storage_volume.go:624
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1478
+#: lxc/storage_volume.go:1480
 #, fuzzy, c-format
 msgid "Content type: %s"
 msgstr "Aggiornamento automatico: %s"
@@ -1540,7 +1554,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1548,12 +1562,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1566,7 +1580,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1665,7 +1679,7 @@ msgstr "Creazione del container in corso"
 msgid "Create and start instances from images"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:143 lxc/file.go:462 lxc/file.go:696
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1709,7 +1723,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1764,12 +1778,12 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:182
+#: lxc/init.go:186
 #, c-format
 msgid "Creating %s"
 msgstr "Creazione di %s in corso"
@@ -1779,7 +1793,7 @@ msgstr "Creazione di %s in corso"
 msgid "Creating %s: %%s"
 msgstr "Creazione di %s in corso"
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 #, fuzzy
 msgid "Creating the instance"
 msgstr "Creazione del container in corso"
@@ -1794,13 +1808,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1749
+#: lxc/storage_volume.go:1751
 msgid "DESCRIPTION"
 msgstr "DESCRIZIONE"
 
@@ -1820,7 +1834,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2653
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1853,7 +1867,7 @@ msgstr ""
 msgid "Delete identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:106 lxc/image_alias.go:107
+#: lxc/image_alias.go:123 lxc/image_alias.go:124
 msgid "Delete image aliases"
 msgstr ""
 
@@ -1878,7 +1892,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:799 lxc/network_forward.go:800
+#: lxc/network_forward.go:807 lxc/network_forward.go:808
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1921,7 +1935,7 @@ msgstr "Il nome del container è: %s"
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
+#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1963,13 +1977,13 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
-#: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
-#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
+#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
+#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
+#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
@@ -1983,10 +1997,10 @@ msgstr ""
 #: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:404 lxc/network_forward.go:489
-#: lxc/network_forward.go:599 lxc/network_forward.go:646
-#: lxc/network_forward.go:800 lxc/network_forward.go:874
-#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_forward.go:412 lxc/network_forward.go:497
+#: lxc/network_forward.go:607 lxc/network_forward.go:654
+#: lxc/network_forward.go:808 lxc/network_forward.go:882
+#: lxc/network_forward.go:897 lxc/network_forward.go:982
 #: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
 #: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
 #: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
@@ -2026,27 +2040,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
-#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
-#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
-#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
-#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
-#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
-#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
-#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1465
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Il nome del container è: %s"
@@ -2059,11 +2073,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
+#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2114,7 +2128,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:403
+#: lxc/init.go:407
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2126,7 +2140,7 @@ msgstr "Import da directory non disponibile su questa piattaforma"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1216
+#: lxc/file.go:1236
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2229,7 +2243,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:377 lxc/file.go:378
+#: lxc/file.go:381 lxc/file.go:382
 #, fuzzy
 msgid "Edit files in instances"
 msgstr "Creazione del container in corso"
@@ -2271,7 +2285,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:653 lxc/network_forward.go:654
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -2315,7 +2329,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2323,7 +2337,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1785
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2377,11 +2391,11 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
-#: lxc/network_acl.go:524 lxc/network_forward.go:572
+#: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
+#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2392,11 +2406,11 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
-#: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
+#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
-#: lxc/storage_volume.go:2210
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
+#: lxc/storage_volume.go:2212
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2439,8 +2453,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
+#: lxc/storage_volume.go:1577
 msgid "Expires at"
 msgstr ""
 
@@ -2464,7 +2478,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2478,11 +2492,11 @@ msgstr "Creazione del container in corso"
 msgid "Export instances as backup tarballs."
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2650
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2779
+#: lxc/export.go:152 lxc/storage_volume.go:2781
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Creazione del container in corso"
@@ -2501,7 +2515,7 @@ msgid "FILENAME"
 msgstr ""
 
 #: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
-#: lxc/image_alias.go:235
+#: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2509,12 +2523,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1467
+#: lxc/file.go:1491
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1490
+#: lxc/file.go:1514
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2529,12 +2543,12 @@ msgstr "Il nome del container è: %s"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1517
+#: lxc/file.go:1541
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1326
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Il nome del container è: %s"
@@ -2564,7 +2578,7 @@ msgstr "Il nome del container è: %s"
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1423
+#: lxc/file.go:1447
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Accetta certificato"
@@ -2579,7 +2593,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1428
+#: lxc/file.go:1452
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Accetta certificato"
@@ -2589,12 +2603,12 @@ msgstr "Accetta certificato"
 msgid "Failed starting command: %w"
 msgstr "Accetta certificato"
 
-#: lxc/file.go:1328
+#: lxc/file.go:1352
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Accetta certificato"
 
-#: lxc/file.go:1455
+#: lxc/file.go:1479
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Accetta certificato"
@@ -2608,7 +2622,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr "Accetta certificato"
 
-#: lxc/move.go:304 lxc/move.go:380
+#: lxc/move.go:309 lxc/move.go:385
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "Il nome del container è: %s"
@@ -2633,7 +2647,7 @@ msgstr "Il nome del container è: %s"
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1440
+#: lxc/file.go:1464
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Accetta certificato"
@@ -2648,7 +2662,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr "Accetta certificato"
 
-#: lxc/file.go:1042
+#: lxc/file.go:1062
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2737,14 +2751,14 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1625 lxc/warning.go:94
+#: lxc/storage_volume.go:1627 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2813,7 +2827,7 @@ msgstr "Creazione del container in corso"
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1602
+#: lxc/image.go:1602 lxc/image.go:1603
 msgid "Get image properties"
 msgstr ""
 
@@ -2829,7 +2843,7 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:414
 msgid "Get the key as a network forward property"
 msgstr ""
 
@@ -2873,7 +2887,7 @@ msgstr "Il nome del container è: %s"
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1249
+#: lxc/storage_volume.go:1251
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2902,7 +2916,7 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:403 lxc/network_forward.go:404
+#: lxc/network_forward.go:411 lxc/network_forward.go:412
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
@@ -2943,11 +2957,11 @@ msgstr "Il nome del container è: %s"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:476
+#: lxc/storage_volume.go:480
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2988,22 +3002,22 @@ msgstr "Creazione del container in corso"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1540
+#: lxc/file.go:1564
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "errore di processamento degli alias %s\n"
 
-#: lxc/file.go:1529
+#: lxc/file.go:1553
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "errore di processamento degli alias %s\n"
 
-#: lxc/file.go:1352
+#: lxc/file.go:1376
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "errore di processamento degli alias %s\n"
 
-#: lxc/file.go:1362
+#: lxc/file.go:1386
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "errore di processamento degli alias %s\n"
@@ -3076,11 +3090,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:415
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3090,7 +3104,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2437
+#: lxc/storage_volume.go:2439
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3103,7 +3117,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:1517
+#: lxc/image.go:1518
 msgid "Image already up to date."
 msgstr ""
 
@@ -3119,11 +3133,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1472
+#: lxc/image.go:364 lxc/image.go:1473
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1698
+#: lxc/image.go:444 lxc/image.go:1699
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -3133,7 +3147,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1515
+#: lxc/image.go:1516
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3141,7 +3155,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2815
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3149,7 +3163,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2814
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -3172,11 +3186,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2822
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2894
+#: lxc/storage_volume.go:2896
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Creazione del container in corso"
@@ -3203,11 +3217,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1354
+#: lxc/file.go:1378
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1531
+#: lxc/file.go:1555
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3216,7 +3230,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:414
+#: lxc/init.go:418
 #, fuzzy, c-format
 msgid "Instance name is: %s"
 msgstr "Il nome del container è: %s"
@@ -3226,7 +3240,7 @@ msgstr "Il nome del container è: %s"
 msgid "Instance name must be specified"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1274
+#: lxc/file.go:1298
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3278,7 +3292,7 @@ msgstr "Proprietà errata: %s"
 msgid "Invalid instance name: %s"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1269
+#: lxc/file.go:1293
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Il nome del container è: %s"
@@ -3304,25 +3318,25 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2023
+#: lxc/move.go:153 lxc/storage_volume.go:2025
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "'/' non è permesso nel nome di uno snapshot"
 
-#: lxc/move.go:144
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2019
+#: lxc/storage_volume.go:2021
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:509
+#: lxc/main.go:518
 #, fuzzy
 msgid "Invalid number of arguments"
 msgstr "numero errato di argomenti del sottocomando"
 
-#: lxc/file.go:353
+#: lxc/file.go:357
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3332,19 +3346,19 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr "Proprietà errata: %s"
 
-#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
-#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
+#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:535
+#: lxc/file.go:548
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:717
+#: lxc/file.go:185 lxc/file.go:739
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3381,7 +3395,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3412,12 +3426,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:176
+#: lxc/init.go:180
 #, fuzzy, c-format
 msgid "Launching %s"
 msgstr "Creazione di %s in corso"
 
-#: lxc/init.go:174
+#: lxc/init.go:178
 #, fuzzy
 msgid "Launching the instance"
 msgstr "Creazione del container in corso"
@@ -3524,11 +3538,11 @@ msgstr "Creazione del container in corso"
 msgid "List identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:151
+#: lxc/image_alias.go:176
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:177
 msgid ""
 "List image aliases\n"
 "\n"
@@ -3700,11 +3714,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1605
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1610
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3764,7 +3778,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1481
+#: lxc/info.go:489 lxc/storage_volume.go:1483
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3959,7 +3973,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:873 lxc/network_forward.go:874
+#: lxc/network_forward.go:881 lxc/network_forward.go:882
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -4118,12 +4132,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:322 lxc/move.go:435
+#: lxc/move.go:327 lxc/move.go:440
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:347 lxc/move.go:440
+#: lxc/move.go:352 lxc/move.go:445
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4197,10 +4211,10 @@ msgstr "Il nome del container è: %s"
 msgid "Missing key name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:449
-#: lxc/network_forward.go:534 lxc/network_forward.go:709
-#: lxc/network_forward.go:840 lxc/network_forward.go:933
-#: lxc/network_forward.go:1015 lxc/network_load_balancer.go:221
+#: lxc/network_forward.go:219 lxc/network_forward.go:457
+#: lxc/network_forward.go:542 lxc/network_forward.go:717
+#: lxc/network_forward.go:848 lxc/network_forward.go:945
+#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
 #: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
 #: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
 #: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
@@ -4227,10 +4241,10 @@ msgstr "Il nome del container è: %s"
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
 #: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
 #: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:284 lxc/network_forward.go:445
-#: lxc/network_forward.go:530 lxc/network_forward.go:705
-#: lxc/network_forward.go:836 lxc/network_forward.go:929
-#: lxc/network_forward.go:1011 lxc/network_load_balancer.go:131
+#: lxc/network_forward.go:292 lxc/network_forward.go:453
+#: lxc/network_forward.go:538 lxc/network_forward.go:713
+#: lxc/network_forward.go:844 lxc/network_forward.go:941
+#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
 #: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
 #: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
 #: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
@@ -4269,13 +4283,13 @@ msgstr "Il nome del container è: %s"
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
-#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
-#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
-#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
+#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
+#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
+#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
+#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
 msgid "Missing pool name"
 msgstr ""
 
@@ -4295,16 +4309,16 @@ msgstr "Il nome del container è: %s"
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
+#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1411
+#: lxc/storage_volume.go:1413
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:820
+#: lxc/file.go:842
 msgid "Missing target directory"
 msgstr ""
 
@@ -4338,16 +4352,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
-#: lxc/storage_volume.go:975
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
+#: lxc/storage_volume.go:977
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:507
+#: lxc/file.go:520
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1207 lxc/file.go:1208
+#: lxc/file.go:1227 lxc/file.go:1228
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Creazione del container in corso"
@@ -4377,7 +4391,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4385,16 +4399,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1869
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1059 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4416,7 +4430,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
 msgid "NAME"
 msgstr ""
 
@@ -4468,8 +4482,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
-#: lxc/storage_volume.go:1573
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Name"
 msgstr ""
 
@@ -4477,7 +4491,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4532,12 +4546,12 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:386
+#: lxc/network_forward.go:394
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:857
+#: lxc/network_forward.go:865
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -4621,7 +4635,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
+#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4629,7 +4643,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1070 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4642,11 +4656,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr "Occorre specificare un nome di container come origine"
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4660,7 +4674,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2035
+#: lxc/storage_volume.go:2037
 #, fuzzy
 msgid "Not a snapshot name"
 msgstr "'/' non è permesso nel nome di uno snapshot"
@@ -4669,16 +4683,21 @@ msgstr "'/' non è permesso nel nome di uno snapshot"
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
-#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
-msgid "Only \"custom\" volumes can be attached to instances"
+#: lxc/storage_volume.go:216
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2701
+#: lxc/storage_volume.go:348
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:2703
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2500
+#: lxc/storage_volume.go:2502
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4690,7 +4709,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1431
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4703,7 +4722,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1577
+#: lxc/info.go:705 lxc/storage_volume.go:1579
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4733,7 +4752,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1767
+#: lxc/storage_volume.go:1769
 msgid "POOL"
 msgstr ""
 
@@ -4750,7 +4769,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167
-#: lxc/storage_volume.go:1773 lxc/warning.go:213
+#: lxc/storage_volume.go:1775 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4774,7 +4793,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:367
+#: lxc/main.go:376
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Password amministratore per %s: "
@@ -4814,7 +4833,7 @@ msgstr "Aggiornamento automatico: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1332
+#: lxc/file.go:1356
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4822,12 +4841,12 @@ msgstr ""
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
-#: lxc/network_acl.go:699 lxc/network_forward.go:768
+#: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
-#: lxc/storage_volume.go:1200
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
+#: lxc/storage_volume.go:1202
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4942,11 +4961,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1649
+#: lxc/image.go:1650
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4960,7 +4979,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1238
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4976,7 +4995,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4997,7 +5016,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1017
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5006,7 +5025,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2094
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5019,7 +5038,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2370
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5050,21 +5069,21 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:455 lxc/file.go:456
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:638 lxc/file.go:989
+#: lxc/file.go:651 lxc/file.go:1009
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:688 lxc/file.go:689
+#: lxc/file.go:701 lxc/file.go:702
 #, fuzzy
 msgid "Push files into instances"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:923 lxc/file.go:1089
+#: lxc/file.go:943 lxc/file.go:1109
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5073,7 +5092,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5104,15 +5123,15 @@ msgstr "Creazione del container in corso"
 msgid "Rebuild instances"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:463 lxc/file.go:695
+#: lxc/file.go:475 lxc/file.go:708
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1444 lxc/image.go:1445
+#: lxc/image.go:1445 lxc/image.go:1446
 msgid "Refresh images"
 msgstr ""
 
@@ -5121,7 +5140,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:1481
+#: lxc/image.go:1482
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5201,7 +5220,7 @@ msgstr "Il nome del container è: %s"
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:971 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -5240,7 +5259,7 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:969 lxc/network_forward.go:970
+#: lxc/network_forward.go:981 lxc/network_forward.go:982
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -5278,8 +5297,8 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
-#: lxc/image_alias.go:255
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:287
+#: lxc/image_alias.go:288
 msgid "Rename aliases"
 msgstr ""
 
@@ -5316,15 +5335,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1962
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
+#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5379,7 +5398,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5396,7 +5415,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:361
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5448,12 +5467,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1460
+#: lxc/file.go:1484
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1461
+#: lxc/file.go:1485
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5531,7 +5550,7 @@ msgstr "Creazione del container in corso"
 msgid "Set a cluster member's configuration keys"
 msgstr "Il nome del container è: %s"
 
-#: lxc/file.go:1217
+#: lxc/file.go:1237
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5557,7 +5576,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1665 lxc/image.go:1666
+#: lxc/image.go:1666 lxc/image.go:1667
 msgid "Set image properties"
 msgstr ""
 
@@ -5600,11 +5619,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:488
+#: lxc/network_forward.go:496
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:489
+#: lxc/network_forward.go:497
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5712,11 +5731,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2088
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2089
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5733,7 +5752,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:698
+#: lxc/file.go:711
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5741,7 +5760,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:699
+#: lxc/file.go:712
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5749,7 +5768,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:710
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5761,7 +5780,7 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:504
 msgid "Set the key as a network forward property"
 msgstr ""
 
@@ -5805,7 +5824,7 @@ msgstr "Creazione del container in corso"
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2105
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5813,7 +5832,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1215
+#: lxc/file.go:1235
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5872,7 +5891,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1535 lxc/image.go:1536
+#: lxc/image.go:1536 lxc/image.go:1537
 msgid "Show image properties"
 msgstr ""
 
@@ -5893,7 +5912,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:271 lxc/main.go:272
+#: lxc/main.go:280 lxc/main.go:281
 msgid "Show less common commands"
 msgstr ""
 
@@ -5965,11 +5984,11 @@ msgstr "Il nome del container è: %s"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -6039,15 +6058,15 @@ msgstr "Aggiornamento automatico: %s"
 msgid "Size: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2190
+#: lxc/storage_volume.go:2192
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1502
+#: lxc/info.go:619 lxc/storage_volume.go:1504
 msgid "Snapshots:"
 msgstr ""
 
@@ -6154,21 +6173,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:703
+#: lxc/storage_volume.go:707
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:791
+#: lxc/storage_volume.go:795
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:516
+#: lxc/storage_volume.go:520
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:524
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -6231,22 +6250,22 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1747 lxc/warning.go:216
+#: lxc/storage_volume.go:1749 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
 #, fuzzy
 msgid "Taken at"
 msgstr "salvato alle %s"
 
-#: lxc/file.go:1262
+#: lxc/file.go:1286
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1256
+#: lxc/file.go:1280
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6256,15 +6275,15 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:181
+#: lxc/move.go:186
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:219 lxc/move.go:240
+#: lxc/move.go:224 lxc/move.go:245
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:193
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -6272,15 +6291,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:185
+#: lxc/move.go:190
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:189
+#: lxc/move.go:194
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:210
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -6302,7 +6321,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:439
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6356,7 +6375,7 @@ msgstr "Il nome del container è: %s"
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network_forward.go:462
+#: lxc/network_forward.go:470
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr "Il nome del container è: %s"
@@ -6396,12 +6415,12 @@ msgstr "Il nome del container è: %s"
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: lxc/storage_volume.go:1340
+#: lxc/storage_volume.go:1342
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: lxc/storage_volume.go:1317
+#: lxc/storage_volume.go:1319
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6416,12 +6435,12 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:309
+#: lxc/move.go:314
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
-#: lxc/storage_volume.go:989
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
+#: lxc/storage_volume.go:991
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6451,7 +6470,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr "Import da directory non disponibile su questa piattaforma"
 
-#: lxc/main.go:298
+#: lxc/main.go:307
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6475,11 +6494,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:437
+#: lxc/init.go:441
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:440
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6487,7 +6506,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:412
+#: lxc/main.go:421
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6498,7 +6517,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1489
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Aggiornamento automatico: %s"
@@ -6513,7 +6532,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1864
+#: lxc/storage_volume.go:1866
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6521,7 +6540,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6538,7 +6557,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:327
+#: lxc/copy.go:382 lxc/move.go:332
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "Creazione del container in corso"
@@ -6581,7 +6600,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1472
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6603,13 +6622,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1752
+#: lxc/project.go:995 lxc/storage_volume.go:1754
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1751
+#: lxc/storage.go:724 lxc/storage_volume.go:1753
 msgid "USED BY"
 msgstr ""
 
@@ -6622,7 +6641,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:411
+#: lxc/file.go:423
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6637,12 +6656,12 @@ msgstr "Aggiungi un nuovo server remoto"
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1483
+#: lxc/file.go:1507
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1791
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6653,7 +6672,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1029
+#: lxc/file.go:1049
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6687,7 +6706,7 @@ msgstr "non tutti i profili dell'origine esistono nella destinazione"
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1728 lxc/image.go:1729
+#: lxc/image.go:1729 lxc/image.go:1730
 msgid "Unset image properties"
 msgstr ""
 
@@ -6703,11 +6722,11 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:598
+#: lxc/network_forward.go:606
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:599
+#: lxc/network_forward.go:607
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -6757,7 +6776,7 @@ msgstr "Il nome del container è: %s"
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6769,7 +6788,7 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:602
+#: lxc/network_forward.go:610
 msgid "Unset the key as a network forward property"
 msgstr ""
 
@@ -6813,7 +6832,7 @@ msgstr "Il nome del container è: %s"
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2381
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6821,7 +6840,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:248
+#: lxc/storage_volume.go:250
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6859,12 +6878,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1485
+#: lxc/storage_volume.go:1487
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2652
+#: lxc/export.go:42 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6931,7 +6950,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1576
+#: lxc/storage_volume.go:1578
 msgid "Volume Only"
 msgstr ""
 
@@ -6983,7 +7002,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr "Occorre specificare un nome di container come origine"
 
-#: lxc/copy.go:98 lxc/move.go:293 lxc/move.go:369
+#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
 #, fuzzy
 msgid "You must specify a source instance name"
 msgstr "Occorre specificare un nome di container come origine"
@@ -6993,14 +7012,14 @@ msgstr "Occorre specificare un nome di container come origine"
 msgid "You need to specify an image name or use --empty"
 msgstr "Occorre specificare un nome di container come origine"
 
-#: lxc/storage_volume.go:909
+#: lxc/storage_volume.go:912
 #, fuzzy
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:282
+#: lxc/storage_volume.go:284
 #, fuzzy
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr "Creazione del container in corso"
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
@@ -7038,7 +7057,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:] [<filter>...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:174
 #, fuzzy
 msgid "[<remote>:] [<filters>...]"
 msgstr "Creazione del container in corso"
@@ -7103,7 +7122,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/image_alias.go:104
+#: lxc/image_alias.go:121
 #, fuzzy
 msgid "[<remote>:]<alias>"
 msgstr "Creazione del container in corso"
@@ -7113,7 +7132,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr "Creazione del container in corso"
 
-#: lxc/image_alias.go:252
+#: lxc/image_alias.go:285
 #, fuzzy
 msgid "[<remote>:]<alias> <new-name>"
 msgstr "Creazione del container in corso"
@@ -7176,17 +7195,17 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:1600 lxc/image.go:1727
+#: lxc/image.go:1601 lxc/image.go:1728
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:1664
+#: lxc/image.go:1665
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr "Creazione del container in corso"
@@ -7211,7 +7230,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<image> [<target>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:334 lxc/image.go:1443
+#: lxc/image.go:334 lxc/image.go:1444
 #, fuzzy
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "Creazione del container in corso"
@@ -7298,7 +7317,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:376
+#: lxc/file.go:380
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr "Creazione del container in corso"
@@ -7313,13 +7332,13 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:454
+#: lxc/file.go:466
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:1206
+#: lxc/file.go:1226
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "Creazione del container in corso"
@@ -7403,8 +7422,8 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:644
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:179
+#: lxc/network_forward.go:177 lxc/network_forward.go:652
+#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
 #: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address>"
@@ -7422,13 +7441,13 @@ msgid ""
 "[<target_port(s)>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_forward.go:402 lxc/network_forward.go:597
+#: lxc/network_forward.go:410 lxc/network_forward.go:605
 #: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_forward.go:487 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr "Creazione del container in corso"
@@ -7440,13 +7459,13 @@ msgid ""
 "<backend_name>[,<backend_name>...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/network_forward.go:887
+#: lxc/network_forward.go:895
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:968 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr "Creazione del container in corso"
@@ -7514,7 +7533,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<pool>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2811
+#: lxc/storage_volume.go:2813
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "Creazione del container in corso"
@@ -7557,79 +7576,79 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1958
+#: lxc/storage_volume.go:1960
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:806
-#, fuzzy
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
-msgstr "Creazione del container in corso"
-
-#: lxc/storage_volume.go:167
-#, fuzzy
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
-msgstr "Creazione del container in corso"
-
-#: lxc/storage_volume.go:2562
+#: lxc/storage_volume.go:2564
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2645
+#: lxc/storage_volume.go:2647
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2428
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:610
+#: lxc/storage_volume.go:614
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:718
+#: lxc/storage_volume.go:722
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2364
+#: lxc/storage_volume.go:810
+#, fuzzy
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
+msgstr "Creazione del container in corso"
+
+#: lxc/storage_volume.go:167
+#, fuzzy
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
+msgstr "Creazione del container in corso"
+
+#: lxc/storage_volume.go:2366
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2087
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2245
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1234
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1858
+#: lxc/storage_volume.go:1860
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:392
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr "Creazione del container in corso"
@@ -7761,7 +7780,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1603
 #, fuzzy
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr "Creazione del container in corso"
@@ -7927,20 +7946,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1230
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:470
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:691
+#: lxc/file.go:704
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -8241,7 +8260,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:618
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -8249,13 +8268,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2817
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2432
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -8290,16 +8309,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1396
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1331
+#: lxc/file.go:1355
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1284
+#: lxc/file.go:1308
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-07 15:11-0700\n"
+"POT-Creation-Date: 2025-01-10 14:44-0600\n"
 "PO-Revision-Date: 2023-03-10 15:14+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -71,7 +71,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:1041
+#: lxc/storage_volume.go:1043
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -364,7 +364,7 @@ msgstr ""
 "### Note that only the ingress and egress rules, description and "
 "configuration keys can be changed."
 
-#: lxc/network_forward.go:667
+#: lxc/network_forward.go:675
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -664,12 +664,12 @@ msgstr "%s (他%d個)"
 msgid "%s (%s) (%d available)"
 msgstr "%s (%d個使用可能)"
 
-#: lxc/file.go:1157
+#: lxc/file.go:1177
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s はディレクトリではありません"
 
-#: lxc/file.go:1047
+#: lxc/file.go:1067
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' はサポートされないタイプのファイルです"
@@ -705,7 +705,7 @@ msgstr "--console と --all は同時に指定できません"
 msgid "--console only works with a single instance"
 msgstr "--console は単一のインスタンスのときのみ指定できます"
 
-#: lxc/init.go:142 lxc/rebuild.go:65
+#: lxc/init.go:146 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr "--empty はイメージ名と同時に指定できません"
 
@@ -758,7 +758,7 @@ msgstr "<remote> <URL>"
 msgid "<remote> <new-name>"
 msgstr "<remote> <new-name>"
 
-#: lxc/file.go:687
+#: lxc/file.go:700
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "<source path>... [<remote>:]<instance>/<path>"
 
@@ -777,7 +777,7 @@ msgstr "<target>"
 msgid "ADDRESS"
 msgstr "IP ADDRESS"
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr "ALIAS"
 
@@ -929,7 +929,7 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr "グループからメンバーを削除します"
 
-#: lxc/network_forward.go:888 lxc/network_forward.go:889
+#: lxc/network_forward.go:896 lxc/network_forward.go:897
 msgid "Add ports to a forward"
 msgstr "フォワードにポートを追加します"
 
@@ -979,7 +979,7 @@ msgstr "エイリアス %s は既に存在します"
 msgid "Alias %s doesn't exist"
 msgstr "エイリアス %s は存在しません"
 
-#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
+#: lxc/image_alias.go:101 lxc/image_alias.go:156 lxc/image_alias.go:320
 msgid "Alias name missing"
 msgstr "エイリアスを指定してください"
 
@@ -992,7 +992,7 @@ msgstr "エイリアス %s は既に存在します"
 msgid "Aliases:"
 msgstr "エイリアス:"
 
-#: lxc/storage_volume.go:1607
+#: lxc/storage_volume.go:1609
 msgid "All projects"
 msgstr "すべてのプロジェクト"
 
@@ -1024,7 +1024,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr "どちらもみつかりませんでした。raw SPICE ソケットはこちらにあります:"
 
-#: lxc/init.go:343 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr "VMを要求しましたが、イメージタイプがコンテナです"
 
@@ -1048,13 +1048,27 @@ msgstr "プロファイルにネットワークインターフェースを追加
 msgid "Attach new network interfaces to instances"
 msgstr "新たなネットワークインターフェースをインスタンスに追加します"
 
-#: lxc/storage_volume.go:168 lxc/storage_volume.go:169
+#: lxc/storage_volume.go:168
 msgid "Attach new storage volumes to instances"
 msgstr "新たにストレージボリュームをインスタンスに追加します"
 
-#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:169
+msgid ""
+"Attach new storage volumes to instances\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
+msgstr ""
+
+#: lxc/storage_volume.go:285
 msgid "Attach new storage volumes to profiles"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
+
+#: lxc/storage_volume.go:286
+msgid ""
+"Attach new storage volumes to profiles\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
+msgstr ""
 
 #: lxc/console.go:39
 msgid "Attach to instance consoles"
@@ -1108,16 +1122,16 @@ msgstr "BASE IMAGE"
 msgid "Backing up instance: %s"
 msgstr "インスタンスのバックアップ中: %s"
 
-#: lxc/storage_volume.go:2719
+#: lxc/storage_volume.go:2721
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr "ストレージボリュームのバックアップ中: %s"
 
-#: lxc/export.go:192 lxc/storage_volume.go:2796
+#: lxc/export.go:192 lxc/storage_volume.go:2798
 msgid "Backup exported successfully!"
 msgstr "バックアップのエクスポートが成功しました!"
 
-#: lxc/info.go:666 lxc/storage_volume.go:1538
+#: lxc/info.go:666 lxc/storage_volume.go:1540
 msgid "Backups:"
 msgstr "バックアップ:"
 
@@ -1128,19 +1142,19 @@ msgstr ""
 "デバイスを上書きする際の書式が不適切です。次のような形式で指定してください "
 "<device>,<key>=<value>: %s"
 
-#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
+#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:326
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr "不適切なキー/値のペア: %s"
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "不適切な キー=値 のペア: %s"
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr "不適切な キー=値 のペア: %s"
@@ -1183,7 +1197,7 @@ msgstr "CANCELABLE"
 msgid "COMMON NAME"
 msgstr "COMMON NAME"
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1752
 msgid "CONTENT-TYPE"
 msgstr "CONTENT-TYPE"
 
@@ -1235,7 +1249,7 @@ msgstr "キャッシュ済: %s"
 msgid "Caches:"
 msgstr "キャッシュ:"
 
-#: lxc/move.go:130
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr "ローカル上のリネームでは、設定やプロファイルの上書きはできません"
 
@@ -1243,7 +1257,7 @@ msgstr "ローカル上のリネームでは、設定やプロファイルの上
 msgid "Can't provide a name for the target image"
 msgstr "ターゲットイメージの名前を取得できません"
 
-#: lxc/file.go:562
+#: lxc/file.go:575
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 "ディレクトリを pull する場合は --recursive オプションを使用してください"
@@ -1269,11 +1283,11 @@ msgstr "--project と --all-project は同時に指定できません"
 msgid "Can't specify a different remote for rename"
 msgstr "リネームの場合は異なるリモートを指定できません"
 
-#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr "クラスタでない場合はカラムとして L は指定できません"
 
-#: lxc/file.go:768
+#: lxc/file.go:790
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "再帰 (recursive) モードでは uid/gid/mode を指定できません"
 
@@ -1286,14 +1300,14 @@ msgstr "キー '%s' が設定されていないので削除できません"
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:493
+#: lxc/storage_volume.go:497
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 "コピー先のサーバーがクラスターに属していない場合は --destination-target は指"
 "定できません"
 
-#: lxc/storage_volume.go:447
+#: lxc/storage_volume.go:451
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 "コピー元のサーバーがクラスターに属していない場合は --target は指定できません"
@@ -1402,9 +1416,9 @@ msgstr "クラスターメンバー %s がグループ %s から削除されま�
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:497 lxc/network_forward.go:649
-#: lxc/network_forward.go:803 lxc/network_forward.go:892
-#: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
+#: lxc/network_forward.go:505 lxc/network_forward.go:657
+#: lxc/network_forward.go:811 lxc/network_forward.go:900
+#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
 #: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
 #: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
@@ -1416,14 +1430,14 @@ msgstr "クラスターメンバー %s がグループ %s から削除されま�
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
-#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
-#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
-#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
+#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
 msgid "Cluster member name"
 msgstr "クラスタメンバ名"
 
@@ -1439,7 +1453,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr "クラスタリングが有効になりました"
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1608
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr "カラムレイアウト"
@@ -1483,21 +1497,21 @@ msgstr "移動先のインスタンスに適用するキー/値の設定"
 #: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
-#: lxc/network_acl.go:698 lxc/network_forward.go:767
+#: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
-#: lxc/storage_volume.go:1199
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
+#: lxc/storage_volume.go:1201
 #, c-format
 msgid "Config parsing error: %s"
 msgstr "設定の構文エラー: %s"
 
-#: lxc/storage_volume.go:620
+#: lxc/storage_volume.go:624
 msgid "Content type, block or filesystem"
 msgstr "ストレージボリュームのタイプ、block もしくは filesystem"
 
-#: lxc/storage_volume.go:1478
+#: lxc/storage_volume.go:1480
 #, c-format
 msgid "Content type: %s"
 msgstr "コンテンツタイプ: %s"
@@ -1575,7 +1589,7 @@ msgstr "プロファイルに継承されたデバイスをコピーし、設定
 msgid "Copy profiles"
 msgstr "プロファイルをコピーします"
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr "ストレージボリュームをコピーします"
 
@@ -1583,12 +1597,12 @@ msgstr "ストレージボリュームをコピーします"
 msgid "Copy the instance without its snapshots"
 msgstr "インスタンスをコピーします。スナップショットはコピーしません"
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr "ボリュームをコピーします (スナップショットはコピーしません)"
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr "コピー／移動元とは異なるプロジェクトにコピーします"
 
@@ -1601,7 +1615,7 @@ msgstr "仮想マシンイメージをコピーします"
 msgid "Copying the image: %s"
 msgstr "イメージのコピー中: %s"
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr "ストレージボリュームのコピー中: %s"
@@ -1698,7 +1712,7 @@ msgstr "警告を削除します"
 msgid "Create and start instances from images"
 msgstr "イメージからインスタンスを作成し、起動します"
 
-#: lxc/file.go:143 lxc/file.go:462 lxc/file.go:696
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
 msgid "Create any directories necessary"
 msgstr "必要なディレクトリをすべて作成します"
 
@@ -1745,7 +1759,7 @@ msgstr "ストレージバケットに対する鍵を作成します"
 msgid "Create new custom storage buckets"
 msgstr "新たにカスタムストレージバケットを作成します"
 
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
 msgid "Create new custom storage volumes"
 msgstr "新たにカスタムストレージボリュームを作成します"
 
@@ -1797,12 +1811,12 @@ msgstr "ストレージプールを作成します"
 msgid "Create the instance with no profiles applied"
 msgstr "プロファイルを適用しないインスタンスを作成します"
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
 #, c-format
 msgid "Created: %s"
 msgstr "作成日時: %s"
 
-#: lxc/init.go:182
+#: lxc/init.go:186
 #, c-format
 msgid "Creating %s"
 msgstr "%s を作成中"
@@ -1812,7 +1826,7 @@ msgstr "%s を作成中"
 msgid "Creating %s: %%s"
 msgstr "%s を作成中"
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 msgid "Creating the instance"
 msgstr "インスタンスを作成中"
 
@@ -1826,13 +1840,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr "DEFAULT TARGET ADDRESS"
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1749
+#: lxc/storage_volume.go:1751
 msgid "DESCRIPTION"
 msgstr "DESCRIPTION"
 
@@ -1852,7 +1866,7 @@ msgstr "DRM:"
 msgid "Default VLAN ID"
 msgstr "デフォルト VLAN ID"
 
-#: lxc/storage_volume.go:2653
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr "圧縮アルゴリズムを指定します: backup or none"
 
@@ -1887,7 +1901,7 @@ msgstr "プロファイルを削除します"
 msgid "Delete identity provider groups"
 msgstr "クラスタグループを削除します"
 
-#: lxc/image_alias.go:106 lxc/image_alias.go:107
+#: lxc/image_alias.go:123 lxc/image_alias.go:124
 msgid "Delete image aliases"
 msgstr "イメージのエイリアスを削除します"
 
@@ -1911,7 +1925,7 @@ msgstr "ストレージバケットからキーを削除します"
 msgid "Delete network ACLs"
 msgstr "ネットワーク ACL を削除します"
 
-#: lxc/network_forward.go:799 lxc/network_forward.go:800
+#: lxc/network_forward.go:807 lxc/network_forward.go:808
 msgid "Delete network forwards"
 msgstr "ネットワークフォワードを削除します"
 
@@ -1951,7 +1965,7 @@ msgstr "ストレージバケットを削除します"
 msgid "Delete storage pools"
 msgstr "ストレージプールを削除します"
 
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
+#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
 msgid "Delete storage volumes"
 msgstr "ストレージボリュームを削除します"
 
@@ -1993,13 +2007,13 @@ msgstr "警告を削除します"
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
-#: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
-#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
+#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
+#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
+#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
@@ -2013,10 +2027,10 @@ msgstr "警告を削除します"
 #: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:404 lxc/network_forward.go:489
-#: lxc/network_forward.go:599 lxc/network_forward.go:646
-#: lxc/network_forward.go:800 lxc/network_forward.go:874
-#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_forward.go:412 lxc/network_forward.go:497
+#: lxc/network_forward.go:607 lxc/network_forward.go:654
+#: lxc/network_forward.go:808 lxc/network_forward.go:882
+#: lxc/network_forward.go:897 lxc/network_forward.go:982
 #: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
 #: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
 #: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
@@ -2056,27 +2070,27 @@ msgstr "警告を削除します"
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
-#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
-#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
-#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
-#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
-#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
-#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
-#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr "説明"
 
-#: lxc/storage_volume.go:1465
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Description: %s"
 msgstr "説明: %s"
 
-#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
 msgid "Destination cluster member name"
 msgstr "コピー先のクラスターメンバー名"
 
@@ -2088,11 +2102,11 @@ msgstr "インスタンスからネットワークインターフェースを取
 msgid "Detach network interfaces from profiles"
 msgstr "プロファイルからネットワークインターフェースを取り外します"
 
-#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
 msgid "Detach storage volumes from instances"
 msgstr "インスタンスからストレージボリュームを取り外します"
 
-#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
+#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
 msgid "Detach storage volumes from profiles"
 msgstr "プロファイルからストレージボリュームを取り外します"
 
@@ -2146,7 +2160,7 @@ msgstr "プロファイルのデバイスは個々のインスタンスでは取
 msgid "Device: %s"
 msgstr "デバイス: %s"
 
-#: lxc/init.go:403
+#: lxc/init.go:407
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 "サーバから変更されたイメージ、インスタンス、スナップショットを取得できません"
@@ -2160,7 +2174,7 @@ msgstr "このプラットフォーム上ではディレクトリのインポー
 msgid "Directory to run the command in (default /root)"
 msgstr "コマンドを実行するディレクトリ (デフォルト /root)"
 
-#: lxc/file.go:1216
+#: lxc/file.go:1236
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr "SSH SFTP リスナーを使う際に認証を無効化します"
 
@@ -2262,7 +2276,7 @@ msgstr "ストレージバケットの設定をYAMLで編集します"
 msgid "Edit cluster member configurations as YAML"
 msgstr "クラスターメンバーの設定をYAMLファイルで編集します"
 
-#: lxc/file.go:377 lxc/file.go:378
+#: lxc/file.go:381 lxc/file.go:382
 msgid "Edit files in instances"
 msgstr "インスタンス内のファイルを編集します"
 
@@ -2305,7 +2319,7 @@ msgstr "ネットワーク ACL をYAMLで編集します"
 msgid "Edit network configurations as YAML"
 msgstr "ネットワーク設定をYAMLで編集します"
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:653 lxc/network_forward.go:654
 msgid "Edit network forward configurations as YAML"
 msgstr "ネットワークフォワード設定をYAMLで編集します"
 
@@ -2345,7 +2359,7 @@ msgstr "ストレージバケットの設定をYAMLで編集します"
 msgid "Edit storage pool configurations as YAML"
 msgstr "ストレージプールの設定をYAMLで編集します"
 
-#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
 msgid "Edit storage volume configurations as YAML"
 msgstr "ストレージボリュームの設定をYAMLで編集します"
 
@@ -2353,7 +2367,7 @@ msgstr "ストレージボリュームの設定をYAMLで編集します"
 msgid "Edit trust configurations as YAML"
 msgstr "信頼済みクライアント設定をYAMLで編集します"
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1785
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2419,11 +2433,11 @@ msgid "Error retrieving aliases: %w"
 msgstr "イメージの取得中: %s"
 
 #: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
-#: lxc/network_acl.go:524 lxc/network_forward.go:572
+#: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
+#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "イメージの取得中: %s"
@@ -2434,11 +2448,11 @@ msgid "Error unsetting properties: %v"
 msgstr "イメージのプロパティを削除します"
 
 #: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
-#: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
+#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
-#: lxc/storage_volume.go:2210
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
+#: lxc/storage_volume.go:2212
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2491,8 +2505,8 @@ msgstr ""
 "デフォルトのモードは non-interactive です。もし標準入出力が両方ともターミナル"
 "の場合は interactive モードが選択されます (標準エラー出力は無視されます)。"
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
+#: lxc/storage_volume.go:1577
 msgid "Expires at"
 msgstr "失効日時"
 
@@ -2519,7 +2533,7 @@ msgstr ""
 "\n"
 "出力先はオプショナルで、デフォルトは現在のディレクトリです。"
 
-#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr "カスタムストレージボリュームをエクスポートします"
 
@@ -2531,12 +2545,12 @@ msgstr "インスタンスのバックアップをエクスポートします"
 msgid "Export instances as backup tarballs."
 msgstr "インスタンスを tarball 形式のバックアップとしてエクスポートします。"
 
-#: lxc/storage_volume.go:2650
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 "ボリュームをエクスポートします (スナップショットはエクスポートしません)"
 
-#: lxc/export.go:152 lxc/storage_volume.go:2779
+#: lxc/export.go:152 lxc/storage_volume.go:2781
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr "バックアップのエクスポート中: %s"
@@ -2555,7 +2569,7 @@ msgid "FILENAME"
 msgstr "FILENAME"
 
 #: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
-#: lxc/image_alias.go:235
+#: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr "FINGERPRINT"
 
@@ -2563,12 +2577,12 @@ msgstr "FINGERPRINT"
 msgid "FIRST SEEN"
 msgstr "FIRST SEEN"
 
-#: lxc/file.go:1467
+#: lxc/file.go:1491
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr "クライアント %q との SSH ハンドシェイクに失敗しました: %v"
 
-#: lxc/file.go:1490
+#: lxc/file.go:1514
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr "クライアント %q のチャンネルの受け入れに失敗しました: %v"
@@ -2583,12 +2597,12 @@ msgstr "インスタンスの存在確認に失敗しました \"%s:%s\": %w"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "インスタンスのスナップショットの存在確認に失敗しました \"%s:%s\": %w"
 
-#: lxc/file.go:1517
+#: lxc/file.go:1541
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr "クライアント %q に対する SFTP インスタンスの接続に失敗しました: %v"
 
-#: lxc/file.go:1302
+#: lxc/file.go:1326
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "インスタンスの SFTP への接続に失敗しました: %w"
@@ -2618,7 +2632,7 @@ msgstr "クライアント %q のチャンネルの受け入れに失敗しま�
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "クライアント %q のチャンネルの受け入れに失敗しました: %v"
 
-#: lxc/file.go:1423
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "SSH ホスト鍵の生成に失敗しました: %w"
@@ -2633,7 +2647,7 @@ msgstr "ピアのステータスの取得に失敗しました: %w"
 msgid "Failed loading profile %q: %w"
 msgstr "デバイス上書きのためのプロファイル %q のロードに失敗しました: %w"
 
-#: lxc/file.go:1428
+#: lxc/file.go:1452
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "SSH ホスト鍵の読み取りに失敗しました: %w"
@@ -2643,12 +2657,12 @@ msgstr "SSH ホスト鍵の読み取りに失敗しました: %w"
 msgid "Failed starting command: %w"
 msgstr "コマンドの実行に失敗しました: %w"
 
-#: lxc/file.go:1328
+#: lxc/file.go:1352
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "sshfs の起動に失敗しました: %w"
 
-#: lxc/file.go:1455
+#: lxc/file.go:1479
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "受信接続の受け入れに失敗しました: %w"
@@ -2662,7 +2676,7 @@ msgstr "リモートの追加に失敗しました"
 msgid "Failed to close server cert file %q: %w"
 msgstr "サーバー証明書ファイル %q のクローズに失敗しました: %w"
 
-#: lxc/move.go:304 lxc/move.go:380
+#: lxc/move.go:309 lxc/move.go:385
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "クラスタメンバへの接続に失敗しました: %w"
@@ -2687,7 +2701,7 @@ msgstr "クラスタメンバへの接続に失敗しました: %w"
 msgid "Failed to find project: %w"
 msgstr "プロジェクトが見つけられませんでした: %w"
 
-#: lxc/file.go:1440
+#: lxc/file.go:1464
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "コネクションのリッスンに失敗しました: %w"
@@ -2702,7 +2716,7 @@ msgstr "コピー先のインスタンス '%s' のリフレッシュに失敗し
 msgid "Failed to remove alias %s: %w"
 msgstr "エイリアス %s の削除に失敗しました: %w"
 
-#: lxc/file.go:1042
+#: lxc/file.go:1062
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr "パス %s にアクセスできませんでした: %s"
@@ -2805,14 +2819,14 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1625 lxc/warning.go:94
+#: lxc/storage_volume.go:1627 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr "フォーマット (csv|json|table|yaml|compact)"
 
@@ -2881,7 +2895,7 @@ msgstr "インスタンスからファイルをマウントします"
 msgid "Get a summary of resource allocations"
 msgstr "リソース割当の状況を表示します"
 
-#: lxc/image.go:1601 lxc/image.go:1602
+#: lxc/image.go:1602 lxc/image.go:1603
 msgid "Get image properties"
 msgstr "イメージのプロパティを取得します"
 
@@ -2898,7 +2912,7 @@ msgstr "クラスターグループを作成します"
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:414
 #, fuzzy
 msgid "Get the key as a network forward property"
 msgstr "ネットワークフォワードのポートを管理します"
@@ -2945,7 +2959,7 @@ msgstr "ストレージバケットに対する鍵を作成します"
 msgid "Get the key as a storage property"
 msgstr "ストレージバケットに対する鍵を作成します"
 
-#: lxc/storage_volume.go:1249
+#: lxc/storage_volume.go:1251
 #, fuzzy
 msgid "Get the key as a storage volume property"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
@@ -2974,7 +2988,7 @@ msgstr "ネットワーク ACL の設定値を取得します"
 msgid "Get values for network configuration keys"
 msgstr "ネットワークの設定値を取得します"
 
-#: lxc/network_forward.go:403 lxc/network_forward.go:404
+#: lxc/network_forward.go:411 lxc/network_forward.go:412
 msgid "Get values for network forward configuration keys"
 msgstr "ネットワークフォワードの設定値を取得します"
 
@@ -3010,11 +3024,11 @@ msgstr "ストレージバケットの設定値を取得します"
 msgid "Get values for storage pool configuration keys"
 msgstr "ストレージプールの設定値を取得します"
 
-#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
 msgid "Get values for storage volume configuration keys"
 msgstr "ストレージボリュームの設定値を取得します"
 
-#: lxc/storage_volume.go:476
+#: lxc/storage_volume.go:480
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr "指定したコピー先 %q がコピー元のボリュームの場所 %q と一致しません"
@@ -3055,22 +3069,22 @@ msgstr "ホストインターフェース"
 msgid "Hugepages:\n"
 msgstr "Hugepages:\n"
 
-#: lxc/file.go:1540
+#: lxc/file.go:1564
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "SSH 経由のインスタンスへの I/O コピーが失敗しました: %v"
 
-#: lxc/file.go:1529
+#: lxc/file.go:1553
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "インスタンスから SSH 経由の I/O コピーに失敗しました: %v"
 
-#: lxc/file.go:1352
+#: lxc/file.go:1376
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "インスタンスから sshfs への I/O コピーに失敗しました: %v"
 
-#: lxc/file.go:1362
+#: lxc/file.go:1386
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "sshfs からインスタンスへの I/O コピーに失敗しました: %v"
@@ -3146,13 +3160,13 @@ msgstr ""
 "存在するスナップショット名の場合は既存のスナップショットを削除したあとに新し"
 "いスナップショットを作成します"
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 "存在するスナップショット名の場合は既存のスナップショットを削除したあとに新し"
 "いスナップショットを作成します"
 
-#: lxc/main.go:406
+#: lxc/main.go:415
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3162,7 +3176,7 @@ msgstr "初めてこのマシンで LXD を使う場合、lxd init と実行す�
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr "設定されている自動でのインスタンスの有効期限設定を無視します"
 
-#: lxc/storage_volume.go:2437
+#: lxc/storage_volume.go:2439
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr "設定されている自動でのストレージボリュームの有効期限設定を無視します"
 
@@ -3174,7 +3188,7 @@ msgstr "コピー中にファイルが更新された場合のエラーを無視
 msgid "Ignore the instance state"
 msgstr "インスタンスの状態を無視します"
 
-#: lxc/image.go:1517
+#: lxc/image.go:1518
 msgid "Image already up to date."
 msgstr "イメージは更新済みです。"
 
@@ -3190,11 +3204,11 @@ msgstr "イメージの失効日（フォーマット: rfc3339）"
 msgid "Image exported successfully!"
 msgstr "イメージのエクスポートが成功しました!"
 
-#: lxc/image.go:364 lxc/image.go:1472
+#: lxc/image.go:364 lxc/image.go:1473
 msgid "Image identifier missing"
 msgstr "イメージ名を指定してください"
 
-#: lxc/image.go:444 lxc/image.go:1698
+#: lxc/image.go:444 lxc/image.go:1699
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr "イメージ名を指定してください: %s"
@@ -3204,7 +3218,7 @@ msgstr "イメージ名を指定してください: %s"
 msgid "Image imported with fingerprint: %s"
 msgstr "イメージは以下のフィンガープリントでインポートされました: %s"
 
-#: lxc/image.go:1515
+#: lxc/image.go:1516
 msgid "Image refreshed successfully!"
 msgstr "イメージの更新が成功しました!"
 
@@ -3212,7 +3226,7 @@ msgstr "イメージの更新が成功しました!"
 msgid "Immediately attach to the console"
 msgstr "起動直後にインスタンスのコンソールに接続します"
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2815
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 "カスタムボリュームのバックアップをスナップショットを含んだ状態でインポートし"
@@ -3223,7 +3237,7 @@ msgid "Import backups of instances including their snapshots."
 msgstr ""
 "インスタンスのバックアップをスナップショットを含んだ状態でインポートします。"
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2814
 msgid "Import custom storage volumes"
 msgstr "新たにカスタムストレージボリュームをインポートします"
 
@@ -3250,11 +3264,11 @@ msgstr "イメージをイメージストアにインポートします"
 msgid "Import instance backups"
 msgstr "インスタンスのバックアップをインポートします"
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2822
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2894
+#: lxc/storage_volume.go:2896
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr "カスタムボリュームのインポート中: %s"
@@ -3280,11 +3294,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr "インスタンスのみ"
 
-#: lxc/file.go:1354
+#: lxc/file.go:1378
 msgid "Instance disconnected"
 msgstr "インスタンスが切断されました"
 
-#: lxc/file.go:1531
+#: lxc/file.go:1555
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr "クライアント %q に対するインスタンスが切断されました"
@@ -3293,7 +3307,7 @@ msgstr "クライアント %q に対するインスタンスが切断されま�
 msgid "Instance name is mandatory"
 msgstr "インスタンス名を指定する必要があります"
 
-#: lxc/init.go:414
+#: lxc/init.go:418
 #, c-format
 msgid "Instance name is: %s"
 msgstr "インスタンス名: %s"
@@ -3303,7 +3317,7 @@ msgstr "インスタンス名: %s"
 msgid "Instance name must be specified"
 msgstr "インスタンス名: %s"
 
-#: lxc/file.go:1274
+#: lxc/file.go:1298
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr "SSH SFTP リスナーモードではインスタンスのパスを使用できません"
 
@@ -3356,7 +3370,7 @@ msgstr "不正なフォーマット %s"
 msgid "Invalid instance name: %s"
 msgstr "不正なインスタンス名: %s"
 
-#: lxc/file.go:1269
+#: lxc/file.go:1293
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr "不正なインスタンスのパス: %q"
@@ -3385,27 +3399,27 @@ msgid ""
 msgstr ""
 "'%s' は不正な名前です。空文字列は maxWidth を指定しているときのみ指定できます"
 
-#: lxc/move.go:148 lxc/storage_volume.go:2023
+#: lxc/move.go:153 lxc/storage_volume.go:2025
 msgid "Invalid new snapshot name"
 msgstr "不適切な新しいスナップショット名"
 
-#: lxc/move.go:144
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 "新しいスナップショット名が不正です。親のスナップショット名はソースと同じでな"
 "ければいけません"
 
-#: lxc/storage_volume.go:2019
+#: lxc/storage_volume.go:2021
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 "新しいスナップショット名が不正です。親のボリュームはソースと同じでなければな"
 "りません"
 
-#: lxc/main.go:509
+#: lxc/main.go:518
 msgid "Invalid number of arguments"
 msgstr "引数の数が不正です"
 
-#: lxc/file.go:353
+#: lxc/file.go:357
 #, c-format
 msgid "Invalid path %s"
 msgstr "不正なパス %s"
@@ -3415,18 +3429,18 @@ msgstr "不正なパス %s"
 msgid "Invalid protocol: %s"
 msgstr "不正なプロトコル: %s"
 
-#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
-#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
+#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
 msgid "Invalid snapshot name"
 msgstr "不正なスナップショット名"
 
-#: lxc/file.go:535
+#: lxc/file.go:548
 #, c-format
 msgid "Invalid source %s"
 msgstr "不正なソース %s"
 
-#: lxc/file.go:185 lxc/file.go:717
+#: lxc/file.go:185 lxc/file.go:739
 #, c-format
 msgid "Invalid target %s"
 msgstr "不正な送り先 %s"
@@ -3463,7 +3477,7 @@ msgstr "LISTEN ADDRESS"
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
 msgid "LOCATION"
 msgstr "LOCATION"
 
@@ -3496,12 +3510,12 @@ msgstr "最終使用: %s"
 msgid "Last used: never"
 msgstr "最終使用: 未使用"
 
-#: lxc/init.go:176
+#: lxc/init.go:180
 #, fuzzy, c-format
 msgid "Launching %s"
 msgstr "%s を作成中"
 
-#: lxc/init.go:174
+#: lxc/init.go:178
 #, fuzzy
 msgid "Launching the instance"
 msgstr "インスタンスを作成中"
@@ -3602,11 +3616,11 @@ msgstr "インスタンスを一覧表示します"
 msgid "List identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:151
+#: lxc/image_alias.go:176
 msgid "List image aliases"
 msgstr "イメージのエイリアスを一覧表示します"
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:177
 msgid ""
 "List image aliases\n"
 "\n"
@@ -3882,11 +3896,11 @@ msgstr "ストレージバケットの鍵を一覧表示します"
 msgid "List storage buckets"
 msgstr "ストレージバケットを一覧表示します"
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1605
 msgid "List storage volumes"
 msgstr "ストレージボリュームを一覧表示します"
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1610
 #, fuzzy
 msgid ""
 "List storage volumes\n"
@@ -3978,7 +3992,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr "バックグラウンド操作の一覧表示、表示、削除を行います"
 
-#: lxc/info.go:489 lxc/storage_volume.go:1481
+#: lxc/info.go:489 lxc/storage_volume.go:1483
 #, c-format
 msgid "Location: %s"
 msgstr "ロケーション: %s"
@@ -4181,7 +4195,7 @@ msgstr "ネットワーク ACL ルールを管理します"
 msgid "Manage network ACLs"
 msgstr "ネットワーク ACL を管理します"
 
-#: lxc/network_forward.go:873 lxc/network_forward.go:874
+#: lxc/network_forward.go:881 lxc/network_forward.go:882
 msgid "Manage network forward ports"
 msgstr "ネットワークフォワードのポートを管理します"
 
@@ -4333,12 +4347,12 @@ msgstr "メモリ消費量:"
 msgid "Memory:"
 msgstr "メモリ:"
 
-#: lxc/move.go:322 lxc/move.go:435
+#: lxc/move.go:327 lxc/move.go:440
 #, c-format
 msgid "Migration API failure: %w"
 msgstr "マイグレーション API が失敗しました: %w"
 
-#: lxc/move.go:347 lxc/move.go:440
+#: lxc/move.go:352 lxc/move.go:445
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr "マイグレーションが失敗しました: %w"
@@ -4407,10 +4421,10 @@ msgstr "インスタンス名を指定する必要があります"
 msgid "Missing key name"
 msgstr "鍵の名前を指定する必要があります"
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:449
-#: lxc/network_forward.go:534 lxc/network_forward.go:709
-#: lxc/network_forward.go:840 lxc/network_forward.go:933
-#: lxc/network_forward.go:1015 lxc/network_load_balancer.go:221
+#: lxc/network_forward.go:219 lxc/network_forward.go:457
+#: lxc/network_forward.go:542 lxc/network_forward.go:717
+#: lxc/network_forward.go:848 lxc/network_forward.go:945
+#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
 #: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
 #: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
 #: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
@@ -4435,10 +4449,10 @@ msgstr "ネットワーク ACL 名を指定する必要があります"
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
 #: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
 #: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:284 lxc/network_forward.go:445
-#: lxc/network_forward.go:530 lxc/network_forward.go:705
-#: lxc/network_forward.go:836 lxc/network_forward.go:929
-#: lxc/network_forward.go:1011 lxc/network_load_balancer.go:131
+#: lxc/network_forward.go:292 lxc/network_forward.go:453
+#: lxc/network_forward.go:538 lxc/network_forward.go:713
+#: lxc/network_forward.go:844 lxc/network_forward.go:941
+#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
 #: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
 #: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
 #: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
@@ -4474,13 +4488,13 @@ msgstr "ピア名を指定する必要があります"
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
-#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
-#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
-#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
+#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
+#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
+#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
+#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
 msgid "Missing pool name"
 msgstr "ストレージプール名を指定する必要があります"
 
@@ -4499,15 +4513,15 @@ msgstr "プロジェクト名を指定する必要があります"
 msgid "Missing source profile name"
 msgstr "コピー元のプロファイル名を指定する必要があります"
 
-#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
+#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
 msgid "Missing source volume name"
 msgstr "コピー元のボリューム名を指定する必要があります"
 
-#: lxc/storage_volume.go:1411
+#: lxc/storage_volume.go:1413
 msgid "Missing storage pool name"
 msgstr "ストレージプール名を指定する必要があります"
 
-#: lxc/file.go:820
+#: lxc/file.go:842
 msgid "Missing target directory"
 msgstr "コピー先のディレクトリを指定する必要があります"
 
@@ -4543,18 +4557,18 @@ msgstr ""
 "\n"
 "デフォルトではすべてのタイプのメッセージをモニタリングします。"
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
-#: lxc/storage_volume.go:975
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
+#: lxc/storage_volume.go:977
 msgid "More than one device matches, specify the device name"
 msgstr "複数のデバイスとマッチします。デバイス名を指定してください"
 
-#: lxc/file.go:507
+#: lxc/file.go:520
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "ダウンロード対象のファイルが複数ありますが、コピー先がディレクトリではありま"
 "せん"
 
-#: lxc/file.go:1207 lxc/file.go:1208
+#: lxc/file.go:1227 lxc/file.go:1228
 msgid "Mount files from instances"
 msgstr "インスタンスからファイルをマウントします"
 
@@ -4594,7 +4608,7 @@ msgstr ""
 "\n"
 "すべての LXD バージョンとの互換性のため、pull 転送モードがデフォルトです。\n"
 
-#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
 msgid "Move storage volumes between pools"
 msgstr "プール間でストレージボリュームを移動します"
 
@@ -4602,16 +4616,16 @@ msgstr "プール間でストレージボリュームを移動します"
 msgid "Move the instance without its snapshots"
 msgstr "インスタンスを移動します。スナップショットは移動しません"
 
-#: lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1869
 msgid "Move to a project different from the source"
 msgstr "コピー／移動元とは異なるプロジェクトに移動します"
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr "ストレージボリュームの移動中: %s"
 
-#: lxc/network_forward.go:1059 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 "複数のポートにマッチしました。すべて削除するには --force を指定してください"
@@ -4635,7 +4649,7 @@ msgstr "インスタンス名を指定する必要があります: "
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
 msgid "NAME"
 msgstr "NAME"
 
@@ -4688,8 +4702,8 @@ msgstr "NVIDIA 情報:"
 msgid "NVRM Version: %v"
 msgstr "NVRM バージョン: %v"
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
-#: lxc/storage_volume.go:1573
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Name"
 msgstr "名前"
 
@@ -4697,7 +4711,7 @@ msgstr "名前"
 msgid "Name of the project to use for this remote:"
 msgstr "このリモートで使うプロジェクト名:"
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
 #, c-format
 msgid "Name: %s"
 msgstr "名前: %s"
@@ -4752,12 +4766,12 @@ msgstr "ネットワークゾーン %s を作成しました"
 msgid "Network Zone %s deleted"
 msgstr "ネットワークゾーン %s を削除しました"
 
-#: lxc/network_forward.go:386
+#: lxc/network_forward.go:394
 #, c-format
 msgid "Network forward %s created"
 msgstr "ネットワークフォワード %s を作成しました"
 
-#: lxc/network_forward.go:857
+#: lxc/network_forward.go:865
 #, c-format
 msgid "Network forward %s deleted"
 msgstr "ネットワークフォワード %s を削除しました"
@@ -4844,7 +4858,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr "このネットワークに対するデバイスがありません"
 
-#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
+#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
 msgid "No device found for this storage volume"
 msgstr "このストレージボリュームに対するデバイスがありません"
 
@@ -4852,7 +4866,7 @@ msgstr "このストレージボリュームに対するデバイスがありま
 msgid "No matching backend found"
 msgstr "マッチするバックエンドが見つかりません"
 
-#: lxc/network_forward.go:1070 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
 msgid "No matching port(s) found"
 msgstr "マッチするポートが見つかりません"
 
@@ -4866,11 +4880,11 @@ msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 "--target オプションを使うときはコピー先のインスタンス名を指定してください"
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
 msgid "No storage pool for source volume specified"
 msgstr "コピー元のボリュームに対するストレージプールが指定されていません"
 
-#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
 msgid "No storage pool for target volume specified"
 msgstr "コピー先のボリュームに対するストレージプールが指定されていません"
 
@@ -4884,7 +4898,7 @@ msgstr "%q に設定する値が指定されていません"
 msgid "Node %d:\n"
 msgstr "ノード %d:\n"
 
-#: lxc/storage_volume.go:2035
+#: lxc/storage_volume.go:2037
 msgid "Not a snapshot name"
 msgstr "スナップショット名ではありません"
 
@@ -4892,16 +4906,23 @@ msgstr "スナップショット名ではありません"
 msgid "OVN:"
 msgstr "OVN:"
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
-#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
-msgid "Only \"custom\" volumes can be attached to instances"
+#: lxc/storage_volume.go:216
+#, fuzzy
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr "\"カスタム\" のボリュームのみがインスタンスにアタッチできます"
 
-#: lxc/storage_volume.go:2701
+#: lxc/storage_volume.go:348
+#, fuzzy
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
+msgstr "\"カスタム\" のボリュームのみがインスタンスにアタッチできます"
+
+#: lxc/storage_volume.go:2703
 msgid "Only \"custom\" volumes can be exported"
 msgstr "\"カスタム\" のボリュームのみがエクスポートできます"
 
-#: lxc/storage_volume.go:2500
+#: lxc/storage_volume.go:2502
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr "\"カスタム\" のボリュームのみがスナップショットを取得できます"
 
@@ -4913,7 +4934,7 @@ msgstr "simplestreams は https の URL のみサポートします"
 msgid "Only https:// is supported for remote image import"
 msgstr "リモートイメージのインポートは https:// のみをサポートします"
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1431
 msgid "Only instance or custom volumes are supported"
 msgstr "インスタンスもしくはカスタムボリュームのみをサポートしています"
 
@@ -4926,7 +4947,7 @@ msgstr "管理対象のネットワークのみ変更できます"
 msgid "Operation %s deleted"
 msgstr "バックグラウンド操作 %s を削除しました"
 
-#: lxc/info.go:705 lxc/storage_volume.go:1577
+#: lxc/info.go:705 lxc/storage_volume.go:1579
 msgid "Optimized Storage"
 msgstr "最適化されたストレージ"
 
@@ -4956,7 +4977,7 @@ msgstr "PID"
 msgid "PID: %d"
 msgstr "PID: %d"
 
-#: lxc/storage_volume.go:1767
+#: lxc/storage_volume.go:1769
 msgid "POOL"
 msgstr ""
 
@@ -4973,7 +4994,7 @@ msgid "PROFILES"
 msgstr "PROFILES"
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167
-#: lxc/storage_volume.go:1773 lxc/warning.go:213
+#: lxc/storage_volume.go:1775 lxc/warning.go:213
 msgid "PROJECT"
 msgstr "PROJECT"
 
@@ -4997,7 +5018,7 @@ msgstr "送信パケット"
 msgid "Partitions:"
 msgstr "パーティション:"
 
-#: lxc/main.go:367
+#: lxc/main.go:376
 #, c-format
 msgid "Password for %s: "
 msgstr "%s のパスワード: "
@@ -5036,7 +5057,7 @@ msgstr "ポートタイプ: %s"
 msgid "Ports:"
 msgstr "ポート:"
 
-#: lxc/file.go:1332
+#: lxc/file.go:1356
 msgid "Press ctrl+c to finish"
 msgstr "終了するには ctrl+c を押してください"
 
@@ -5044,12 +5065,12 @@ msgstr "終了するには ctrl+c を押してください"
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
-#: lxc/network_acl.go:699 lxc/network_forward.go:768
+#: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
-#: lxc/storage_volume.go:1200
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
+#: lxc/storage_volume.go:1202
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 "再度エディタを開くためには Enter キーを、変更を取り消すには ctrl+c を入力しま"
@@ -5164,11 +5185,11 @@ msgstr "リモートで使用するプロジェクト"
 msgid "Properties:"
 msgstr "プロパティ:"
 
-#: lxc/image.go:1649
+#: lxc/image.go:1650
 msgid "Property not found"
 msgstr "プロパティが見つかりません"
 
-#: lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -5182,7 +5203,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1238
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5198,7 +5219,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5219,7 +5240,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1017
 #, fuzzy
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
@@ -5231,7 +5252,7 @@ msgstr ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    pool.yaml の内容でストレージボリュームを更新します。"
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2094
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5244,7 +5265,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2370
 #, fuzzy
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
@@ -5278,20 +5299,20 @@ msgstr "インスタンスをイメージとして出力します"
 msgid "Publishing instance: %s"
 msgstr "インスタンスの出力中: %s"
 
-#: lxc/file.go:455 lxc/file.go:456
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Pull files from instances"
 msgstr "インスタンスからファイルを取得します"
 
-#: lxc/file.go:638 lxc/file.go:989
+#: lxc/file.go:651 lxc/file.go:1009
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr "ファイル %s を %s から取得します: %%s"
 
-#: lxc/file.go:688 lxc/file.go:689
+#: lxc/file.go:701 lxc/file.go:702
 msgid "Push files into instances"
 msgstr "インスタンス内にファイルをコピーします"
 
-#: lxc/file.go:923 lxc/file.go:1089
+#: lxc/file.go:943 lxc/file.go:1109
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr "ファイル %s をコンテナ %s 内にコピーします: %%s"
@@ -5300,7 +5321,7 @@ msgstr "ファイル %s をコンテナ %s 内にコピーします: %%s"
 msgid "Query path must start with /"
 msgstr "query のパスは / で始める必要があります"
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
 msgid "Query virtual machine images"
 msgstr "仮想マシンイメージを対象にします"
 
@@ -5331,15 +5352,15 @@ msgstr "空のインスタンスを作成"
 msgid "Rebuild instances"
 msgstr "インスタンスを一覧表示します"
 
-#: lxc/file.go:463 lxc/file.go:695
+#: lxc/file.go:475 lxc/file.go:708
 msgid "Recursively transfer files"
 msgstr "再帰的にファイルを転送します"
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr "既存のストレージボリュームのコピーの再読込と更新"
 
-#: lxc/image.go:1444 lxc/image.go:1445
+#: lxc/image.go:1445 lxc/image.go:1446
 msgid "Refresh images"
 msgstr "イメージを更新します"
 
@@ -5348,7 +5369,7 @@ msgstr "イメージを更新します"
 msgid "Refreshing instance: %s"
 msgstr "インスタンスの更新中: %s"
 
-#: lxc/image.go:1481
+#: lxc/image.go:1482
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr "イメージの更新中: %s"
@@ -5427,7 +5448,7 @@ msgstr "ネットワークゾーンレコードエントリを削除します"
 msgid "Remove aliases"
 msgstr "エイリアスを削除します"
 
-#: lxc/network_forward.go:971 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
 msgid "Remove all ports that match"
 msgstr "マッチするポートをすべて削除します"
 
@@ -5465,7 +5486,7 @@ msgstr "グループからメンバーを削除します"
 msgid "Remove permissions from groups"
 msgstr "グループからメンバーを削除します"
 
-#: lxc/network_forward.go:969 lxc/network_forward.go:970
+#: lxc/network_forward.go:981 lxc/network_forward.go:982
 msgid "Remove ports from a forward"
 msgstr "フォワードからポートを削除します"
 
@@ -5501,8 +5522,8 @@ msgstr "クラスタグループの名前を変更します"
 msgid "Rename a cluster member"
 msgstr "クラスタメンバの名前を変更します"
 
-#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
-#: lxc/image_alias.go:255
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:287
+#: lxc/image_alias.go:288
 msgid "Rename aliases"
 msgstr "エイリアスの名前を変更します"
 
@@ -5540,16 +5561,16 @@ msgstr "プロジェクト名を変更します"
 msgid "Rename remotes"
 msgstr "リモートサーバ名を変更します"
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1962
 msgid "Rename storage volumes"
 msgstr "ストレージボリューム名を変更します"
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 "ストレージボリューム名とストレージボリュームのスナップショット名を変更します"
 
-#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
+#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr "ストレージボリューム名 \"%s\" を \"%s\" に変更しました"
@@ -5607,7 +5628,7 @@ msgstr ""
 "\n"
 "--stateful オプションを指定すると、インスタンスの実行状態もリストアします。"
 
-#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
 msgid "Restore storage volume snapshots"
 msgstr "スナップショットからストレージボリュームをリストアします"
 
@@ -5625,7 +5646,7 @@ msgstr "証明書の使用を1つ以上のプロジェクトに制限します"
 msgid "Retrieve the container's console log"
 msgstr "インスタンスのコンソールログを取得します"
 
-#: lxc/init.go:357
+#: lxc/init.go:361
 #, c-format
 msgid "Retrieving image: %s"
 msgstr "イメージの取得中: %s"
@@ -5675,12 +5696,12 @@ msgstr "SOURCE"
 msgid "SR-IOV information:"
 msgstr "SR-IOV 情報:"
 
-#: lxc/file.go:1460
+#: lxc/file.go:1484
 #, c-format
 msgid "SSH client connected %q"
 msgstr "SSH クライアントが %q に接続されました"
 
-#: lxc/file.go:1461
+#: lxc/file.go:1485
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr "SSH クライアントが切断されました %q"
@@ -5758,7 +5779,7 @@ msgstr "インスタンスからファイルをマウントします"
 msgid "Set a cluster member's configuration keys"
 msgstr "クラスターメンバーの設定を行います"
 
-#: lxc/file.go:1217
+#: lxc/file.go:1237
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr "SSH SFTP リスナーを使う際の認証ユーザーを設定する"
 
@@ -5792,7 +5813,7 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 
-#: lxc/image.go:1665 lxc/image.go:1666
+#: lxc/image.go:1666 lxc/image.go:1667
 msgid "Set image properties"
 msgstr "イメージのプロパティを設定します"
 
@@ -5847,11 +5868,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc network set [<remote>:]<network> <key> <value>"
 
-#: lxc/network_forward.go:488
+#: lxc/network_forward.go:496
 msgid "Set network forward keys"
 msgstr "ネットワークフォワードの設定値を設定します"
 
-#: lxc/network_forward.go:489
+#: lxc/network_forward.go:497
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5987,11 +6008,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行うには次の形式でも設定できます:\n"
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2088
 msgid "Set storage volume configuration keys"
 msgstr "ストレージボリュームの設定項目を設定します"
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2089
 #, fuzzy
 msgid ""
 "Set storage volume configuration keys\n"
@@ -6014,7 +6035,7 @@ msgstr "リモートの URL を設定します"
 msgid "Set the file's gid on create"
 msgstr "プッシュ時にファイルのgidを設定します"
 
-#: lxc/file.go:698
+#: lxc/file.go:711
 msgid "Set the file's gid on push"
 msgstr "プッシュ時にファイルのgidを設定します"
 
@@ -6023,7 +6044,7 @@ msgstr "プッシュ時にファイルのgidを設定します"
 msgid "Set the file's perms on create"
 msgstr "プッシュ時にファイルのパーミションを設定します"
 
-#: lxc/file.go:699
+#: lxc/file.go:712
 msgid "Set the file's perms on push"
 msgstr "プッシュ時にファイルのパーミションを設定します"
 
@@ -6032,7 +6053,7 @@ msgstr "プッシュ時にファイルのパーミションを設定します"
 msgid "Set the file's uid on create"
 msgstr "プッシュ時にファイルのuidを設定します"
 
-#: lxc/file.go:697
+#: lxc/file.go:710
 msgid "Set the file's uid on push"
 msgstr "プッシュ時にファイルのuidを設定します"
 
@@ -6045,7 +6066,7 @@ msgstr "クラスターグループを作成します"
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:504
 #, fuzzy
 msgid "Set the key as a network forward property"
 msgstr "ネットワークフォワードの設定値を設定します"
@@ -6092,7 +6113,7 @@ msgstr "ストレージバケットに対する鍵を作成します"
 msgid "Set the key as a storage property"
 msgstr "ストレージバケットに対する鍵を作成します"
 
-#: lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2105
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
@@ -6101,7 +6122,7 @@ msgstr "新しいストレージボリュームをプロファイルに追加し
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1215
+#: lxc/file.go:1235
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 "マウントの代わりに address:port で SSH SFTP リスナーをセットアップします"
@@ -6160,7 +6181,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1535 lxc/image.go:1536
+#: lxc/image.go:1536 lxc/image.go:1537
 msgid "Show image properties"
 msgstr "イメージのプロパティを表示します"
 
@@ -6181,7 +6202,7 @@ msgstr "インスタンスもしくはサーバの設定を表示します"
 msgid "Show instance or server information"
 msgstr "インスタンスもしくはサーバの情報を表示します"
 
-#: lxc/main.go:271 lxc/main.go:272
+#: lxc/main.go:280 lxc/main.go:281
 msgid "Show less common commands"
 msgstr "全てのコマンドを表示します (主なコマンドだけではなく)"
 
@@ -6245,11 +6266,11 @@ msgstr "ストレージバケットの鍵の設定を表示する"
 msgid "Show storage pool configurations and resources"
 msgstr "ストレージプールの設定とリソースを表示します"
 
-#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
 msgid "Show storage volume configurations"
 msgstr "ストレージボリュームの設定を表示する"
 
-#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
 msgid "Show storage volume state information"
 msgstr "ストレージボリュームの状態を表示します"
 
@@ -6318,15 +6339,15 @@ msgstr "サイズ: %.2fMB"
 msgid "Size: %s"
 msgstr "サイズ: %s"
 
-#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
 msgid "Snapshot storage volumes"
 msgstr "ストレージボリュームのスナップショットを取得します"
 
-#: lxc/storage_volume.go:2190
+#: lxc/storage_volume.go:2192
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr "スナップショットは読み取り専用です。設定を変更することはできません"
 
-#: lxc/info.go:619 lxc/storage_volume.go:1502
+#: lxc/info.go:619 lxc/storage_volume.go:1504
 msgid "Snapshots:"
 msgstr "スナップショット:"
 
@@ -6431,21 +6452,21 @@ msgstr "ストレージプール %s はメンバ %s 上でペンディング状�
 msgid "Storage pool name"
 msgstr "ストレージプール名"
 
-#: lxc/storage_volume.go:703
+#: lxc/storage_volume.go:707
 #, c-format
 msgid "Storage volume %s created"
 msgstr "ストレージボリューム %s を作成しました"
 
-#: lxc/storage_volume.go:791
+#: lxc/storage_volume.go:795
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr "ストレージボリューム %s を削除しました"
 
-#: lxc/storage_volume.go:516
+#: lxc/storage_volume.go:520
 msgid "Storage volume copied successfully!"
 msgstr "ストレージボリュームのコピーが成功しました!"
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:524
 msgid "Storage volume moved successfully!"
 msgstr "ストレージボリュームの移動が成功しました!"
 
@@ -6507,21 +6528,21 @@ msgid "TOKEN"
 msgstr "TOKEN"
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1747 lxc/warning.go:216
+#: lxc/storage_volume.go:1749 lxc/warning.go:216
 msgid "TYPE"
 msgstr "TYPE"
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
 msgid "Taken at"
 msgstr "取得日時"
 
-#: lxc/file.go:1262
+#: lxc/file.go:1286
 msgid "Target path and --listen flag cannot be used together"
 msgstr "ターゲットのパスと --listen オプションは同時に指定できません"
 
-#: lxc/file.go:1256
+#: lxc/file.go:1280
 msgid "Target path must be a directory"
 msgstr "ターゲットのパスはディレクトリでなければなりません"
 
@@ -6531,16 +6552,16 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:181
+#: lxc/move.go:186
 msgid "The --instance-only flag can't be used with --target"
 msgstr "--instance-only と --target は同時に指定できません"
 
-#: lxc/move.go:219 lxc/move.go:240
+#: lxc/move.go:224 lxc/move.go:245
 #, fuzzy
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr "--mode と --target-project は同時に指定できません"
 
-#: lxc/move.go:193
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --target"
 msgstr "--mode と --target は同時に指定できません"
 
@@ -6548,15 +6569,15 @@ msgstr "--mode と --target は同時に指定できません"
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr "--show-log フラグは 'console' アウトプットタイプの時だけ使えます"
 
-#: lxc/move.go:185
+#: lxc/move.go:190
 msgid "The --storage flag can't be used with --target"
 msgstr "--storage と --target は同時に指定できません"
 
-#: lxc/move.go:189
+#: lxc/move.go:194
 msgid "The --target-project flag can't be used with --target"
 msgstr "--target-project と --target は同時に指定できません"
 
-#: lxc/move.go:205
+#: lxc/move.go:210
 msgid "The destination LXD server is not clustered"
 msgstr "移動先の LXD サーバはクラスタに属していません"
 
@@ -6580,7 +6601,7 @@ msgstr ""
 "インスタンスは現在実行中です。停止して、再起動するために --force を使用してく"
 "ださい"
 
-#: lxc/init.go:435
+#: lxc/init.go:439
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr "起動しようとしたインスタンスに接続されているネットワークがありません。"
 
@@ -6636,7 +6657,7 @@ msgstr "設定 %q はクラスタメンバー %q には存在しません"
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: lxc/network_forward.go:462
+#: lxc/network_forward.go:470
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
@@ -6676,12 +6697,12 @@ msgstr "設定 %q はクラスタメンバー %q には存在しません"
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: lxc/storage_volume.go:1340
+#: lxc/storage_volume.go:1342
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: lxc/storage_volume.go:1317
+#: lxc/storage_volume.go:1319
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6698,12 +6719,12 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr "サーバには新しい v2 resource API が実装されていません"
 
-#: lxc/move.go:309
+#: lxc/move.go:314
 msgid "The source LXD server is not clustered"
 msgstr "移動元の LXD サーバはクラスタに属していません"
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
-#: lxc/storage_volume.go:989
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
+#: lxc/storage_volume.go:991
 msgid "The specified device doesn't exist"
 msgstr "指定したデバイスが存在しません"
 
@@ -6734,7 +6755,7 @@ msgstr "LXD サーバはすでにクラスターに属しています"
 msgid "This LXD server is not available on the network"
 msgstr "この LXD サーバはネットワークから利用できません"
 
-#: lxc/main.go:298
+#: lxc/main.go:307
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6767,13 +6788,13 @@ msgstr "インスタンスがクリーンにシャットダウンするまで待
 msgid "Timestamps:"
 msgstr "タイムスタンプ:"
 
-#: lxc/init.go:437
+#: lxc/init.go:441
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 "インスタンスにネットワークを接続するには、lxc network attach を使用してくださ"
 "い"
 
-#: lxc/init.go:436
+#: lxc/init.go:440
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 "新しいネットワークを作成するには、lxc network create を使用してください"
@@ -6782,7 +6803,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr "コンソールから切り離すには <ctrl>+a q を押します"
 
-#: lxc/main.go:412
+#: lxc/main.go:421
 #, fuzzy
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
@@ -6799,7 +6820,7 @@ msgstr ""
 "--target オプションは、コピー先のリモートサーバがクラスタに属していなければな"
 "りません"
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1489
 #, c-format
 msgid "Total: %s"
 msgstr "合計: %s"
@@ -6814,7 +6835,7 @@ msgstr "合計: %v"
 msgid "Transceiver type: %s"
 msgstr "トランシーバータイプ: %s"
 
-#: lxc/storage_volume.go:1864
+#: lxc/storage_volume.go:1866
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpull)"
 
@@ -6822,7 +6843,7 @@ msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpu
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpull)"
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpull)。"
 
@@ -6839,7 +6860,7 @@ msgstr "転送モード。pull, push, relay のいずれか。"
 msgid "Transferring image: %s"
 msgstr "イメージを転送中: %s"
 
-#: lxc/copy.go:382 lxc/move.go:327
+#: lxc/copy.go:382 lxc/move.go:332
 #, c-format
 msgid "Transferring instance: %s"
 msgstr "インスタンスを転送中: %s"
@@ -6884,7 +6905,7 @@ msgstr ""
 "フィカル出力の場合は 'vga'"
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1472
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Type: %s"
 msgstr "タイプ: %s"
@@ -6906,13 +6927,13 @@ msgstr "UPLOAD DATE"
 msgid "URL"
 msgstr "URL"
 
-#: lxc/project.go:995 lxc/storage_volume.go:1752
+#: lxc/project.go:995 lxc/storage_volume.go:1754
 msgid "USAGE"
 msgstr "USAGE"
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1751
+#: lxc/storage.go:724 lxc/storage_volume.go:1753
 msgid "USED BY"
 msgstr "USED BY"
 
@@ -6925,7 +6946,7 @@ msgstr "UUID"
 msgid "UUID: %v"
 msgstr "UUID: %v"
 
-#: lxc/file.go:411
+#: lxc/file.go:423
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr "テンポラリファイルを作成できません: %v"
@@ -6939,12 +6960,12 @@ msgstr "リモートサーバーが利用できません"
 msgid "Unknown certificate type %q"
 msgstr "未知の証明書タイプ %q"
 
-#: lxc/file.go:1483
+#: lxc/file.go:1507
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr "クライアント %q の未知のチャンネルタイプ: %s"
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1791
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6955,7 +6976,7 @@ msgstr "未知のカラム名の短縮形です '%c' ('%s' 中)"
 msgid "Unknown console type %q"
 msgstr "未知のコンソールタイプ %q"
 
-#: lxc/file.go:1029
+#: lxc/file.go:1049
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr "未知のファイルタイプ '%s'"
@@ -6987,7 +7008,7 @@ msgstr "移動先のインスタンスのすべてのプロファイルを削除
 msgid "Unset device configuration keys"
 msgstr "デバイスの設定を削除します"
 
-#: lxc/image.go:1728 lxc/image.go:1729
+#: lxc/image.go:1729 lxc/image.go:1730
 msgid "Unset image properties"
 msgstr "イメージのプロパティを削除します"
 
@@ -7003,11 +7024,11 @@ msgstr "ネットワーク ACL の設定を削除します"
 msgid "Unset network configuration keys"
 msgstr "ネットワークの設定を削除します"
 
-#: lxc/network_forward.go:598
+#: lxc/network_forward.go:606
 msgid "Unset network forward configuration keys"
 msgstr "ネットワークフォワードの設定を削除します"
 
-#: lxc/network_forward.go:599
+#: lxc/network_forward.go:607
 msgid "Unset network forward keys"
 msgstr "ネットワークフォワードの設定を削除します"
 
@@ -7051,7 +7072,7 @@ msgstr "ストレージバケットの設定を削除します"
 msgid "Unset storage pool configuration keys"
 msgstr "ストレージプールの設定を削除します"
 
-#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
 msgid "Unset storage volume configuration keys"
 msgstr "ストレージボリュームの設定を削除します"
 
@@ -7063,7 +7084,7 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:602
+#: lxc/network_forward.go:610
 #, fuzzy
 msgid "Unset the key as a network forward property"
 msgstr "ネットワークフォワードの設定を削除します"
@@ -7111,7 +7132,7 @@ msgstr "ストレージバケットに対する鍵を作成します"
 msgid "Unset the key as a storage property"
 msgstr "ストレージバケットに対する鍵を作成します"
 
-#: lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2381
 #, fuzzy
 msgid "Unset the key as a storage volume property"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
@@ -7120,7 +7141,7 @@ msgstr "新しいストレージボリュームをプロファイルに追加し
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:248
+#: lxc/storage_volume.go:250
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -7158,12 +7179,12 @@ msgstr "アップロード日時: %s"
 msgid "Upper devices"
 msgstr "上位デバイス"
 
-#: lxc/storage_volume.go:1485
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Usage: %s"
 msgstr "使い方: %s"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2652
+#: lxc/export.go:42 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -7235,7 +7256,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr "現在のプロジェクトを切り替えます"
 
-#: lxc/storage_volume.go:1576
+#: lxc/storage_volume.go:1578
 msgid "Volume Only"
 msgstr "Volume Only"
 
@@ -7289,7 +7310,7 @@ msgstr "--mode と同時に -t または -T は指定できません"
 msgid "You must specify a destination instance name"
 msgstr "コピー元のインスタンス名を指定してください"
 
-#: lxc/copy.go:98 lxc/move.go:293 lxc/move.go:369
+#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
 msgid "You must specify a source instance name"
 msgstr "コピー元のインスタンス名を指定してください"
 
@@ -7299,12 +7320,14 @@ msgid "You need to specify an image name or use --empty"
 msgstr ""
 "--target オプションを使うときはコピー先のインスタンス名を指定してください"
 
-#: lxc/storage_volume.go:909
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:912
+#, fuzzy
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr "[<remote:>]<pool> <volume> <profile> [<device name>]"
 
-#: lxc/storage_volume.go:282
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:284
+#, fuzzy
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
@@ -7336,7 +7359,7 @@ msgstr "[<remote>:] [<cert>]"
 msgid "[<remote>:] [<filter>...]"
 msgstr "[<remote>:] [<filter>...]"
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:174
 msgid "[<remote>:] [<filters>...]"
 msgstr "[<remote>:] [<filters>...]"
 
@@ -7389,7 +7412,7 @@ msgstr "[<remote>:]<Zone> <key>=<value>..."
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr "[<remote>:]<Zone> [key=value...]"
 
-#: lxc/image_alias.go:104
+#: lxc/image_alias.go:121
 msgid "[<remote>:]<alias>"
 msgstr "[<remote>:]<alias>"
 
@@ -7397,7 +7420,7 @@ msgstr "[<remote>:]<alias>"
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr "[<remote>:]<alias> <fingerprint>"
 
-#: lxc/image_alias.go:252
+#: lxc/image_alias.go:285
 msgid "[<remote>:]<alias> <new-name>"
 msgstr "[<remote>:]<alias> <new-name>"
 
@@ -7456,15 +7479,15 @@ msgstr "[<remote>:]<member> <group>"
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr "[<remote>:]<group> <new-name>"
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
 msgid "[<remote>:]<image>"
 msgstr "[<remote>:]<image>"
 
-#: lxc/image.go:1600 lxc/image.go:1727
+#: lxc/image.go:1601 lxc/image.go:1728
 msgid "[<remote>:]<image> <key>"
 msgstr "[<remote>:]<image> <key>"
 
-#: lxc/image.go:1664
+#: lxc/image.go:1665
 msgid "[<remote>:]<image> <key> <value>"
 msgstr "[<remote>:]<image> <key> <value>"
 
@@ -7485,7 +7508,7 @@ msgstr "[<remote>:]<image> [<remote>:][<name>]"
 msgid "[<remote>:]<image> [<target>]"
 msgstr "[<remote>:]<image> [<target>]"
 
-#: lxc/image.go:334 lxc/image.go:1443
+#: lxc/image.go:334 lxc/image.go:1444
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "[<remote>:]<image> [[<remote>:]<image>...]"
 
@@ -7558,7 +7581,7 @@ msgstr "[<remote>:]<instance> [flags] [--] <command line>"
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 
-#: lxc/file.go:376
+#: lxc/file.go:380
 msgid "[<remote>:]<instance>/<path>"
 msgstr "[<remote>:]<instance>/<path>"
 
@@ -7571,13 +7594,13 @@ msgstr "[<remote>:]<instance>[/<path>] [<target path>]"
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 
-#: lxc/file.go:454
+#: lxc/file.go:466
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 
-#: lxc/file.go:1206
+#: lxc/file.go:1226
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "[<remote>:]<instance>[/<path>] [<target path>]"
 
@@ -7647,8 +7670,8 @@ msgstr "[<remote>:]<network> <key>"
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr "[<remote>:]<network> <key>=<value>..."
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:644
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:179
+#: lxc/network_forward.go:177 lxc/network_forward.go:652
+#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
 #: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
 msgid "[<remote>:]<network> <listen_address>"
 msgstr "[<remote>:]<network> <listen_address>"
@@ -7665,12 +7688,12 @@ msgstr ""
 "[<remote>:]<network> <listen_address> <backend_name> <target_address> "
 "[<target_port(s)>]"
 
-#: lxc/network_forward.go:402 lxc/network_forward.go:597
+#: lxc/network_forward.go:410 lxc/network_forward.go:605
 #: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr "[<remote>:]<network> <listen_address> <key>"
 
-#: lxc/network_forward.go:487 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr "[<remote>:]<network> <listen_address> <key>=<value>..."
 
@@ -7682,7 +7705,7 @@ msgstr ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<backend_name>[,<backend_name>...]"
 
-#: lxc/network_forward.go:887
+#: lxc/network_forward.go:895
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
@@ -7690,7 +7713,7 @@ msgstr ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 
-#: lxc/network_forward.go:968 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 
@@ -7748,7 +7771,7 @@ msgstr "[<remote>:]<operation>"
 msgid "[<remote>:]<pool>"
 msgstr "[<remote>:]<pool>"
 
-#: lxc/storage_volume.go:2811
+#: lxc/storage_volume.go:2813
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "[<remote>:]<pool> <backup file> [<volume name>]"
 
@@ -7783,7 +7806,7 @@ msgstr "[<remote>:]<pool> <key>"
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr "[<remote>:]<pool> <key> <value>"
 
-#: lxc/storage_volume.go:1958
+#: lxc/storage_volume.go:1960
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
@@ -7791,64 +7814,66 @@ msgstr ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 
-#: lxc/storage_volume.go:806
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
-msgstr "[<remote>:]<pool> <volume> <instance> [<device name>]"
-
-#: lxc/storage_volume.go:167
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
-msgstr "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
-
-#: lxc/storage_volume.go:2562
+#: lxc/storage_volume.go:2564
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr "[<remote>:]<pool> <volume> <snapshot>"
 
-#: lxc/storage_volume.go:2645
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "[<remote>:]<pool> <volume> [<path>]"
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2428
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr "[<remote>:]<pool> <volume> [<snapshot>]"
 
-#: lxc/storage_volume.go:610
+#: lxc/storage_volume.go:614
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr "[<remote>:]<pool> <volume> [key=value...]"
 
-#: lxc/storage_volume.go:718
+#: lxc/storage_volume.go:722
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr "[<remote>:]<pool> <volume>[/<snapshot>]"
 
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr "[<remote>:]<pool> <volume>"
 
-#: lxc/storage_volume.go:2364
+#: lxc/storage_volume.go:810
+#, fuzzy
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
+msgstr "[<remote>:]<pool> <volume> <instance> [<device name>]"
+
+#: lxc/storage_volume.go:167
+#, fuzzy
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
+msgstr "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
+
+#: lxc/storage_volume.go:2366
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr "[<remote>:]<pool> <volume>"
 
-#: lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2087
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr "[<remote>:]<pool> <volume> <key>=<value>..."
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2245
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr "[<remote>:]<pool> <volume>[/<snapshot>]"
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1234
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 
-#: lxc/storage_volume.go:1858
+#: lxc/storage_volume.go:1860
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 
@@ -7956,7 +7981,7 @@ msgstr "[<remote>:][<instance>] <key>"
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr "[<remote>:][<instance>] <key>=<value>..."
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1603
 #, fuzzy
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr "[<remote>:]<pool> [<filter>...]"
@@ -8171,7 +8196,7 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1230
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
@@ -8180,7 +8205,7 @@ msgstr ""
 "   インスタンス foo の /root をローカルの fooroot ディレクトリにマウントしま"
 "す。"
 
-#: lxc/file.go:458
+#: lxc/file.go:470
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
@@ -8190,7 +8215,7 @@ msgstr ""
 "   インスタンスの /etc/hosts ファイルを取得し、カレントディレクトリにコピーし"
 "ます。"
 
-#: lxc/file.go:691
+#: lxc/file.go:704
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -8637,7 +8662,7 @@ msgstr ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    pool.yaml の内容でストレージプールを更新します。"
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:618
 #, fuzzy
 msgid ""
 "lxc storage volume create p1 v1\n"
@@ -8650,7 +8675,7 @@ msgstr ""
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
 "    config.yaml の設定を使ってインスタンスを作成します"
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2817
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
@@ -8658,7 +8683,7 @@ msgstr ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tbackup0.tar.gz を使って新しいカスタムボリュームを作成します。"
 
-#: lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2432
 #, fuzzy
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
@@ -8697,16 +8722,16 @@ msgstr "`lxc profile` コマンドを使ってください"
 msgid "space used"
 msgstr "使用量"
 
-#: lxc/file.go:1372
+#: lxc/file.go:1396
 msgid "sshfs has stopped"
 msgstr "sshfs が停止しました"
 
-#: lxc/file.go:1331
+#: lxc/file.go:1355
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr "sshfs で %q を %q にマウントします"
 
-#: lxc/file.go:1284
+#: lxc/file.go:1308
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 "sshfs が見つかりません。--listen オプションを使って SSH SFTP モードを試してみ"

--- a/po/ka.po
+++ b/po/ka.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-07 15:11-0700\n"
+"POT-Creation-Date: 2025-01-10 14:44-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -46,7 +46,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1041
+#: lxc/storage_volume.go:1043
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -251,7 +251,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:667
+#: lxc/network_forward.go:675
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -427,12 +427,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1157
+#: lxc/file.go:1177
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1047
+#: lxc/file.go:1067
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -468,7 +468,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:65
+#: lxc/init.go:146 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -521,7 +521,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:687
+#: lxc/file.go:700
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -538,7 +538,7 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
@@ -669,7 +669,7 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:888 lxc/network_forward.go:889
+#: lxc/network_forward.go:896 lxc/network_forward.go:897
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -719,7 +719,7 @@ msgstr ""
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
+#: lxc/image_alias.go:101 lxc/image_alias.go:156 lxc/image_alias.go:320
 msgid "Alias name missing"
 msgstr ""
 
@@ -732,7 +732,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1607
+#: lxc/storage_volume.go:1609
 msgid "All projects"
 msgstr ""
 
@@ -763,7 +763,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -787,12 +787,26 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168 lxc/storage_volume.go:169
+#: lxc/storage_volume.go:168
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:169
+msgid ""
+"Attach new storage volumes to instances\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
+msgstr ""
+
+#: lxc/storage_volume.go:285
 msgid "Attach new storage volumes to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:286
+msgid ""
+"Attach new storage volumes to profiles\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
 #: lxc/console.go:39
@@ -843,16 +857,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2719
+#: lxc/storage_volume.go:2721
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2796
+#: lxc/export.go:192 lxc/storage_volume.go:2798
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1538
+#: lxc/info.go:666 lxc/storage_volume.go:1540
 msgid "Backups:"
 msgstr ""
 
@@ -861,19 +875,19 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
+#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:326
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -916,7 +930,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1752
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -968,7 +982,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -976,7 +990,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:562
+#: lxc/file.go:575
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1001,11 +1015,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:768
+#: lxc/file.go:790
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1018,12 +1032,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:493
+#: lxc/storage_volume.go:497
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:447
+#: lxc/storage_volume.go:451
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1129,9 +1143,9 @@ msgstr ""
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:497 lxc/network_forward.go:649
-#: lxc/network_forward.go:803 lxc/network_forward.go:892
-#: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
+#: lxc/network_forward.go:505 lxc/network_forward.go:657
+#: lxc/network_forward.go:811 lxc/network_forward.go:900
+#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
 #: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
 #: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
@@ -1143,14 +1157,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
-#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
-#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
-#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
+#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
 msgid "Cluster member name"
 msgstr ""
 
@@ -1166,7 +1180,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1608
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1206,21 +1220,21 @@ msgstr ""
 #: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
-#: lxc/network_acl.go:698 lxc/network_forward.go:767
+#: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
-#: lxc/storage_volume.go:1199
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
+#: lxc/storage_volume.go:1201
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:620
+#: lxc/storage_volume.go:624
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1478
+#: lxc/storage_volume.go:1480
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1282,7 +1296,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1290,12 +1304,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1308,7 +1322,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1403,7 +1417,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:462 lxc/file.go:696
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1443,7 +1457,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1495,12 +1509,12 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:182
+#: lxc/init.go:186
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1510,7 +1524,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 msgid "Creating the instance"
 msgstr ""
 
@@ -1524,13 +1538,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1749
+#: lxc/storage_volume.go:1751
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1550,7 +1564,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2653
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1582,7 +1596,7 @@ msgstr ""
 msgid "Delete identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:106 lxc/image_alias.go:107
+#: lxc/image_alias.go:123 lxc/image_alias.go:124
 msgid "Delete image aliases"
 msgstr ""
 
@@ -1606,7 +1620,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:799 lxc/network_forward.go:800
+#: lxc/network_forward.go:807 lxc/network_forward.go:808
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1646,7 +1660,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
+#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1688,13 +1702,13 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
-#: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
-#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
+#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
+#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
+#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
@@ -1708,10 +1722,10 @@ msgstr ""
 #: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:404 lxc/network_forward.go:489
-#: lxc/network_forward.go:599 lxc/network_forward.go:646
-#: lxc/network_forward.go:800 lxc/network_forward.go:874
-#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_forward.go:412 lxc/network_forward.go:497
+#: lxc/network_forward.go:607 lxc/network_forward.go:654
+#: lxc/network_forward.go:808 lxc/network_forward.go:882
+#: lxc/network_forward.go:897 lxc/network_forward.go:982
 #: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
 #: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
 #: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
@@ -1751,27 +1765,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
-#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
-#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
-#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
-#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
-#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
-#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
-#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1465
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1783,11 +1797,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
+#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1837,7 +1851,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:403
+#: lxc/init.go:407
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1849,7 +1863,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1216
+#: lxc/file.go:1236
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1945,7 +1959,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:377 lxc/file.go:378
+#: lxc/file.go:381 lxc/file.go:382
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1985,7 +1999,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:653 lxc/network_forward.go:654
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -2025,7 +2039,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2033,7 +2047,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1785
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2087,11 +2101,11 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
-#: lxc/network_acl.go:524 lxc/network_forward.go:572
+#: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
+#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2102,11 +2116,11 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
-#: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
+#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
-#: lxc/storage_volume.go:2210
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
+#: lxc/storage_volume.go:2212
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2148,8 +2162,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
+#: lxc/storage_volume.go:1577
 msgid "Expires at"
 msgstr ""
 
@@ -2173,7 +2187,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2185,11 +2199,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2650
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2779
+#: lxc/export.go:152 lxc/storage_volume.go:2781
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2208,7 +2222,7 @@ msgid "FILENAME"
 msgstr ""
 
 #: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
-#: lxc/image_alias.go:235
+#: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2216,12 +2230,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1467
+#: lxc/file.go:1491
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1490
+#: lxc/file.go:1514
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2236,12 +2250,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1517
+#: lxc/file.go:1541
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1326
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2271,7 +2285,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1423
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2286,7 +2300,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1428
+#: lxc/file.go:1452
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2296,12 +2310,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1352
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1455
+#: lxc/file.go:1479
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2315,7 +2329,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:304 lxc/move.go:380
+#: lxc/move.go:309 lxc/move.go:385
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2340,7 +2354,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1440
+#: lxc/file.go:1464
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2355,7 +2369,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1042
+#: lxc/file.go:1062
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2442,14 +2456,14 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1625 lxc/warning.go:94
+#: lxc/storage_volume.go:1627 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2517,7 +2531,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1602
+#: lxc/image.go:1602 lxc/image.go:1603
 msgid "Get image properties"
 msgstr ""
 
@@ -2533,7 +2547,7 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:414
 msgid "Get the key as a network forward property"
 msgstr ""
 
@@ -2573,7 +2587,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1249
+#: lxc/storage_volume.go:1251
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2601,7 +2615,7 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:403 lxc/network_forward.go:404
+#: lxc/network_forward.go:411 lxc/network_forward.go:412
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
@@ -2637,11 +2651,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:476
+#: lxc/storage_volume.go:480
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2681,22 +2695,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1540
+#: lxc/file.go:1564
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1529
+#: lxc/file.go:1553
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1376
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1362
+#: lxc/file.go:1386
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2769,11 +2783,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:415
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2783,7 +2797,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2437
+#: lxc/storage_volume.go:2439
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2795,7 +2809,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1517
+#: lxc/image.go:1518
 msgid "Image already up to date."
 msgstr ""
 
@@ -2811,11 +2825,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1472
+#: lxc/image.go:364 lxc/image.go:1473
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1698
+#: lxc/image.go:444 lxc/image.go:1699
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2825,7 +2839,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1515
+#: lxc/image.go:1516
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2833,7 +2847,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2815
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2841,7 +2855,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2814
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2863,11 +2877,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2822
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2894
+#: lxc/storage_volume.go:2896
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2893,11 +2907,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1378
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1531
+#: lxc/file.go:1555
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2906,7 +2920,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:414
+#: lxc/init.go:418
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2915,7 +2929,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1298
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2967,7 +2981,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1293
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2993,23 +3007,23 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2023
+#: lxc/move.go:153 lxc/storage_volume.go:2025
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:144
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2019
+#: lxc/storage_volume.go:2021
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:509
+#: lxc/main.go:518
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:353
+#: lxc/file.go:357
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3019,18 +3033,18 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
-#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
+#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:535
+#: lxc/file.go:548
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:717
+#: lxc/file.go:185 lxc/file.go:739
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3067,7 +3081,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3098,12 +3112,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:176
+#: lxc/init.go:180
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:174
+#: lxc/init.go:178
 msgid "Launching the instance"
 msgstr ""
 
@@ -3201,11 +3215,11 @@ msgstr ""
 msgid "List identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:151
+#: lxc/image_alias.go:176
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:177
 msgid ""
 "List image aliases\n"
 "\n"
@@ -3372,11 +3386,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1605
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1610
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3435,7 +3449,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1481
+#: lxc/info.go:489 lxc/storage_volume.go:1483
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3621,7 +3635,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:873 lxc/network_forward.go:874
+#: lxc/network_forward.go:881 lxc/network_forward.go:882
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -3767,12 +3781,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:322 lxc/move.go:435
+#: lxc/move.go:327 lxc/move.go:440
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:347 lxc/move.go:440
+#: lxc/move.go:352 lxc/move.go:445
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3837,10 +3851,10 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:449
-#: lxc/network_forward.go:534 lxc/network_forward.go:709
-#: lxc/network_forward.go:840 lxc/network_forward.go:933
-#: lxc/network_forward.go:1015 lxc/network_load_balancer.go:221
+#: lxc/network_forward.go:219 lxc/network_forward.go:457
+#: lxc/network_forward.go:542 lxc/network_forward.go:717
+#: lxc/network_forward.go:848 lxc/network_forward.go:945
+#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
 #: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
 #: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
 #: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
@@ -3865,10 +3879,10 @@ msgstr ""
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
 #: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
 #: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:284 lxc/network_forward.go:445
-#: lxc/network_forward.go:530 lxc/network_forward.go:705
-#: lxc/network_forward.go:836 lxc/network_forward.go:929
-#: lxc/network_forward.go:1011 lxc/network_load_balancer.go:131
+#: lxc/network_forward.go:292 lxc/network_forward.go:453
+#: lxc/network_forward.go:538 lxc/network_forward.go:713
+#: lxc/network_forward.go:844 lxc/network_forward.go:941
+#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
 #: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
 #: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
 #: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
@@ -3904,13 +3918,13 @@ msgstr ""
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
-#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
-#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
-#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
+#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
+#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
+#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
+#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
 msgid "Missing pool name"
 msgstr ""
 
@@ -3929,15 +3943,15 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
+#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1411
+#: lxc/storage_volume.go:1413
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:820
+#: lxc/file.go:842
 msgid "Missing target directory"
 msgstr ""
 
@@ -3970,16 +3984,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
-#: lxc/storage_volume.go:975
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
+#: lxc/storage_volume.go:977
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:507
+#: lxc/file.go:520
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1207 lxc/file.go:1208
+#: lxc/file.go:1227 lxc/file.go:1228
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4008,7 +4022,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4016,16 +4030,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1869
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1059 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4047,7 +4061,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
 msgid "NAME"
 msgstr ""
 
@@ -4099,8 +4113,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
-#: lxc/storage_volume.go:1573
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Name"
 msgstr ""
 
@@ -4108,7 +4122,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4163,12 +4177,12 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:386
+#: lxc/network_forward.go:394
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:857
+#: lxc/network_forward.go:865
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -4252,7 +4266,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
+#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4260,7 +4274,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1070 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4272,11 +4286,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4290,7 +4304,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2035
+#: lxc/storage_volume.go:2037
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4298,16 +4312,21 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
-#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
-msgid "Only \"custom\" volumes can be attached to instances"
+#: lxc/storage_volume.go:216
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2701
+#: lxc/storage_volume.go:348
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:2703
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2500
+#: lxc/storage_volume.go:2502
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4319,7 +4338,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1431
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4332,7 +4351,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1577
+#: lxc/info.go:705 lxc/storage_volume.go:1579
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4362,7 +4381,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1767
+#: lxc/storage_volume.go:1769
 msgid "POOL"
 msgstr ""
 
@@ -4379,7 +4398,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167
-#: lxc/storage_volume.go:1773 lxc/warning.go:213
+#: lxc/storage_volume.go:1775 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4403,7 +4422,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:367
+#: lxc/main.go:376
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4441,7 +4460,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1332
+#: lxc/file.go:1356
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4449,12 +4468,12 @@ msgstr ""
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
-#: lxc/network_acl.go:699 lxc/network_forward.go:768
+#: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
-#: lxc/storage_volume.go:1200
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
+#: lxc/storage_volume.go:1202
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4567,11 +4586,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1649
+#: lxc/image.go:1650
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4585,7 +4604,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1238
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4601,7 +4620,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4622,7 +4641,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1017
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4631,7 +4650,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2094
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4644,7 +4663,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2370
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4675,20 +4694,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:455 lxc/file.go:456
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:638 lxc/file.go:989
+#: lxc/file.go:651 lxc/file.go:1009
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:688 lxc/file.go:689
+#: lxc/file.go:701 lxc/file.go:702
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:923 lxc/file.go:1089
+#: lxc/file.go:943 lxc/file.go:1109
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4697,7 +4716,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4726,15 +4745,15 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:463 lxc/file.go:695
+#: lxc/file.go:475 lxc/file.go:708
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1444 lxc/image.go:1445
+#: lxc/image.go:1445 lxc/image.go:1446
 msgid "Refresh images"
 msgstr ""
 
@@ -4743,7 +4762,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1481
+#: lxc/image.go:1482
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4820,7 +4839,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:971 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4856,7 +4875,7 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:969 lxc/network_forward.go:970
+#: lxc/network_forward.go:981 lxc/network_forward.go:982
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -4892,8 +4911,8 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
-#: lxc/image_alias.go:255
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:287
+#: lxc/image_alias.go:288
 msgid "Rename aliases"
 msgstr ""
 
@@ -4929,15 +4948,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1962
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
+#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4989,7 +5008,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5006,7 +5025,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:361
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5055,12 +5074,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1460
+#: lxc/file.go:1484
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1461
+#: lxc/file.go:1485
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5136,7 +5155,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1217
+#: lxc/file.go:1237
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5162,7 +5181,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1665 lxc/image.go:1666
+#: lxc/image.go:1666 lxc/image.go:1667
 msgid "Set image properties"
 msgstr ""
 
@@ -5205,11 +5224,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:488
+#: lxc/network_forward.go:496
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:489
+#: lxc/network_forward.go:497
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5313,11 +5332,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2088
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2089
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5334,7 +5353,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:698
+#: lxc/file.go:711
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5342,7 +5361,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:699
+#: lxc/file.go:712
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5350,7 +5369,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:710
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5362,7 +5381,7 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:504
 msgid "Set the key as a network forward property"
 msgstr ""
 
@@ -5402,7 +5421,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2105
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5410,7 +5429,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1215
+#: lxc/file.go:1235
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5467,7 +5486,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1535 lxc/image.go:1536
+#: lxc/image.go:1536 lxc/image.go:1537
 msgid "Show image properties"
 msgstr ""
 
@@ -5487,7 +5506,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:271 lxc/main.go:272
+#: lxc/main.go:280 lxc/main.go:281
 msgid "Show less common commands"
 msgstr ""
 
@@ -5551,11 +5570,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5623,15 +5642,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2190
+#: lxc/storage_volume.go:2192
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1502
+#: lxc/info.go:619 lxc/storage_volume.go:1504
 msgid "Snapshots:"
 msgstr ""
 
@@ -5736,21 +5755,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:703
+#: lxc/storage_volume.go:707
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:791
+#: lxc/storage_volume.go:795
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:516
+#: lxc/storage_volume.go:520
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:524
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5812,21 +5831,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1747 lxc/warning.go:216
+#: lxc/storage_volume.go:1749 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1262
+#: lxc/file.go:1286
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1256
+#: lxc/file.go:1280
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5836,15 +5855,15 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:181
+#: lxc/move.go:186
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:219 lxc/move.go:240
+#: lxc/move.go:224 lxc/move.go:245
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:193
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5852,15 +5871,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:185
+#: lxc/move.go:190
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:189
+#: lxc/move.go:194
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:210
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5882,7 +5901,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:439
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5935,7 +5954,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:462
+#: lxc/network_forward.go:470
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -5975,12 +5994,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1340
+#: lxc/storage_volume.go:1342
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1317
+#: lxc/storage_volume.go:1319
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -5995,12 +6014,12 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:309
+#: lxc/move.go:314
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
-#: lxc/storage_volume.go:989
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
+#: lxc/storage_volume.go:991
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6028,7 +6047,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:298
+#: lxc/main.go:307
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6052,11 +6071,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:437
+#: lxc/init.go:441
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:440
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6064,7 +6083,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:412
+#: lxc/main.go:421
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6075,7 +6094,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1489
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6090,7 +6109,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1864
+#: lxc/storage_volume.go:1866
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6098,7 +6117,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6115,7 +6134,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:327
+#: lxc/copy.go:382 lxc/move.go:332
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6157,7 +6176,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1472
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6179,13 +6198,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1752
+#: lxc/project.go:995 lxc/storage_volume.go:1754
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1751
+#: lxc/storage.go:724 lxc/storage_volume.go:1753
 msgid "USED BY"
 msgstr ""
 
@@ -6198,7 +6217,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:411
+#: lxc/file.go:423
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6212,12 +6231,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1483
+#: lxc/file.go:1507
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1791
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6228,7 +6247,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1029
+#: lxc/file.go:1049
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6259,7 +6278,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1728 lxc/image.go:1729
+#: lxc/image.go:1729 lxc/image.go:1730
 msgid "Unset image properties"
 msgstr ""
 
@@ -6275,11 +6294,11 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:598
+#: lxc/network_forward.go:606
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:599
+#: lxc/network_forward.go:607
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -6323,7 +6342,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6335,7 +6354,7 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:602
+#: lxc/network_forward.go:610
 msgid "Unset the key as a network forward property"
 msgstr ""
 
@@ -6375,7 +6394,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2381
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6383,7 +6402,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:248
+#: lxc/storage_volume.go:250
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6419,12 +6438,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1485
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2652
+#: lxc/export.go:42 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6491,7 +6510,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1576
+#: lxc/storage_volume.go:1578
 msgid "Volume Only"
 msgstr ""
 
@@ -6542,7 +6561,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:293 lxc/move.go:369
+#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6550,12 +6569,12 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:909
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:912
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:282
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:284
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
@@ -6587,7 +6606,7 @@ msgstr ""
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:174
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
@@ -6640,7 +6659,7 @@ msgstr ""
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: lxc/image_alias.go:104
+#: lxc/image_alias.go:121
 msgid "[<remote>:]<alias>"
 msgstr ""
 
@@ -6648,7 +6667,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/image_alias.go:252
+#: lxc/image_alias.go:285
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
@@ -6702,15 +6721,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1600 lxc/image.go:1727
+#: lxc/image.go:1601 lxc/image.go:1728
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1664
+#: lxc/image.go:1665
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6730,7 +6749,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1443
+#: lxc/image.go:334 lxc/image.go:1444
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6801,7 +6820,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:376
+#: lxc/file.go:380
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -6813,12 +6832,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:454
+#: lxc/file.go:466
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1226
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6886,8 +6905,8 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:644
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:179
+#: lxc/network_forward.go:177 lxc/network_forward.go:652
+#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
 #: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
@@ -6902,12 +6921,12 @@ msgid ""
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:402 lxc/network_forward.go:597
+#: lxc/network_forward.go:410 lxc/network_forward.go:605
 #: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
@@ -6917,13 +6936,13 @@ msgid ""
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:887
+#: lxc/network_forward.go:895
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:968 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -6978,7 +6997,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2811
+#: lxc/storage_volume.go:2813
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7013,65 +7032,65 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1958
+#: lxc/storage_volume.go:1960
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:806
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:167
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
-msgstr ""
-
-#: lxc/storage_volume.go:2562
+#: lxc/storage_volume.go:2564
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2645
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2428
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:610
+#: lxc/storage_volume.go:614
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:718
+#: lxc/storage_volume.go:722
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2364
+#: lxc/storage_volume.go:810
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
+msgstr ""
+
+#: lxc/storage_volume.go:167
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
+msgstr ""
+
+#: lxc/storage_volume.go:2366
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2087
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2245
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1234
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1858
+#: lxc/storage_volume.go:1860
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7177,7 +7196,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1603
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7339,20 +7358,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1230
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:470
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:691
+#: lxc/file.go:704
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7653,7 +7672,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:618
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7661,13 +7680,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2817
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2432
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7701,16 +7720,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1396
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1331
+#: lxc/file.go:1355
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1284
+#: lxc/file.go:1308
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-07 15:11-0700\n"
+"POT-Creation-Date: 2025-01-10 14:44-0600\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1041
+#: lxc/storage_volume.go:1043
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:667
+#: lxc/network_forward.go:675
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,12 +430,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1157
+#: lxc/file.go:1177
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1047
+#: lxc/file.go:1067
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -471,7 +471,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:65
+#: lxc/init.go:146 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:687
+#: lxc/file.go:700
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -541,7 +541,7 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
@@ -672,7 +672,7 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:888 lxc/network_forward.go:889
+#: lxc/network_forward.go:896 lxc/network_forward.go:897
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -722,7 +722,7 @@ msgstr ""
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
+#: lxc/image_alias.go:101 lxc/image_alias.go:156 lxc/image_alias.go:320
 msgid "Alias name missing"
 msgstr ""
 
@@ -735,7 +735,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1607
+#: lxc/storage_volume.go:1609
 msgid "All projects"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -790,12 +790,26 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168 lxc/storage_volume.go:169
+#: lxc/storage_volume.go:168
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:169
+msgid ""
+"Attach new storage volumes to instances\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
+msgstr ""
+
+#: lxc/storage_volume.go:285
 msgid "Attach new storage volumes to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:286
+msgid ""
+"Attach new storage volumes to profiles\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
 #: lxc/console.go:39
@@ -846,16 +860,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2719
+#: lxc/storage_volume.go:2721
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2796
+#: lxc/export.go:192 lxc/storage_volume.go:2798
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1538
+#: lxc/info.go:666 lxc/storage_volume.go:1540
 msgid "Backups:"
 msgstr ""
 
@@ -864,19 +878,19 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
+#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:326
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -919,7 +933,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1752
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -971,7 +985,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -979,7 +993,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:562
+#: lxc/file.go:575
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1004,11 +1018,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:768
+#: lxc/file.go:790
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1021,12 +1035,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:493
+#: lxc/storage_volume.go:497
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:447
+#: lxc/storage_volume.go:451
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1132,9 +1146,9 @@ msgstr ""
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:497 lxc/network_forward.go:649
-#: lxc/network_forward.go:803 lxc/network_forward.go:892
-#: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
+#: lxc/network_forward.go:505 lxc/network_forward.go:657
+#: lxc/network_forward.go:811 lxc/network_forward.go:900
+#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
 #: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
 #: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
@@ -1146,14 +1160,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
-#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
-#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
-#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
+#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
 msgid "Cluster member name"
 msgstr ""
 
@@ -1169,7 +1183,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1608
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1209,21 +1223,21 @@ msgstr ""
 #: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
-#: lxc/network_acl.go:698 lxc/network_forward.go:767
+#: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
-#: lxc/storage_volume.go:1199
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
+#: lxc/storage_volume.go:1201
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:620
+#: lxc/storage_volume.go:624
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1478
+#: lxc/storage_volume.go:1480
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1285,7 +1299,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1293,12 +1307,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1311,7 +1325,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1406,7 +1420,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:462 lxc/file.go:696
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1446,7 +1460,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1498,12 +1512,12 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:182
+#: lxc/init.go:186
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1513,7 +1527,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 msgid "Creating the instance"
 msgstr ""
 
@@ -1527,13 +1541,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1749
+#: lxc/storage_volume.go:1751
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1553,7 +1567,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2653
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1585,7 +1599,7 @@ msgstr ""
 msgid "Delete identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:106 lxc/image_alias.go:107
+#: lxc/image_alias.go:123 lxc/image_alias.go:124
 msgid "Delete image aliases"
 msgstr ""
 
@@ -1609,7 +1623,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:799 lxc/network_forward.go:800
+#: lxc/network_forward.go:807 lxc/network_forward.go:808
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1649,7 +1663,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
+#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1691,13 +1705,13 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
-#: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
-#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
+#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
+#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
+#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
@@ -1711,10 +1725,10 @@ msgstr ""
 #: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:404 lxc/network_forward.go:489
-#: lxc/network_forward.go:599 lxc/network_forward.go:646
-#: lxc/network_forward.go:800 lxc/network_forward.go:874
-#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_forward.go:412 lxc/network_forward.go:497
+#: lxc/network_forward.go:607 lxc/network_forward.go:654
+#: lxc/network_forward.go:808 lxc/network_forward.go:882
+#: lxc/network_forward.go:897 lxc/network_forward.go:982
 #: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
 #: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
 #: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
@@ -1754,27 +1768,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
-#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
-#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
-#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
-#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
-#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
-#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
-#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1465
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1786,11 +1800,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
+#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1840,7 +1854,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:403
+#: lxc/init.go:407
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1852,7 +1866,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1216
+#: lxc/file.go:1236
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1948,7 +1962,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:377 lxc/file.go:378
+#: lxc/file.go:381 lxc/file.go:382
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1988,7 +2002,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:653 lxc/network_forward.go:654
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -2028,7 +2042,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2036,7 +2050,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1785
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2090,11 +2104,11 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
-#: lxc/network_acl.go:524 lxc/network_forward.go:572
+#: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
+#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2105,11 +2119,11 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
-#: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
+#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
-#: lxc/storage_volume.go:2210
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
+#: lxc/storage_volume.go:2212
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2151,8 +2165,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
+#: lxc/storage_volume.go:1577
 msgid "Expires at"
 msgstr ""
 
@@ -2176,7 +2190,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2188,11 +2202,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2650
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2779
+#: lxc/export.go:152 lxc/storage_volume.go:2781
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2211,7 +2225,7 @@ msgid "FILENAME"
 msgstr ""
 
 #: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
-#: lxc/image_alias.go:235
+#: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2219,12 +2233,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1467
+#: lxc/file.go:1491
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1490
+#: lxc/file.go:1514
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2239,12 +2253,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1517
+#: lxc/file.go:1541
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1326
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2274,7 +2288,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1423
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2289,7 +2303,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1428
+#: lxc/file.go:1452
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2299,12 +2313,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1352
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1455
+#: lxc/file.go:1479
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2318,7 +2332,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:304 lxc/move.go:380
+#: lxc/move.go:309 lxc/move.go:385
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2343,7 +2357,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1440
+#: lxc/file.go:1464
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2358,7 +2372,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1042
+#: lxc/file.go:1062
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2445,14 +2459,14 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1625 lxc/warning.go:94
+#: lxc/storage_volume.go:1627 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2520,7 +2534,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1602
+#: lxc/image.go:1602 lxc/image.go:1603
 msgid "Get image properties"
 msgstr ""
 
@@ -2536,7 +2550,7 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:414
 msgid "Get the key as a network forward property"
 msgstr ""
 
@@ -2576,7 +2590,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1249
+#: lxc/storage_volume.go:1251
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2604,7 +2618,7 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:403 lxc/network_forward.go:404
+#: lxc/network_forward.go:411 lxc/network_forward.go:412
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
@@ -2640,11 +2654,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:476
+#: lxc/storage_volume.go:480
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2684,22 +2698,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1540
+#: lxc/file.go:1564
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1529
+#: lxc/file.go:1553
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1376
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1362
+#: lxc/file.go:1386
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2772,11 +2786,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:415
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2786,7 +2800,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2437
+#: lxc/storage_volume.go:2439
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2798,7 +2812,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1517
+#: lxc/image.go:1518
 msgid "Image already up to date."
 msgstr ""
 
@@ -2814,11 +2828,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1472
+#: lxc/image.go:364 lxc/image.go:1473
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1698
+#: lxc/image.go:444 lxc/image.go:1699
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2828,7 +2842,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1515
+#: lxc/image.go:1516
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2836,7 +2850,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2815
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2844,7 +2858,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2814
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2866,11 +2880,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2822
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2894
+#: lxc/storage_volume.go:2896
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2896,11 +2910,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1378
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1531
+#: lxc/file.go:1555
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2909,7 +2923,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:414
+#: lxc/init.go:418
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2918,7 +2932,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1298
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2970,7 +2984,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1293
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2996,23 +3010,23 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2023
+#: lxc/move.go:153 lxc/storage_volume.go:2025
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:144
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2019
+#: lxc/storage_volume.go:2021
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:509
+#: lxc/main.go:518
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:353
+#: lxc/file.go:357
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3022,18 +3036,18 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
-#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
+#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:535
+#: lxc/file.go:548
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:717
+#: lxc/file.go:185 lxc/file.go:739
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3070,7 +3084,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3101,12 +3115,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:176
+#: lxc/init.go:180
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:174
+#: lxc/init.go:178
 msgid "Launching the instance"
 msgstr ""
 
@@ -3204,11 +3218,11 @@ msgstr ""
 msgid "List identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:151
+#: lxc/image_alias.go:176
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:177
 msgid ""
 "List image aliases\n"
 "\n"
@@ -3375,11 +3389,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1605
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1610
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3438,7 +3452,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1481
+#: lxc/info.go:489 lxc/storage_volume.go:1483
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3624,7 +3638,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:873 lxc/network_forward.go:874
+#: lxc/network_forward.go:881 lxc/network_forward.go:882
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -3770,12 +3784,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:322 lxc/move.go:435
+#: lxc/move.go:327 lxc/move.go:440
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:347 lxc/move.go:440
+#: lxc/move.go:352 lxc/move.go:445
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3840,10 +3854,10 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:449
-#: lxc/network_forward.go:534 lxc/network_forward.go:709
-#: lxc/network_forward.go:840 lxc/network_forward.go:933
-#: lxc/network_forward.go:1015 lxc/network_load_balancer.go:221
+#: lxc/network_forward.go:219 lxc/network_forward.go:457
+#: lxc/network_forward.go:542 lxc/network_forward.go:717
+#: lxc/network_forward.go:848 lxc/network_forward.go:945
+#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
 #: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
 #: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
 #: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
@@ -3868,10 +3882,10 @@ msgstr ""
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
 #: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
 #: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:284 lxc/network_forward.go:445
-#: lxc/network_forward.go:530 lxc/network_forward.go:705
-#: lxc/network_forward.go:836 lxc/network_forward.go:929
-#: lxc/network_forward.go:1011 lxc/network_load_balancer.go:131
+#: lxc/network_forward.go:292 lxc/network_forward.go:453
+#: lxc/network_forward.go:538 lxc/network_forward.go:713
+#: lxc/network_forward.go:844 lxc/network_forward.go:941
+#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
 #: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
 #: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
 #: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
@@ -3907,13 +3921,13 @@ msgstr ""
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
-#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
-#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
-#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
+#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
+#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
+#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
+#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
 msgid "Missing pool name"
 msgstr ""
 
@@ -3932,15 +3946,15 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
+#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1411
+#: lxc/storage_volume.go:1413
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:820
+#: lxc/file.go:842
 msgid "Missing target directory"
 msgstr ""
 
@@ -3973,16 +3987,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
-#: lxc/storage_volume.go:975
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
+#: lxc/storage_volume.go:977
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:507
+#: lxc/file.go:520
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1207 lxc/file.go:1208
+#: lxc/file.go:1227 lxc/file.go:1228
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4011,7 +4025,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4019,16 +4033,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1869
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1059 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4050,7 +4064,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
 msgid "NAME"
 msgstr ""
 
@@ -4102,8 +4116,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
-#: lxc/storage_volume.go:1573
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Name"
 msgstr ""
 
@@ -4111,7 +4125,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4166,12 +4180,12 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:386
+#: lxc/network_forward.go:394
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:857
+#: lxc/network_forward.go:865
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -4255,7 +4269,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
+#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4263,7 +4277,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1070 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4275,11 +4289,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4293,7 +4307,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2035
+#: lxc/storage_volume.go:2037
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4301,16 +4315,21 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
-#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
-msgid "Only \"custom\" volumes can be attached to instances"
+#: lxc/storage_volume.go:216
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2701
+#: lxc/storage_volume.go:348
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:2703
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2500
+#: lxc/storage_volume.go:2502
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4322,7 +4341,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1431
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4335,7 +4354,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1577
+#: lxc/info.go:705 lxc/storage_volume.go:1579
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4365,7 +4384,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1767
+#: lxc/storage_volume.go:1769
 msgid "POOL"
 msgstr ""
 
@@ -4382,7 +4401,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167
-#: lxc/storage_volume.go:1773 lxc/warning.go:213
+#: lxc/storage_volume.go:1775 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4406,7 +4425,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:367
+#: lxc/main.go:376
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4444,7 +4463,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1332
+#: lxc/file.go:1356
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4452,12 +4471,12 @@ msgstr ""
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
-#: lxc/network_acl.go:699 lxc/network_forward.go:768
+#: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
-#: lxc/storage_volume.go:1200
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
+#: lxc/storage_volume.go:1202
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4570,11 +4589,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1649
+#: lxc/image.go:1650
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4588,7 +4607,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1238
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4604,7 +4623,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4625,7 +4644,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1017
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4634,7 +4653,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2094
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4647,7 +4666,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2370
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4678,20 +4697,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:455 lxc/file.go:456
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:638 lxc/file.go:989
+#: lxc/file.go:651 lxc/file.go:1009
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:688 lxc/file.go:689
+#: lxc/file.go:701 lxc/file.go:702
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:923 lxc/file.go:1089
+#: lxc/file.go:943 lxc/file.go:1109
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4700,7 +4719,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4729,15 +4748,15 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:463 lxc/file.go:695
+#: lxc/file.go:475 lxc/file.go:708
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1444 lxc/image.go:1445
+#: lxc/image.go:1445 lxc/image.go:1446
 msgid "Refresh images"
 msgstr ""
 
@@ -4746,7 +4765,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1481
+#: lxc/image.go:1482
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4823,7 +4842,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:971 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4859,7 +4878,7 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:969 lxc/network_forward.go:970
+#: lxc/network_forward.go:981 lxc/network_forward.go:982
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -4895,8 +4914,8 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
-#: lxc/image_alias.go:255
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:287
+#: lxc/image_alias.go:288
 msgid "Rename aliases"
 msgstr ""
 
@@ -4932,15 +4951,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1962
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
+#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4992,7 +5011,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5009,7 +5028,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:361
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5058,12 +5077,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1460
+#: lxc/file.go:1484
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1461
+#: lxc/file.go:1485
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5139,7 +5158,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1217
+#: lxc/file.go:1237
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5165,7 +5184,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1665 lxc/image.go:1666
+#: lxc/image.go:1666 lxc/image.go:1667
 msgid "Set image properties"
 msgstr ""
 
@@ -5208,11 +5227,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:488
+#: lxc/network_forward.go:496
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:489
+#: lxc/network_forward.go:497
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5316,11 +5335,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2088
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2089
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5337,7 +5356,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:698
+#: lxc/file.go:711
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5345,7 +5364,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:699
+#: lxc/file.go:712
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5353,7 +5372,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:710
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5365,7 +5384,7 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:504
 msgid "Set the key as a network forward property"
 msgstr ""
 
@@ -5405,7 +5424,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2105
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5413,7 +5432,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1215
+#: lxc/file.go:1235
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5470,7 +5489,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1535 lxc/image.go:1536
+#: lxc/image.go:1536 lxc/image.go:1537
 msgid "Show image properties"
 msgstr ""
 
@@ -5490,7 +5509,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:271 lxc/main.go:272
+#: lxc/main.go:280 lxc/main.go:281
 msgid "Show less common commands"
 msgstr ""
 
@@ -5554,11 +5573,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5626,15 +5645,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2190
+#: lxc/storage_volume.go:2192
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1502
+#: lxc/info.go:619 lxc/storage_volume.go:1504
 msgid "Snapshots:"
 msgstr ""
 
@@ -5739,21 +5758,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:703
+#: lxc/storage_volume.go:707
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:791
+#: lxc/storage_volume.go:795
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:516
+#: lxc/storage_volume.go:520
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:524
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5815,21 +5834,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1747 lxc/warning.go:216
+#: lxc/storage_volume.go:1749 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1262
+#: lxc/file.go:1286
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1256
+#: lxc/file.go:1280
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5839,15 +5858,15 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:181
+#: lxc/move.go:186
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:219 lxc/move.go:240
+#: lxc/move.go:224 lxc/move.go:245
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:193
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5855,15 +5874,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:185
+#: lxc/move.go:190
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:189
+#: lxc/move.go:194
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:210
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5885,7 +5904,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:439
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5938,7 +5957,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:462
+#: lxc/network_forward.go:470
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -5978,12 +5997,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1340
+#: lxc/storage_volume.go:1342
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1317
+#: lxc/storage_volume.go:1319
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -5998,12 +6017,12 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:309
+#: lxc/move.go:314
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
-#: lxc/storage_volume.go:989
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
+#: lxc/storage_volume.go:991
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6031,7 +6050,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:298
+#: lxc/main.go:307
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6055,11 +6074,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:437
+#: lxc/init.go:441
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:440
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6067,7 +6086,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:412
+#: lxc/main.go:421
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6078,7 +6097,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1489
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6093,7 +6112,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1864
+#: lxc/storage_volume.go:1866
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6101,7 +6120,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6118,7 +6137,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:327
+#: lxc/copy.go:382 lxc/move.go:332
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6160,7 +6179,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1472
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6182,13 +6201,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1752
+#: lxc/project.go:995 lxc/storage_volume.go:1754
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1751
+#: lxc/storage.go:724 lxc/storage_volume.go:1753
 msgid "USED BY"
 msgstr ""
 
@@ -6201,7 +6220,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:411
+#: lxc/file.go:423
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6215,12 +6234,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1483
+#: lxc/file.go:1507
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1791
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6231,7 +6250,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1029
+#: lxc/file.go:1049
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6262,7 +6281,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1728 lxc/image.go:1729
+#: lxc/image.go:1729 lxc/image.go:1730
 msgid "Unset image properties"
 msgstr ""
 
@@ -6278,11 +6297,11 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:598
+#: lxc/network_forward.go:606
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:599
+#: lxc/network_forward.go:607
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -6326,7 +6345,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6338,7 +6357,7 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:602
+#: lxc/network_forward.go:610
 msgid "Unset the key as a network forward property"
 msgstr ""
 
@@ -6378,7 +6397,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2381
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6386,7 +6405,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:248
+#: lxc/storage_volume.go:250
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6422,12 +6441,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1485
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2652
+#: lxc/export.go:42 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6494,7 +6513,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1576
+#: lxc/storage_volume.go:1578
 msgid "Volume Only"
 msgstr ""
 
@@ -6545,7 +6564,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:293 lxc/move.go:369
+#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6553,12 +6572,12 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:909
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:912
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:282
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:284
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
@@ -6590,7 +6609,7 @@ msgstr ""
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:174
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
@@ -6643,7 +6662,7 @@ msgstr ""
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: lxc/image_alias.go:104
+#: lxc/image_alias.go:121
 msgid "[<remote>:]<alias>"
 msgstr ""
 
@@ -6651,7 +6670,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/image_alias.go:252
+#: lxc/image_alias.go:285
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
@@ -6705,15 +6724,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1600 lxc/image.go:1727
+#: lxc/image.go:1601 lxc/image.go:1728
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1664
+#: lxc/image.go:1665
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6733,7 +6752,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1443
+#: lxc/image.go:334 lxc/image.go:1444
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6804,7 +6823,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:376
+#: lxc/file.go:380
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -6816,12 +6835,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:454
+#: lxc/file.go:466
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1226
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6889,8 +6908,8 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:644
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:179
+#: lxc/network_forward.go:177 lxc/network_forward.go:652
+#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
 #: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
@@ -6905,12 +6924,12 @@ msgid ""
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:402 lxc/network_forward.go:597
+#: lxc/network_forward.go:410 lxc/network_forward.go:605
 #: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
@@ -6920,13 +6939,13 @@ msgid ""
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:887
+#: lxc/network_forward.go:895
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:968 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -6981,7 +7000,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2811
+#: lxc/storage_volume.go:2813
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7016,65 +7035,65 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1958
+#: lxc/storage_volume.go:1960
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:806
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:167
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
-msgstr ""
-
-#: lxc/storage_volume.go:2562
+#: lxc/storage_volume.go:2564
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2645
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2428
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:610
+#: lxc/storage_volume.go:614
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:718
+#: lxc/storage_volume.go:722
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2364
+#: lxc/storage_volume.go:810
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
+msgstr ""
+
+#: lxc/storage_volume.go:167
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
+msgstr ""
+
+#: lxc/storage_volume.go:2366
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2087
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2245
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1234
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1858
+#: lxc/storage_volume.go:1860
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7180,7 +7199,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1603
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7342,20 +7361,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1230
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:470
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:691
+#: lxc/file.go:704
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7656,7 +7675,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:618
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7664,13 +7683,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2817
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2432
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7704,16 +7723,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1396
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1331
+#: lxc/file.go:1355
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1284
+#: lxc/file.go:1308
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-        "POT-Creation-Date: 2025-01-07 15:11-0700\n"
+        "POT-Creation-Date: 2025-01-10 14:44-0600\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -44,7 +44,7 @@ msgid   "### This is a YAML representation of a storage pool.\n"
         "###   zfs.pool_name: default"
 msgstr  ""
 
-#: lxc/storage_volume.go:1041
+#: lxc/storage_volume.go:1043
 msgid   "### This is a YAML representation of a storage volume.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -234,7 +234,7 @@ msgid   "### This is a YAML representation of the network ACL.\n"
         "### Note that only the ingress and egress rules, description and configuration keys can be changed."
 msgstr  ""
 
-#: lxc/network_forward.go:667
+#: lxc/network_forward.go:675
 msgid   "### This is a YAML representation of the network forward.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -398,12 +398,12 @@ msgstr  ""
 msgid   "%s (%s) (%d available)"
 msgstr  ""
 
-#: lxc/file.go:1157
+#: lxc/file.go:1177
 #, c-format
 msgid   "%s is not a directory"
 msgstr  ""
 
-#: lxc/file.go:1047
+#: lxc/file.go:1067
 #, c-format
 msgid   "'%s' isn't a supported file type"
 msgstr  ""
@@ -439,7 +439,7 @@ msgstr  ""
 msgid   "--console only works with a single instance"
 msgstr  ""
 
-#: lxc/init.go:142 lxc/rebuild.go:65
+#: lxc/init.go:146 lxc/rebuild.go:65
 msgid   "--empty cannot be combined with an image name"
 msgstr  ""
 
@@ -491,7 +491,7 @@ msgstr  ""
 msgid   "<remote> <new-name>"
 msgstr  ""
 
-#: lxc/file.go:687
+#: lxc/file.go:700
 msgid   "<source path>... [<remote>:]<instance>/<path>"
 msgstr  ""
 
@@ -507,7 +507,7 @@ msgstr  ""
 msgid   "ADDRESS"
 msgstr  ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
 msgid   "ALIAS"
 msgstr  ""
 
@@ -631,7 +631,7 @@ msgstr  ""
 msgid   "Add permissions to groups"
 msgstr  ""
 
-#: lxc/network_forward.go:888 lxc/network_forward.go:889
+#: lxc/network_forward.go:896 lxc/network_forward.go:897
 msgid   "Add ports to a forward"
 msgstr  ""
 
@@ -681,7 +681,7 @@ msgstr  ""
 msgid   "Alias %s doesn't exist"
 msgstr  ""
 
-#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
+#: lxc/image_alias.go:101 lxc/image_alias.go:156 lxc/image_alias.go:320
 msgid   "Alias name missing"
 msgstr  ""
 
@@ -694,7 +694,7 @@ msgstr  ""
 msgid   "Aliases:"
 msgstr  ""
 
-#: lxc/storage_volume.go:1607
+#: lxc/storage_volume.go:1609
 msgid   "All projects"
 msgstr  ""
 
@@ -725,7 +725,7 @@ msgstr  ""
 msgid   "As neither could be found, the raw SPICE socket can be found at:"
 msgstr  ""
 
-#: lxc/init.go:343 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:131
 msgid   "Asked for a VM but image is of type container"
 msgstr  ""
 
@@ -749,12 +749,24 @@ msgstr  ""
 msgid   "Attach new network interfaces to instances"
 msgstr  ""
 
-#: lxc/storage_volume.go:168 lxc/storage_volume.go:169
+#: lxc/storage_volume.go:168
 msgid   "Attach new storage volumes to instances"
 msgstr  ""
 
-#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:169
+msgid   "Attach new storage volumes to instances\n"
+        "\n"
+        "<type> must be one of \"custom\" or \"virtual-machine\""
+msgstr  ""
+
+#: lxc/storage_volume.go:285
 msgid   "Attach new storage volumes to profiles"
+msgstr  ""
+
+#: lxc/storage_volume.go:286
+msgid   "Attach new storage volumes to profiles\n"
+        "\n"
+        "<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr  ""
 
 #: lxc/console.go:39
@@ -804,16 +816,16 @@ msgstr  ""
 msgid   "Backing up instance: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:2719
+#: lxc/storage_volume.go:2721
 #, c-format
 msgid   "Backing up storage volume: %s"
 msgstr  ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2796
+#: lxc/export.go:192 lxc/storage_volume.go:2798
 msgid   "Backup exported successfully!"
 msgstr  ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1538
+#: lxc/info.go:666 lxc/storage_volume.go:1540
 msgid   "Backups:"
 msgstr  ""
 
@@ -822,17 +834,17 @@ msgstr  ""
 msgid   "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr  ""
 
-#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318 lxc/network_load_balancer.go:321 lxc/network_peer.go:309 lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
+#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:326 lxc/network_load_balancer.go:321 lxc/network_peer.go:309 lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid   "Bad key/value pair: %s"
 msgstr  ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
 #, c-format
 msgid   "Bad key=value pair: %q"
 msgstr  ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
 #, c-format
 msgid   "Bad key=value pair: %s"
 msgstr  ""
@@ -875,7 +887,7 @@ msgstr  ""
 msgid   "COMMON NAME"
 msgstr  ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1752
 msgid   "CONTENT-TYPE"
 msgstr  ""
 
@@ -927,7 +939,7 @@ msgstr  ""
 msgid   "Caches:"
 msgstr  ""
 
-#: lxc/move.go:130
+#: lxc/move.go:135
 msgid   "Can't override configuration or profiles in local rename"
 msgstr  ""
 
@@ -935,7 +947,7 @@ msgstr  ""
 msgid   "Can't provide a name for the target image"
 msgstr  ""
 
-#: lxc/file.go:562
+#: lxc/file.go:575
 msgid   "Can't pull a directory without --recursive"
 msgstr  ""
 
@@ -960,11 +972,11 @@ msgstr  ""
 msgid   "Can't specify a different remote for rename"
 msgstr  ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
 msgid   "Can't specify column L when not clustered"
 msgstr  ""
 
-#: lxc/file.go:768
+#: lxc/file.go:790
 msgid   "Can't supply uid/gid/mode in recursive mode"
 msgstr  ""
 
@@ -977,11 +989,11 @@ msgstr  ""
 msgid   "Can't use an image with --empty"
 msgstr  ""
 
-#: lxc/storage_volume.go:493
+#: lxc/storage_volume.go:497
 msgid   "Cannot set --destination-target when destination server is not clustered"
 msgstr  ""
 
-#: lxc/storage_volume.go:447
+#: lxc/storage_volume.go:451
 msgid   "Cannot set --target when source server is not clustered"
 msgstr  ""
 
@@ -1081,7 +1093,7 @@ msgstr  ""
 msgid   "Cluster member %s removed from group %s"
 msgstr  ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776 lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65 lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877 lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353 lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264 lxc/network_forward.go:497 lxc/network_forward.go:649 lxc/network_forward.go:803 lxc/network_forward.go:892 lxc/network_forward.go:974 lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484 lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774 lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938 lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125 lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748 lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91 lxc/storage_bucket.go:191 lxc/storage_bucket.go:254 lxc/storage_bucket.go:385 lxc/storage_bucket.go:542 lxc/storage_bucket.go:635 lxc/storage_bucket.go:701 lxc/storage_bucket.go:776 lxc/storage_bucket.go:862 lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027 lxc/storage_bucket.go:1163 lxc/storage_volume.go:395 lxc/storage_volume.go:619 lxc/storage_volume.go:724 lxc/storage_volume.go:1022 lxc/storage_volume.go:1248 lxc/storage_volume.go:1377 lxc/storage_volume.go:1865 lxc/storage_volume.go:1963 lxc/storage_volume.go:2102 lxc/storage_volume.go:2262 lxc/storage_volume.go:2378 lxc/storage_volume.go:2439 lxc/storage_volume.go:2566 lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776 lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65 lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877 lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353 lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264 lxc/network_forward.go:505 lxc/network_forward.go:657 lxc/network_forward.go:811 lxc/network_forward.go:900 lxc/network_forward.go:986 lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484 lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774 lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938 lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125 lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748 lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91 lxc/storage_bucket.go:191 lxc/storage_bucket.go:254 lxc/storage_bucket.go:385 lxc/storage_bucket.go:542 lxc/storage_bucket.go:635 lxc/storage_bucket.go:701 lxc/storage_bucket.go:776 lxc/storage_bucket.go:862 lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027 lxc/storage_bucket.go:1163 lxc/storage_volume.go:399 lxc/storage_volume.go:623 lxc/storage_volume.go:728 lxc/storage_volume.go:1024 lxc/storage_volume.go:1250 lxc/storage_volume.go:1379 lxc/storage_volume.go:1867 lxc/storage_volume.go:1965 lxc/storage_volume.go:2104 lxc/storage_volume.go:2264 lxc/storage_volume.go:2380 lxc/storage_volume.go:2441 lxc/storage_volume.go:2568 lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
 msgid   "Cluster member name"
 msgstr  ""
 
@@ -1097,7 +1109,7 @@ msgstr  ""
 msgid   "Clustering enabled"
 msgstr  ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606 lxc/warning.go:93
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1608 lxc/warning.go:93
 msgid   "Columns"
 msgstr  ""
 
@@ -1132,16 +1144,16 @@ msgstr  ""
 msgid   "Config key/value to apply to the target instance"
 msgstr  ""
 
-#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281 lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156 lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759 lxc/network_acl.go:698 lxc/network_forward.go:767 lxc/network_load_balancer.go:738 lxc/network_peer.go:698 lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:595 lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349 lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167 lxc/storage_volume.go:1199
+#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281 lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156 lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759 lxc/network_acl.go:698 lxc/network_forward.go:775 lxc/network_load_balancer.go:738 lxc/network_peer.go:698 lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:595 lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349 lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169 lxc/storage_volume.go:1201
 #, c-format
 msgid   "Config parsing error: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:620
+#: lxc/storage_volume.go:624
 msgid   "Content type, block or filesystem"
 msgstr  ""
 
-#: lxc/storage_volume.go:1478
+#: lxc/storage_volume.go:1480
 #, c-format
 msgid   "Content type: %s"
 msgstr  ""
@@ -1197,7 +1209,7 @@ msgstr  ""
 msgid   "Copy profiles"
 msgstr  ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid   "Copy storage volumes"
 msgstr  ""
 
@@ -1205,11 +1217,11 @@ msgstr  ""
 msgid   "Copy the instance without its snapshots"
 msgstr  ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:401
 msgid   "Copy the volume without its snapshots"
 msgstr  ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273 lxc/storage_volume.go:398
+#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273 lxc/storage_volume.go:402
 msgid   "Copy to a project different from the source"
 msgstr  ""
 
@@ -1222,7 +1234,7 @@ msgstr  ""
 msgid   "Copying the image: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:519
 #, c-format
 msgid   "Copying the storage volume: %s"
 msgstr  ""
@@ -1317,7 +1329,7 @@ msgstr  ""
 msgid   "Create and start instances from images"
 msgstr  ""
 
-#: lxc/file.go:143 lxc/file.go:462 lxc/file.go:696
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
 msgid   "Create any directories necessary"
 msgstr  ""
 
@@ -1356,7 +1368,7 @@ msgstr  ""
 msgid   "Create new custom storage buckets"
 msgstr  ""
 
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
 msgid   "Create new custom storage volumes"
 msgstr  ""
 
@@ -1408,12 +1420,12 @@ msgstr  ""
 msgid   "Create the instance with no profiles applied"
 msgstr  ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
 #, c-format
 msgid   "Created: %s"
 msgstr  ""
 
-#: lxc/init.go:182
+#: lxc/init.go:186
 #, c-format
 msgid   "Creating %s"
 msgstr  ""
@@ -1423,7 +1435,7 @@ msgstr  ""
 msgid   "Creating %s: %%s"
 msgstr  ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 msgid   "Creating the instance"
 msgstr  ""
 
@@ -1436,7 +1448,7 @@ msgstr  ""
 msgid   "DEFAULT TARGET ADDRESS"
 msgstr  ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504 lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095 lxc/network_acl.go:157 lxc/network_forward.go:157 lxc/network_load_balancer.go:160 lxc/network_peer.go:149 lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173 lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723 lxc/storage_bucket.go:513 lxc/storage_bucket.go:833 lxc/storage_volume.go:1749
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504 lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095 lxc/network_acl.go:157 lxc/network_forward.go:157 lxc/network_load_balancer.go:160 lxc/network_peer.go:149 lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173 lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723 lxc/storage_bucket.go:513 lxc/storage_bucket.go:833 lxc/storage_volume.go:1751
 msgid   "DESCRIPTION"
 msgstr  ""
 
@@ -1456,7 +1468,7 @@ msgstr  ""
 msgid   "Default VLAN ID"
 msgstr  ""
 
-#: lxc/storage_volume.go:2653
+#: lxc/storage_volume.go:2655
 msgid   "Define a compression algorithm: for backup or none"
 msgstr  ""
 
@@ -1488,7 +1500,7 @@ msgstr  ""
 msgid   "Delete identity provider groups"
 msgstr  ""
 
-#: lxc/image_alias.go:106 lxc/image_alias.go:107
+#: lxc/image_alias.go:123 lxc/image_alias.go:124
 msgid   "Delete image aliases"
 msgstr  ""
 
@@ -1512,7 +1524,7 @@ msgstr  ""
 msgid   "Delete network ACLs"
 msgstr  ""
 
-#: lxc/network_forward.go:799 lxc/network_forward.go:800
+#: lxc/network_forward.go:807 lxc/network_forward.go:808
 msgid   "Delete network forwards"
 msgstr  ""
 
@@ -1552,7 +1564,7 @@ msgstr  ""
 msgid   "Delete storage pools"
 msgstr  ""
 
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
+#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
 msgid   "Delete storage volumes"
 msgstr  ""
 
@@ -1560,16 +1572,16 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104 lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396 lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579 lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983 lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290 lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462 lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779 lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058 lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088 lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330 lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170 lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957 lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174 lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409 lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634 lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28 lxc/config_metadata.go:56 lxc/config_metadata.go:189 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:119 lxc/config_template.go:173 lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689 lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602 lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194 lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422 lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53 lxc/network_forward.go:33 lxc/network_forward.go:90 lxc/network_forward.go:179 lxc/network_forward.go:256 lxc/network_forward.go:404 lxc/network_forward.go:489 lxc/network_forward.go:599 lxc/network_forward.go:646 lxc/network_forward.go:800 lxc/network_forward.go:874 lxc/network_forward.go:889 lxc/network_forward.go:970 lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121 lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29 lxc/network_zone.go:87 lxc/network_zone.go:183 lxc/network_zone.go:246 lxc/network_zone.go:319 lxc/network_zone.go:414 lxc/network_zone.go:502 lxc/network_zone.go:545 lxc/network_zone.go:672 lxc/network_zone.go:728 lxc/network_zone.go:785 lxc/network_zone.go:863 lxc/network_zone.go:927 lxc/network_zone.go:1003 lxc/network_zone.go:1101 lxc/network_zone.go:1190 lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428 lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749 lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018 lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250 lxc/storage_bucket.go:383 lxc/storage_bucket.go:459 lxc/storage_bucket.go:536 lxc/storage_bucket.go:630 lxc/storage_bucket.go:699 lxc/storage_bucket.go:733 lxc/storage_bucket.go:774 lxc/storage_bucket.go:853 lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158 lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:284 lxc/storage_volume.go:391 lxc/storage_volume.go:612 lxc/storage_volume.go:721 lxc/storage_volume.go:808 lxc/storage_volume.go:911 lxc/storage_volume.go:1013 lxc/storage_volume.go:1234 lxc/storage_volume.go:1365 lxc/storage_volume.go:1524 lxc/storage_volume.go:1608 lxc/storage_volume.go:1861 lxc/storage_volume.go:1960 lxc/storage_volume.go:2087 lxc/storage_volume.go:2245 lxc/storage_volume.go:2366 lxc/storage_volume.go:2428 lxc/storage_volume.go:2564 lxc/storage_volume.go:2647 lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104 lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396 lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579 lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983 lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290 lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462 lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779 lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058 lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088 lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330 lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170 lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957 lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174 lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409 lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634 lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28 lxc/config_metadata.go:56 lxc/config_metadata.go:189 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:119 lxc/config_template.go:173 lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702 lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603 lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177 lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194 lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422 lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53 lxc/network_forward.go:33 lxc/network_forward.go:90 lxc/network_forward.go:179 lxc/network_forward.go:256 lxc/network_forward.go:412 lxc/network_forward.go:497 lxc/network_forward.go:607 lxc/network_forward.go:654 lxc/network_forward.go:808 lxc/network_forward.go:882 lxc/network_forward.go:897 lxc/network_forward.go:982 lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121 lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29 lxc/network_zone.go:87 lxc/network_zone.go:183 lxc/network_zone.go:246 lxc/network_zone.go:319 lxc/network_zone.go:414 lxc/network_zone.go:502 lxc/network_zone.go:545 lxc/network_zone.go:672 lxc/network_zone.go:728 lxc/network_zone.go:785 lxc/network_zone.go:863 lxc/network_zone.go:927 lxc/network_zone.go:1003 lxc/network_zone.go:1101 lxc/network_zone.go:1190 lxc/network_zone.go:1237 lxc/network_zone.go:1367 lxc/network_zone.go:1428 lxc/network_zone.go:1443 lxc/network_zone.go:1501 lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749 lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018 lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250 lxc/storage_bucket.go:383 lxc/storage_bucket.go:459 lxc/storage_bucket.go:536 lxc/storage_bucket.go:630 lxc/storage_bucket.go:699 lxc/storage_bucket.go:733 lxc/storage_bucket.go:774 lxc/storage_bucket.go:853 lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158 lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:286 lxc/storage_volume.go:395 lxc/storage_volume.go:616 lxc/storage_volume.go:725 lxc/storage_volume.go:812 lxc/storage_volume.go:914 lxc/storage_volume.go:1015 lxc/storage_volume.go:1236 lxc/storage_volume.go:1367 lxc/storage_volume.go:1526 lxc/storage_volume.go:1610 lxc/storage_volume.go:1863 lxc/storage_volume.go:1962 lxc/storage_volume.go:2089 lxc/storage_volume.go:2247 lxc/storage_volume.go:2368 lxc/storage_volume.go:2430 lxc/storage_volume.go:2566 lxc/storage_volume.go:2649 lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid   "Description"
 msgstr  ""
 
-#: lxc/storage_volume.go:1465
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid   "Description: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
 msgid   "Destination cluster member name"
 msgstr  ""
 
@@ -1581,11 +1593,11 @@ msgstr  ""
 msgid   "Detach network interfaces from profiles"
 msgstr  ""
 
-#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
 msgid   "Detach storage volumes from instances"
 msgstr  ""
 
-#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
+#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
 msgid   "Detach storage volumes from profiles"
 msgstr  ""
 
@@ -1630,7 +1642,7 @@ msgstr  ""
 msgid   "Device: %s"
 msgstr  ""
 
-#: lxc/init.go:403
+#: lxc/init.go:407
 msgid   "Didn't get any affected image, instance or snapshot from server"
 msgstr  ""
 
@@ -1642,7 +1654,7 @@ msgstr  ""
 msgid   "Directory to run the command in (default /root)"
 msgstr  ""
 
-#: lxc/file.go:1216
+#: lxc/file.go:1236
 msgid   "Disable authentication when using SSH SFTP listener"
 msgstr  ""
 
@@ -1736,7 +1748,7 @@ msgstr  ""
 msgid   "Edit cluster member configurations as YAML"
 msgstr  ""
 
-#: lxc/file.go:377 lxc/file.go:378
+#: lxc/file.go:381 lxc/file.go:382
 msgid   "Edit files in instances"
 msgstr  ""
 
@@ -1776,7 +1788,7 @@ msgstr  ""
 msgid   "Edit network configurations as YAML"
 msgstr  ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:653 lxc/network_forward.go:654
 msgid   "Edit network forward configurations as YAML"
 msgstr  ""
 
@@ -1816,7 +1828,7 @@ msgstr  ""
 msgid   "Edit storage pool configurations as YAML"
 msgstr  ""
 
-#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
 msgid   "Edit storage volume configurations as YAML"
 msgstr  ""
 
@@ -1824,7 +1836,7 @@ msgstr  ""
 msgid   "Edit trust configurations as YAML"
 msgstr  ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783 lxc/warning.go:236
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1785 lxc/warning.go:236
 #, c-format
 msgid   "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr  ""
@@ -1872,7 +1884,7 @@ msgstr  ""
 msgid   "Error retrieving aliases: %w"
 msgstr  ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328 lxc/network_acl.go:524 lxc/network_forward.go:572 lxc/network_load_balancer.go:559 lxc/network_peer.go:522 lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:987 lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603 lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328 lxc/network_acl.go:524 lxc/network_forward.go:580 lxc/network_load_balancer.go:559 lxc/network_peer.go:522 lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:987 lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603 lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
 #, c-format
 msgid   "Error setting properties: %v"
 msgstr  ""
@@ -1882,7 +1894,7 @@ msgstr  ""
 msgid   "Error unsetting properties: %v"
 msgstr  ""
 
-#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518 lxc/network_forward.go:566 lxc/network_load_balancer.go:553 lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159 lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806 lxc/storage_bucket.go:597 lxc/storage_volume.go:2172 lxc/storage_volume.go:2210
+#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518 lxc/network_forward.go:574 lxc/network_load_balancer.go:553 lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159 lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806 lxc/storage_bucket.go:597 lxc/storage_volume.go:2174 lxc/storage_volume.go:2212
 #, c-format
 msgid   "Error unsetting property: %v"
 msgstr  ""
@@ -1922,7 +1934,7 @@ msgid   "Execute commands in instances\n"
         "Mode defaults to non-interactive, interactive mode is selected if both stdin AND stdout are terminals (stderr is ignored)."
 msgstr  ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525 lxc/storage_volume.go:1575
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527 lxc/storage_volume.go:1577
 msgid   "Expires at"
 msgstr  ""
 
@@ -1945,7 +1957,7 @@ msgid   "Export and download images\n"
         "The output target is optional and defaults to the working directory."
 msgstr  ""
 
-#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid   "Export custom storage volume"
 msgstr  ""
 
@@ -1957,11 +1969,11 @@ msgstr  ""
 msgid   "Export instances as backup tarballs."
 msgstr  ""
 
-#: lxc/storage_volume.go:2650
+#: lxc/storage_volume.go:2652
 msgid   "Export the volume without its snapshots"
 msgstr  ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2779
+#: lxc/export.go:152 lxc/storage_volume.go:2781
 #, c-format
 msgid   "Exporting the backup: %s"
 msgstr  ""
@@ -1979,7 +1991,7 @@ msgstr  ""
 msgid   "FILENAME"
 msgstr  ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142 lxc/image_alias.go:235
+#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142 lxc/image_alias.go:268
 msgid   "FINGERPRINT"
 msgstr  ""
 
@@ -1987,12 +1999,12 @@ msgstr  ""
 msgid   "FIRST SEEN"
 msgstr  ""
 
-#: lxc/file.go:1467
+#: lxc/file.go:1491
 #, c-format
 msgid   "Failed SSH handshake with client %q: %v"
 msgstr  ""
 
-#: lxc/file.go:1490
+#: lxc/file.go:1514
 #, c-format
 msgid   "Failed accepting channel client %q: %v"
 msgstr  ""
@@ -2007,12 +2019,12 @@ msgstr  ""
 msgid   "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr  ""
 
-#: lxc/file.go:1517
+#: lxc/file.go:1541
 #, c-format
 msgid   "Failed connecting to instance SFTP for client %q: %v"
 msgstr  ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1326
 #, c-format
 msgid   "Failed connecting to instance SFTP: %w"
 msgstr  ""
@@ -2042,7 +2054,7 @@ msgstr  ""
 msgid   "Failed fetching fingerprint %q: %w"
 msgstr  ""
 
-#: lxc/file.go:1423
+#: lxc/file.go:1447
 #, c-format
 msgid   "Failed generating SSH host key: %w"
 msgstr  ""
@@ -2057,7 +2069,7 @@ msgstr  ""
 msgid   "Failed loading profile %q: %w"
 msgstr  ""
 
-#: lxc/file.go:1428
+#: lxc/file.go:1452
 #, c-format
 msgid   "Failed parsing SSH host key: %w"
 msgstr  ""
@@ -2067,12 +2079,12 @@ msgstr  ""
 msgid   "Failed starting command: %w"
 msgstr  ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1352
 #, c-format
 msgid   "Failed starting sshfs: %w"
 msgstr  ""
 
-#: lxc/file.go:1455
+#: lxc/file.go:1479
 #, c-format
 msgid   "Failed to accept incoming connection: %w"
 msgstr  ""
@@ -2086,7 +2098,7 @@ msgstr  ""
 msgid   "Failed to close server cert file %q: %w"
 msgstr  ""
 
-#: lxc/move.go:304 lxc/move.go:380
+#: lxc/move.go:309 lxc/move.go:385
 #, c-format
 msgid   "Failed to connect to cluster member: %w"
 msgstr  ""
@@ -2111,7 +2123,7 @@ msgstr  ""
 msgid   "Failed to find project: %w"
 msgstr  ""
 
-#: lxc/file.go:1440
+#: lxc/file.go:1464
 #, c-format
 msgid   "Failed to listen for connection: %w"
 msgstr  ""
@@ -2126,7 +2138,7 @@ msgstr  ""
 msgid   "Failed to remove alias %s: %w"
 msgstr  ""
 
-#: lxc/file.go:1042
+#: lxc/file.go:1062
 #, c-format
 msgid   "Failed to walk path for %s: %s"
 msgstr  ""
@@ -2204,7 +2216,7 @@ msgid   "Forcefully removing a server from the cluster should only be done as a 
         "Are you really sure you want to force removing %s? (yes/no): "
 msgstr  ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902 lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442 lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434 lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010 lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59 lxc/network_forward.go:93 lxc/network_load_balancer.go:97 lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788 lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474 lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657 lxc/storage_bucket.go:460 lxc/storage_bucket.go:775 lxc/storage_volume.go:1625 lxc/warning.go:94
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902 lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442 lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434 lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010 lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59 lxc/network_forward.go:93 lxc/network_load_balancer.go:97 lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788 lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474 lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657 lxc/storage_bucket.go:460 lxc/storage_bucket.go:775 lxc/storage_volume.go:1627 lxc/warning.go:94
 msgid   "Format (csv|json|table|yaml|compact)"
 msgstr  ""
 
@@ -2272,7 +2284,7 @@ msgstr  ""
 msgid   "Get a summary of resource allocations"
 msgstr  ""
 
-#: lxc/image.go:1601 lxc/image.go:1602
+#: lxc/image.go:1602 lxc/image.go:1603
 msgid   "Get image properties"
 msgstr  ""
 
@@ -2288,7 +2300,7 @@ msgstr  ""
 msgid   "Get the key as a network ACL property"
 msgstr  ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:414
 msgid   "Get the key as a network forward property"
 msgstr  ""
 
@@ -2328,7 +2340,7 @@ msgstr  ""
 msgid   "Get the key as a storage property"
 msgstr  ""
 
-#: lxc/storage_volume.go:1249
+#: lxc/storage_volume.go:1251
 msgid   "Get the key as a storage volume property"
 msgstr  ""
 
@@ -2356,7 +2368,7 @@ msgstr  ""
 msgid   "Get values for network configuration keys"
 msgstr  ""
 
-#: lxc/network_forward.go:403 lxc/network_forward.go:404
+#: lxc/network_forward.go:411 lxc/network_forward.go:412
 msgid   "Get values for network forward configuration keys"
 msgstr  ""
 
@@ -2392,11 +2404,11 @@ msgstr  ""
 msgid   "Get values for storage pool configuration keys"
 msgstr  ""
 
-#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
 msgid   "Get values for storage volume configuration keys"
 msgstr  ""
 
-#: lxc/storage_volume.go:476
+#: lxc/storage_volume.go:480
 #, c-format
 msgid   "Given target %q does not match source volume location %q"
 msgstr  ""
@@ -2436,22 +2448,22 @@ msgstr  ""
 msgid   "Hugepages:\n"
 msgstr  ""
 
-#: lxc/file.go:1540
+#: lxc/file.go:1564
 #, c-format
 msgid   "I/O copy from SSH to instance failed: %v"
 msgstr  ""
 
-#: lxc/file.go:1529
+#: lxc/file.go:1553
 #, c-format
 msgid   "I/O copy from instance to SSH failed: %v"
 msgstr  ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1376
 #, c-format
 msgid   "I/O copy from instance to sshfs failed: %v"
 msgstr  ""
 
-#: lxc/file.go:1362
+#: lxc/file.go:1386
 #, c-format
 msgid   "I/O copy from sshfs to instance failed: %v"
 msgstr  ""
@@ -2524,11 +2536,11 @@ msgstr  ""
 msgid   "If the image alias already exists, delete and create a new one"
 msgstr  ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
 msgid   "If the snapshot name already exists, delete and create a new one"
 msgstr  ""
 
-#: lxc/main.go:406
+#: lxc/main.go:415
 msgid   "If this is your first time running LXD on this machine, you should also run: lxd init"
 msgstr  ""
 
@@ -2536,7 +2548,7 @@ msgstr  ""
 msgid   "Ignore any configured auto-expiry for the instance"
 msgstr  ""
 
-#: lxc/storage_volume.go:2437
+#: lxc/storage_volume.go:2439
 msgid   "Ignore any configured auto-expiry for the storage volume"
 msgstr  ""
 
@@ -2548,7 +2560,7 @@ msgstr  ""
 msgid   "Ignore the instance state"
 msgstr  ""
 
-#: lxc/image.go:1517
+#: lxc/image.go:1518
 msgid   "Image already up to date."
 msgstr  ""
 
@@ -2564,11 +2576,11 @@ msgstr  ""
 msgid   "Image exported successfully!"
 msgstr  ""
 
-#: lxc/image.go:364 lxc/image.go:1472
+#: lxc/image.go:364 lxc/image.go:1473
 msgid   "Image identifier missing"
 msgstr  ""
 
-#: lxc/image.go:444 lxc/image.go:1698
+#: lxc/image.go:444 lxc/image.go:1699
 #, c-format
 msgid   "Image identifier missing: %s"
 msgstr  ""
@@ -2578,7 +2590,7 @@ msgstr  ""
 msgid   "Image imported with fingerprint: %s"
 msgstr  ""
 
-#: lxc/image.go:1515
+#: lxc/image.go:1516
 msgid   "Image refreshed successfully!"
 msgstr  ""
 
@@ -2586,7 +2598,7 @@ msgstr  ""
 msgid   "Immediately attach to the console"
 msgstr  ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2815
 msgid   "Import backups of custom volumes including their snapshots."
 msgstr  ""
 
@@ -2594,7 +2606,7 @@ msgstr  ""
 msgid   "Import backups of instances including their snapshots."
 msgstr  ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2814
 msgid   "Import custom storage volumes"
 msgstr  ""
 
@@ -2614,11 +2626,11 @@ msgstr  ""
 msgid   "Import instance backups"
 msgstr  ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2822
 msgid   "Import type, backup or iso (default \"backup\")"
 msgstr  ""
 
-#: lxc/storage_volume.go:2894
+#: lxc/storage_volume.go:2896
 #, c-format
 msgid   "Importing custom volume: %s"
 msgstr  ""
@@ -2644,11 +2656,11 @@ msgstr  ""
 msgid   "Instance Only"
 msgstr  ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1378
 msgid   "Instance disconnected"
 msgstr  ""
 
-#: lxc/file.go:1531
+#: lxc/file.go:1555
 #, c-format
 msgid   "Instance disconnected for client %q"
 msgstr  ""
@@ -2657,7 +2669,7 @@ msgstr  ""
 msgid   "Instance name is mandatory"
 msgstr  ""
 
-#: lxc/init.go:414
+#: lxc/init.go:418
 #, c-format
 msgid   "Instance name is: %s"
 msgstr  ""
@@ -2666,7 +2678,7 @@ msgstr  ""
 msgid   "Instance name must be specified"
 msgstr  ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1298
 msgid   "Instance path cannot be used in SSH SFTP listener mode"
 msgstr  ""
 
@@ -2718,7 +2730,7 @@ msgstr  ""
 msgid   "Invalid instance name: %s"
 msgstr  ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1293
 #, c-format
 msgid   "Invalid instance path: %q"
 msgstr  ""
@@ -2743,23 +2755,23 @@ msgstr  ""
 msgid   "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr  ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2023
+#: lxc/move.go:153 lxc/storage_volume.go:2025
 msgid   "Invalid new snapshot name"
 msgstr  ""
 
-#: lxc/move.go:144
+#: lxc/move.go:149
 msgid   "Invalid new snapshot name, parent must be the same as source"
 msgstr  ""
 
-#: lxc/storage_volume.go:2019
+#: lxc/storage_volume.go:2021
 msgid   "Invalid new snapshot name, parent volume must be the same as source"
 msgstr  ""
 
-#: lxc/main.go:509
+#: lxc/main.go:518
 msgid   "Invalid number of arguments"
 msgstr  ""
 
-#: lxc/file.go:353
+#: lxc/file.go:357
 #, c-format
 msgid   "Invalid path %s"
 msgstr  ""
@@ -2769,16 +2781,16 @@ msgstr  ""
 msgid   "Invalid protocol: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298 lxc/storage_volume.go:1422 lxc/storage_volume.go:2008 lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
+#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300 lxc/storage_volume.go:1424 lxc/storage_volume.go:2010 lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
 msgid   "Invalid snapshot name"
 msgstr  ""
 
-#: lxc/file.go:535
+#: lxc/file.go:548
 #, c-format
 msgid   "Invalid source %s"
 msgstr  ""
 
-#: lxc/file.go:185 lxc/file.go:717
+#: lxc/file.go:185 lxc/file.go:739
 #, c-format
 msgid   "Invalid target %s"
 msgstr  ""
@@ -2813,7 +2825,7 @@ msgstr  ""
 msgid   "LISTEN ADDRESS"
 msgstr  ""
 
-#: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163 lxc/network_load_balancer.go:165 lxc/operation.go:178 lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163 lxc/network_load_balancer.go:165 lxc/operation.go:178 lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
 msgid   "LOCATION"
 msgstr  ""
 
@@ -2843,12 +2855,12 @@ msgstr  ""
 msgid   "Last used: never"
 msgstr  ""
 
-#: lxc/init.go:176
+#: lxc/init.go:180
 #, c-format
 msgid   "Launching %s"
 msgstr  ""
 
-#: lxc/init.go:174
+#: lxc/init.go:178
 msgid   "Launching the instance"
 msgstr  ""
 
@@ -2946,11 +2958,11 @@ msgstr  ""
 msgid   "List identity provider groups"
 msgstr  ""
 
-#: lxc/image_alias.go:151
+#: lxc/image_alias.go:176
 msgid   "List image aliases"
 msgstr  ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:177
 msgid   "List image aliases\n"
         "\n"
         "Filters may be part of the image hash or part of the image alias name.\n"
@@ -3106,11 +3118,11 @@ msgstr  ""
 msgid   "List storage buckets"
 msgstr  ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1605
 msgid   "List storage volumes"
 msgstr  ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1610
 msgid   "List storage volumes\n"
         "\n"
         "The -c option takes a (optionally comma-separated) list of arguments\n"
@@ -3167,7 +3179,7 @@ msgstr  ""
 msgid   "List, show and delete background operations"
 msgstr  ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1481
+#: lxc/info.go:489 lxc/storage_volume.go:1483
 #, c-format
 msgid   "Location: %s"
 msgstr  ""
@@ -3350,7 +3362,7 @@ msgstr  ""
 msgid   "Manage network ACLs"
 msgstr  ""
 
-#: lxc/network_forward.go:873 lxc/network_forward.go:874
+#: lxc/network_forward.go:881 lxc/network_forward.go:882
 msgid   "Manage network forward ports"
 msgstr  ""
 
@@ -3494,12 +3506,12 @@ msgstr  ""
 msgid   "Memory:"
 msgstr  ""
 
-#: lxc/move.go:322 lxc/move.go:435
+#: lxc/move.go:327 lxc/move.go:440
 #, c-format
 msgid   "Migration API failure: %w"
 msgstr  ""
 
-#: lxc/move.go:347 lxc/move.go:440
+#: lxc/move.go:352 lxc/move.go:445
 #, c-format
 msgid   "Migration operation failure: %w"
 msgstr  ""
@@ -3548,7 +3560,7 @@ msgstr  ""
 msgid   "Missing key name"
 msgstr  ""
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:449 lxc/network_forward.go:534 lxc/network_forward.go:709 lxc/network_forward.go:840 lxc/network_forward.go:933 lxc/network_forward.go:1015 lxc/network_load_balancer.go:221 lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521 lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811 lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975 lxc/network_load_balancer.go:1088 lxc/network_load_balancer.go:1162
+#: lxc/network_forward.go:219 lxc/network_forward.go:457 lxc/network_forward.go:542 lxc/network_forward.go:717 lxc/network_forward.go:848 lxc/network_forward.go:945 lxc/network_forward.go:1031 lxc/network_load_balancer.go:221 lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521 lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811 lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975 lxc/network_load_balancer.go:1088 lxc/network_load_balancer.go:1162
 msgid   "Missing listen address"
 msgstr  ""
 
@@ -3560,7 +3572,7 @@ msgstr  ""
 msgid   "Missing network ACL name"
 msgstr  ""
 
-#: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499 lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908 lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292 lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215 lxc/network_forward.go:284 lxc/network_forward.go:445 lxc/network_forward.go:530 lxc/network_forward.go:705 lxc/network_forward.go:836 lxc/network_forward.go:929 lxc/network_forward.go:1011 lxc/network_load_balancer.go:131 lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286 lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517 lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807 lxc/network_load_balancer.go:895 lxc/network_load_balancer.go:971 lxc/network_load_balancer.go:1084 lxc/network_load_balancer.go:1158 lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266 lxc/network_peer.go:401 lxc/network_peer.go:485 lxc/network_peer.go:644 lxc/network_peer.go:765
+#: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499 lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908 lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292 lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215 lxc/network_forward.go:292 lxc/network_forward.go:453 lxc/network_forward.go:538 lxc/network_forward.go:713 lxc/network_forward.go:844 lxc/network_forward.go:941 lxc/network_forward.go:1027 lxc/network_load_balancer.go:131 lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286 lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517 lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807 lxc/network_load_balancer.go:895 lxc/network_load_balancer.go:971 lxc/network_load_balancer.go:1084 lxc/network_load_balancer.go:1158 lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266 lxc/network_peer.go:401 lxc/network_peer.go:485 lxc/network_peer.go:644 lxc/network_peer.go:765
 msgid   "Missing network name"
 msgstr  ""
 
@@ -3576,7 +3588,7 @@ msgstr  ""
 msgid   "Missing peer name"
 msgstr  ""
 
-#: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509 lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113 lxc/storage_bucket.go:213 lxc/storage_bucket.go:289 lxc/storage_bucket.go:408 lxc/storage_bucket.go:483 lxc/storage_bucket.go:565 lxc/storage_bucket.go:657 lxc/storage_bucket.go:799 lxc/storage_bucket.go:886 lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062 lxc/storage_bucket.go:1185 lxc/storage_volume.go:209 lxc/storage_volume.go:324 lxc/storage_volume.go:650 lxc/storage_volume.go:757 lxc/storage_volume.go:848 lxc/storage_volume.go:951 lxc/storage_volume.go:1070 lxc/storage_volume.go:1287 lxc/storage_volume.go:1997 lxc/storage_volume.go:2138 lxc/storage_volume.go:2296 lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
+#: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509 lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113 lxc/storage_bucket.go:213 lxc/storage_bucket.go:289 lxc/storage_bucket.go:408 lxc/storage_bucket.go:483 lxc/storage_bucket.go:565 lxc/storage_bucket.go:657 lxc/storage_bucket.go:799 lxc/storage_bucket.go:886 lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062 lxc/storage_bucket.go:1185 lxc/storage_volume.go:211 lxc/storage_volume.go:328 lxc/storage_volume.go:654 lxc/storage_volume.go:761 lxc/storage_volume.go:852 lxc/storage_volume.go:954 lxc/storage_volume.go:1072 lxc/storage_volume.go:1289 lxc/storage_volume.go:1999 lxc/storage_volume.go:2140 lxc/storage_volume.go:2298 lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
 msgid   "Missing pool name"
 msgstr  ""
 
@@ -3592,15 +3604,15 @@ msgstr  ""
 msgid   "Missing source profile name"
 msgstr  ""
 
-#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
+#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
 msgid   "Missing source volume name"
 msgstr  ""
 
-#: lxc/storage_volume.go:1411
+#: lxc/storage_volume.go:1413
 msgid   "Missing storage pool name"
 msgstr  ""
 
-#: lxc/file.go:820
+#: lxc/file.go:842
 msgid   "Missing target directory"
 msgstr  ""
 
@@ -3632,15 +3644,15 @@ msgid   "Monitor a local or remote LXD server\n"
         "By default the monitor will listen to all message types."
 msgstr  ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873 lxc/storage_volume.go:975
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876 lxc/storage_volume.go:977
 msgid   "More than one device matches, specify the device name"
 msgstr  ""
 
-#: lxc/file.go:507
+#: lxc/file.go:520
 msgid   "More than one file to download, but target is not a directory"
 msgstr  ""
 
-#: lxc/file.go:1207 lxc/file.go:1208
+#: lxc/file.go:1227 lxc/file.go:1228
 msgid   "Mount files from instances"
 msgstr  ""
 
@@ -3664,7 +3676,7 @@ msgid   "Move instances within or in between LXD servers\n"
         "The pull transfer mode is the default as it is compatible with all LXD versions.\n"
 msgstr  ""
 
-#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
 msgid   "Move storage volumes between pools"
 msgstr  ""
 
@@ -3672,16 +3684,16 @@ msgstr  ""
 msgid   "Move the instance without its snapshots"
 msgstr  ""
 
-#: lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1869
 msgid   "Move to a project different from the source"
 msgstr  ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 #, c-format
 msgid   "Moving the storage volume: %s"
 msgstr  ""
 
-#: lxc/network_forward.go:1059 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
 msgid   "Multiple ports match. Use --force to remove them all"
 msgstr  ""
 
@@ -3697,7 +3709,7 @@ msgstr  ""
 msgid   "Must supply instance name for: "
 msgstr  ""
 
-#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192 lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090 lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161 lxc/network_zone.go:845 lxc/profile.go:755 lxc/project.go:567 lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512 lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192 lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090 lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161 lxc/network_zone.go:845 lxc/profile.go:755 lxc/project.go:567 lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512 lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
 msgid   "NAME"
 msgstr  ""
 
@@ -3747,7 +3759,7 @@ msgstr  ""
 msgid   "NVRM Version: %v"
 msgstr  ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523 lxc/storage_volume.go:1573
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525 lxc/storage_volume.go:1575
 msgid   "Name"
 msgstr  ""
 
@@ -3755,7 +3767,7 @@ msgstr  ""
 msgid   "Name of the project to use for this remote:"
 msgstr  ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
 #, c-format
 msgid   "Name: %s"
 msgstr  ""
@@ -3810,12 +3822,12 @@ msgstr  ""
 msgid   "Network Zone %s deleted"
 msgstr  ""
 
-#: lxc/network_forward.go:386
+#: lxc/network_forward.go:394
 #, c-format
 msgid   "Network forward %s created"
 msgstr  ""
 
-#: lxc/network_forward.go:857
+#: lxc/network_forward.go:865
 #, c-format
 msgid   "Network forward %s deleted"
 msgstr  ""
@@ -3898,7 +3910,7 @@ msgstr  ""
 msgid   "No device found for this network"
 msgstr  ""
 
-#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
+#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
 msgid   "No device found for this storage volume"
 msgstr  ""
 
@@ -3906,7 +3918,7 @@ msgstr  ""
 msgid   "No matching backend found"
 msgstr  ""
 
-#: lxc/network_forward.go:1070 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
 msgid   "No matching port(s) found"
 msgstr  ""
 
@@ -3918,11 +3930,11 @@ msgstr  ""
 msgid   "No need to specify a warning UUID when using --all"
 msgstr  ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
 msgid   "No storage pool for source volume specified"
 msgstr  ""
 
-#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
 msgid   "No storage pool for target volume specified"
 msgstr  ""
 
@@ -3936,7 +3948,7 @@ msgstr  ""
 msgid   "Node %d:\n"
 msgstr  ""
 
-#: lxc/storage_volume.go:2035
+#: lxc/storage_volume.go:2037
 msgid   "Not a snapshot name"
 msgstr  ""
 
@@ -3944,15 +3956,19 @@ msgstr  ""
 msgid   "OVN:"
 msgstr  ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:344 lxc/storage_volume.go:865 lxc/storage_volume.go:967
-msgid   "Only \"custom\" volumes can be attached to instances"
+#: lxc/storage_volume.go:216
+msgid   "Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr  ""
 
-#: lxc/storage_volume.go:2701
+#: lxc/storage_volume.go:348
+msgid   "Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
+msgstr  ""
+
+#: lxc/storage_volume.go:2703
 msgid   "Only \"custom\" volumes can be exported"
 msgstr  ""
 
-#: lxc/storage_volume.go:2500
+#: lxc/storage_volume.go:2502
 msgid   "Only \"custom\" volumes can be snapshotted"
 msgstr  ""
 
@@ -3964,7 +3980,7 @@ msgstr  ""
 msgid   "Only https:// is supported for remote image import"
 msgstr  ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1431
 msgid   "Only instance or custom volumes are supported"
 msgstr  ""
 
@@ -3977,7 +3993,7 @@ msgstr  ""
 msgid   "Operation %s deleted"
 msgstr  ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1577
+#: lxc/info.go:705 lxc/storage_volume.go:1579
 msgid   "Optimized Storage"
 msgstr  ""
 
@@ -4007,7 +4023,7 @@ msgstr  ""
 msgid   "PID: %d"
 msgstr  ""
 
-#: lxc/storage_volume.go:1767
+#: lxc/storage_volume.go:1769
 msgid   "POOL"
 msgstr  ""
 
@@ -4023,7 +4039,7 @@ msgstr  ""
 msgid   "PROFILES"
 msgstr  ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/storage_volume.go:1773 lxc/warning.go:213
+#: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167 lxc/storage_volume.go:1775 lxc/warning.go:213
 msgid   "PROJECT"
 msgstr  ""
 
@@ -4047,7 +4063,7 @@ msgstr  ""
 msgid   "Partitions:"
 msgstr  ""
 
-#: lxc/main.go:367
+#: lxc/main.go:376
 #, c-format
 msgid   "Password for %s: "
 msgstr  ""
@@ -4085,11 +4101,11 @@ msgstr  ""
 msgid   "Ports:"
 msgstr  ""
 
-#: lxc/file.go:1332
+#: lxc/file.go:1356
 msgid   "Press ctrl+c to finish"
 msgstr  ""
 
-#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861 lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357 lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239 lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760 lxc/network_acl.go:699 lxc/network_forward.go:768 lxc/network_load_balancer.go:739 lxc/network_peer.go:699 lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:596 lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350 lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168 lxc/storage_volume.go:1200
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861 lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357 lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239 lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760 lxc/network_acl.go:699 lxc/network_forward.go:776 lxc/network_load_balancer.go:739 lxc/network_peer.go:699 lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:596 lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350 lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170 lxc/storage_volume.go:1202
 msgid   "Press enter to open the editor again or ctrl+c to abort change"
 msgstr  ""
 
@@ -4202,11 +4218,11 @@ msgstr  ""
 msgid   "Properties:"
 msgstr  ""
 
-#: lxc/image.go:1649
+#: lxc/image.go:1650
 msgid   "Property not found"
 msgstr  ""
 
-#: lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1369
 msgid   "Provide the type of the storage volume if it is not custom.\n"
         "Supported types are custom, container and virtual-machine.\n"
         "\n"
@@ -4217,7 +4233,7 @@ msgid   "Provide the type of the storage volume if it is not custom.\n"
         "    Returns state information for a virtual machine \"data\" in pool \"default\"."
 msgstr  ""
 
-#: lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1238
 msgid   "Provide the type of the storage volume if it is not custom.\n"
         "Supported types are custom, image, container and virtual-machine.\n"
         "\n"
@@ -4230,7 +4246,7 @@ msgid   "Provide the type of the storage volume if it is not custom.\n"
         "    Returns the snapshot expiration period for a virtual machine \"data\" in pool \"default\"."
 msgstr  ""
 
-#: lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2249
 msgid   "Provide the type of the storage volume if it is not custom.\n"
         "Supported types are custom, image, container and virtual-machine.\n"
         "\n"
@@ -4246,7 +4262,7 @@ msgid   "Provide the type of the storage volume if it is not custom.\n"
         "    Will show the properties of snapshot \"snap0\" for a virtual machine called \"data\" in the \"default\" pool."
 msgstr  ""
 
-#: lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1017
 msgid   "Provide the type of the storage volume if it is not custom.\n"
         "Supported types are custom, image, container and virtual-machine.\n"
         "\n"
@@ -4254,7 +4270,7 @@ msgid   "Provide the type of the storage volume if it is not custom.\n"
         "    Update a storage volume using the content of pool.yaml."
 msgstr  ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2094
 msgid   "Provide the type of the storage volume if it is not custom.\n"
         "Supported types are custom, image, container and virtual-machine.\n"
         "\n"
@@ -4265,7 +4281,7 @@ msgid   "Provide the type of the storage volume if it is not custom.\n"
         "    Sets the snapshot expiration period for a virtual machine \"data\" in pool \"default\" to seven days."
 msgstr  ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2370
 msgid   "Provide the type of the storage volume if it is not custom.\n"
         "Supported types are custom, image, container and virtual-machine.\n"
         "\n"
@@ -4294,20 +4310,20 @@ msgstr  ""
 msgid   "Publishing instance: %s"
 msgstr  ""
 
-#: lxc/file.go:455 lxc/file.go:456
+#: lxc/file.go:467 lxc/file.go:468
 msgid   "Pull files from instances"
 msgstr  ""
 
-#: lxc/file.go:638 lxc/file.go:989
+#: lxc/file.go:651 lxc/file.go:1009
 #, c-format
 msgid   "Pulling %s from %s: %%s"
 msgstr  ""
 
-#: lxc/file.go:688 lxc/file.go:689
+#: lxc/file.go:701 lxc/file.go:702
 msgid   "Push files into instances"
 msgstr  ""
 
-#: lxc/file.go:923 lxc/file.go:1089
+#: lxc/file.go:943 lxc/file.go:1109
 #, c-format
 msgid   "Pushing %s to %s: %%s"
 msgstr  ""
@@ -4316,7 +4332,7 @@ msgstr  ""
 msgid   "Query path must start with /"
 msgstr  ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
 msgid   "Query virtual machine images"
 msgstr  ""
 
@@ -4345,15 +4361,15 @@ msgstr  ""
 msgid   "Rebuild instances"
 msgstr  ""
 
-#: lxc/file.go:463 lxc/file.go:695
+#: lxc/file.go:475 lxc/file.go:708
 msgid   "Recursively transfer files"
 msgstr  ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:403
 msgid   "Refresh and update the existing storage volume copies"
 msgstr  ""
 
-#: lxc/image.go:1444 lxc/image.go:1445
+#: lxc/image.go:1445 lxc/image.go:1446
 msgid   "Refresh images"
 msgstr  ""
 
@@ -4362,7 +4378,7 @@ msgstr  ""
 msgid   "Refreshing instance: %s"
 msgstr  ""
 
-#: lxc/image.go:1481
+#: lxc/image.go:1482
 #, c-format
 msgid   "Refreshing the image: %s"
 msgstr  ""
@@ -4438,7 +4454,7 @@ msgstr  ""
 msgid   "Remove aliases"
 msgstr  ""
 
-#: lxc/network_forward.go:971 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
 msgid   "Remove all ports that match"
 msgstr  ""
 
@@ -4474,7 +4490,7 @@ msgstr  ""
 msgid   "Remove permissions from groups"
 msgstr  ""
 
-#: lxc/network_forward.go:969 lxc/network_forward.go:970
+#: lxc/network_forward.go:981 lxc/network_forward.go:982
 msgid   "Remove ports from a forward"
 msgstr  ""
 
@@ -4510,7 +4526,7 @@ msgstr  ""
 msgid   "Rename a cluster member"
 msgstr  ""
 
-#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254 lxc/image_alias.go:255
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:287 lxc/image_alias.go:288
 msgid   "Rename aliases"
 msgstr  ""
 
@@ -4546,15 +4562,15 @@ msgstr  ""
 msgid   "Rename remotes"
 msgstr  ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1962
 msgid   "Rename storage volumes"
 msgstr  ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1961
 msgid   "Rename storage volumes and storage volume snapshots"
 msgstr  ""
 
-#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
+#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
 #, c-format
 msgid   "Renamed storage volume from \"%s\" to \"%s\""
 msgstr  ""
@@ -4604,7 +4620,7 @@ msgid   "Restore instances from snapshots\n"
         "If --stateful is passed, then the running state will be restored too."
 msgstr  ""
 
-#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
 msgid   "Restore storage volume snapshots"
 msgstr  ""
 
@@ -4621,7 +4637,7 @@ msgstr  ""
 msgid   "Retrieve the container's console log"
 msgstr  ""
 
-#: lxc/init.go:357
+#: lxc/init.go:361
 #, c-format
 msgid   "Retrieving image: %s"
 msgstr  ""
@@ -4670,12 +4686,12 @@ msgstr  ""
 msgid   "SR-IOV information:"
 msgstr  ""
 
-#: lxc/file.go:1460
+#: lxc/file.go:1484
 #, c-format
 msgid   "SSH client connected %q"
 msgstr  ""
 
-#: lxc/file.go:1461
+#: lxc/file.go:1485
 #, c-format
 msgid   "SSH client disconnected %q"
 msgstr  ""
@@ -4750,7 +4766,7 @@ msgstr  ""
 msgid   "Set a cluster member's configuration keys"
 msgstr  ""
 
-#: lxc/file.go:1217
+#: lxc/file.go:1237
 msgid   "Set authentication user when using SSH SFTP listener"
 msgstr  ""
 
@@ -4772,7 +4788,7 @@ msgid   "Set device configuration keys\n"
         "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr  ""
 
-#: lxc/image.go:1665 lxc/image.go:1666
+#: lxc/image.go:1666 lxc/image.go:1667
 msgid   "Set image properties"
 msgstr  ""
 
@@ -4809,11 +4825,11 @@ msgid   "Set network configuration keys\n"
         "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr  ""
 
-#: lxc/network_forward.go:488
+#: lxc/network_forward.go:496
 msgid   "Set network forward keys"
 msgstr  ""
 
-#: lxc/network_forward.go:489
+#: lxc/network_forward.go:497
 msgid   "Set network forward keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
@@ -4901,11 +4917,11 @@ msgid   "Set storage pool configuration keys\n"
         "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr  ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2088
 msgid   "Set storage volume configuration keys"
 msgstr  ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2089
 msgid   "Set storage volume configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
@@ -4920,7 +4936,7 @@ msgstr  ""
 msgid   "Set the file's gid on create"
 msgstr  ""
 
-#: lxc/file.go:698
+#: lxc/file.go:711
 msgid   "Set the file's gid on push"
 msgstr  ""
 
@@ -4928,7 +4944,7 @@ msgstr  ""
 msgid   "Set the file's perms on create"
 msgstr  ""
 
-#: lxc/file.go:699
+#: lxc/file.go:712
 msgid   "Set the file's perms on push"
 msgstr  ""
 
@@ -4936,7 +4952,7 @@ msgstr  ""
 msgid   "Set the file's uid on create"
 msgstr  ""
 
-#: lxc/file.go:697
+#: lxc/file.go:710
 msgid   "Set the file's uid on push"
 msgstr  ""
 
@@ -4948,7 +4964,7 @@ msgstr  ""
 msgid   "Set the key as a network ACL property"
 msgstr  ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:504
 msgid   "Set the key as a network forward property"
 msgstr  ""
 
@@ -4988,7 +5004,7 @@ msgstr  ""
 msgid   "Set the key as a storage property"
 msgstr  ""
 
-#: lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2105
 msgid   "Set the key as a storage volume property"
 msgstr  ""
 
@@ -4996,7 +5012,7 @@ msgstr  ""
 msgid   "Set the key as an instance property"
 msgstr  ""
 
-#: lxc/file.go:1215
+#: lxc/file.go:1235
 msgid   "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr  ""
 
@@ -5049,7 +5065,7 @@ msgid   "Show identity configurations\n"
         "method. Use the identifier instead if this occurs.\n"
 msgstr  ""
 
-#: lxc/image.go:1535 lxc/image.go:1536
+#: lxc/image.go:1536 lxc/image.go:1537
 msgid   "Show image properties"
 msgstr  ""
 
@@ -5069,7 +5085,7 @@ msgstr  ""
 msgid   "Show instance or server information"
 msgstr  ""
 
-#: lxc/main.go:271 lxc/main.go:272
+#: lxc/main.go:280 lxc/main.go:281
 msgid   "Show less common commands"
 msgstr  ""
 
@@ -5133,11 +5149,11 @@ msgstr  ""
 msgid   "Show storage pool configurations and resources"
 msgstr  ""
 
-#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
 msgid   "Show storage volume configurations"
 msgstr  ""
 
-#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
 msgid   "Show storage volume state information"
 msgstr  ""
 
@@ -5203,15 +5219,15 @@ msgstr  ""
 msgid   "Size: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
 msgid   "Snapshot storage volumes"
 msgstr  ""
 
-#: lxc/storage_volume.go:2190
+#: lxc/storage_volume.go:2192
 msgid   "Snapshots are read-only and can't have their configuration changed"
 msgstr  ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1502
+#: lxc/info.go:619 lxc/storage_volume.go:1504
 msgid   "Snapshots:"
 msgstr  ""
 
@@ -5316,21 +5332,21 @@ msgstr  ""
 msgid   "Storage pool name"
 msgstr  ""
 
-#: lxc/storage_volume.go:703
+#: lxc/storage_volume.go:707
 #, c-format
 msgid   "Storage volume %s created"
 msgstr  ""
 
-#: lxc/storage_volume.go:791
+#: lxc/storage_volume.go:795
 #, c-format
 msgid   "Storage volume %s deleted"
 msgstr  ""
 
-#: lxc/storage_volume.go:516
+#: lxc/storage_volume.go:520
 msgid   "Storage volume copied successfully!"
 msgstr  ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:524
 msgid   "Storage volume moved successfully!"
 msgstr  ""
 
@@ -5391,19 +5407,19 @@ msgstr  ""
 msgid   "TOKEN"
 msgstr  ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147 lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091 lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172 lxc/storage_volume.go:1747 lxc/warning.go:216
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147 lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091 lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172 lxc/storage_volume.go:1749 lxc/warning.go:216
 msgid   "TYPE"
 msgstr  ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
 msgid   "Taken at"
 msgstr  ""
 
-#: lxc/file.go:1262
+#: lxc/file.go:1286
 msgid   "Target path and --listen flag cannot be used together"
 msgstr  ""
 
-#: lxc/file.go:1256
+#: lxc/file.go:1280
 msgid   "Target path must be a directory"
 msgstr  ""
 
@@ -5411,15 +5427,15 @@ msgstr  ""
 msgid   "The --accept-certificate flag is not supported when adding a remote using a trust token"
 msgstr  ""
 
-#: lxc/move.go:181
+#: lxc/move.go:186
 msgid   "The --instance-only flag can't be used with --target"
 msgstr  ""
 
-#: lxc/move.go:219 lxc/move.go:240
+#: lxc/move.go:224 lxc/move.go:245
 msgid   "The --mode flag can't be used with --storage or --target-project"
 msgstr  ""
 
-#: lxc/move.go:193
+#: lxc/move.go:198
 msgid   "The --mode flag can't be used with --target"
 msgstr  ""
 
@@ -5427,15 +5443,15 @@ msgstr  ""
 msgid   "The --show-log flag is only supported for by 'console' output type"
 msgstr  ""
 
-#: lxc/move.go:185
+#: lxc/move.go:190
 msgid   "The --storage flag can't be used with --target"
 msgstr  ""
 
-#: lxc/move.go:189
+#: lxc/move.go:194
 msgid   "The --target-project flag can't be used with --target"
 msgstr  ""
 
-#: lxc/move.go:205
+#: lxc/move.go:210
 msgid   "The destination LXD server is not clustered"
 msgstr  ""
 
@@ -5455,7 +5471,7 @@ msgstr  ""
 msgid   "The instance is currently running. Use --force to have it stopped and restarted"
 msgstr  ""
 
-#: lxc/init.go:435
+#: lxc/init.go:439
 msgid   "The instance you are starting doesn't have any network attached to it."
 msgstr  ""
 
@@ -5508,7 +5524,7 @@ msgstr  ""
 msgid   "The property %q does not exist on the network ACL %q: %v"
 msgstr  ""
 
-#: lxc/network_forward.go:462
+#: lxc/network_forward.go:470
 #, c-format
 msgid   "The property %q does not exist on the network forward %q: %v"
 msgstr  ""
@@ -5548,12 +5564,12 @@ msgstr  ""
 msgid   "The property %q does not exist on the storage pool %q: %v"
 msgstr  ""
 
-#: lxc/storage_volume.go:1340
+#: lxc/storage_volume.go:1342
 #, c-format
 msgid   "The property %q does not exist on the storage pool volume %q: %v"
 msgstr  ""
 
-#: lxc/storage_volume.go:1317
+#: lxc/storage_volume.go:1319
 #, c-format
 msgid   "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr  ""
@@ -5566,11 +5582,11 @@ msgstr  ""
 msgid   "The server doesn't implement the newer v2 resources API"
 msgstr  ""
 
-#: lxc/move.go:309
+#: lxc/move.go:314
 msgid   "The source LXD server is not clustered"
 msgstr  ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887 lxc/storage_volume.go:989
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890 lxc/storage_volume.go:991
 msgid   "The specified device doesn't exist"
 msgstr  ""
 
@@ -5598,7 +5614,7 @@ msgstr  ""
 msgid   "This LXD server is not available on the network"
 msgstr  ""
 
-#: lxc/main.go:298
+#: lxc/main.go:307
 msgid   "This client hasn't been configured to use a remote LXD server yet.\n"
         "As your platform can't run native Linux instances, you must connect to a remote LXD server.\n"
         "\n"
@@ -5618,11 +5634,11 @@ msgstr  ""
 msgid   "Timestamps:"
 msgstr  ""
 
-#: lxc/init.go:437
+#: lxc/init.go:441
 msgid   "To attach a network to an instance, use: lxc network attach"
 msgstr  ""
 
-#: lxc/init.go:436
+#: lxc/init.go:440
 msgid   "To create a new network, use: lxc network create"
 msgstr  ""
 
@@ -5630,7 +5646,7 @@ msgstr  ""
 msgid   "To detach from the console, press: <ctrl>+a q"
 msgstr  ""
 
-#: lxc/main.go:412
+#: lxc/main.go:421
 msgid   "To start your first container, try: lxc launch ubuntu:24.04\n"
         "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr  ""
@@ -5639,7 +5655,7 @@ msgstr  ""
 msgid   "To use --target, the destination remote must be a cluster"
 msgstr  ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1489
 #, c-format
 msgid   "Total: %s"
 msgstr  ""
@@ -5654,7 +5670,7 @@ msgstr  ""
 msgid   "Transceiver type: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:1864
+#: lxc/storage_volume.go:1866
 msgid   "Transfer mode, one of pull (default), push or relay"
 msgstr  ""
 
@@ -5662,7 +5678,7 @@ msgstr  ""
 msgid   "Transfer mode. One of pull (default), push or relay"
 msgstr  ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:398
 msgid   "Transfer mode. One of pull (default), push or relay."
 msgstr  ""
 
@@ -5679,7 +5695,7 @@ msgstr  ""
 msgid   "Transferring image: %s"
 msgstr  ""
 
-#: lxc/copy.go:382 lxc/move.go:327
+#: lxc/copy.go:382 lxc/move.go:332
 #, c-format
 msgid   "Transferring instance: %s"
 msgstr  ""
@@ -5718,7 +5734,7 @@ msgstr  ""
 msgid   "Type of connection to establish: 'console' for serial console, 'vga' for SPICE graphical output"
 msgstr  ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930 lxc/storage_volume.go:1472
+#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930 lxc/storage_volume.go:1474
 #, c-format
 msgid   "Type: %s"
 msgstr  ""
@@ -5740,11 +5756,11 @@ msgstr  ""
 msgid   "URL"
 msgstr  ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1752
+#: lxc/project.go:995 lxc/storage_volume.go:1754
 msgid   "USAGE"
 msgstr  ""
 
-#: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24 lxc/network_zone.go:163 lxc/profile.go:757 lxc/project.go:575 lxc/storage.go:724 lxc/storage_volume.go:1751
+#: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24 lxc/network_zone.go:163 lxc/profile.go:757 lxc/project.go:575 lxc/storage.go:724 lxc/storage_volume.go:1753
 msgid   "USED BY"
 msgstr  ""
 
@@ -5757,7 +5773,7 @@ msgstr  ""
 msgid   "UUID: %v"
 msgstr  ""
 
-#: lxc/file.go:411
+#: lxc/file.go:423
 #, c-format
 msgid   "Unable to create a temporary file: %v"
 msgstr  ""
@@ -5771,12 +5787,12 @@ msgstr  ""
 msgid   "Unknown certificate type %q"
 msgstr  ""
 
-#: lxc/file.go:1483
+#: lxc/file.go:1507
 #, c-format
 msgid   "Unknown channel type for client %q: %s"
 msgstr  ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789 lxc/warning.go:242
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1791 lxc/warning.go:242
 #, c-format
 msgid   "Unknown column shorthand char '%c' in '%s'"
 msgstr  ""
@@ -5786,7 +5802,7 @@ msgstr  ""
 msgid   "Unknown console type %q"
 msgstr  ""
 
-#: lxc/file.go:1029
+#: lxc/file.go:1049
 #, c-format
 msgid   "Unknown file type '%s'"
 msgstr  ""
@@ -5817,7 +5833,7 @@ msgstr  ""
 msgid   "Unset device configuration keys"
 msgstr  ""
 
-#: lxc/image.go:1728 lxc/image.go:1729
+#: lxc/image.go:1729 lxc/image.go:1730
 msgid   "Unset image properties"
 msgstr  ""
 
@@ -5833,11 +5849,11 @@ msgstr  ""
 msgid   "Unset network configuration keys"
 msgstr  ""
 
-#: lxc/network_forward.go:598
+#: lxc/network_forward.go:606
 msgid   "Unset network forward configuration keys"
 msgstr  ""
 
-#: lxc/network_forward.go:599
+#: lxc/network_forward.go:607
 msgid   "Unset network forward keys"
 msgstr  ""
 
@@ -5881,7 +5897,7 @@ msgstr  ""
 msgid   "Unset storage pool configuration keys"
 msgstr  ""
 
-#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
 msgid   "Unset storage volume configuration keys"
 msgstr  ""
 
@@ -5893,7 +5909,7 @@ msgstr  ""
 msgid   "Unset the key as a network ACL property"
 msgstr  ""
 
-#: lxc/network_forward.go:602
+#: lxc/network_forward.go:610
 msgid   "Unset the key as a network forward property"
 msgstr  ""
 
@@ -5933,7 +5949,7 @@ msgstr  ""
 msgid   "Unset the key as a storage property"
 msgstr  ""
 
-#: lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2381
 msgid   "Unset the key as a storage volume property"
 msgstr  ""
 
@@ -5941,7 +5957,7 @@ msgstr  ""
 msgid   "Unset the key as an instance property"
 msgstr  ""
 
-#: lxc/storage_volume.go:248
+#: lxc/storage_volume.go:250
 msgid   "Unsupported content type for attaching to instances"
 msgstr  ""
 
@@ -5975,12 +5991,12 @@ msgstr  ""
 msgid   "Upper devices"
 msgstr  ""
 
-#: lxc/storage_volume.go:1485
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid   "Usage: %s"
 msgstr  ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2652
+#: lxc/export.go:42 lxc/storage_volume.go:2654
 msgid   "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr  ""
 
@@ -6045,7 +6061,7 @@ msgstr  ""
 msgid   "View the current identity"
 msgstr  ""
 
-#: lxc/storage_volume.go:1576
+#: lxc/storage_volume.go:1578
 msgid   "Volume Only"
 msgstr  ""
 
@@ -6090,7 +6106,7 @@ msgstr  ""
 msgid   "You must specify a destination instance name"
 msgstr  ""
 
-#: lxc/copy.go:98 lxc/move.go:293 lxc/move.go:369
+#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
 msgid   "You must specify a source instance name"
 msgstr  ""
 
@@ -6098,12 +6114,12 @@ msgstr  ""
 msgid   "You need to specify an image name or use --empty"
 msgstr  ""
 
-#: lxc/storage_volume.go:909
-msgid   "[<remote:>]<pool> <volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:912
+msgid   "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:282
-msgid   "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:284
+msgid   "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr  ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895 lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437 lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32 lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:84 lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469 lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
@@ -6130,7 +6146,7 @@ msgstr  ""
 msgid   "[<remote>:] [<filter>...]"
 msgstr  ""
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:174
 msgid   "[<remote>:] [<filters>...]"
 msgstr  ""
 
@@ -6182,7 +6198,7 @@ msgstr  ""
 msgid   "[<remote>:]<Zone> [key=value...]"
 msgstr  ""
 
-#: lxc/image_alias.go:104
+#: lxc/image_alias.go:121
 msgid   "[<remote>:]<alias>"
 msgstr  ""
 
@@ -6190,7 +6206,7 @@ msgstr  ""
 msgid   "[<remote>:]<alias> <fingerprint>"
 msgstr  ""
 
-#: lxc/image_alias.go:252
+#: lxc/image_alias.go:285
 msgid   "[<remote>:]<alias> <new-name>"
 msgstr  ""
 
@@ -6238,15 +6254,15 @@ msgstr  ""
 msgid   "[<remote>:]<identity_provider_group> <new_name>"
 msgstr  ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
 msgid   "[<remote>:]<image>"
 msgstr  ""
 
-#: lxc/image.go:1600 lxc/image.go:1727
+#: lxc/image.go:1601 lxc/image.go:1728
 msgid   "[<remote>:]<image> <key>"
 msgstr  ""
 
-#: lxc/image.go:1664
+#: lxc/image.go:1665
 msgid   "[<remote>:]<image> <key> <value>"
 msgstr  ""
 
@@ -6266,7 +6282,7 @@ msgstr  ""
 msgid   "[<remote>:]<image> [<target>]"
 msgstr  ""
 
-#: lxc/image.go:334 lxc/image.go:1443
+#: lxc/image.go:334 lxc/image.go:1444
 msgid   "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr  ""
 
@@ -6334,7 +6350,7 @@ msgstr  ""
 msgid   "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr  ""
 
-#: lxc/file.go:376
+#: lxc/file.go:380
 msgid   "[<remote>:]<instance>/<path>"
 msgstr  ""
 
@@ -6346,11 +6362,11 @@ msgstr  ""
 msgid   "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr  ""
 
-#: lxc/file.go:454
+#: lxc/file.go:466
 msgid   "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr  ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1226
 msgid   "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr  ""
 
@@ -6414,7 +6430,7 @@ msgstr  ""
 msgid   "[<remote>:]<network> <key>=<value>..."
 msgstr  ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:644 lxc/network_forward.go:797 lxc/network_load_balancer.go:179 lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
+#: lxc/network_forward.go:177 lxc/network_forward.go:652 lxc/network_forward.go:805 lxc/network_load_balancer.go:179 lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
 msgid   "[<remote>:]<network> <listen_address>"
 msgstr  ""
 
@@ -6426,11 +6442,11 @@ msgstr  ""
 msgid   "[<remote>:]<network> <listen_address> <backend_name> <target_address> [<target_port(s)>]"
 msgstr  ""
 
-#: lxc/network_forward.go:402 lxc/network_forward.go:597 lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
+#: lxc/network_forward.go:410 lxc/network_forward.go:605 lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
 msgid   "[<remote>:]<network> <listen_address> <key>"
 msgstr  ""
 
-#: lxc/network_forward.go:487 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
 msgid   "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr  ""
 
@@ -6438,11 +6454,11 @@ msgstr  ""
 msgid   "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> <backend_name>[,<backend_name>...]"
 msgstr  ""
 
-#: lxc/network_forward.go:887
+#: lxc/network_forward.go:895
 msgid   "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> <target_address> [<target_port(s)>]"
 msgstr  ""
 
-#: lxc/network_forward.go:968 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
 msgid   "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr  ""
 
@@ -6494,7 +6510,7 @@ msgstr  ""
 msgid   "[<remote>:]<pool>"
 msgstr  ""
 
-#: lxc/storage_volume.go:2811
+#: lxc/storage_volume.go:2813
 msgid   "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr  ""
 
@@ -6526,63 +6542,63 @@ msgstr  ""
 msgid   "[<remote>:]<pool> <key> <value>"
 msgstr  ""
 
-#: lxc/storage_volume.go:1958
+#: lxc/storage_volume.go:1960
 msgid   "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot name>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:806
-msgid   "[<remote>:]<pool> <volume> <instance> [<device name>]"
-msgstr  ""
-
-#: lxc/storage_volume.go:167
-msgid   "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
-msgstr  ""
-
-#: lxc/storage_volume.go:2562
+#: lxc/storage_volume.go:2564
 msgid   "[<remote>:]<pool> <volume> <snapshot>"
 msgstr  ""
 
-#: lxc/storage_volume.go:2645
+#: lxc/storage_volume.go:2647
 msgid   "[<remote>:]<pool> <volume> [<path>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2428
 msgid   "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:610
+#: lxc/storage_volume.go:614
 msgid   "[<remote>:]<pool> <volume> [key=value...]"
 msgstr  ""
 
-#: lxc/storage_volume.go:718
+#: lxc/storage_volume.go:722
 msgid   "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
 msgid   "[<remote>:]<pool> [<type>/]<volume>"
 msgstr  ""
 
-#: lxc/storage_volume.go:2364
+#: lxc/storage_volume.go:810
+msgid   "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
+msgstr  ""
+
+#: lxc/storage_volume.go:167
+msgid   "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
+msgstr  ""
+
+#: lxc/storage_volume.go:2366
 msgid   "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr  ""
 
-#: lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2087
 msgid   "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr  ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2245
 msgid   "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1234
 msgid   "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr  ""
 
-#: lxc/storage_volume.go:1858
+#: lxc/storage_volume.go:1860
 msgid   "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr  ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:392
 msgid   "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr  ""
 
@@ -6686,7 +6702,7 @@ msgstr  ""
 msgid   "[<remote>:][<instance>] <key>=<value>..."
 msgstr  ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1603
 msgid   "[<remote>:][<pool>] [<filter>...]"
 msgstr  ""
 
@@ -6824,17 +6840,17 @@ msgid   "lxc file create foo/bar\n"
         "	   To create a symlink /bar in instance foo whose target is baz."
 msgstr  ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1230
 msgid   "lxc file mount foo/root fooroot\n"
         "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr  ""
 
-#: lxc/file.go:458
+#: lxc/file.go:470
 msgid   "lxc file pull foo/etc/hosts .\n"
         "   To pull /etc/hosts from the instance and write it to the current directory."
 msgstr  ""
 
-#: lxc/file.go:691
+#: lxc/file.go:704
 msgid   "lxc file push /etc/hosts foo/etc/hosts\n"
         "   To push /etc/hosts into the instance \"foo\"."
 msgstr  ""
@@ -7084,19 +7100,19 @@ msgid   "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
         "    Update a storage pool using the content of pool.yaml."
 msgstr  ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:618
 msgid   "lxc storage volume create p1 v1\n"
         "\n"
         "lxc storage volume create p1 v1 < config.yaml\n"
         "	Create storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr  ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2817
 msgid   "lxc storage volume import default backup0.tar.gz\n"
         "		Create a new custom volume using backup0.tar.gz as the source."
 msgstr  ""
 
-#: lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2432
 msgid   "lxc storage volume snapshot default v1 snap0\n"
         "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
         "\n"
@@ -7128,16 +7144,16 @@ msgstr  ""
 msgid   "space used"
 msgstr  ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1396
 msgid   "sshfs has stopped"
 msgstr  ""
 
-#: lxc/file.go:1331
+#: lxc/file.go:1355
 #, c-format
 msgid   "sshfs mounting %q on %q"
 msgstr  ""
 
-#: lxc/file.go:1284
+#: lxc/file.go:1308
 msgid   "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr  ""
 

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-07 15:11-0700\n"
+"POT-Creation-Date: 2025-01-10 14:44-0600\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1041
+#: lxc/storage_volume.go:1043
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:667
+#: lxc/network_forward.go:675
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,12 +430,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1157
+#: lxc/file.go:1177
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1047
+#: lxc/file.go:1067
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -471,7 +471,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:65
+#: lxc/init.go:146 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:687
+#: lxc/file.go:700
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -541,7 +541,7 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
@@ -672,7 +672,7 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:888 lxc/network_forward.go:889
+#: lxc/network_forward.go:896 lxc/network_forward.go:897
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -722,7 +722,7 @@ msgstr ""
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
+#: lxc/image_alias.go:101 lxc/image_alias.go:156 lxc/image_alias.go:320
 msgid "Alias name missing"
 msgstr ""
 
@@ -735,7 +735,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1607
+#: lxc/storage_volume.go:1609
 msgid "All projects"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -790,12 +790,26 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168 lxc/storage_volume.go:169
+#: lxc/storage_volume.go:168
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:169
+msgid ""
+"Attach new storage volumes to instances\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
+msgstr ""
+
+#: lxc/storage_volume.go:285
 msgid "Attach new storage volumes to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:286
+msgid ""
+"Attach new storage volumes to profiles\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
 #: lxc/console.go:39
@@ -846,16 +860,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2719
+#: lxc/storage_volume.go:2721
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2796
+#: lxc/export.go:192 lxc/storage_volume.go:2798
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1538
+#: lxc/info.go:666 lxc/storage_volume.go:1540
 msgid "Backups:"
 msgstr ""
 
@@ -864,19 +878,19 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
+#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:326
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -919,7 +933,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1752
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -971,7 +985,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -979,7 +993,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:562
+#: lxc/file.go:575
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1004,11 +1018,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:768
+#: lxc/file.go:790
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1021,12 +1035,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:493
+#: lxc/storage_volume.go:497
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:447
+#: lxc/storage_volume.go:451
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1132,9 +1146,9 @@ msgstr ""
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:497 lxc/network_forward.go:649
-#: lxc/network_forward.go:803 lxc/network_forward.go:892
-#: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
+#: lxc/network_forward.go:505 lxc/network_forward.go:657
+#: lxc/network_forward.go:811 lxc/network_forward.go:900
+#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
 #: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
 #: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
@@ -1146,14 +1160,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
-#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
-#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
-#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
+#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
 msgid "Cluster member name"
 msgstr ""
 
@@ -1169,7 +1183,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1608
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1209,21 +1223,21 @@ msgstr ""
 #: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
-#: lxc/network_acl.go:698 lxc/network_forward.go:767
+#: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
-#: lxc/storage_volume.go:1199
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
+#: lxc/storage_volume.go:1201
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:620
+#: lxc/storage_volume.go:624
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1478
+#: lxc/storage_volume.go:1480
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1285,7 +1299,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1293,12 +1307,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1311,7 +1325,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1406,7 +1420,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:462 lxc/file.go:696
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1446,7 +1460,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1498,12 +1512,12 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:182
+#: lxc/init.go:186
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1513,7 +1527,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 msgid "Creating the instance"
 msgstr ""
 
@@ -1527,13 +1541,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1749
+#: lxc/storage_volume.go:1751
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1553,7 +1567,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2653
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1585,7 +1599,7 @@ msgstr ""
 msgid "Delete identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:106 lxc/image_alias.go:107
+#: lxc/image_alias.go:123 lxc/image_alias.go:124
 msgid "Delete image aliases"
 msgstr ""
 
@@ -1609,7 +1623,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:799 lxc/network_forward.go:800
+#: lxc/network_forward.go:807 lxc/network_forward.go:808
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1649,7 +1663,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
+#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1691,13 +1705,13 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
-#: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
-#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
+#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
+#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
+#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
@@ -1711,10 +1725,10 @@ msgstr ""
 #: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:404 lxc/network_forward.go:489
-#: lxc/network_forward.go:599 lxc/network_forward.go:646
-#: lxc/network_forward.go:800 lxc/network_forward.go:874
-#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_forward.go:412 lxc/network_forward.go:497
+#: lxc/network_forward.go:607 lxc/network_forward.go:654
+#: lxc/network_forward.go:808 lxc/network_forward.go:882
+#: lxc/network_forward.go:897 lxc/network_forward.go:982
 #: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
 #: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
 #: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
@@ -1754,27 +1768,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
-#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
-#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
-#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
-#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
-#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
-#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
-#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1465
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1786,11 +1800,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
+#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1840,7 +1854,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:403
+#: lxc/init.go:407
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1852,7 +1866,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1216
+#: lxc/file.go:1236
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1948,7 +1962,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:377 lxc/file.go:378
+#: lxc/file.go:381 lxc/file.go:382
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1988,7 +2002,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:653 lxc/network_forward.go:654
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -2028,7 +2042,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2036,7 +2050,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1785
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2090,11 +2104,11 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
-#: lxc/network_acl.go:524 lxc/network_forward.go:572
+#: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
+#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2105,11 +2119,11 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
-#: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
+#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
-#: lxc/storage_volume.go:2210
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
+#: lxc/storage_volume.go:2212
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2151,8 +2165,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
+#: lxc/storage_volume.go:1577
 msgid "Expires at"
 msgstr ""
 
@@ -2176,7 +2190,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2188,11 +2202,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2650
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2779
+#: lxc/export.go:152 lxc/storage_volume.go:2781
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2211,7 +2225,7 @@ msgid "FILENAME"
 msgstr ""
 
 #: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
-#: lxc/image_alias.go:235
+#: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2219,12 +2233,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1467
+#: lxc/file.go:1491
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1490
+#: lxc/file.go:1514
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2239,12 +2253,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1517
+#: lxc/file.go:1541
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1326
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2274,7 +2288,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1423
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2289,7 +2303,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1428
+#: lxc/file.go:1452
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2299,12 +2313,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1352
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1455
+#: lxc/file.go:1479
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2318,7 +2332,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:304 lxc/move.go:380
+#: lxc/move.go:309 lxc/move.go:385
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2343,7 +2357,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1440
+#: lxc/file.go:1464
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2358,7 +2372,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1042
+#: lxc/file.go:1062
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2445,14 +2459,14 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1625 lxc/warning.go:94
+#: lxc/storage_volume.go:1627 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2520,7 +2534,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1602
+#: lxc/image.go:1602 lxc/image.go:1603
 msgid "Get image properties"
 msgstr ""
 
@@ -2536,7 +2550,7 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:414
 msgid "Get the key as a network forward property"
 msgstr ""
 
@@ -2576,7 +2590,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1249
+#: lxc/storage_volume.go:1251
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2604,7 +2618,7 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:403 lxc/network_forward.go:404
+#: lxc/network_forward.go:411 lxc/network_forward.go:412
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
@@ -2640,11 +2654,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:476
+#: lxc/storage_volume.go:480
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2684,22 +2698,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1540
+#: lxc/file.go:1564
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1529
+#: lxc/file.go:1553
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1376
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1362
+#: lxc/file.go:1386
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2772,11 +2786,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:415
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2786,7 +2800,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2437
+#: lxc/storage_volume.go:2439
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2798,7 +2812,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1517
+#: lxc/image.go:1518
 msgid "Image already up to date."
 msgstr ""
 
@@ -2814,11 +2828,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1472
+#: lxc/image.go:364 lxc/image.go:1473
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1698
+#: lxc/image.go:444 lxc/image.go:1699
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2828,7 +2842,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1515
+#: lxc/image.go:1516
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2836,7 +2850,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2815
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2844,7 +2858,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2814
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2866,11 +2880,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2822
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2894
+#: lxc/storage_volume.go:2896
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2896,11 +2910,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1378
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1531
+#: lxc/file.go:1555
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2909,7 +2923,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:414
+#: lxc/init.go:418
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2918,7 +2932,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1298
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2970,7 +2984,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1293
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2996,23 +3010,23 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2023
+#: lxc/move.go:153 lxc/storage_volume.go:2025
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:144
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2019
+#: lxc/storage_volume.go:2021
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:509
+#: lxc/main.go:518
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:353
+#: lxc/file.go:357
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3022,18 +3036,18 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
-#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
+#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:535
+#: lxc/file.go:548
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:717
+#: lxc/file.go:185 lxc/file.go:739
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3070,7 +3084,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3101,12 +3115,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:176
+#: lxc/init.go:180
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:174
+#: lxc/init.go:178
 msgid "Launching the instance"
 msgstr ""
 
@@ -3204,11 +3218,11 @@ msgstr ""
 msgid "List identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:151
+#: lxc/image_alias.go:176
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:177
 msgid ""
 "List image aliases\n"
 "\n"
@@ -3375,11 +3389,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1605
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1610
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3438,7 +3452,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1481
+#: lxc/info.go:489 lxc/storage_volume.go:1483
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3624,7 +3638,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:873 lxc/network_forward.go:874
+#: lxc/network_forward.go:881 lxc/network_forward.go:882
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -3770,12 +3784,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:322 lxc/move.go:435
+#: lxc/move.go:327 lxc/move.go:440
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:347 lxc/move.go:440
+#: lxc/move.go:352 lxc/move.go:445
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3840,10 +3854,10 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:449
-#: lxc/network_forward.go:534 lxc/network_forward.go:709
-#: lxc/network_forward.go:840 lxc/network_forward.go:933
-#: lxc/network_forward.go:1015 lxc/network_load_balancer.go:221
+#: lxc/network_forward.go:219 lxc/network_forward.go:457
+#: lxc/network_forward.go:542 lxc/network_forward.go:717
+#: lxc/network_forward.go:848 lxc/network_forward.go:945
+#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
 #: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
 #: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
 #: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
@@ -3868,10 +3882,10 @@ msgstr ""
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
 #: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
 #: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:284 lxc/network_forward.go:445
-#: lxc/network_forward.go:530 lxc/network_forward.go:705
-#: lxc/network_forward.go:836 lxc/network_forward.go:929
-#: lxc/network_forward.go:1011 lxc/network_load_balancer.go:131
+#: lxc/network_forward.go:292 lxc/network_forward.go:453
+#: lxc/network_forward.go:538 lxc/network_forward.go:713
+#: lxc/network_forward.go:844 lxc/network_forward.go:941
+#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
 #: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
 #: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
 #: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
@@ -3907,13 +3921,13 @@ msgstr ""
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
-#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
-#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
-#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
+#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
+#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
+#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
+#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
 msgid "Missing pool name"
 msgstr ""
 
@@ -3932,15 +3946,15 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
+#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1411
+#: lxc/storage_volume.go:1413
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:820
+#: lxc/file.go:842
 msgid "Missing target directory"
 msgstr ""
 
@@ -3973,16 +3987,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
-#: lxc/storage_volume.go:975
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
+#: lxc/storage_volume.go:977
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:507
+#: lxc/file.go:520
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1207 lxc/file.go:1208
+#: lxc/file.go:1227 lxc/file.go:1228
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4011,7 +4025,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4019,16 +4033,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1869
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1059 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4050,7 +4064,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
 msgid "NAME"
 msgstr ""
 
@@ -4102,8 +4116,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
-#: lxc/storage_volume.go:1573
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Name"
 msgstr ""
 
@@ -4111,7 +4125,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4166,12 +4180,12 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:386
+#: lxc/network_forward.go:394
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:857
+#: lxc/network_forward.go:865
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -4255,7 +4269,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
+#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4263,7 +4277,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1070 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4275,11 +4289,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4293,7 +4307,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2035
+#: lxc/storage_volume.go:2037
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4301,16 +4315,21 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
-#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
-msgid "Only \"custom\" volumes can be attached to instances"
+#: lxc/storage_volume.go:216
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2701
+#: lxc/storage_volume.go:348
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:2703
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2500
+#: lxc/storage_volume.go:2502
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4322,7 +4341,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1431
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4335,7 +4354,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1577
+#: lxc/info.go:705 lxc/storage_volume.go:1579
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4365,7 +4384,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1767
+#: lxc/storage_volume.go:1769
 msgid "POOL"
 msgstr ""
 
@@ -4382,7 +4401,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167
-#: lxc/storage_volume.go:1773 lxc/warning.go:213
+#: lxc/storage_volume.go:1775 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4406,7 +4425,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:367
+#: lxc/main.go:376
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4444,7 +4463,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1332
+#: lxc/file.go:1356
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4452,12 +4471,12 @@ msgstr ""
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
-#: lxc/network_acl.go:699 lxc/network_forward.go:768
+#: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
-#: lxc/storage_volume.go:1200
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
+#: lxc/storage_volume.go:1202
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4570,11 +4589,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1649
+#: lxc/image.go:1650
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4588,7 +4607,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1238
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4604,7 +4623,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4625,7 +4644,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1017
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4634,7 +4653,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2094
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4647,7 +4666,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2370
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4678,20 +4697,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:455 lxc/file.go:456
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:638 lxc/file.go:989
+#: lxc/file.go:651 lxc/file.go:1009
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:688 lxc/file.go:689
+#: lxc/file.go:701 lxc/file.go:702
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:923 lxc/file.go:1089
+#: lxc/file.go:943 lxc/file.go:1109
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4700,7 +4719,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4729,15 +4748,15 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:463 lxc/file.go:695
+#: lxc/file.go:475 lxc/file.go:708
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1444 lxc/image.go:1445
+#: lxc/image.go:1445 lxc/image.go:1446
 msgid "Refresh images"
 msgstr ""
 
@@ -4746,7 +4765,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1481
+#: lxc/image.go:1482
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4823,7 +4842,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:971 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4859,7 +4878,7 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:969 lxc/network_forward.go:970
+#: lxc/network_forward.go:981 lxc/network_forward.go:982
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -4895,8 +4914,8 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
-#: lxc/image_alias.go:255
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:287
+#: lxc/image_alias.go:288
 msgid "Rename aliases"
 msgstr ""
 
@@ -4932,15 +4951,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1962
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
+#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4992,7 +5011,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5009,7 +5028,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:361
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5058,12 +5077,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1460
+#: lxc/file.go:1484
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1461
+#: lxc/file.go:1485
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5139,7 +5158,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1217
+#: lxc/file.go:1237
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5165,7 +5184,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1665 lxc/image.go:1666
+#: lxc/image.go:1666 lxc/image.go:1667
 msgid "Set image properties"
 msgstr ""
 
@@ -5208,11 +5227,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:488
+#: lxc/network_forward.go:496
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:489
+#: lxc/network_forward.go:497
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5316,11 +5335,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2088
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2089
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5337,7 +5356,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:698
+#: lxc/file.go:711
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5345,7 +5364,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:699
+#: lxc/file.go:712
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5353,7 +5372,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:710
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5365,7 +5384,7 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:504
 msgid "Set the key as a network forward property"
 msgstr ""
 
@@ -5405,7 +5424,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2105
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5413,7 +5432,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1215
+#: lxc/file.go:1235
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5470,7 +5489,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1535 lxc/image.go:1536
+#: lxc/image.go:1536 lxc/image.go:1537
 msgid "Show image properties"
 msgstr ""
 
@@ -5490,7 +5509,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:271 lxc/main.go:272
+#: lxc/main.go:280 lxc/main.go:281
 msgid "Show less common commands"
 msgstr ""
 
@@ -5554,11 +5573,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5626,15 +5645,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2190
+#: lxc/storage_volume.go:2192
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1502
+#: lxc/info.go:619 lxc/storage_volume.go:1504
 msgid "Snapshots:"
 msgstr ""
 
@@ -5739,21 +5758,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:703
+#: lxc/storage_volume.go:707
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:791
+#: lxc/storage_volume.go:795
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:516
+#: lxc/storage_volume.go:520
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:524
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5815,21 +5834,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1747 lxc/warning.go:216
+#: lxc/storage_volume.go:1749 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1262
+#: lxc/file.go:1286
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1256
+#: lxc/file.go:1280
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5839,15 +5858,15 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:181
+#: lxc/move.go:186
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:219 lxc/move.go:240
+#: lxc/move.go:224 lxc/move.go:245
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:193
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5855,15 +5874,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:185
+#: lxc/move.go:190
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:189
+#: lxc/move.go:194
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:210
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5885,7 +5904,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:439
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5938,7 +5957,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:462
+#: lxc/network_forward.go:470
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -5978,12 +5997,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1340
+#: lxc/storage_volume.go:1342
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1317
+#: lxc/storage_volume.go:1319
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -5998,12 +6017,12 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:309
+#: lxc/move.go:314
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
-#: lxc/storage_volume.go:989
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
+#: lxc/storage_volume.go:991
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6031,7 +6050,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:298
+#: lxc/main.go:307
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6055,11 +6074,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:437
+#: lxc/init.go:441
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:440
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6067,7 +6086,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:412
+#: lxc/main.go:421
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6078,7 +6097,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1489
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6093,7 +6112,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1864
+#: lxc/storage_volume.go:1866
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6101,7 +6120,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6118,7 +6137,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:327
+#: lxc/copy.go:382 lxc/move.go:332
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6160,7 +6179,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1472
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6182,13 +6201,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1752
+#: lxc/project.go:995 lxc/storage_volume.go:1754
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1751
+#: lxc/storage.go:724 lxc/storage_volume.go:1753
 msgid "USED BY"
 msgstr ""
 
@@ -6201,7 +6220,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:411
+#: lxc/file.go:423
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6215,12 +6234,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1483
+#: lxc/file.go:1507
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1791
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6231,7 +6250,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1029
+#: lxc/file.go:1049
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6262,7 +6281,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1728 lxc/image.go:1729
+#: lxc/image.go:1729 lxc/image.go:1730
 msgid "Unset image properties"
 msgstr ""
 
@@ -6278,11 +6297,11 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:598
+#: lxc/network_forward.go:606
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:599
+#: lxc/network_forward.go:607
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -6326,7 +6345,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6338,7 +6357,7 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:602
+#: lxc/network_forward.go:610
 msgid "Unset the key as a network forward property"
 msgstr ""
 
@@ -6378,7 +6397,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2381
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6386,7 +6405,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:248
+#: lxc/storage_volume.go:250
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6422,12 +6441,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1485
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2652
+#: lxc/export.go:42 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6494,7 +6513,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1576
+#: lxc/storage_volume.go:1578
 msgid "Volume Only"
 msgstr ""
 
@@ -6545,7 +6564,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:293 lxc/move.go:369
+#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6553,12 +6572,12 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:909
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:912
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:282
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:284
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
@@ -6590,7 +6609,7 @@ msgstr ""
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:174
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
@@ -6643,7 +6662,7 @@ msgstr ""
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: lxc/image_alias.go:104
+#: lxc/image_alias.go:121
 msgid "[<remote>:]<alias>"
 msgstr ""
 
@@ -6651,7 +6670,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/image_alias.go:252
+#: lxc/image_alias.go:285
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
@@ -6705,15 +6724,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1600 lxc/image.go:1727
+#: lxc/image.go:1601 lxc/image.go:1728
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1664
+#: lxc/image.go:1665
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6733,7 +6752,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1443
+#: lxc/image.go:334 lxc/image.go:1444
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6804,7 +6823,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:376
+#: lxc/file.go:380
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -6816,12 +6835,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:454
+#: lxc/file.go:466
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1226
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6889,8 +6908,8 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:644
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:179
+#: lxc/network_forward.go:177 lxc/network_forward.go:652
+#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
 #: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
@@ -6905,12 +6924,12 @@ msgid ""
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:402 lxc/network_forward.go:597
+#: lxc/network_forward.go:410 lxc/network_forward.go:605
 #: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
@@ -6920,13 +6939,13 @@ msgid ""
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:887
+#: lxc/network_forward.go:895
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:968 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -6981,7 +7000,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2811
+#: lxc/storage_volume.go:2813
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7016,65 +7035,65 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1958
+#: lxc/storage_volume.go:1960
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:806
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:167
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
-msgstr ""
-
-#: lxc/storage_volume.go:2562
+#: lxc/storage_volume.go:2564
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2645
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2428
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:610
+#: lxc/storage_volume.go:614
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:718
+#: lxc/storage_volume.go:722
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2364
+#: lxc/storage_volume.go:810
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
+msgstr ""
+
+#: lxc/storage_volume.go:167
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
+msgstr ""
+
+#: lxc/storage_volume.go:2366
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2087
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2245
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1234
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1858
+#: lxc/storage_volume.go:1860
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7180,7 +7199,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1603
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7342,20 +7361,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1230
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:470
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:691
+#: lxc/file.go:704
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7656,7 +7675,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:618
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7664,13 +7683,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2817
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2432
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7704,16 +7723,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1396
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1331
+#: lxc/file.go:1355
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1284
+#: lxc/file.go:1308
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-07 15:11-0700\n"
+"POT-Creation-Date: 2025-01-10 14:44-0600\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1041
+#: lxc/storage_volume.go:1043
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:667
+#: lxc/network_forward.go:675
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,12 +430,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1157
+#: lxc/file.go:1177
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1047
+#: lxc/file.go:1067
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -471,7 +471,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:65
+#: lxc/init.go:146 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:687
+#: lxc/file.go:700
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -541,7 +541,7 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
@@ -672,7 +672,7 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:888 lxc/network_forward.go:889
+#: lxc/network_forward.go:896 lxc/network_forward.go:897
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -722,7 +722,7 @@ msgstr ""
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
+#: lxc/image_alias.go:101 lxc/image_alias.go:156 lxc/image_alias.go:320
 msgid "Alias name missing"
 msgstr ""
 
@@ -735,7 +735,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1607
+#: lxc/storage_volume.go:1609
 msgid "All projects"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -790,12 +790,26 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168 lxc/storage_volume.go:169
+#: lxc/storage_volume.go:168
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:169
+msgid ""
+"Attach new storage volumes to instances\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
+msgstr ""
+
+#: lxc/storage_volume.go:285
 msgid "Attach new storage volumes to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:286
+msgid ""
+"Attach new storage volumes to profiles\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
 #: lxc/console.go:39
@@ -846,16 +860,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2719
+#: lxc/storage_volume.go:2721
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2796
+#: lxc/export.go:192 lxc/storage_volume.go:2798
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1538
+#: lxc/info.go:666 lxc/storage_volume.go:1540
 msgid "Backups:"
 msgstr ""
 
@@ -864,19 +878,19 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
+#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:326
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -919,7 +933,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1752
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -971,7 +985,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -979,7 +993,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:562
+#: lxc/file.go:575
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1004,11 +1018,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:768
+#: lxc/file.go:790
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1021,12 +1035,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:493
+#: lxc/storage_volume.go:497
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:447
+#: lxc/storage_volume.go:451
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1132,9 +1146,9 @@ msgstr ""
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:497 lxc/network_forward.go:649
-#: lxc/network_forward.go:803 lxc/network_forward.go:892
-#: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
+#: lxc/network_forward.go:505 lxc/network_forward.go:657
+#: lxc/network_forward.go:811 lxc/network_forward.go:900
+#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
 #: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
 #: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
@@ -1146,14 +1160,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
-#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
-#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
-#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
+#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
 msgid "Cluster member name"
 msgstr ""
 
@@ -1169,7 +1183,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1608
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1209,21 +1223,21 @@ msgstr ""
 #: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
-#: lxc/network_acl.go:698 lxc/network_forward.go:767
+#: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
-#: lxc/storage_volume.go:1199
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
+#: lxc/storage_volume.go:1201
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:620
+#: lxc/storage_volume.go:624
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1478
+#: lxc/storage_volume.go:1480
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1285,7 +1299,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1293,12 +1307,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1311,7 +1325,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1406,7 +1420,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:462 lxc/file.go:696
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1446,7 +1460,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1498,12 +1512,12 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:182
+#: lxc/init.go:186
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1513,7 +1527,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 msgid "Creating the instance"
 msgstr ""
 
@@ -1527,13 +1541,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1749
+#: lxc/storage_volume.go:1751
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1553,7 +1567,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2653
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1585,7 +1599,7 @@ msgstr ""
 msgid "Delete identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:106 lxc/image_alias.go:107
+#: lxc/image_alias.go:123 lxc/image_alias.go:124
 msgid "Delete image aliases"
 msgstr ""
 
@@ -1609,7 +1623,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:799 lxc/network_forward.go:800
+#: lxc/network_forward.go:807 lxc/network_forward.go:808
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1649,7 +1663,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
+#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1691,13 +1705,13 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
-#: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
-#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
+#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
+#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
+#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
@@ -1711,10 +1725,10 @@ msgstr ""
 #: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:404 lxc/network_forward.go:489
-#: lxc/network_forward.go:599 lxc/network_forward.go:646
-#: lxc/network_forward.go:800 lxc/network_forward.go:874
-#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_forward.go:412 lxc/network_forward.go:497
+#: lxc/network_forward.go:607 lxc/network_forward.go:654
+#: lxc/network_forward.go:808 lxc/network_forward.go:882
+#: lxc/network_forward.go:897 lxc/network_forward.go:982
 #: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
 #: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
 #: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
@@ -1754,27 +1768,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
-#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
-#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
-#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
-#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
-#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
-#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
-#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1465
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1786,11 +1800,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
+#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1840,7 +1854,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:403
+#: lxc/init.go:407
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1852,7 +1866,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1216
+#: lxc/file.go:1236
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1948,7 +1962,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:377 lxc/file.go:378
+#: lxc/file.go:381 lxc/file.go:382
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1988,7 +2002,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:653 lxc/network_forward.go:654
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -2028,7 +2042,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2036,7 +2050,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1785
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2090,11 +2104,11 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
-#: lxc/network_acl.go:524 lxc/network_forward.go:572
+#: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
+#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2105,11 +2119,11 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
-#: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
+#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
-#: lxc/storage_volume.go:2210
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
+#: lxc/storage_volume.go:2212
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2151,8 +2165,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
+#: lxc/storage_volume.go:1577
 msgid "Expires at"
 msgstr ""
 
@@ -2176,7 +2190,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2188,11 +2202,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2650
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2779
+#: lxc/export.go:152 lxc/storage_volume.go:2781
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2211,7 +2225,7 @@ msgid "FILENAME"
 msgstr ""
 
 #: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
-#: lxc/image_alias.go:235
+#: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2219,12 +2233,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1467
+#: lxc/file.go:1491
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1490
+#: lxc/file.go:1514
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2239,12 +2253,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1517
+#: lxc/file.go:1541
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1326
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2274,7 +2288,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1423
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2289,7 +2303,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1428
+#: lxc/file.go:1452
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2299,12 +2313,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1352
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1455
+#: lxc/file.go:1479
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2318,7 +2332,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:304 lxc/move.go:380
+#: lxc/move.go:309 lxc/move.go:385
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2343,7 +2357,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1440
+#: lxc/file.go:1464
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2358,7 +2372,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1042
+#: lxc/file.go:1062
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2445,14 +2459,14 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1625 lxc/warning.go:94
+#: lxc/storage_volume.go:1627 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2520,7 +2534,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1602
+#: lxc/image.go:1602 lxc/image.go:1603
 msgid "Get image properties"
 msgstr ""
 
@@ -2536,7 +2550,7 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:414
 msgid "Get the key as a network forward property"
 msgstr ""
 
@@ -2576,7 +2590,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1249
+#: lxc/storage_volume.go:1251
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2604,7 +2618,7 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:403 lxc/network_forward.go:404
+#: lxc/network_forward.go:411 lxc/network_forward.go:412
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
@@ -2640,11 +2654,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:476
+#: lxc/storage_volume.go:480
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2684,22 +2698,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1540
+#: lxc/file.go:1564
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1529
+#: lxc/file.go:1553
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1376
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1362
+#: lxc/file.go:1386
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2772,11 +2786,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:415
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2786,7 +2800,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2437
+#: lxc/storage_volume.go:2439
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2798,7 +2812,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1517
+#: lxc/image.go:1518
 msgid "Image already up to date."
 msgstr ""
 
@@ -2814,11 +2828,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1472
+#: lxc/image.go:364 lxc/image.go:1473
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1698
+#: lxc/image.go:444 lxc/image.go:1699
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2828,7 +2842,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1515
+#: lxc/image.go:1516
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2836,7 +2850,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2815
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2844,7 +2858,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2814
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2866,11 +2880,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2822
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2894
+#: lxc/storage_volume.go:2896
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2896,11 +2910,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1378
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1531
+#: lxc/file.go:1555
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2909,7 +2923,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:414
+#: lxc/init.go:418
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2918,7 +2932,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1298
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2970,7 +2984,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1293
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2996,23 +3010,23 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2023
+#: lxc/move.go:153 lxc/storage_volume.go:2025
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:144
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2019
+#: lxc/storage_volume.go:2021
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:509
+#: lxc/main.go:518
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:353
+#: lxc/file.go:357
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3022,18 +3036,18 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
-#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
+#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:535
+#: lxc/file.go:548
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:717
+#: lxc/file.go:185 lxc/file.go:739
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3070,7 +3084,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3101,12 +3115,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:176
+#: lxc/init.go:180
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:174
+#: lxc/init.go:178
 msgid "Launching the instance"
 msgstr ""
 
@@ -3204,11 +3218,11 @@ msgstr ""
 msgid "List identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:151
+#: lxc/image_alias.go:176
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:177
 msgid ""
 "List image aliases\n"
 "\n"
@@ -3375,11 +3389,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1605
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1610
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3438,7 +3452,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1481
+#: lxc/info.go:489 lxc/storage_volume.go:1483
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3624,7 +3638,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:873 lxc/network_forward.go:874
+#: lxc/network_forward.go:881 lxc/network_forward.go:882
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -3770,12 +3784,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:322 lxc/move.go:435
+#: lxc/move.go:327 lxc/move.go:440
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:347 lxc/move.go:440
+#: lxc/move.go:352 lxc/move.go:445
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3840,10 +3854,10 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:449
-#: lxc/network_forward.go:534 lxc/network_forward.go:709
-#: lxc/network_forward.go:840 lxc/network_forward.go:933
-#: lxc/network_forward.go:1015 lxc/network_load_balancer.go:221
+#: lxc/network_forward.go:219 lxc/network_forward.go:457
+#: lxc/network_forward.go:542 lxc/network_forward.go:717
+#: lxc/network_forward.go:848 lxc/network_forward.go:945
+#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
 #: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
 #: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
 #: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
@@ -3868,10 +3882,10 @@ msgstr ""
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
 #: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
 #: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:284 lxc/network_forward.go:445
-#: lxc/network_forward.go:530 lxc/network_forward.go:705
-#: lxc/network_forward.go:836 lxc/network_forward.go:929
-#: lxc/network_forward.go:1011 lxc/network_load_balancer.go:131
+#: lxc/network_forward.go:292 lxc/network_forward.go:453
+#: lxc/network_forward.go:538 lxc/network_forward.go:713
+#: lxc/network_forward.go:844 lxc/network_forward.go:941
+#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
 #: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
 #: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
 #: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
@@ -3907,13 +3921,13 @@ msgstr ""
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
-#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
-#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
-#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
+#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
+#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
+#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
+#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
 msgid "Missing pool name"
 msgstr ""
 
@@ -3932,15 +3946,15 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
+#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1411
+#: lxc/storage_volume.go:1413
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:820
+#: lxc/file.go:842
 msgid "Missing target directory"
 msgstr ""
 
@@ -3973,16 +3987,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
-#: lxc/storage_volume.go:975
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
+#: lxc/storage_volume.go:977
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:507
+#: lxc/file.go:520
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1207 lxc/file.go:1208
+#: lxc/file.go:1227 lxc/file.go:1228
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4011,7 +4025,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4019,16 +4033,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1869
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1059 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4050,7 +4064,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
 msgid "NAME"
 msgstr ""
 
@@ -4102,8 +4116,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
-#: lxc/storage_volume.go:1573
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Name"
 msgstr ""
 
@@ -4111,7 +4125,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4166,12 +4180,12 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:386
+#: lxc/network_forward.go:394
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:857
+#: lxc/network_forward.go:865
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -4255,7 +4269,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
+#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4263,7 +4277,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1070 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4275,11 +4289,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4293,7 +4307,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2035
+#: lxc/storage_volume.go:2037
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4301,16 +4315,21 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
-#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
-msgid "Only \"custom\" volumes can be attached to instances"
+#: lxc/storage_volume.go:216
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2701
+#: lxc/storage_volume.go:348
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:2703
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2500
+#: lxc/storage_volume.go:2502
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4322,7 +4341,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1431
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4335,7 +4354,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1577
+#: lxc/info.go:705 lxc/storage_volume.go:1579
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4365,7 +4384,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1767
+#: lxc/storage_volume.go:1769
 msgid "POOL"
 msgstr ""
 
@@ -4382,7 +4401,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167
-#: lxc/storage_volume.go:1773 lxc/warning.go:213
+#: lxc/storage_volume.go:1775 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4406,7 +4425,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:367
+#: lxc/main.go:376
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4444,7 +4463,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1332
+#: lxc/file.go:1356
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4452,12 +4471,12 @@ msgstr ""
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
-#: lxc/network_acl.go:699 lxc/network_forward.go:768
+#: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
-#: lxc/storage_volume.go:1200
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
+#: lxc/storage_volume.go:1202
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4570,11 +4589,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1649
+#: lxc/image.go:1650
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4588,7 +4607,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1238
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4604,7 +4623,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4625,7 +4644,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1017
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4634,7 +4653,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2094
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4647,7 +4666,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2370
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4678,20 +4697,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:455 lxc/file.go:456
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:638 lxc/file.go:989
+#: lxc/file.go:651 lxc/file.go:1009
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:688 lxc/file.go:689
+#: lxc/file.go:701 lxc/file.go:702
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:923 lxc/file.go:1089
+#: lxc/file.go:943 lxc/file.go:1109
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4700,7 +4719,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4729,15 +4748,15 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:463 lxc/file.go:695
+#: lxc/file.go:475 lxc/file.go:708
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1444 lxc/image.go:1445
+#: lxc/image.go:1445 lxc/image.go:1446
 msgid "Refresh images"
 msgstr ""
 
@@ -4746,7 +4765,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1481
+#: lxc/image.go:1482
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4823,7 +4842,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:971 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4859,7 +4878,7 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:969 lxc/network_forward.go:970
+#: lxc/network_forward.go:981 lxc/network_forward.go:982
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -4895,8 +4914,8 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
-#: lxc/image_alias.go:255
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:287
+#: lxc/image_alias.go:288
 msgid "Rename aliases"
 msgstr ""
 
@@ -4932,15 +4951,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1962
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
+#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4992,7 +5011,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5009,7 +5028,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:361
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5058,12 +5077,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1460
+#: lxc/file.go:1484
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1461
+#: lxc/file.go:1485
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5139,7 +5158,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1217
+#: lxc/file.go:1237
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5165,7 +5184,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1665 lxc/image.go:1666
+#: lxc/image.go:1666 lxc/image.go:1667
 msgid "Set image properties"
 msgstr ""
 
@@ -5208,11 +5227,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:488
+#: lxc/network_forward.go:496
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:489
+#: lxc/network_forward.go:497
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5316,11 +5335,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2088
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2089
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5337,7 +5356,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:698
+#: lxc/file.go:711
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5345,7 +5364,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:699
+#: lxc/file.go:712
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5353,7 +5372,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:710
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5365,7 +5384,7 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:504
 msgid "Set the key as a network forward property"
 msgstr ""
 
@@ -5405,7 +5424,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2105
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5413,7 +5432,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1215
+#: lxc/file.go:1235
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5470,7 +5489,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1535 lxc/image.go:1536
+#: lxc/image.go:1536 lxc/image.go:1537
 msgid "Show image properties"
 msgstr ""
 
@@ -5490,7 +5509,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:271 lxc/main.go:272
+#: lxc/main.go:280 lxc/main.go:281
 msgid "Show less common commands"
 msgstr ""
 
@@ -5554,11 +5573,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5626,15 +5645,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2190
+#: lxc/storage_volume.go:2192
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1502
+#: lxc/info.go:619 lxc/storage_volume.go:1504
 msgid "Snapshots:"
 msgstr ""
 
@@ -5739,21 +5758,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:703
+#: lxc/storage_volume.go:707
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:791
+#: lxc/storage_volume.go:795
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:516
+#: lxc/storage_volume.go:520
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:524
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5815,21 +5834,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1747 lxc/warning.go:216
+#: lxc/storage_volume.go:1749 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1262
+#: lxc/file.go:1286
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1256
+#: lxc/file.go:1280
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5839,15 +5858,15 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:181
+#: lxc/move.go:186
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:219 lxc/move.go:240
+#: lxc/move.go:224 lxc/move.go:245
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:193
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5855,15 +5874,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:185
+#: lxc/move.go:190
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:189
+#: lxc/move.go:194
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:210
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5885,7 +5904,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:439
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5938,7 +5957,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:462
+#: lxc/network_forward.go:470
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -5978,12 +5997,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1340
+#: lxc/storage_volume.go:1342
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1317
+#: lxc/storage_volume.go:1319
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -5998,12 +6017,12 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:309
+#: lxc/move.go:314
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
-#: lxc/storage_volume.go:989
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
+#: lxc/storage_volume.go:991
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6031,7 +6050,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:298
+#: lxc/main.go:307
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6055,11 +6074,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:437
+#: lxc/init.go:441
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:440
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6067,7 +6086,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:412
+#: lxc/main.go:421
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6078,7 +6097,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1489
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6093,7 +6112,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1864
+#: lxc/storage_volume.go:1866
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6101,7 +6120,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6118,7 +6137,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:327
+#: lxc/copy.go:382 lxc/move.go:332
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6160,7 +6179,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1472
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6182,13 +6201,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1752
+#: lxc/project.go:995 lxc/storage_volume.go:1754
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1751
+#: lxc/storage.go:724 lxc/storage_volume.go:1753
 msgid "USED BY"
 msgstr ""
 
@@ -6201,7 +6220,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:411
+#: lxc/file.go:423
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6215,12 +6234,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1483
+#: lxc/file.go:1507
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1791
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6231,7 +6250,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1029
+#: lxc/file.go:1049
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6262,7 +6281,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1728 lxc/image.go:1729
+#: lxc/image.go:1729 lxc/image.go:1730
 msgid "Unset image properties"
 msgstr ""
 
@@ -6278,11 +6297,11 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:598
+#: lxc/network_forward.go:606
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:599
+#: lxc/network_forward.go:607
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -6326,7 +6345,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6338,7 +6357,7 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:602
+#: lxc/network_forward.go:610
 msgid "Unset the key as a network forward property"
 msgstr ""
 
@@ -6378,7 +6397,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2381
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6386,7 +6405,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:248
+#: lxc/storage_volume.go:250
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6422,12 +6441,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1485
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2652
+#: lxc/export.go:42 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6494,7 +6513,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1576
+#: lxc/storage_volume.go:1578
 msgid "Volume Only"
 msgstr ""
 
@@ -6545,7 +6564,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:293 lxc/move.go:369
+#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6553,12 +6572,12 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:909
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:912
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:282
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:284
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
@@ -6590,7 +6609,7 @@ msgstr ""
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:174
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
@@ -6643,7 +6662,7 @@ msgstr ""
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: lxc/image_alias.go:104
+#: lxc/image_alias.go:121
 msgid "[<remote>:]<alias>"
 msgstr ""
 
@@ -6651,7 +6670,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/image_alias.go:252
+#: lxc/image_alias.go:285
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
@@ -6705,15 +6724,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1600 lxc/image.go:1727
+#: lxc/image.go:1601 lxc/image.go:1728
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1664
+#: lxc/image.go:1665
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6733,7 +6752,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1443
+#: lxc/image.go:334 lxc/image.go:1444
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6804,7 +6823,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:376
+#: lxc/file.go:380
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -6816,12 +6835,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:454
+#: lxc/file.go:466
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1226
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6889,8 +6908,8 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:644
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:179
+#: lxc/network_forward.go:177 lxc/network_forward.go:652
+#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
 #: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
@@ -6905,12 +6924,12 @@ msgid ""
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:402 lxc/network_forward.go:597
+#: lxc/network_forward.go:410 lxc/network_forward.go:605
 #: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
@@ -6920,13 +6939,13 @@ msgid ""
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:887
+#: lxc/network_forward.go:895
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:968 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -6981,7 +7000,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2811
+#: lxc/storage_volume.go:2813
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7016,65 +7035,65 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1958
+#: lxc/storage_volume.go:1960
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:806
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:167
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
-msgstr ""
-
-#: lxc/storage_volume.go:2562
+#: lxc/storage_volume.go:2564
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2645
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2428
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:610
+#: lxc/storage_volume.go:614
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:718
+#: lxc/storage_volume.go:722
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2364
+#: lxc/storage_volume.go:810
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
+msgstr ""
+
+#: lxc/storage_volume.go:167
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
+msgstr ""
+
+#: lxc/storage_volume.go:2366
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2087
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2245
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1234
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1858
+#: lxc/storage_volume.go:1860
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7180,7 +7199,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1603
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7342,20 +7361,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1230
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:470
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:691
+#: lxc/file.go:704
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7656,7 +7675,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:618
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7664,13 +7683,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2817
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2432
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7704,16 +7723,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1396
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1331
+#: lxc/file.go:1355
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1284
+#: lxc/file.go:1308
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-07 15:11-0700\n"
+"POT-Creation-Date: 2025-01-10 14:44-0600\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -74,7 +74,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:1041
+#: lxc/storage_volume.go:1043
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -368,7 +368,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/network_forward.go:667
+#: lxc/network_forward.go:675
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -654,12 +654,12 @@ msgstr "%s (en nog %d)"
 msgid "%s (%s) (%d available)"
 msgstr "%s (en nog %d)"
 
-#: lxc/file.go:1157
+#: lxc/file.go:1177
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1047
+#: lxc/file.go:1067
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -695,7 +695,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:65
+#: lxc/init.go:146 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -748,7 +748,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:687
+#: lxc/file.go:700
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -765,7 +765,7 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr "ALIAS"
 
@@ -896,7 +896,7 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:888 lxc/network_forward.go:889
+#: lxc/network_forward.go:896 lxc/network_forward.go:897
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -946,7 +946,7 @@ msgstr ""
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
+#: lxc/image_alias.go:101 lxc/image_alias.go:156 lxc/image_alias.go:320
 msgid "Alias name missing"
 msgstr ""
 
@@ -959,7 +959,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1607
+#: lxc/storage_volume.go:1609
 msgid "All projects"
 msgstr ""
 
@@ -990,7 +990,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1014,12 +1014,26 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168 lxc/storage_volume.go:169
+#: lxc/storage_volume.go:168
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:169
+msgid ""
+"Attach new storage volumes to instances\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
+msgstr ""
+
+#: lxc/storage_volume.go:285
 msgid "Attach new storage volumes to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:286
+msgid ""
+"Attach new storage volumes to profiles\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
 #: lxc/console.go:39
@@ -1070,16 +1084,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2719
+#: lxc/storage_volume.go:2721
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2796
+#: lxc/export.go:192 lxc/storage_volume.go:2798
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1538
+#: lxc/info.go:666 lxc/storage_volume.go:1540
 msgid "Backups:"
 msgstr ""
 
@@ -1088,19 +1102,19 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
+#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:326
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1143,7 +1157,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1752
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1195,7 +1209,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1203,7 +1217,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:562
+#: lxc/file.go:575
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1228,11 +1242,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:768
+#: lxc/file.go:790
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1245,12 +1259,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:493
+#: lxc/storage_volume.go:497
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:447
+#: lxc/storage_volume.go:451
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1356,9 +1370,9 @@ msgstr ""
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:497 lxc/network_forward.go:649
-#: lxc/network_forward.go:803 lxc/network_forward.go:892
-#: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
+#: lxc/network_forward.go:505 lxc/network_forward.go:657
+#: lxc/network_forward.go:811 lxc/network_forward.go:900
+#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
 #: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
 #: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
@@ -1370,14 +1384,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
-#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
-#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
-#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
+#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
 msgid "Cluster member name"
 msgstr ""
 
@@ -1393,7 +1407,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1608
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1433,21 +1447,21 @@ msgstr ""
 #: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
-#: lxc/network_acl.go:698 lxc/network_forward.go:767
+#: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
-#: lxc/storage_volume.go:1199
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
+#: lxc/storage_volume.go:1201
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:620
+#: lxc/storage_volume.go:624
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1478
+#: lxc/storage_volume.go:1480
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1509,7 +1523,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1517,12 +1531,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1535,7 +1549,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1630,7 +1644,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:462 lxc/file.go:696
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1670,7 +1684,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1722,12 +1736,12 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:182
+#: lxc/init.go:186
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1737,7 +1751,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 msgid "Creating the instance"
 msgstr ""
 
@@ -1751,13 +1765,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1749
+#: lxc/storage_volume.go:1751
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1777,7 +1791,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2653
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1809,7 +1823,7 @@ msgstr ""
 msgid "Delete identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:106 lxc/image_alias.go:107
+#: lxc/image_alias.go:123 lxc/image_alias.go:124
 msgid "Delete image aliases"
 msgstr ""
 
@@ -1833,7 +1847,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:799 lxc/network_forward.go:800
+#: lxc/network_forward.go:807 lxc/network_forward.go:808
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1873,7 +1887,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
+#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1915,13 +1929,13 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
-#: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
-#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
+#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
+#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
+#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
@@ -1935,10 +1949,10 @@ msgstr ""
 #: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:404 lxc/network_forward.go:489
-#: lxc/network_forward.go:599 lxc/network_forward.go:646
-#: lxc/network_forward.go:800 lxc/network_forward.go:874
-#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_forward.go:412 lxc/network_forward.go:497
+#: lxc/network_forward.go:607 lxc/network_forward.go:654
+#: lxc/network_forward.go:808 lxc/network_forward.go:882
+#: lxc/network_forward.go:897 lxc/network_forward.go:982
 #: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
 #: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
 #: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
@@ -1978,27 +1992,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
-#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
-#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
-#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
-#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
-#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
-#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
-#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1465
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -2010,11 +2024,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
+#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2064,7 +2078,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:403
+#: lxc/init.go:407
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2076,7 +2090,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1216
+#: lxc/file.go:1236
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2172,7 +2186,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:377 lxc/file.go:378
+#: lxc/file.go:381 lxc/file.go:382
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2212,7 +2226,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:653 lxc/network_forward.go:654
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -2252,7 +2266,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2260,7 +2274,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1785
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2314,11 +2328,11 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
-#: lxc/network_acl.go:524 lxc/network_forward.go:572
+#: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
+#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2329,11 +2343,11 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
-#: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
+#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
-#: lxc/storage_volume.go:2210
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
+#: lxc/storage_volume.go:2212
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2375,8 +2389,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
+#: lxc/storage_volume.go:1577
 msgid "Expires at"
 msgstr ""
 
@@ -2400,7 +2414,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2412,11 +2426,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2650
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2779
+#: lxc/export.go:152 lxc/storage_volume.go:2781
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2435,7 +2449,7 @@ msgid "FILENAME"
 msgstr ""
 
 #: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
-#: lxc/image_alias.go:235
+#: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2443,12 +2457,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1467
+#: lxc/file.go:1491
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1490
+#: lxc/file.go:1514
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2463,12 +2477,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1517
+#: lxc/file.go:1541
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1326
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2498,7 +2512,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1423
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2513,7 +2527,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1428
+#: lxc/file.go:1452
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2523,12 +2537,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1352
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1455
+#: lxc/file.go:1479
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2542,7 +2556,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:304 lxc/move.go:380
+#: lxc/move.go:309 lxc/move.go:385
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2567,7 +2581,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1440
+#: lxc/file.go:1464
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2582,7 +2596,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1042
+#: lxc/file.go:1062
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2669,14 +2683,14 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1625 lxc/warning.go:94
+#: lxc/storage_volume.go:1627 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2744,7 +2758,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1602
+#: lxc/image.go:1602 lxc/image.go:1603
 msgid "Get image properties"
 msgstr ""
 
@@ -2760,7 +2774,7 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:414
 msgid "Get the key as a network forward property"
 msgstr ""
 
@@ -2800,7 +2814,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1249
+#: lxc/storage_volume.go:1251
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2828,7 +2842,7 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:403 lxc/network_forward.go:404
+#: lxc/network_forward.go:411 lxc/network_forward.go:412
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
@@ -2864,11 +2878,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:476
+#: lxc/storage_volume.go:480
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2908,22 +2922,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1540
+#: lxc/file.go:1564
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1529
+#: lxc/file.go:1553
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1376
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1362
+#: lxc/file.go:1386
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2996,11 +3010,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:415
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3010,7 +3024,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2437
+#: lxc/storage_volume.go:2439
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3022,7 +3036,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1517
+#: lxc/image.go:1518
 msgid "Image already up to date."
 msgstr ""
 
@@ -3038,11 +3052,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1472
+#: lxc/image.go:364 lxc/image.go:1473
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1698
+#: lxc/image.go:444 lxc/image.go:1699
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -3052,7 +3066,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1515
+#: lxc/image.go:1516
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3060,7 +3074,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2815
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3068,7 +3082,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2814
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -3090,11 +3104,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2822
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2894
+#: lxc/storage_volume.go:2896
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3120,11 +3134,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1378
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1531
+#: lxc/file.go:1555
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3133,7 +3147,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:414
+#: lxc/init.go:418
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3142,7 +3156,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1298
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3194,7 +3208,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1293
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3220,23 +3234,23 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2023
+#: lxc/move.go:153 lxc/storage_volume.go:2025
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:144
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2019
+#: lxc/storage_volume.go:2021
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:509
+#: lxc/main.go:518
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:353
+#: lxc/file.go:357
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3246,18 +3260,18 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
-#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
+#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:535
+#: lxc/file.go:548
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:717
+#: lxc/file.go:185 lxc/file.go:739
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3294,7 +3308,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3325,12 +3339,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:176
+#: lxc/init.go:180
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:174
+#: lxc/init.go:178
 msgid "Launching the instance"
 msgstr ""
 
@@ -3428,11 +3442,11 @@ msgstr ""
 msgid "List identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:151
+#: lxc/image_alias.go:176
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:177
 msgid ""
 "List image aliases\n"
 "\n"
@@ -3599,11 +3613,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1605
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1610
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3662,7 +3676,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1481
+#: lxc/info.go:489 lxc/storage_volume.go:1483
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3848,7 +3862,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:873 lxc/network_forward.go:874
+#: lxc/network_forward.go:881 lxc/network_forward.go:882
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -3994,12 +4008,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:322 lxc/move.go:435
+#: lxc/move.go:327 lxc/move.go:440
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:347 lxc/move.go:440
+#: lxc/move.go:352 lxc/move.go:445
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4064,10 +4078,10 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:449
-#: lxc/network_forward.go:534 lxc/network_forward.go:709
-#: lxc/network_forward.go:840 lxc/network_forward.go:933
-#: lxc/network_forward.go:1015 lxc/network_load_balancer.go:221
+#: lxc/network_forward.go:219 lxc/network_forward.go:457
+#: lxc/network_forward.go:542 lxc/network_forward.go:717
+#: lxc/network_forward.go:848 lxc/network_forward.go:945
+#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
 #: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
 #: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
 #: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
@@ -4092,10 +4106,10 @@ msgstr ""
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
 #: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
 #: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:284 lxc/network_forward.go:445
-#: lxc/network_forward.go:530 lxc/network_forward.go:705
-#: lxc/network_forward.go:836 lxc/network_forward.go:929
-#: lxc/network_forward.go:1011 lxc/network_load_balancer.go:131
+#: lxc/network_forward.go:292 lxc/network_forward.go:453
+#: lxc/network_forward.go:538 lxc/network_forward.go:713
+#: lxc/network_forward.go:844 lxc/network_forward.go:941
+#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
 #: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
 #: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
 #: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
@@ -4131,13 +4145,13 @@ msgstr ""
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
-#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
-#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
-#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
+#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
+#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
+#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
+#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
 msgid "Missing pool name"
 msgstr ""
 
@@ -4156,15 +4170,15 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
+#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1411
+#: lxc/storage_volume.go:1413
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:820
+#: lxc/file.go:842
 msgid "Missing target directory"
 msgstr ""
 
@@ -4197,16 +4211,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
-#: lxc/storage_volume.go:975
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
+#: lxc/storage_volume.go:977
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:507
+#: lxc/file.go:520
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1207 lxc/file.go:1208
+#: lxc/file.go:1227 lxc/file.go:1228
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4235,7 +4249,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4243,16 +4257,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1869
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1059 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4274,7 +4288,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
 msgid "NAME"
 msgstr ""
 
@@ -4326,8 +4340,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
-#: lxc/storage_volume.go:1573
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Name"
 msgstr ""
 
@@ -4335,7 +4349,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4390,12 +4404,12 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:386
+#: lxc/network_forward.go:394
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:857
+#: lxc/network_forward.go:865
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -4479,7 +4493,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
+#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4487,7 +4501,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1070 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4499,11 +4513,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4517,7 +4531,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2035
+#: lxc/storage_volume.go:2037
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4525,16 +4539,21 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
-#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
-msgid "Only \"custom\" volumes can be attached to instances"
+#: lxc/storage_volume.go:216
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2701
+#: lxc/storage_volume.go:348
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:2703
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2500
+#: lxc/storage_volume.go:2502
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4546,7 +4565,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1431
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4559,7 +4578,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1577
+#: lxc/info.go:705 lxc/storage_volume.go:1579
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4589,7 +4608,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1767
+#: lxc/storage_volume.go:1769
 msgid "POOL"
 msgstr ""
 
@@ -4606,7 +4625,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167
-#: lxc/storage_volume.go:1773 lxc/warning.go:213
+#: lxc/storage_volume.go:1775 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4630,7 +4649,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:367
+#: lxc/main.go:376
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4668,7 +4687,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1332
+#: lxc/file.go:1356
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4676,12 +4695,12 @@ msgstr ""
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
-#: lxc/network_acl.go:699 lxc/network_forward.go:768
+#: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
-#: lxc/storage_volume.go:1200
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
+#: lxc/storage_volume.go:1202
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4794,11 +4813,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1649
+#: lxc/image.go:1650
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4812,7 +4831,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1238
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4828,7 +4847,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4849,7 +4868,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1017
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4858,7 +4877,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2094
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4871,7 +4890,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2370
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4902,20 +4921,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:455 lxc/file.go:456
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:638 lxc/file.go:989
+#: lxc/file.go:651 lxc/file.go:1009
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:688 lxc/file.go:689
+#: lxc/file.go:701 lxc/file.go:702
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:923 lxc/file.go:1089
+#: lxc/file.go:943 lxc/file.go:1109
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4924,7 +4943,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4953,15 +4972,15 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:463 lxc/file.go:695
+#: lxc/file.go:475 lxc/file.go:708
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1444 lxc/image.go:1445
+#: lxc/image.go:1445 lxc/image.go:1446
 msgid "Refresh images"
 msgstr ""
 
@@ -4970,7 +4989,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1481
+#: lxc/image.go:1482
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5047,7 +5066,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:971 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -5083,7 +5102,7 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:969 lxc/network_forward.go:970
+#: lxc/network_forward.go:981 lxc/network_forward.go:982
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -5119,8 +5138,8 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
-#: lxc/image_alias.go:255
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:287
+#: lxc/image_alias.go:288
 msgid "Rename aliases"
 msgstr ""
 
@@ -5156,15 +5175,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1962
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
+#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5216,7 +5235,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5233,7 +5252,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:361
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5282,12 +5301,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1460
+#: lxc/file.go:1484
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1461
+#: lxc/file.go:1485
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5363,7 +5382,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1217
+#: lxc/file.go:1237
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5389,7 +5408,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1665 lxc/image.go:1666
+#: lxc/image.go:1666 lxc/image.go:1667
 msgid "Set image properties"
 msgstr ""
 
@@ -5432,11 +5451,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:488
+#: lxc/network_forward.go:496
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:489
+#: lxc/network_forward.go:497
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5540,11 +5559,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2088
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2089
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5561,7 +5580,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:698
+#: lxc/file.go:711
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5569,7 +5588,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:699
+#: lxc/file.go:712
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5577,7 +5596,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:710
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5589,7 +5608,7 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:504
 msgid "Set the key as a network forward property"
 msgstr ""
 
@@ -5629,7 +5648,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2105
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5637,7 +5656,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1215
+#: lxc/file.go:1235
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5694,7 +5713,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1535 lxc/image.go:1536
+#: lxc/image.go:1536 lxc/image.go:1537
 msgid "Show image properties"
 msgstr ""
 
@@ -5714,7 +5733,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:271 lxc/main.go:272
+#: lxc/main.go:280 lxc/main.go:281
 msgid "Show less common commands"
 msgstr ""
 
@@ -5778,11 +5797,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5850,15 +5869,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2190
+#: lxc/storage_volume.go:2192
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1502
+#: lxc/info.go:619 lxc/storage_volume.go:1504
 msgid "Snapshots:"
 msgstr ""
 
@@ -5963,21 +5982,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:703
+#: lxc/storage_volume.go:707
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:791
+#: lxc/storage_volume.go:795
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:516
+#: lxc/storage_volume.go:520
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:524
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -6039,21 +6058,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1747 lxc/warning.go:216
+#: lxc/storage_volume.go:1749 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1262
+#: lxc/file.go:1286
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1256
+#: lxc/file.go:1280
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6063,15 +6082,15 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:181
+#: lxc/move.go:186
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:219 lxc/move.go:240
+#: lxc/move.go:224 lxc/move.go:245
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:193
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -6079,15 +6098,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:185
+#: lxc/move.go:190
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:189
+#: lxc/move.go:194
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:210
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -6109,7 +6128,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:439
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6162,7 +6181,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:462
+#: lxc/network_forward.go:470
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6202,12 +6221,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1340
+#: lxc/storage_volume.go:1342
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1317
+#: lxc/storage_volume.go:1319
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6222,12 +6241,12 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:309
+#: lxc/move.go:314
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
-#: lxc/storage_volume.go:989
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
+#: lxc/storage_volume.go:991
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6255,7 +6274,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:298
+#: lxc/main.go:307
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6279,11 +6298,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:437
+#: lxc/init.go:441
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:440
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6291,7 +6310,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:412
+#: lxc/main.go:421
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6302,7 +6321,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1489
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6317,7 +6336,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1864
+#: lxc/storage_volume.go:1866
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6325,7 +6344,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6342,7 +6361,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:327
+#: lxc/copy.go:382 lxc/move.go:332
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6384,7 +6403,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1472
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6406,13 +6425,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1752
+#: lxc/project.go:995 lxc/storage_volume.go:1754
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1751
+#: lxc/storage.go:724 lxc/storage_volume.go:1753
 msgid "USED BY"
 msgstr ""
 
@@ -6425,7 +6444,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:411
+#: lxc/file.go:423
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6439,12 +6458,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1483
+#: lxc/file.go:1507
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1791
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6455,7 +6474,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1029
+#: lxc/file.go:1049
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6486,7 +6505,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1728 lxc/image.go:1729
+#: lxc/image.go:1729 lxc/image.go:1730
 msgid "Unset image properties"
 msgstr ""
 
@@ -6502,11 +6521,11 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:598
+#: lxc/network_forward.go:606
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:599
+#: lxc/network_forward.go:607
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -6550,7 +6569,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6562,7 +6581,7 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:602
+#: lxc/network_forward.go:610
 msgid "Unset the key as a network forward property"
 msgstr ""
 
@@ -6602,7 +6621,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2381
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6610,7 +6629,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:248
+#: lxc/storage_volume.go:250
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6646,12 +6665,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1485
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2652
+#: lxc/export.go:42 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6718,7 +6737,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1576
+#: lxc/storage_volume.go:1578
 msgid "Volume Only"
 msgstr ""
 
@@ -6769,7 +6788,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:293 lxc/move.go:369
+#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6777,12 +6796,12 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:909
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:912
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:282
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:284
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
@@ -6814,7 +6833,7 @@ msgstr ""
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:174
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
@@ -6867,7 +6886,7 @@ msgstr ""
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: lxc/image_alias.go:104
+#: lxc/image_alias.go:121
 msgid "[<remote>:]<alias>"
 msgstr ""
 
@@ -6875,7 +6894,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/image_alias.go:252
+#: lxc/image_alias.go:285
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
@@ -6929,15 +6948,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1600 lxc/image.go:1727
+#: lxc/image.go:1601 lxc/image.go:1728
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1664
+#: lxc/image.go:1665
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6957,7 +6976,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1443
+#: lxc/image.go:334 lxc/image.go:1444
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7028,7 +7047,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:376
+#: lxc/file.go:380
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -7040,12 +7059,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:454
+#: lxc/file.go:466
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1226
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7113,8 +7132,8 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:644
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:179
+#: lxc/network_forward.go:177 lxc/network_forward.go:652
+#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
 #: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
@@ -7129,12 +7148,12 @@ msgid ""
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:402 lxc/network_forward.go:597
+#: lxc/network_forward.go:410 lxc/network_forward.go:605
 #: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
@@ -7144,13 +7163,13 @@ msgid ""
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:887
+#: lxc/network_forward.go:895
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:968 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -7205,7 +7224,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2811
+#: lxc/storage_volume.go:2813
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7240,65 +7259,65 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1958
+#: lxc/storage_volume.go:1960
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:806
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:167
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
-msgstr ""
-
-#: lxc/storage_volume.go:2562
+#: lxc/storage_volume.go:2564
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2645
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2428
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:610
+#: lxc/storage_volume.go:614
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:718
+#: lxc/storage_volume.go:722
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2364
+#: lxc/storage_volume.go:810
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
+msgstr ""
+
+#: lxc/storage_volume.go:167
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
+msgstr ""
+
+#: lxc/storage_volume.go:2366
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2087
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2245
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1234
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1858
+#: lxc/storage_volume.go:1860
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7404,7 +7423,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1603
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7566,20 +7585,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1230
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:470
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:691
+#: lxc/file.go:704
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7880,7 +7899,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:618
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7888,13 +7907,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2817
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2432
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7928,16 +7947,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1396
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1331
+#: lxc/file.go:1355
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1284
+#: lxc/file.go:1308
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-07 15:11-0700\n"
+"POT-Creation-Date: 2025-01-10 14:44-0600\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1041
+#: lxc/storage_volume.go:1043
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:667
+#: lxc/network_forward.go:675
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,12 +430,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1157
+#: lxc/file.go:1177
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1047
+#: lxc/file.go:1067
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -471,7 +471,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:65
+#: lxc/init.go:146 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:687
+#: lxc/file.go:700
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -541,7 +541,7 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
@@ -672,7 +672,7 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:888 lxc/network_forward.go:889
+#: lxc/network_forward.go:896 lxc/network_forward.go:897
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -722,7 +722,7 @@ msgstr ""
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
+#: lxc/image_alias.go:101 lxc/image_alias.go:156 lxc/image_alias.go:320
 msgid "Alias name missing"
 msgstr ""
 
@@ -735,7 +735,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1607
+#: lxc/storage_volume.go:1609
 msgid "All projects"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -790,12 +790,26 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168 lxc/storage_volume.go:169
+#: lxc/storage_volume.go:168
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:169
+msgid ""
+"Attach new storage volumes to instances\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
+msgstr ""
+
+#: lxc/storage_volume.go:285
 msgid "Attach new storage volumes to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:286
+msgid ""
+"Attach new storage volumes to profiles\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
 #: lxc/console.go:39
@@ -846,16 +860,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2719
+#: lxc/storage_volume.go:2721
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2796
+#: lxc/export.go:192 lxc/storage_volume.go:2798
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1538
+#: lxc/info.go:666 lxc/storage_volume.go:1540
 msgid "Backups:"
 msgstr ""
 
@@ -864,19 +878,19 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
+#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:326
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -919,7 +933,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1752
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -971,7 +985,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -979,7 +993,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:562
+#: lxc/file.go:575
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1004,11 +1018,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:768
+#: lxc/file.go:790
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1021,12 +1035,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:493
+#: lxc/storage_volume.go:497
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:447
+#: lxc/storage_volume.go:451
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1132,9 +1146,9 @@ msgstr ""
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:497 lxc/network_forward.go:649
-#: lxc/network_forward.go:803 lxc/network_forward.go:892
-#: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
+#: lxc/network_forward.go:505 lxc/network_forward.go:657
+#: lxc/network_forward.go:811 lxc/network_forward.go:900
+#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
 #: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
 #: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
@@ -1146,14 +1160,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
-#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
-#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
-#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
+#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
 msgid "Cluster member name"
 msgstr ""
 
@@ -1169,7 +1183,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1608
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1209,21 +1223,21 @@ msgstr ""
 #: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
-#: lxc/network_acl.go:698 lxc/network_forward.go:767
+#: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
-#: lxc/storage_volume.go:1199
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
+#: lxc/storage_volume.go:1201
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:620
+#: lxc/storage_volume.go:624
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1478
+#: lxc/storage_volume.go:1480
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1285,7 +1299,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1293,12 +1307,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1311,7 +1325,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1406,7 +1420,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:462 lxc/file.go:696
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1446,7 +1460,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1498,12 +1512,12 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:182
+#: lxc/init.go:186
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1513,7 +1527,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 msgid "Creating the instance"
 msgstr ""
 
@@ -1527,13 +1541,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1749
+#: lxc/storage_volume.go:1751
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1553,7 +1567,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2653
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1585,7 +1599,7 @@ msgstr ""
 msgid "Delete identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:106 lxc/image_alias.go:107
+#: lxc/image_alias.go:123 lxc/image_alias.go:124
 msgid "Delete image aliases"
 msgstr ""
 
@@ -1609,7 +1623,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:799 lxc/network_forward.go:800
+#: lxc/network_forward.go:807 lxc/network_forward.go:808
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1649,7 +1663,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
+#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1691,13 +1705,13 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
-#: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
-#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
+#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
+#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
+#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
@@ -1711,10 +1725,10 @@ msgstr ""
 #: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:404 lxc/network_forward.go:489
-#: lxc/network_forward.go:599 lxc/network_forward.go:646
-#: lxc/network_forward.go:800 lxc/network_forward.go:874
-#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_forward.go:412 lxc/network_forward.go:497
+#: lxc/network_forward.go:607 lxc/network_forward.go:654
+#: lxc/network_forward.go:808 lxc/network_forward.go:882
+#: lxc/network_forward.go:897 lxc/network_forward.go:982
 #: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
 #: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
 #: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
@@ -1754,27 +1768,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
-#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
-#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
-#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
-#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
-#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
-#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
-#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1465
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1786,11 +1800,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
+#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1840,7 +1854,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:403
+#: lxc/init.go:407
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1852,7 +1866,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1216
+#: lxc/file.go:1236
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1948,7 +1962,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:377 lxc/file.go:378
+#: lxc/file.go:381 lxc/file.go:382
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1988,7 +2002,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:653 lxc/network_forward.go:654
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -2028,7 +2042,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2036,7 +2050,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1785
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2090,11 +2104,11 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
-#: lxc/network_acl.go:524 lxc/network_forward.go:572
+#: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
+#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2105,11 +2119,11 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
-#: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
+#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
-#: lxc/storage_volume.go:2210
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
+#: lxc/storage_volume.go:2212
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2151,8 +2165,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
+#: lxc/storage_volume.go:1577
 msgid "Expires at"
 msgstr ""
 
@@ -2176,7 +2190,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2188,11 +2202,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2650
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2779
+#: lxc/export.go:152 lxc/storage_volume.go:2781
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2211,7 +2225,7 @@ msgid "FILENAME"
 msgstr ""
 
 #: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
-#: lxc/image_alias.go:235
+#: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2219,12 +2233,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1467
+#: lxc/file.go:1491
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1490
+#: lxc/file.go:1514
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2239,12 +2253,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1517
+#: lxc/file.go:1541
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1326
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2274,7 +2288,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1423
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2289,7 +2303,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1428
+#: lxc/file.go:1452
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2299,12 +2313,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1352
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1455
+#: lxc/file.go:1479
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2318,7 +2332,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:304 lxc/move.go:380
+#: lxc/move.go:309 lxc/move.go:385
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2343,7 +2357,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1440
+#: lxc/file.go:1464
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2358,7 +2372,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1042
+#: lxc/file.go:1062
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2445,14 +2459,14 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1625 lxc/warning.go:94
+#: lxc/storage_volume.go:1627 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2520,7 +2534,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1602
+#: lxc/image.go:1602 lxc/image.go:1603
 msgid "Get image properties"
 msgstr ""
 
@@ -2536,7 +2550,7 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:414
 msgid "Get the key as a network forward property"
 msgstr ""
 
@@ -2576,7 +2590,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1249
+#: lxc/storage_volume.go:1251
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2604,7 +2618,7 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:403 lxc/network_forward.go:404
+#: lxc/network_forward.go:411 lxc/network_forward.go:412
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
@@ -2640,11 +2654,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:476
+#: lxc/storage_volume.go:480
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2684,22 +2698,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1540
+#: lxc/file.go:1564
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1529
+#: lxc/file.go:1553
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1376
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1362
+#: lxc/file.go:1386
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2772,11 +2786,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:415
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2786,7 +2800,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2437
+#: lxc/storage_volume.go:2439
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2798,7 +2812,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1517
+#: lxc/image.go:1518
 msgid "Image already up to date."
 msgstr ""
 
@@ -2814,11 +2828,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1472
+#: lxc/image.go:364 lxc/image.go:1473
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1698
+#: lxc/image.go:444 lxc/image.go:1699
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2828,7 +2842,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1515
+#: lxc/image.go:1516
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2836,7 +2850,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2815
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2844,7 +2858,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2814
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2866,11 +2880,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2822
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2894
+#: lxc/storage_volume.go:2896
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2896,11 +2910,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1378
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1531
+#: lxc/file.go:1555
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2909,7 +2923,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:414
+#: lxc/init.go:418
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2918,7 +2932,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1298
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2970,7 +2984,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1293
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2996,23 +3010,23 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2023
+#: lxc/move.go:153 lxc/storage_volume.go:2025
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:144
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2019
+#: lxc/storage_volume.go:2021
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:509
+#: lxc/main.go:518
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:353
+#: lxc/file.go:357
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3022,18 +3036,18 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
-#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
+#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:535
+#: lxc/file.go:548
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:717
+#: lxc/file.go:185 lxc/file.go:739
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3070,7 +3084,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3101,12 +3115,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:176
+#: lxc/init.go:180
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:174
+#: lxc/init.go:178
 msgid "Launching the instance"
 msgstr ""
 
@@ -3204,11 +3218,11 @@ msgstr ""
 msgid "List identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:151
+#: lxc/image_alias.go:176
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:177
 msgid ""
 "List image aliases\n"
 "\n"
@@ -3375,11 +3389,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1605
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1610
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3438,7 +3452,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1481
+#: lxc/info.go:489 lxc/storage_volume.go:1483
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3624,7 +3638,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:873 lxc/network_forward.go:874
+#: lxc/network_forward.go:881 lxc/network_forward.go:882
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -3770,12 +3784,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:322 lxc/move.go:435
+#: lxc/move.go:327 lxc/move.go:440
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:347 lxc/move.go:440
+#: lxc/move.go:352 lxc/move.go:445
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3840,10 +3854,10 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:449
-#: lxc/network_forward.go:534 lxc/network_forward.go:709
-#: lxc/network_forward.go:840 lxc/network_forward.go:933
-#: lxc/network_forward.go:1015 lxc/network_load_balancer.go:221
+#: lxc/network_forward.go:219 lxc/network_forward.go:457
+#: lxc/network_forward.go:542 lxc/network_forward.go:717
+#: lxc/network_forward.go:848 lxc/network_forward.go:945
+#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
 #: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
 #: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
 #: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
@@ -3868,10 +3882,10 @@ msgstr ""
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
 #: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
 #: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:284 lxc/network_forward.go:445
-#: lxc/network_forward.go:530 lxc/network_forward.go:705
-#: lxc/network_forward.go:836 lxc/network_forward.go:929
-#: lxc/network_forward.go:1011 lxc/network_load_balancer.go:131
+#: lxc/network_forward.go:292 lxc/network_forward.go:453
+#: lxc/network_forward.go:538 lxc/network_forward.go:713
+#: lxc/network_forward.go:844 lxc/network_forward.go:941
+#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
 #: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
 #: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
 #: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
@@ -3907,13 +3921,13 @@ msgstr ""
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
-#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
-#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
-#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
+#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
+#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
+#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
+#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
 msgid "Missing pool name"
 msgstr ""
 
@@ -3932,15 +3946,15 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
+#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1411
+#: lxc/storage_volume.go:1413
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:820
+#: lxc/file.go:842
 msgid "Missing target directory"
 msgstr ""
 
@@ -3973,16 +3987,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
-#: lxc/storage_volume.go:975
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
+#: lxc/storage_volume.go:977
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:507
+#: lxc/file.go:520
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1207 lxc/file.go:1208
+#: lxc/file.go:1227 lxc/file.go:1228
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4011,7 +4025,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4019,16 +4033,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1869
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1059 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4050,7 +4064,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
 msgid "NAME"
 msgstr ""
 
@@ -4102,8 +4116,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
-#: lxc/storage_volume.go:1573
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Name"
 msgstr ""
 
@@ -4111,7 +4125,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4166,12 +4180,12 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:386
+#: lxc/network_forward.go:394
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:857
+#: lxc/network_forward.go:865
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -4255,7 +4269,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
+#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4263,7 +4277,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1070 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4275,11 +4289,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4293,7 +4307,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2035
+#: lxc/storage_volume.go:2037
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4301,16 +4315,21 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
-#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
-msgid "Only \"custom\" volumes can be attached to instances"
+#: lxc/storage_volume.go:216
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2701
+#: lxc/storage_volume.go:348
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:2703
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2500
+#: lxc/storage_volume.go:2502
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4322,7 +4341,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1431
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4335,7 +4354,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1577
+#: lxc/info.go:705 lxc/storage_volume.go:1579
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4365,7 +4384,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1767
+#: lxc/storage_volume.go:1769
 msgid "POOL"
 msgstr ""
 
@@ -4382,7 +4401,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167
-#: lxc/storage_volume.go:1773 lxc/warning.go:213
+#: lxc/storage_volume.go:1775 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4406,7 +4425,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:367
+#: lxc/main.go:376
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4444,7 +4463,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1332
+#: lxc/file.go:1356
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4452,12 +4471,12 @@ msgstr ""
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
-#: lxc/network_acl.go:699 lxc/network_forward.go:768
+#: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
-#: lxc/storage_volume.go:1200
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
+#: lxc/storage_volume.go:1202
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4570,11 +4589,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1649
+#: lxc/image.go:1650
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4588,7 +4607,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1238
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4604,7 +4623,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4625,7 +4644,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1017
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4634,7 +4653,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2094
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4647,7 +4666,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2370
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4678,20 +4697,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:455 lxc/file.go:456
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:638 lxc/file.go:989
+#: lxc/file.go:651 lxc/file.go:1009
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:688 lxc/file.go:689
+#: lxc/file.go:701 lxc/file.go:702
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:923 lxc/file.go:1089
+#: lxc/file.go:943 lxc/file.go:1109
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4700,7 +4719,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4729,15 +4748,15 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:463 lxc/file.go:695
+#: lxc/file.go:475 lxc/file.go:708
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1444 lxc/image.go:1445
+#: lxc/image.go:1445 lxc/image.go:1446
 msgid "Refresh images"
 msgstr ""
 
@@ -4746,7 +4765,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1481
+#: lxc/image.go:1482
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4823,7 +4842,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:971 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4859,7 +4878,7 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:969 lxc/network_forward.go:970
+#: lxc/network_forward.go:981 lxc/network_forward.go:982
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -4895,8 +4914,8 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
-#: lxc/image_alias.go:255
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:287
+#: lxc/image_alias.go:288
 msgid "Rename aliases"
 msgstr ""
 
@@ -4932,15 +4951,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1962
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
+#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4992,7 +5011,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5009,7 +5028,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:361
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5058,12 +5077,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1460
+#: lxc/file.go:1484
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1461
+#: lxc/file.go:1485
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5139,7 +5158,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1217
+#: lxc/file.go:1237
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5165,7 +5184,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1665 lxc/image.go:1666
+#: lxc/image.go:1666 lxc/image.go:1667
 msgid "Set image properties"
 msgstr ""
 
@@ -5208,11 +5227,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:488
+#: lxc/network_forward.go:496
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:489
+#: lxc/network_forward.go:497
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5316,11 +5335,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2088
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2089
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5337,7 +5356,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:698
+#: lxc/file.go:711
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5345,7 +5364,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:699
+#: lxc/file.go:712
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5353,7 +5372,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:710
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5365,7 +5384,7 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:504
 msgid "Set the key as a network forward property"
 msgstr ""
 
@@ -5405,7 +5424,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2105
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5413,7 +5432,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1215
+#: lxc/file.go:1235
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5470,7 +5489,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1535 lxc/image.go:1536
+#: lxc/image.go:1536 lxc/image.go:1537
 msgid "Show image properties"
 msgstr ""
 
@@ -5490,7 +5509,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:271 lxc/main.go:272
+#: lxc/main.go:280 lxc/main.go:281
 msgid "Show less common commands"
 msgstr ""
 
@@ -5554,11 +5573,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5626,15 +5645,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2190
+#: lxc/storage_volume.go:2192
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1502
+#: lxc/info.go:619 lxc/storage_volume.go:1504
 msgid "Snapshots:"
 msgstr ""
 
@@ -5739,21 +5758,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:703
+#: lxc/storage_volume.go:707
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:791
+#: lxc/storage_volume.go:795
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:516
+#: lxc/storage_volume.go:520
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:524
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5815,21 +5834,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1747 lxc/warning.go:216
+#: lxc/storage_volume.go:1749 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1262
+#: lxc/file.go:1286
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1256
+#: lxc/file.go:1280
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5839,15 +5858,15 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:181
+#: lxc/move.go:186
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:219 lxc/move.go:240
+#: lxc/move.go:224 lxc/move.go:245
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:193
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5855,15 +5874,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:185
+#: lxc/move.go:190
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:189
+#: lxc/move.go:194
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:210
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5885,7 +5904,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:439
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5938,7 +5957,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:462
+#: lxc/network_forward.go:470
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -5978,12 +5997,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1340
+#: lxc/storage_volume.go:1342
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1317
+#: lxc/storage_volume.go:1319
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -5998,12 +6017,12 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:309
+#: lxc/move.go:314
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
-#: lxc/storage_volume.go:989
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
+#: lxc/storage_volume.go:991
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6031,7 +6050,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:298
+#: lxc/main.go:307
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6055,11 +6074,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:437
+#: lxc/init.go:441
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:440
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6067,7 +6086,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:412
+#: lxc/main.go:421
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6078,7 +6097,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1489
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6093,7 +6112,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1864
+#: lxc/storage_volume.go:1866
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6101,7 +6120,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6118,7 +6137,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:327
+#: lxc/copy.go:382 lxc/move.go:332
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6160,7 +6179,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1472
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6182,13 +6201,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1752
+#: lxc/project.go:995 lxc/storage_volume.go:1754
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1751
+#: lxc/storage.go:724 lxc/storage_volume.go:1753
 msgid "USED BY"
 msgstr ""
 
@@ -6201,7 +6220,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:411
+#: lxc/file.go:423
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6215,12 +6234,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1483
+#: lxc/file.go:1507
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1791
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6231,7 +6250,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1029
+#: lxc/file.go:1049
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6262,7 +6281,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1728 lxc/image.go:1729
+#: lxc/image.go:1729 lxc/image.go:1730
 msgid "Unset image properties"
 msgstr ""
 
@@ -6278,11 +6297,11 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:598
+#: lxc/network_forward.go:606
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:599
+#: lxc/network_forward.go:607
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -6326,7 +6345,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6338,7 +6357,7 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:602
+#: lxc/network_forward.go:610
 msgid "Unset the key as a network forward property"
 msgstr ""
 
@@ -6378,7 +6397,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2381
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6386,7 +6405,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:248
+#: lxc/storage_volume.go:250
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6422,12 +6441,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1485
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2652
+#: lxc/export.go:42 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6494,7 +6513,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1576
+#: lxc/storage_volume.go:1578
 msgid "Volume Only"
 msgstr ""
 
@@ -6545,7 +6564,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:293 lxc/move.go:369
+#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6553,12 +6572,12 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:909
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:912
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:282
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:284
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
@@ -6590,7 +6609,7 @@ msgstr ""
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:174
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
@@ -6643,7 +6662,7 @@ msgstr ""
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: lxc/image_alias.go:104
+#: lxc/image_alias.go:121
 msgid "[<remote>:]<alias>"
 msgstr ""
 
@@ -6651,7 +6670,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/image_alias.go:252
+#: lxc/image_alias.go:285
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
@@ -6705,15 +6724,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1600 lxc/image.go:1727
+#: lxc/image.go:1601 lxc/image.go:1728
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1664
+#: lxc/image.go:1665
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6733,7 +6752,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1443
+#: lxc/image.go:334 lxc/image.go:1444
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6804,7 +6823,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:376
+#: lxc/file.go:380
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -6816,12 +6835,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:454
+#: lxc/file.go:466
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1226
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6889,8 +6908,8 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:644
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:179
+#: lxc/network_forward.go:177 lxc/network_forward.go:652
+#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
 #: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
@@ -6905,12 +6924,12 @@ msgid ""
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:402 lxc/network_forward.go:597
+#: lxc/network_forward.go:410 lxc/network_forward.go:605
 #: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
@@ -6920,13 +6939,13 @@ msgid ""
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:887
+#: lxc/network_forward.go:895
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:968 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -6981,7 +7000,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2811
+#: lxc/storage_volume.go:2813
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7016,65 +7035,65 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1958
+#: lxc/storage_volume.go:1960
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:806
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:167
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
-msgstr ""
-
-#: lxc/storage_volume.go:2562
+#: lxc/storage_volume.go:2564
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2645
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2428
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:610
+#: lxc/storage_volume.go:614
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:718
+#: lxc/storage_volume.go:722
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2364
+#: lxc/storage_volume.go:810
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
+msgstr ""
+
+#: lxc/storage_volume.go:167
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
+msgstr ""
+
+#: lxc/storage_volume.go:2366
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2087
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2245
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1234
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1858
+#: lxc/storage_volume.go:1860
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7180,7 +7199,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1603
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7342,20 +7361,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1230
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:470
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:691
+#: lxc/file.go:704
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7656,7 +7675,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:618
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7664,13 +7683,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2817
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2432
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7704,16 +7723,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1396
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1331
+#: lxc/file.go:1355
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1284
+#: lxc/file.go:1308
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-07 15:11-0700\n"
+"POT-Creation-Date: 2025-01-10 14:44-0600\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -72,7 +72,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/storage_volume.go:1041
+#: lxc/storage_volume.go:1043
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -386,7 +386,7 @@ msgstr ""
 "###\n"
 "### Nazwa jest widoczna, ale nie może zostać zmieniona"
 
-#: lxc/network_forward.go:667
+#: lxc/network_forward.go:675
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -692,12 +692,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1157
+#: lxc/file.go:1177
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1047
+#: lxc/file.go:1067
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -733,7 +733,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:65
+#: lxc/init.go:146 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -786,7 +786,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:687
+#: lxc/file.go:700
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -803,7 +803,7 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
@@ -934,7 +934,7 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:888 lxc/network_forward.go:889
+#: lxc/network_forward.go:896 lxc/network_forward.go:897
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -984,7 +984,7 @@ msgstr ""
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
+#: lxc/image_alias.go:101 lxc/image_alias.go:156 lxc/image_alias.go:320
 msgid "Alias name missing"
 msgstr ""
 
@@ -997,7 +997,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1607
+#: lxc/storage_volume.go:1609
 msgid "All projects"
 msgstr ""
 
@@ -1028,7 +1028,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1052,12 +1052,26 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168 lxc/storage_volume.go:169
+#: lxc/storage_volume.go:168
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:169
+msgid ""
+"Attach new storage volumes to instances\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
+msgstr ""
+
+#: lxc/storage_volume.go:285
 msgid "Attach new storage volumes to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:286
+msgid ""
+"Attach new storage volumes to profiles\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
 #: lxc/console.go:39
@@ -1108,16 +1122,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2719
+#: lxc/storage_volume.go:2721
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2796
+#: lxc/export.go:192 lxc/storage_volume.go:2798
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1538
+#: lxc/info.go:666 lxc/storage_volume.go:1540
 msgid "Backups:"
 msgstr ""
 
@@ -1126,19 +1140,19 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
+#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:326
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1181,7 +1195,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1752
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1233,7 +1247,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1241,7 +1255,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:562
+#: lxc/file.go:575
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1266,11 +1280,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:768
+#: lxc/file.go:790
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1283,12 +1297,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:493
+#: lxc/storage_volume.go:497
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:447
+#: lxc/storage_volume.go:451
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1394,9 +1408,9 @@ msgstr ""
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:497 lxc/network_forward.go:649
-#: lxc/network_forward.go:803 lxc/network_forward.go:892
-#: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
+#: lxc/network_forward.go:505 lxc/network_forward.go:657
+#: lxc/network_forward.go:811 lxc/network_forward.go:900
+#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
 #: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
 #: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
@@ -1408,14 +1422,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
-#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
-#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
-#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
+#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
 msgid "Cluster member name"
 msgstr ""
 
@@ -1431,7 +1445,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1608
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1471,21 +1485,21 @@ msgstr ""
 #: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
-#: lxc/network_acl.go:698 lxc/network_forward.go:767
+#: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
-#: lxc/storage_volume.go:1199
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
+#: lxc/storage_volume.go:1201
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:620
+#: lxc/storage_volume.go:624
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1478
+#: lxc/storage_volume.go:1480
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1547,7 +1561,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1555,12 +1569,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1573,7 +1587,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1668,7 +1682,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:462 lxc/file.go:696
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1708,7 +1722,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1760,12 +1774,12 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:182
+#: lxc/init.go:186
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1775,7 +1789,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 msgid "Creating the instance"
 msgstr ""
 
@@ -1789,13 +1803,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1749
+#: lxc/storage_volume.go:1751
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1815,7 +1829,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2653
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1847,7 +1861,7 @@ msgstr ""
 msgid "Delete identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:106 lxc/image_alias.go:107
+#: lxc/image_alias.go:123 lxc/image_alias.go:124
 msgid "Delete image aliases"
 msgstr ""
 
@@ -1871,7 +1885,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:799 lxc/network_forward.go:800
+#: lxc/network_forward.go:807 lxc/network_forward.go:808
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1911,7 +1925,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
+#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1953,13 +1967,13 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
-#: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
-#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
+#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
+#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
+#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
@@ -1973,10 +1987,10 @@ msgstr ""
 #: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:404 lxc/network_forward.go:489
-#: lxc/network_forward.go:599 lxc/network_forward.go:646
-#: lxc/network_forward.go:800 lxc/network_forward.go:874
-#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_forward.go:412 lxc/network_forward.go:497
+#: lxc/network_forward.go:607 lxc/network_forward.go:654
+#: lxc/network_forward.go:808 lxc/network_forward.go:882
+#: lxc/network_forward.go:897 lxc/network_forward.go:982
 #: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
 #: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
 #: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
@@ -2016,27 +2030,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
-#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
-#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
-#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
-#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
-#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
-#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
-#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1465
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -2048,11 +2062,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
+#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2102,7 +2116,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:403
+#: lxc/init.go:407
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2114,7 +2128,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1216
+#: lxc/file.go:1236
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2210,7 +2224,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:377 lxc/file.go:378
+#: lxc/file.go:381 lxc/file.go:382
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2250,7 +2264,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:653 lxc/network_forward.go:654
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -2290,7 +2304,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2298,7 +2312,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1785
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2352,11 +2366,11 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
-#: lxc/network_acl.go:524 lxc/network_forward.go:572
+#: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
+#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2367,11 +2381,11 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
-#: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
+#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
-#: lxc/storage_volume.go:2210
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
+#: lxc/storage_volume.go:2212
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2413,8 +2427,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
+#: lxc/storage_volume.go:1577
 msgid "Expires at"
 msgstr ""
 
@@ -2438,7 +2452,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2450,11 +2464,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2650
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2779
+#: lxc/export.go:152 lxc/storage_volume.go:2781
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2473,7 +2487,7 @@ msgid "FILENAME"
 msgstr ""
 
 #: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
-#: lxc/image_alias.go:235
+#: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2481,12 +2495,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1467
+#: lxc/file.go:1491
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1490
+#: lxc/file.go:1514
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2501,12 +2515,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1517
+#: lxc/file.go:1541
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1326
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2536,7 +2550,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1423
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2551,7 +2565,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1428
+#: lxc/file.go:1452
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2561,12 +2575,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1352
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1455
+#: lxc/file.go:1479
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2580,7 +2594,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:304 lxc/move.go:380
+#: lxc/move.go:309 lxc/move.go:385
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2605,7 +2619,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1440
+#: lxc/file.go:1464
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2620,7 +2634,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1042
+#: lxc/file.go:1062
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2707,14 +2721,14 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1625 lxc/warning.go:94
+#: lxc/storage_volume.go:1627 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2782,7 +2796,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1602
+#: lxc/image.go:1602 lxc/image.go:1603
 msgid "Get image properties"
 msgstr ""
 
@@ -2798,7 +2812,7 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:414
 msgid "Get the key as a network forward property"
 msgstr ""
 
@@ -2838,7 +2852,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1249
+#: lxc/storage_volume.go:1251
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2866,7 +2880,7 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:403 lxc/network_forward.go:404
+#: lxc/network_forward.go:411 lxc/network_forward.go:412
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
@@ -2902,11 +2916,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:476
+#: lxc/storage_volume.go:480
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2946,22 +2960,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1540
+#: lxc/file.go:1564
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1529
+#: lxc/file.go:1553
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1376
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1362
+#: lxc/file.go:1386
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -3034,11 +3048,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:415
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3048,7 +3062,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2437
+#: lxc/storage_volume.go:2439
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3060,7 +3074,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1517
+#: lxc/image.go:1518
 msgid "Image already up to date."
 msgstr ""
 
@@ -3076,11 +3090,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1472
+#: lxc/image.go:364 lxc/image.go:1473
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1698
+#: lxc/image.go:444 lxc/image.go:1699
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -3090,7 +3104,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1515
+#: lxc/image.go:1516
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3098,7 +3112,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2815
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3106,7 +3120,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2814
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -3128,11 +3142,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2822
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2894
+#: lxc/storage_volume.go:2896
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3158,11 +3172,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1378
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1531
+#: lxc/file.go:1555
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3171,7 +3185,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:414
+#: lxc/init.go:418
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3180,7 +3194,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1298
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3232,7 +3246,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1293
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3258,23 +3272,23 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2023
+#: lxc/move.go:153 lxc/storage_volume.go:2025
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:144
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2019
+#: lxc/storage_volume.go:2021
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:509
+#: lxc/main.go:518
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:353
+#: lxc/file.go:357
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3284,18 +3298,18 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
-#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
+#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:535
+#: lxc/file.go:548
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:717
+#: lxc/file.go:185 lxc/file.go:739
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3332,7 +3346,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3363,12 +3377,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:176
+#: lxc/init.go:180
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:174
+#: lxc/init.go:178
 msgid "Launching the instance"
 msgstr ""
 
@@ -3466,11 +3480,11 @@ msgstr ""
 msgid "List identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:151
+#: lxc/image_alias.go:176
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:177
 msgid ""
 "List image aliases\n"
 "\n"
@@ -3637,11 +3651,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1605
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1610
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3700,7 +3714,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1481
+#: lxc/info.go:489 lxc/storage_volume.go:1483
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3886,7 +3900,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:873 lxc/network_forward.go:874
+#: lxc/network_forward.go:881 lxc/network_forward.go:882
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -4032,12 +4046,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:322 lxc/move.go:435
+#: lxc/move.go:327 lxc/move.go:440
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:347 lxc/move.go:440
+#: lxc/move.go:352 lxc/move.go:445
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4102,10 +4116,10 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:449
-#: lxc/network_forward.go:534 lxc/network_forward.go:709
-#: lxc/network_forward.go:840 lxc/network_forward.go:933
-#: lxc/network_forward.go:1015 lxc/network_load_balancer.go:221
+#: lxc/network_forward.go:219 lxc/network_forward.go:457
+#: lxc/network_forward.go:542 lxc/network_forward.go:717
+#: lxc/network_forward.go:848 lxc/network_forward.go:945
+#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
 #: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
 #: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
 #: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
@@ -4130,10 +4144,10 @@ msgstr ""
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
 #: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
 #: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:284 lxc/network_forward.go:445
-#: lxc/network_forward.go:530 lxc/network_forward.go:705
-#: lxc/network_forward.go:836 lxc/network_forward.go:929
-#: lxc/network_forward.go:1011 lxc/network_load_balancer.go:131
+#: lxc/network_forward.go:292 lxc/network_forward.go:453
+#: lxc/network_forward.go:538 lxc/network_forward.go:713
+#: lxc/network_forward.go:844 lxc/network_forward.go:941
+#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
 #: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
 #: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
 #: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
@@ -4169,13 +4183,13 @@ msgstr ""
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
-#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
-#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
-#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
+#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
+#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
+#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
+#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
 msgid "Missing pool name"
 msgstr ""
 
@@ -4194,15 +4208,15 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
+#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1411
+#: lxc/storage_volume.go:1413
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:820
+#: lxc/file.go:842
 msgid "Missing target directory"
 msgstr ""
 
@@ -4235,16 +4249,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
-#: lxc/storage_volume.go:975
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
+#: lxc/storage_volume.go:977
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:507
+#: lxc/file.go:520
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1207 lxc/file.go:1208
+#: lxc/file.go:1227 lxc/file.go:1228
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4273,7 +4287,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4281,16 +4295,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1869
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1059 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4312,7 +4326,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
 msgid "NAME"
 msgstr ""
 
@@ -4364,8 +4378,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
-#: lxc/storage_volume.go:1573
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Name"
 msgstr ""
 
@@ -4373,7 +4387,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4428,12 +4442,12 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:386
+#: lxc/network_forward.go:394
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:857
+#: lxc/network_forward.go:865
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -4517,7 +4531,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
+#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4525,7 +4539,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1070 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4537,11 +4551,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4555,7 +4569,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2035
+#: lxc/storage_volume.go:2037
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4563,16 +4577,21 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
-#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
-msgid "Only \"custom\" volumes can be attached to instances"
+#: lxc/storage_volume.go:216
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2701
+#: lxc/storage_volume.go:348
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:2703
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2500
+#: lxc/storage_volume.go:2502
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4584,7 +4603,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1431
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4597,7 +4616,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1577
+#: lxc/info.go:705 lxc/storage_volume.go:1579
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4627,7 +4646,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1767
+#: lxc/storage_volume.go:1769
 msgid "POOL"
 msgstr ""
 
@@ -4644,7 +4663,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167
-#: lxc/storage_volume.go:1773 lxc/warning.go:213
+#: lxc/storage_volume.go:1775 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4668,7 +4687,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:367
+#: lxc/main.go:376
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4706,7 +4725,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1332
+#: lxc/file.go:1356
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4714,12 +4733,12 @@ msgstr ""
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
-#: lxc/network_acl.go:699 lxc/network_forward.go:768
+#: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
-#: lxc/storage_volume.go:1200
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
+#: lxc/storage_volume.go:1202
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4832,11 +4851,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1649
+#: lxc/image.go:1650
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4850,7 +4869,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1238
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4866,7 +4885,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4887,7 +4906,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1017
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4896,7 +4915,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2094
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4909,7 +4928,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2370
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4940,20 +4959,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:455 lxc/file.go:456
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:638 lxc/file.go:989
+#: lxc/file.go:651 lxc/file.go:1009
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:688 lxc/file.go:689
+#: lxc/file.go:701 lxc/file.go:702
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:923 lxc/file.go:1089
+#: lxc/file.go:943 lxc/file.go:1109
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4962,7 +4981,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4991,15 +5010,15 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:463 lxc/file.go:695
+#: lxc/file.go:475 lxc/file.go:708
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1444 lxc/image.go:1445
+#: lxc/image.go:1445 lxc/image.go:1446
 msgid "Refresh images"
 msgstr ""
 
@@ -5008,7 +5027,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1481
+#: lxc/image.go:1482
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5085,7 +5104,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:971 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -5121,7 +5140,7 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:969 lxc/network_forward.go:970
+#: lxc/network_forward.go:981 lxc/network_forward.go:982
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -5157,8 +5176,8 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
-#: lxc/image_alias.go:255
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:287
+#: lxc/image_alias.go:288
 msgid "Rename aliases"
 msgstr ""
 
@@ -5194,15 +5213,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1962
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
+#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5254,7 +5273,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5271,7 +5290,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:361
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5320,12 +5339,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1460
+#: lxc/file.go:1484
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1461
+#: lxc/file.go:1485
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5401,7 +5420,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1217
+#: lxc/file.go:1237
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5427,7 +5446,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1665 lxc/image.go:1666
+#: lxc/image.go:1666 lxc/image.go:1667
 msgid "Set image properties"
 msgstr ""
 
@@ -5470,11 +5489,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:488
+#: lxc/network_forward.go:496
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:489
+#: lxc/network_forward.go:497
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5578,11 +5597,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2088
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2089
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5599,7 +5618,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:698
+#: lxc/file.go:711
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5607,7 +5626,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:699
+#: lxc/file.go:712
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5615,7 +5634,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:710
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5627,7 +5646,7 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:504
 msgid "Set the key as a network forward property"
 msgstr ""
 
@@ -5667,7 +5686,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2105
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5675,7 +5694,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1215
+#: lxc/file.go:1235
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5732,7 +5751,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1535 lxc/image.go:1536
+#: lxc/image.go:1536 lxc/image.go:1537
 msgid "Show image properties"
 msgstr ""
 
@@ -5752,7 +5771,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:271 lxc/main.go:272
+#: lxc/main.go:280 lxc/main.go:281
 msgid "Show less common commands"
 msgstr ""
 
@@ -5816,11 +5835,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5888,15 +5907,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2190
+#: lxc/storage_volume.go:2192
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1502
+#: lxc/info.go:619 lxc/storage_volume.go:1504
 msgid "Snapshots:"
 msgstr ""
 
@@ -6001,21 +6020,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:703
+#: lxc/storage_volume.go:707
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:791
+#: lxc/storage_volume.go:795
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:516
+#: lxc/storage_volume.go:520
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:524
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -6077,21 +6096,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1747 lxc/warning.go:216
+#: lxc/storage_volume.go:1749 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1262
+#: lxc/file.go:1286
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1256
+#: lxc/file.go:1280
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6101,15 +6120,15 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:181
+#: lxc/move.go:186
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:219 lxc/move.go:240
+#: lxc/move.go:224 lxc/move.go:245
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:193
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -6117,15 +6136,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:185
+#: lxc/move.go:190
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:189
+#: lxc/move.go:194
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:210
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -6147,7 +6166,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:439
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6200,7 +6219,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:462
+#: lxc/network_forward.go:470
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6240,12 +6259,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1340
+#: lxc/storage_volume.go:1342
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1317
+#: lxc/storage_volume.go:1319
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6260,12 +6279,12 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:309
+#: lxc/move.go:314
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
-#: lxc/storage_volume.go:989
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
+#: lxc/storage_volume.go:991
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6293,7 +6312,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:298
+#: lxc/main.go:307
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6317,11 +6336,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:437
+#: lxc/init.go:441
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:440
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6329,7 +6348,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:412
+#: lxc/main.go:421
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6340,7 +6359,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1489
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6355,7 +6374,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1864
+#: lxc/storage_volume.go:1866
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6363,7 +6382,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6380,7 +6399,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:327
+#: lxc/copy.go:382 lxc/move.go:332
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6422,7 +6441,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1472
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6444,13 +6463,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1752
+#: lxc/project.go:995 lxc/storage_volume.go:1754
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1751
+#: lxc/storage.go:724 lxc/storage_volume.go:1753
 msgid "USED BY"
 msgstr ""
 
@@ -6463,7 +6482,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:411
+#: lxc/file.go:423
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6477,12 +6496,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1483
+#: lxc/file.go:1507
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1791
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6493,7 +6512,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1029
+#: lxc/file.go:1049
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6524,7 +6543,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1728 lxc/image.go:1729
+#: lxc/image.go:1729 lxc/image.go:1730
 msgid "Unset image properties"
 msgstr ""
 
@@ -6540,11 +6559,11 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:598
+#: lxc/network_forward.go:606
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:599
+#: lxc/network_forward.go:607
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -6588,7 +6607,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6600,7 +6619,7 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:602
+#: lxc/network_forward.go:610
 msgid "Unset the key as a network forward property"
 msgstr ""
 
@@ -6640,7 +6659,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2381
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6648,7 +6667,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:248
+#: lxc/storage_volume.go:250
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6684,12 +6703,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1485
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2652
+#: lxc/export.go:42 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6756,7 +6775,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1576
+#: lxc/storage_volume.go:1578
 msgid "Volume Only"
 msgstr ""
 
@@ -6807,7 +6826,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:293 lxc/move.go:369
+#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6815,12 +6834,12 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:909
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:912
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:282
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:284
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
@@ -6852,7 +6871,7 @@ msgstr ""
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:174
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
@@ -6905,7 +6924,7 @@ msgstr ""
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: lxc/image_alias.go:104
+#: lxc/image_alias.go:121
 msgid "[<remote>:]<alias>"
 msgstr ""
 
@@ -6913,7 +6932,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/image_alias.go:252
+#: lxc/image_alias.go:285
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
@@ -6967,15 +6986,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1600 lxc/image.go:1727
+#: lxc/image.go:1601 lxc/image.go:1728
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1664
+#: lxc/image.go:1665
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6995,7 +7014,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1443
+#: lxc/image.go:334 lxc/image.go:1444
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7066,7 +7085,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:376
+#: lxc/file.go:380
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -7078,12 +7097,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:454
+#: lxc/file.go:466
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1226
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7151,8 +7170,8 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:644
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:179
+#: lxc/network_forward.go:177 lxc/network_forward.go:652
+#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
 #: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
@@ -7167,12 +7186,12 @@ msgid ""
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:402 lxc/network_forward.go:597
+#: lxc/network_forward.go:410 lxc/network_forward.go:605
 #: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
@@ -7182,13 +7201,13 @@ msgid ""
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:887
+#: lxc/network_forward.go:895
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:968 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -7243,7 +7262,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2811
+#: lxc/storage_volume.go:2813
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7278,65 +7297,65 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1958
+#: lxc/storage_volume.go:1960
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:806
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:167
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
-msgstr ""
-
-#: lxc/storage_volume.go:2562
+#: lxc/storage_volume.go:2564
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2645
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2428
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:610
+#: lxc/storage_volume.go:614
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:718
+#: lxc/storage_volume.go:722
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2364
+#: lxc/storage_volume.go:810
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
+msgstr ""
+
+#: lxc/storage_volume.go:167
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
+msgstr ""
+
+#: lxc/storage_volume.go:2366
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2087
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2245
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1234
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1858
+#: lxc/storage_volume.go:1860
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7442,7 +7461,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1603
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7604,20 +7623,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1230
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:470
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:691
+#: lxc/file.go:704
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7918,7 +7937,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:618
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7926,13 +7945,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2817
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2432
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7966,16 +7985,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1396
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1331
+#: lxc/file.go:1355
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1284
+#: lxc/file.go:1308
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-07 15:11-0700\n"
+"POT-Creation-Date: 2025-01-10 14:44-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -46,7 +46,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1041
+#: lxc/storage_volume.go:1043
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -251,7 +251,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:667
+#: lxc/network_forward.go:675
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -427,12 +427,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1157
+#: lxc/file.go:1177
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1047
+#: lxc/file.go:1067
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -468,7 +468,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:65
+#: lxc/init.go:146 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -521,7 +521,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:687
+#: lxc/file.go:700
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -538,7 +538,7 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
@@ -669,7 +669,7 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:888 lxc/network_forward.go:889
+#: lxc/network_forward.go:896 lxc/network_forward.go:897
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -719,7 +719,7 @@ msgstr ""
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
+#: lxc/image_alias.go:101 lxc/image_alias.go:156 lxc/image_alias.go:320
 msgid "Alias name missing"
 msgstr ""
 
@@ -732,7 +732,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1607
+#: lxc/storage_volume.go:1609
 msgid "All projects"
 msgstr ""
 
@@ -763,7 +763,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -787,12 +787,26 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168 lxc/storage_volume.go:169
+#: lxc/storage_volume.go:168
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:169
+msgid ""
+"Attach new storage volumes to instances\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
+msgstr ""
+
+#: lxc/storage_volume.go:285
 msgid "Attach new storage volumes to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:286
+msgid ""
+"Attach new storage volumes to profiles\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
 #: lxc/console.go:39
@@ -843,16 +857,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2719
+#: lxc/storage_volume.go:2721
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2796
+#: lxc/export.go:192 lxc/storage_volume.go:2798
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1538
+#: lxc/info.go:666 lxc/storage_volume.go:1540
 msgid "Backups:"
 msgstr ""
 
@@ -861,19 +875,19 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
+#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:326
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -916,7 +930,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1752
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -968,7 +982,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -976,7 +990,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:562
+#: lxc/file.go:575
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1001,11 +1015,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:768
+#: lxc/file.go:790
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1018,12 +1032,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:493
+#: lxc/storage_volume.go:497
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:447
+#: lxc/storage_volume.go:451
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1129,9 +1143,9 @@ msgstr ""
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:497 lxc/network_forward.go:649
-#: lxc/network_forward.go:803 lxc/network_forward.go:892
-#: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
+#: lxc/network_forward.go:505 lxc/network_forward.go:657
+#: lxc/network_forward.go:811 lxc/network_forward.go:900
+#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
 #: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
 #: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
@@ -1143,14 +1157,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
-#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
-#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
-#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
+#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
 msgid "Cluster member name"
 msgstr ""
 
@@ -1166,7 +1180,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1608
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1206,21 +1220,21 @@ msgstr ""
 #: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
-#: lxc/network_acl.go:698 lxc/network_forward.go:767
+#: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
-#: lxc/storage_volume.go:1199
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
+#: lxc/storage_volume.go:1201
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:620
+#: lxc/storage_volume.go:624
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1478
+#: lxc/storage_volume.go:1480
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1282,7 +1296,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1290,12 +1304,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1308,7 +1322,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1403,7 +1417,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:462 lxc/file.go:696
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1443,7 +1457,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1495,12 +1509,12 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:182
+#: lxc/init.go:186
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1510,7 +1524,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 msgid "Creating the instance"
 msgstr ""
 
@@ -1524,13 +1538,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1749
+#: lxc/storage_volume.go:1751
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1550,7 +1564,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2653
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1582,7 +1596,7 @@ msgstr ""
 msgid "Delete identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:106 lxc/image_alias.go:107
+#: lxc/image_alias.go:123 lxc/image_alias.go:124
 msgid "Delete image aliases"
 msgstr ""
 
@@ -1606,7 +1620,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:799 lxc/network_forward.go:800
+#: lxc/network_forward.go:807 lxc/network_forward.go:808
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1646,7 +1660,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
+#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1688,13 +1702,13 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
-#: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
-#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
+#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
+#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
+#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
@@ -1708,10 +1722,10 @@ msgstr ""
 #: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:404 lxc/network_forward.go:489
-#: lxc/network_forward.go:599 lxc/network_forward.go:646
-#: lxc/network_forward.go:800 lxc/network_forward.go:874
-#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_forward.go:412 lxc/network_forward.go:497
+#: lxc/network_forward.go:607 lxc/network_forward.go:654
+#: lxc/network_forward.go:808 lxc/network_forward.go:882
+#: lxc/network_forward.go:897 lxc/network_forward.go:982
 #: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
 #: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
 #: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
@@ -1751,27 +1765,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
-#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
-#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
-#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
-#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
-#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
-#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
-#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1465
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1783,11 +1797,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
+#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1837,7 +1851,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:403
+#: lxc/init.go:407
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1849,7 +1863,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1216
+#: lxc/file.go:1236
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1945,7 +1959,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:377 lxc/file.go:378
+#: lxc/file.go:381 lxc/file.go:382
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1985,7 +1999,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:653 lxc/network_forward.go:654
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -2025,7 +2039,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2033,7 +2047,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1785
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2087,11 +2101,11 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
-#: lxc/network_acl.go:524 lxc/network_forward.go:572
+#: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
+#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2102,11 +2116,11 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
-#: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
+#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
-#: lxc/storage_volume.go:2210
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
+#: lxc/storage_volume.go:2212
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2148,8 +2162,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
+#: lxc/storage_volume.go:1577
 msgid "Expires at"
 msgstr ""
 
@@ -2173,7 +2187,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2185,11 +2199,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2650
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2779
+#: lxc/export.go:152 lxc/storage_volume.go:2781
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2208,7 +2222,7 @@ msgid "FILENAME"
 msgstr ""
 
 #: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
-#: lxc/image_alias.go:235
+#: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2216,12 +2230,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1467
+#: lxc/file.go:1491
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1490
+#: lxc/file.go:1514
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2236,12 +2250,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1517
+#: lxc/file.go:1541
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1326
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2271,7 +2285,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1423
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2286,7 +2300,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1428
+#: lxc/file.go:1452
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2296,12 +2310,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1352
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1455
+#: lxc/file.go:1479
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2315,7 +2329,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:304 lxc/move.go:380
+#: lxc/move.go:309 lxc/move.go:385
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2340,7 +2354,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1440
+#: lxc/file.go:1464
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2355,7 +2369,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1042
+#: lxc/file.go:1062
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2442,14 +2456,14 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1625 lxc/warning.go:94
+#: lxc/storage_volume.go:1627 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2517,7 +2531,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1602
+#: lxc/image.go:1602 lxc/image.go:1603
 msgid "Get image properties"
 msgstr ""
 
@@ -2533,7 +2547,7 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:414
 msgid "Get the key as a network forward property"
 msgstr ""
 
@@ -2573,7 +2587,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1249
+#: lxc/storage_volume.go:1251
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2601,7 +2615,7 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:403 lxc/network_forward.go:404
+#: lxc/network_forward.go:411 lxc/network_forward.go:412
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
@@ -2637,11 +2651,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:476
+#: lxc/storage_volume.go:480
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2681,22 +2695,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1540
+#: lxc/file.go:1564
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1529
+#: lxc/file.go:1553
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1376
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1362
+#: lxc/file.go:1386
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2769,11 +2783,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:415
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2783,7 +2797,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2437
+#: lxc/storage_volume.go:2439
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2795,7 +2809,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1517
+#: lxc/image.go:1518
 msgid "Image already up to date."
 msgstr ""
 
@@ -2811,11 +2825,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1472
+#: lxc/image.go:364 lxc/image.go:1473
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1698
+#: lxc/image.go:444 lxc/image.go:1699
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2825,7 +2839,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1515
+#: lxc/image.go:1516
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2833,7 +2847,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2815
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2841,7 +2855,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2814
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2863,11 +2877,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2822
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2894
+#: lxc/storage_volume.go:2896
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2893,11 +2907,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1378
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1531
+#: lxc/file.go:1555
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2906,7 +2920,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:414
+#: lxc/init.go:418
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2915,7 +2929,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1298
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2967,7 +2981,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1293
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2993,23 +3007,23 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2023
+#: lxc/move.go:153 lxc/storage_volume.go:2025
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:144
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2019
+#: lxc/storage_volume.go:2021
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:509
+#: lxc/main.go:518
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:353
+#: lxc/file.go:357
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3019,18 +3033,18 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
-#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
+#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:535
+#: lxc/file.go:548
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:717
+#: lxc/file.go:185 lxc/file.go:739
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3067,7 +3081,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3098,12 +3112,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:176
+#: lxc/init.go:180
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:174
+#: lxc/init.go:178
 msgid "Launching the instance"
 msgstr ""
 
@@ -3201,11 +3215,11 @@ msgstr ""
 msgid "List identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:151
+#: lxc/image_alias.go:176
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:177
 msgid ""
 "List image aliases\n"
 "\n"
@@ -3372,11 +3386,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1605
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1610
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3435,7 +3449,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1481
+#: lxc/info.go:489 lxc/storage_volume.go:1483
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3621,7 +3635,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:873 lxc/network_forward.go:874
+#: lxc/network_forward.go:881 lxc/network_forward.go:882
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -3767,12 +3781,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:322 lxc/move.go:435
+#: lxc/move.go:327 lxc/move.go:440
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:347 lxc/move.go:440
+#: lxc/move.go:352 lxc/move.go:445
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3837,10 +3851,10 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:449
-#: lxc/network_forward.go:534 lxc/network_forward.go:709
-#: lxc/network_forward.go:840 lxc/network_forward.go:933
-#: lxc/network_forward.go:1015 lxc/network_load_balancer.go:221
+#: lxc/network_forward.go:219 lxc/network_forward.go:457
+#: lxc/network_forward.go:542 lxc/network_forward.go:717
+#: lxc/network_forward.go:848 lxc/network_forward.go:945
+#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
 #: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
 #: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
 #: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
@@ -3865,10 +3879,10 @@ msgstr ""
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
 #: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
 #: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:284 lxc/network_forward.go:445
-#: lxc/network_forward.go:530 lxc/network_forward.go:705
-#: lxc/network_forward.go:836 lxc/network_forward.go:929
-#: lxc/network_forward.go:1011 lxc/network_load_balancer.go:131
+#: lxc/network_forward.go:292 lxc/network_forward.go:453
+#: lxc/network_forward.go:538 lxc/network_forward.go:713
+#: lxc/network_forward.go:844 lxc/network_forward.go:941
+#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
 #: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
 #: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
 #: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
@@ -3904,13 +3918,13 @@ msgstr ""
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
-#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
-#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
-#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
+#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
+#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
+#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
+#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
 msgid "Missing pool name"
 msgstr ""
 
@@ -3929,15 +3943,15 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
+#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1411
+#: lxc/storage_volume.go:1413
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:820
+#: lxc/file.go:842
 msgid "Missing target directory"
 msgstr ""
 
@@ -3970,16 +3984,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
-#: lxc/storage_volume.go:975
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
+#: lxc/storage_volume.go:977
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:507
+#: lxc/file.go:520
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1207 lxc/file.go:1208
+#: lxc/file.go:1227 lxc/file.go:1228
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4008,7 +4022,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4016,16 +4030,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1869
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1059 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4047,7 +4061,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
 msgid "NAME"
 msgstr ""
 
@@ -4099,8 +4113,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
-#: lxc/storage_volume.go:1573
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Name"
 msgstr ""
 
@@ -4108,7 +4122,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4163,12 +4177,12 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:386
+#: lxc/network_forward.go:394
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:857
+#: lxc/network_forward.go:865
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -4252,7 +4266,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
+#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4260,7 +4274,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1070 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4272,11 +4286,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4290,7 +4304,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2035
+#: lxc/storage_volume.go:2037
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4298,16 +4312,21 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
-#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
-msgid "Only \"custom\" volumes can be attached to instances"
+#: lxc/storage_volume.go:216
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2701
+#: lxc/storage_volume.go:348
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:2703
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2500
+#: lxc/storage_volume.go:2502
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4319,7 +4338,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1431
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4332,7 +4351,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1577
+#: lxc/info.go:705 lxc/storage_volume.go:1579
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4362,7 +4381,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1767
+#: lxc/storage_volume.go:1769
 msgid "POOL"
 msgstr ""
 
@@ -4379,7 +4398,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167
-#: lxc/storage_volume.go:1773 lxc/warning.go:213
+#: lxc/storage_volume.go:1775 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4403,7 +4422,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:367
+#: lxc/main.go:376
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4441,7 +4460,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1332
+#: lxc/file.go:1356
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4449,12 +4468,12 @@ msgstr ""
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
-#: lxc/network_acl.go:699 lxc/network_forward.go:768
+#: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
-#: lxc/storage_volume.go:1200
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
+#: lxc/storage_volume.go:1202
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4567,11 +4586,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1649
+#: lxc/image.go:1650
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4585,7 +4604,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1238
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4601,7 +4620,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4622,7 +4641,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1017
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4631,7 +4650,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2094
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4644,7 +4663,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2370
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4675,20 +4694,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:455 lxc/file.go:456
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:638 lxc/file.go:989
+#: lxc/file.go:651 lxc/file.go:1009
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:688 lxc/file.go:689
+#: lxc/file.go:701 lxc/file.go:702
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:923 lxc/file.go:1089
+#: lxc/file.go:943 lxc/file.go:1109
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4697,7 +4716,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4726,15 +4745,15 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:463 lxc/file.go:695
+#: lxc/file.go:475 lxc/file.go:708
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1444 lxc/image.go:1445
+#: lxc/image.go:1445 lxc/image.go:1446
 msgid "Refresh images"
 msgstr ""
 
@@ -4743,7 +4762,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1481
+#: lxc/image.go:1482
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4820,7 +4839,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:971 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4856,7 +4875,7 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:969 lxc/network_forward.go:970
+#: lxc/network_forward.go:981 lxc/network_forward.go:982
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -4892,8 +4911,8 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
-#: lxc/image_alias.go:255
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:287
+#: lxc/image_alias.go:288
 msgid "Rename aliases"
 msgstr ""
 
@@ -4929,15 +4948,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1962
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
+#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4989,7 +5008,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5006,7 +5025,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:361
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5055,12 +5074,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1460
+#: lxc/file.go:1484
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1461
+#: lxc/file.go:1485
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5136,7 +5155,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1217
+#: lxc/file.go:1237
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5162,7 +5181,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1665 lxc/image.go:1666
+#: lxc/image.go:1666 lxc/image.go:1667
 msgid "Set image properties"
 msgstr ""
 
@@ -5205,11 +5224,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:488
+#: lxc/network_forward.go:496
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:489
+#: lxc/network_forward.go:497
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5313,11 +5332,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2088
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2089
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5334,7 +5353,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:698
+#: lxc/file.go:711
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5342,7 +5361,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:699
+#: lxc/file.go:712
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5350,7 +5369,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:710
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5362,7 +5381,7 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:504
 msgid "Set the key as a network forward property"
 msgstr ""
 
@@ -5402,7 +5421,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2105
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5410,7 +5429,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1215
+#: lxc/file.go:1235
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5467,7 +5486,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1535 lxc/image.go:1536
+#: lxc/image.go:1536 lxc/image.go:1537
 msgid "Show image properties"
 msgstr ""
 
@@ -5487,7 +5506,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:271 lxc/main.go:272
+#: lxc/main.go:280 lxc/main.go:281
 msgid "Show less common commands"
 msgstr ""
 
@@ -5551,11 +5570,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5623,15 +5642,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2190
+#: lxc/storage_volume.go:2192
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1502
+#: lxc/info.go:619 lxc/storage_volume.go:1504
 msgid "Snapshots:"
 msgstr ""
 
@@ -5736,21 +5755,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:703
+#: lxc/storage_volume.go:707
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:791
+#: lxc/storage_volume.go:795
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:516
+#: lxc/storage_volume.go:520
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:524
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5812,21 +5831,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1747 lxc/warning.go:216
+#: lxc/storage_volume.go:1749 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1262
+#: lxc/file.go:1286
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1256
+#: lxc/file.go:1280
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5836,15 +5855,15 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:181
+#: lxc/move.go:186
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:219 lxc/move.go:240
+#: lxc/move.go:224 lxc/move.go:245
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:193
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5852,15 +5871,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:185
+#: lxc/move.go:190
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:189
+#: lxc/move.go:194
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:210
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5882,7 +5901,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:439
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5935,7 +5954,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:462
+#: lxc/network_forward.go:470
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -5975,12 +5994,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1340
+#: lxc/storage_volume.go:1342
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1317
+#: lxc/storage_volume.go:1319
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -5995,12 +6014,12 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:309
+#: lxc/move.go:314
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
-#: lxc/storage_volume.go:989
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
+#: lxc/storage_volume.go:991
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6028,7 +6047,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:298
+#: lxc/main.go:307
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6052,11 +6071,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:437
+#: lxc/init.go:441
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:440
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6064,7 +6083,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:412
+#: lxc/main.go:421
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6075,7 +6094,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1489
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6090,7 +6109,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1864
+#: lxc/storage_volume.go:1866
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6098,7 +6117,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6115,7 +6134,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:327
+#: lxc/copy.go:382 lxc/move.go:332
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6157,7 +6176,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1472
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6179,13 +6198,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1752
+#: lxc/project.go:995 lxc/storage_volume.go:1754
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1751
+#: lxc/storage.go:724 lxc/storage_volume.go:1753
 msgid "USED BY"
 msgstr ""
 
@@ -6198,7 +6217,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:411
+#: lxc/file.go:423
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6212,12 +6231,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1483
+#: lxc/file.go:1507
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1791
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6228,7 +6247,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1029
+#: lxc/file.go:1049
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6259,7 +6278,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1728 lxc/image.go:1729
+#: lxc/image.go:1729 lxc/image.go:1730
 msgid "Unset image properties"
 msgstr ""
 
@@ -6275,11 +6294,11 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:598
+#: lxc/network_forward.go:606
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:599
+#: lxc/network_forward.go:607
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -6323,7 +6342,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6335,7 +6354,7 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:602
+#: lxc/network_forward.go:610
 msgid "Unset the key as a network forward property"
 msgstr ""
 
@@ -6375,7 +6394,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2381
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6383,7 +6402,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:248
+#: lxc/storage_volume.go:250
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6419,12 +6438,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1485
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2652
+#: lxc/export.go:42 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6491,7 +6510,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1576
+#: lxc/storage_volume.go:1578
 msgid "Volume Only"
 msgstr ""
 
@@ -6542,7 +6561,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:293 lxc/move.go:369
+#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6550,12 +6569,12 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:909
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:912
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:282
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:284
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
@@ -6587,7 +6606,7 @@ msgstr ""
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:174
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
@@ -6640,7 +6659,7 @@ msgstr ""
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: lxc/image_alias.go:104
+#: lxc/image_alias.go:121
 msgid "[<remote>:]<alias>"
 msgstr ""
 
@@ -6648,7 +6667,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/image_alias.go:252
+#: lxc/image_alias.go:285
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
@@ -6702,15 +6721,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1600 lxc/image.go:1727
+#: lxc/image.go:1601 lxc/image.go:1728
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1664
+#: lxc/image.go:1665
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6730,7 +6749,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1443
+#: lxc/image.go:334 lxc/image.go:1444
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6801,7 +6820,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:376
+#: lxc/file.go:380
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -6813,12 +6832,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:454
+#: lxc/file.go:466
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1226
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6886,8 +6905,8 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:644
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:179
+#: lxc/network_forward.go:177 lxc/network_forward.go:652
+#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
 #: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
@@ -6902,12 +6921,12 @@ msgid ""
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:402 lxc/network_forward.go:597
+#: lxc/network_forward.go:410 lxc/network_forward.go:605
 #: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
@@ -6917,13 +6936,13 @@ msgid ""
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:887
+#: lxc/network_forward.go:895
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:968 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -6978,7 +6997,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2811
+#: lxc/storage_volume.go:2813
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7013,65 +7032,65 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1958
+#: lxc/storage_volume.go:1960
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:806
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:167
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
-msgstr ""
-
-#: lxc/storage_volume.go:2562
+#: lxc/storage_volume.go:2564
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2645
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2428
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:610
+#: lxc/storage_volume.go:614
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:718
+#: lxc/storage_volume.go:722
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2364
+#: lxc/storage_volume.go:810
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
+msgstr ""
+
+#: lxc/storage_volume.go:167
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
+msgstr ""
+
+#: lxc/storage_volume.go:2366
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2087
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2245
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1234
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1858
+#: lxc/storage_volume.go:1860
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7177,7 +7196,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1603
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7339,20 +7358,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1230
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:470
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:691
+#: lxc/file.go:704
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7653,7 +7672,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:618
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7661,13 +7680,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2817
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2432
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7701,16 +7720,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1396
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1331
+#: lxc/file.go:1355
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1284
+#: lxc/file.go:1308
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-07 15:11-0700\n"
+"POT-Creation-Date: 2025-01-10 14:44-0600\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -76,7 +76,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:1041
+#: lxc/storage_volume.go:1043
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -377,7 +377,7 @@ msgstr ""
 "###\n"
 "### Note que o nome é exibido, porém não pode ser alterado."
 
-#: lxc/network_forward.go:667
+#: lxc/network_forward.go:675
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -678,12 +678,12 @@ msgstr "%s (%d mais)"
 msgid "%s (%s) (%d available)"
 msgstr "%s (%d mais)"
 
-#: lxc/file.go:1157
+#: lxc/file.go:1177
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s não é um diretório"
 
-#: lxc/file.go:1047
+#: lxc/file.go:1067
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' não é um tipo de arquivo suportado"
@@ -722,7 +722,7 @@ msgstr "--refresh só pode ser usado com containers"
 msgid "--console only works with a single instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
-#: lxc/init.go:142 lxc/rebuild.go:65
+#: lxc/init.go:146 lxc/rebuild.go:65
 #, fuzzy
 msgid "--empty cannot be combined with an image name"
 msgstr "--refresh só pode ser usado com containers"
@@ -782,7 +782,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:687
+#: lxc/file.go:700
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr "Editar templates de arquivo do container"
@@ -800,7 +800,7 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr "ALIAS"
 
@@ -936,7 +936,7 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:888 lxc/network_forward.go:889
+#: lxc/network_forward.go:896 lxc/network_forward.go:897
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -989,7 +989,7 @@ msgstr "Alias %s já existe"
 msgid "Alias %s doesn't exist"
 msgstr "Alias %s não existe"
 
-#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
+#: lxc/image_alias.go:101 lxc/image_alias.go:156 lxc/image_alias.go:320
 msgid "Alias name missing"
 msgstr "Nome do alias ausente"
 
@@ -1002,7 +1002,7 @@ msgstr "Alias %s já existe"
 msgid "Aliases:"
 msgstr "Aliases:"
 
-#: lxc/storage_volume.go:1607
+#: lxc/storage_volume.go:1609
 #, fuzzy
 msgid "All projects"
 msgstr "Criar projetos"
@@ -1035,7 +1035,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1063,13 +1063,27 @@ msgstr "Anexar interfaces de rede aos perfis"
 msgid "Attach new network interfaces to instances"
 msgstr "Anexar uma nova interface de rede aos containers"
 
-#: lxc/storage_volume.go:168 lxc/storage_volume.go:169
+#: lxc/storage_volume.go:168
 #, fuzzy
 msgid "Attach new storage volumes to instances"
 msgstr "Desconectar volumes de armazenamento dos containers"
 
-#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:169
+msgid ""
+"Attach new storage volumes to instances\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
+msgstr ""
+
+#: lxc/storage_volume.go:285
 msgid "Attach new storage volumes to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:286
+msgid ""
+"Attach new storage volumes to profiles\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
 #: lxc/console.go:39
@@ -1122,16 +1136,16 @@ msgstr "IMAGEM BASE"
 msgid "Backing up instance: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/storage_volume.go:2719
+#: lxc/storage_volume.go:2721
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/export.go:192 lxc/storage_volume.go:2796
+#: lxc/export.go:192 lxc/storage_volume.go:2798
 msgid "Backup exported successfully!"
 msgstr "Backup exportado com sucesso!"
 
-#: lxc/info.go:666 lxc/storage_volume.go:1538
+#: lxc/info.go:666 lxc/storage_volume.go:1540
 msgid "Backups:"
 msgstr ""
 
@@ -1140,19 +1154,19 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr "Erro de sintaxe, esperado <dispositivo>,<chave>=<valor>: %s"
 
-#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
+#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:326
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr "par de chave/valor inválido %s"
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "par de chave=valor inválido %s"
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr "par de chave=valor inválido %s"
@@ -1195,7 +1209,7 @@ msgstr "CANCELÁVEL"
 msgid "COMMON NAME"
 msgstr "NOME COMUM"
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1752
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1248,7 +1262,7 @@ msgstr "Em cache: %s"
 msgid "Caches:"
 msgstr "Em cache: %s"
 
-#: lxc/move.go:130
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1256,7 +1270,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr "Não pode fornecer um nome para a imagem de destino"
 
-#: lxc/file.go:562
+#: lxc/file.go:575
 msgid "Can't pull a directory without --recursive"
 msgstr "Não pode pegar um diretório sem --recursive"
 
@@ -1282,11 +1296,11 @@ msgstr "Não é possível especificar --fast com --columns"
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr "Não pode especificar a coluna L, quando não em cluster"
 
-#: lxc/file.go:768
+#: lxc/file.go:790
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "Não é possível fornecer o uid/gid/modo no modo recursivo"
 
@@ -1299,12 +1313,12 @@ msgstr "Não é possível remover chave '%s', não está atualmente definido"
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:493
+#: lxc/storage_volume.go:497
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:447
+#: lxc/storage_volume.go:451
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1412,9 +1426,9 @@ msgstr "Dispositivo %s removido de %s"
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:497 lxc/network_forward.go:649
-#: lxc/network_forward.go:803 lxc/network_forward.go:892
-#: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
+#: lxc/network_forward.go:505 lxc/network_forward.go:657
+#: lxc/network_forward.go:811 lxc/network_forward.go:900
+#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
 #: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
 #: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
@@ -1426,14 +1440,14 @@ msgstr "Dispositivo %s removido de %s"
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
-#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
-#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
-#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
+#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
 msgid "Cluster member name"
 msgstr "Nome de membro do cluster"
 
@@ -1449,7 +1463,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr "Clustering ativado"
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1608
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr "Colunas"
@@ -1498,21 +1512,21 @@ msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 #: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
-#: lxc/network_acl.go:698 lxc/network_forward.go:767
+#: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
-#: lxc/storage_volume.go:1199
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
+#: lxc/storage_volume.go:1201
 #, c-format
 msgid "Config parsing error: %s"
 msgstr "Erro de análise de configuração: %s"
 
-#: lxc/storage_volume.go:620
+#: lxc/storage_volume.go:624
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1478
+#: lxc/storage_volume.go:1480
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1576,7 +1590,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr "Copiar perfis"
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1584,12 +1598,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1603,7 +1617,7 @@ msgstr "Copiar a imagem: %s"
 msgid "Copying the image: %s"
 msgstr "Copiar a imagem: %s"
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1701,7 +1715,7 @@ msgstr "Editar configurações de rede como YAML"
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:462 lxc/file.go:696
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1750,7 +1764,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr "Criar novas redes"
 
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1809,12 +1823,12 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
 #, c-format
 msgid "Created: %s"
 msgstr "Criado: %s"
 
-#: lxc/init.go:182
+#: lxc/init.go:186
 #, c-format
 msgid "Creating %s"
 msgstr "Criando %s"
@@ -1824,7 +1838,7 @@ msgstr "Criando %s"
 msgid "Creating %s: %%s"
 msgstr "Criando %s"
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 #, fuzzy
 msgid "Creating the instance"
 msgstr "Criando %s"
@@ -1839,13 +1853,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1749
+#: lxc/storage_volume.go:1751
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1865,7 +1879,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2653
+#: lxc/storage_volume.go:2655
 #, fuzzy
 msgid "Define a compression algorithm: for backup or none"
 msgstr "Definir um algoritmo de compressão: para imagem ou nenhum"
@@ -1902,7 +1916,7 @@ msgstr "Apagar projetos"
 msgid "Delete identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:106 lxc/image_alias.go:107
+#: lxc/image_alias.go:123 lxc/image_alias.go:124
 msgid "Delete image aliases"
 msgstr "Apagar nomes alternativos da imagem"
 
@@ -1929,7 +1943,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr "Criar novas redes"
 
-#: lxc/network_forward.go:799 lxc/network_forward.go:800
+#: lxc/network_forward.go:807 lxc/network_forward.go:808
 #, fuzzy
 msgid "Delete network forwards"
 msgstr "Criar novas redes"
@@ -1975,7 +1989,7 @@ msgstr "Apagar projetos"
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
+#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -2017,13 +2031,13 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
-#: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
-#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
+#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
+#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
+#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
@@ -2037,10 +2051,10 @@ msgstr ""
 #: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:404 lxc/network_forward.go:489
-#: lxc/network_forward.go:599 lxc/network_forward.go:646
-#: lxc/network_forward.go:800 lxc/network_forward.go:874
-#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_forward.go:412 lxc/network_forward.go:497
+#: lxc/network_forward.go:607 lxc/network_forward.go:654
+#: lxc/network_forward.go:808 lxc/network_forward.go:882
+#: lxc/network_forward.go:897 lxc/network_forward.go:982
 #: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
 #: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
 #: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
@@ -2080,27 +2094,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
-#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
-#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
-#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
-#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
-#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
-#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
-#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr "Descrição"
 
-#: lxc/storage_volume.go:1465
+#: lxc/storage_volume.go:1467
 #, fuzzy, c-format
 msgid "Description: %s"
 msgstr "Descrição"
 
-#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Nome de membro do cluster"
@@ -2114,12 +2128,12 @@ msgstr "Desconectar interfaces de rede dos containers"
 msgid "Detach network interfaces from profiles"
 msgstr "Desconectar interfaces de rede dos perfis"
 
-#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
 #, fuzzy
 msgid "Detach storage volumes from instances"
 msgstr "Desconectar volumes de armazenamento dos containers"
 
-#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
+#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
 msgid "Detach storage volumes from profiles"
 msgstr "Desconectar volumes de armazenamento dos perfis"
 
@@ -2170,7 +2184,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr "Em cache: %s"
 
-#: lxc/init.go:403
+#: lxc/init.go:407
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2182,7 +2196,7 @@ msgstr "A importação de diretório não está disponível nessa plataforma"
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1216
+#: lxc/file.go:1236
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2286,7 +2300,7 @@ msgstr "Editar configurações de rede como YAML"
 msgid "Edit cluster member configurations as YAML"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/file.go:377 lxc/file.go:378
+#: lxc/file.go:381 lxc/file.go:382
 #, fuzzy
 msgid "Edit files in instances"
 msgstr "Editar arquivos no container"
@@ -2334,7 +2348,7 @@ msgstr "Editar configurações de rede como YAML"
 msgid "Edit network configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:653 lxc/network_forward.go:654
 #, fuzzy
 msgid "Edit network forward configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
@@ -2381,7 +2395,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2390,7 +2404,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1785
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2444,11 +2458,11 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
-#: lxc/network_acl.go:524 lxc/network_forward.go:572
+#: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
+#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Editar propriedades da imagem"
@@ -2459,11 +2473,11 @@ msgid "Error unsetting properties: %v"
 msgstr "Editar propriedades da imagem"
 
 #: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
-#: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
+#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
-#: lxc/storage_volume.go:2210
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
+#: lxc/storage_volume.go:2212
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2506,8 +2520,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
+#: lxc/storage_volume.go:1577
 msgid "Expires at"
 msgstr ""
 
@@ -2531,7 +2545,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2543,11 +2557,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2650
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2779
+#: lxc/export.go:152 lxc/storage_volume.go:2781
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2566,7 +2580,7 @@ msgid "FILENAME"
 msgstr ""
 
 #: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
-#: lxc/image_alias.go:235
+#: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2574,12 +2588,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1467
+#: lxc/file.go:1491
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1490
+#: lxc/file.go:1514
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2594,12 +2608,12 @@ msgstr "Nome de membro do cluster"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Nome de membro do cluster"
 
-#: lxc/file.go:1517
+#: lxc/file.go:1541
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1326
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Nome de membro do cluster"
@@ -2629,7 +2643,7 @@ msgstr "Nome de membro do cluster"
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "Nome de membro do cluster"
 
-#: lxc/file.go:1423
+#: lxc/file.go:1447
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Aceitar certificado"
@@ -2644,7 +2658,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr "Nome de membro do cluster"
 
-#: lxc/file.go:1428
+#: lxc/file.go:1452
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Aceitar certificado"
@@ -2654,12 +2668,12 @@ msgstr "Aceitar certificado"
 msgid "Failed starting command: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/file.go:1328
+#: lxc/file.go:1352
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/file.go:1455
+#: lxc/file.go:1479
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Aceitar certificado"
@@ -2673,7 +2687,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/move.go:304 lxc/move.go:380
+#: lxc/move.go:309 lxc/move.go:385
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "Nome de membro do cluster"
@@ -2698,7 +2712,7 @@ msgstr "Nome de membro do cluster"
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1440
+#: lxc/file.go:1464
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Aceitar certificado"
@@ -2713,7 +2727,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr "Aceitar certificado"
 
-#: lxc/file.go:1042
+#: lxc/file.go:1062
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2801,14 +2815,14 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1625 lxc/warning.go:94
+#: lxc/storage_volume.go:1627 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2877,7 +2891,7 @@ msgstr "Adicionar perfis aos containers"
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1602
+#: lxc/image.go:1602 lxc/image.go:1603
 #, fuzzy
 msgid "Get image properties"
 msgstr "Editar propriedades da imagem"
@@ -2894,7 +2908,7 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:414
 #, fuzzy
 msgid "Get the key as a network forward property"
 msgstr "Criar novas redes"
@@ -2940,7 +2954,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1249
+#: lxc/storage_volume.go:1251
 #, fuzzy
 msgid "Get the key as a storage volume property"
 msgstr "Desconectar volumes de armazenamento dos perfis"
@@ -2973,7 +2987,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:403 lxc/network_forward.go:404
+#: lxc/network_forward.go:411 lxc/network_forward.go:412
 #, fuzzy
 msgid "Get values for network forward configuration keys"
 msgstr "Editar configurações de perfil como YAML"
@@ -3016,11 +3030,11 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:476
+#: lxc/storage_volume.go:480
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -3060,22 +3074,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1540
+#: lxc/file.go:1564
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Copiar a imagem: %s"
 
-#: lxc/file.go:1529
+#: lxc/file.go:1553
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Copiar a imagem: %s"
 
-#: lxc/file.go:1352
+#: lxc/file.go:1376
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Dispositivo %s adicionado a %s"
 
-#: lxc/file.go:1362
+#: lxc/file.go:1386
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Copiar a imagem: %s"
@@ -3148,11 +3162,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:415
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3162,7 +3176,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2437
+#: lxc/storage_volume.go:2439
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3175,7 +3189,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr "Ignorar o estado do container"
 
-#: lxc/image.go:1517
+#: lxc/image.go:1518
 msgid "Image already up to date."
 msgstr ""
 
@@ -3191,11 +3205,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr "Imagem exportada com sucesso!"
 
-#: lxc/image.go:364 lxc/image.go:1472
+#: lxc/image.go:364 lxc/image.go:1473
 msgid "Image identifier missing"
 msgstr "Falta o identificador da imagem"
 
-#: lxc/image.go:444 lxc/image.go:1698
+#: lxc/image.go:444 lxc/image.go:1699
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr "Falta o identificador da imagem: %s"
@@ -3205,7 +3219,7 @@ msgstr "Falta o identificador da imagem: %s"
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1515
+#: lxc/image.go:1516
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3214,7 +3228,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr "Anexar interfaces de rede aos perfis"
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2815
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3222,7 +3236,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2814
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -3244,11 +3258,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2822
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2894
+#: lxc/storage_volume.go:2896
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Editar arquivos no container"
@@ -3274,11 +3288,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1378
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1531
+#: lxc/file.go:1555
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3287,7 +3301,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:414
+#: lxc/init.go:418
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3296,7 +3310,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1298
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3348,7 +3362,7 @@ msgstr "Editar arquivos no container"
 msgid "Invalid instance name: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:1269
+#: lxc/file.go:1293
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Editar arquivos no container"
@@ -3374,24 +3388,24 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2023
+#: lxc/move.go:153 lxc/storage_volume.go:2025
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "Editar arquivos no container"
 
-#: lxc/move.go:144
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2019
+#: lxc/storage_volume.go:2021
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:509
+#: lxc/main.go:518
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:353
+#: lxc/file.go:357
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3401,19 +3415,19 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
-#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
+#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:535
+#: lxc/file.go:548
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:717
+#: lxc/file.go:185 lxc/file.go:739
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3450,7 +3464,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3481,12 +3495,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:176
+#: lxc/init.go:180
 #, fuzzy, c-format
 msgid "Launching %s"
 msgstr "Criando %s"
 
-#: lxc/init.go:174
+#: lxc/init.go:178
 #, fuzzy
 msgid "Launching the instance"
 msgstr "Criando %s"
@@ -3590,11 +3604,11 @@ msgstr ""
 msgid "List identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:151
+#: lxc/image_alias.go:176
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:177
 msgid ""
 "List image aliases\n"
 "\n"
@@ -3764,11 +3778,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1605
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1610
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3827,7 +3841,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1481
+#: lxc/info.go:489 lxc/storage_volume.go:1483
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4025,7 +4039,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr "Criar novas redes"
 
-#: lxc/network_forward.go:873 lxc/network_forward.go:874
+#: lxc/network_forward.go:881 lxc/network_forward.go:882
 #, fuzzy
 msgid "Manage network forward ports"
 msgstr "Criar novas redes"
@@ -4187,12 +4201,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:322 lxc/move.go:435
+#: lxc/move.go:327 lxc/move.go:440
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:347 lxc/move.go:440
+#: lxc/move.go:352 lxc/move.go:445
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4266,10 +4280,10 @@ msgstr ""
 msgid "Missing key name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:449
-#: lxc/network_forward.go:534 lxc/network_forward.go:709
-#: lxc/network_forward.go:840 lxc/network_forward.go:933
-#: lxc/network_forward.go:1015 lxc/network_load_balancer.go:221
+#: lxc/network_forward.go:219 lxc/network_forward.go:457
+#: lxc/network_forward.go:542 lxc/network_forward.go:717
+#: lxc/network_forward.go:848 lxc/network_forward.go:945
+#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
 #: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
 #: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
 #: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
@@ -4296,10 +4310,10 @@ msgstr "Nome de membro do cluster"
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
 #: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
 #: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:284 lxc/network_forward.go:445
-#: lxc/network_forward.go:530 lxc/network_forward.go:705
-#: lxc/network_forward.go:836 lxc/network_forward.go:929
-#: lxc/network_forward.go:1011 lxc/network_load_balancer.go:131
+#: lxc/network_forward.go:292 lxc/network_forward.go:453
+#: lxc/network_forward.go:538 lxc/network_forward.go:713
+#: lxc/network_forward.go:844 lxc/network_forward.go:941
+#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
 #: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
 #: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
 #: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
@@ -4338,13 +4352,13 @@ msgstr "Nome de membro do cluster"
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
-#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
-#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
-#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
+#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
+#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
+#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
+#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
 msgid "Missing pool name"
 msgstr ""
 
@@ -4363,16 +4377,16 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
+#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1411
+#: lxc/storage_volume.go:1413
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/file.go:820
+#: lxc/file.go:842
 msgid "Missing target directory"
 msgstr ""
 
@@ -4406,16 +4420,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
-#: lxc/storage_volume.go:975
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
+#: lxc/storage_volume.go:977
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:507
+#: lxc/file.go:520
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1207 lxc/file.go:1208
+#: lxc/file.go:1227 lxc/file.go:1228
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Adicionar perfis aos containers"
@@ -4445,7 +4459,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4453,16 +4467,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1869
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1059 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4484,7 +4498,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
 msgid "NAME"
 msgstr ""
 
@@ -4536,8 +4550,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
-#: lxc/storage_volume.go:1573
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Name"
 msgstr ""
 
@@ -4545,7 +4559,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4600,12 +4614,12 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:386
+#: lxc/network_forward.go:394
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:857
+#: lxc/network_forward.go:865
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -4689,7 +4703,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
+#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4697,7 +4711,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1070 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4709,11 +4723,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4727,7 +4741,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2035
+#: lxc/storage_volume.go:2037
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4735,16 +4749,21 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
-#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
-msgid "Only \"custom\" volumes can be attached to instances"
+#: lxc/storage_volume.go:216
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2701
+#: lxc/storage_volume.go:348
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:2703
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2500
+#: lxc/storage_volume.go:2502
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4756,7 +4775,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1431
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4769,7 +4788,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1577
+#: lxc/info.go:705 lxc/storage_volume.go:1579
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4799,7 +4818,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1767
+#: lxc/storage_volume.go:1769
 msgid "POOL"
 msgstr ""
 
@@ -4816,7 +4835,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167
-#: lxc/storage_volume.go:1773 lxc/warning.go:213
+#: lxc/storage_volume.go:1775 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4840,7 +4859,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:367
+#: lxc/main.go:376
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4879,7 +4898,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1332
+#: lxc/file.go:1356
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4887,12 +4906,12 @@ msgstr ""
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
-#: lxc/network_acl.go:699 lxc/network_forward.go:768
+#: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
-#: lxc/storage_volume.go:1200
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
+#: lxc/storage_volume.go:1202
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -5010,11 +5029,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1649
+#: lxc/image.go:1650
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -5028,7 +5047,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1238
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5044,7 +5063,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5065,7 +5084,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1017
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5074,7 +5093,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2094
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5087,7 +5106,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2370
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5118,21 +5137,21 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:455 lxc/file.go:456
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:638 lxc/file.go:989
+#: lxc/file.go:651 lxc/file.go:1009
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:688 lxc/file.go:689
+#: lxc/file.go:701 lxc/file.go:702
 #, fuzzy
 msgid "Push files into instances"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:923 lxc/file.go:1089
+#: lxc/file.go:943 lxc/file.go:1109
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5141,7 +5160,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5172,15 +5191,15 @@ msgstr "Editar arquivos no container"
 msgid "Rebuild instances"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:463 lxc/file.go:695
+#: lxc/file.go:475 lxc/file.go:708
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1444 lxc/image.go:1445
+#: lxc/image.go:1445 lxc/image.go:1446
 msgid "Refresh images"
 msgstr ""
 
@@ -5189,7 +5208,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/image.go:1481
+#: lxc/image.go:1482
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5271,7 +5290,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:971 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -5312,7 +5331,7 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr "Adicionar perfis aos containers"
 
-#: lxc/network_forward.go:969 lxc/network_forward.go:970
+#: lxc/network_forward.go:981 lxc/network_forward.go:982
 #, fuzzy
 msgid "Remove ports from a forward"
 msgstr "Adicionar perfis aos containers"
@@ -5354,8 +5373,8 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
-#: lxc/image_alias.go:255
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:287
+#: lxc/image_alias.go:288
 msgid "Rename aliases"
 msgstr ""
 
@@ -5392,15 +5411,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1962
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
+#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5459,7 +5478,7 @@ msgstr ""
 "Quando --stateful é usado, o LXD tenta criar um checkpoint do estado atual \n"
 "do container, incluindo estado de memória dos processos, conexões TCP, ..."
 
-#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5476,7 +5495,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:361
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5528,12 +5547,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1460
+#: lxc/file.go:1484
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1461
+#: lxc/file.go:1485
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5611,7 +5630,7 @@ msgstr "Adicionar perfis aos containers"
 msgid "Set a cluster member's configuration keys"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/file.go:1217
+#: lxc/file.go:1237
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5638,7 +5657,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1665 lxc/image.go:1666
+#: lxc/image.go:1666 lxc/image.go:1667
 #, fuzzy
 msgid "Set image properties"
 msgstr "Editar propriedades da imagem"
@@ -5684,12 +5703,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:488
+#: lxc/network_forward.go:496
 #, fuzzy
 msgid "Set network forward keys"
 msgstr "Criar novas redes"
 
-#: lxc/network_forward.go:489
+#: lxc/network_forward.go:497
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5799,11 +5818,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2088
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2089
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5820,7 +5839,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:698
+#: lxc/file.go:711
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5828,7 +5847,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:699
+#: lxc/file.go:712
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5836,7 +5855,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:710
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5848,7 +5867,7 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:504
 #, fuzzy
 msgid "Set the key as a network forward property"
 msgstr "Criar novas redes"
@@ -5894,7 +5913,7 @@ msgstr "Criar novas redes"
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2105
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "Desconectar volumes de armazenamento dos perfis"
@@ -5903,7 +5922,7 @@ msgstr "Desconectar volumes de armazenamento dos perfis"
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1215
+#: lxc/file.go:1235
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5964,7 +5983,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1535 lxc/image.go:1536
+#: lxc/image.go:1536 lxc/image.go:1537
 msgid "Show image properties"
 msgstr ""
 
@@ -5988,7 +6007,7 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Show instance or server information"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/main.go:271 lxc/main.go:272
+#: lxc/main.go:280 lxc/main.go:281
 msgid "Show less common commands"
 msgstr ""
 
@@ -6062,11 +6081,11 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
 #, fuzzy
 msgid "Show storage volume state information"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -6138,15 +6157,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2190
+#: lxc/storage_volume.go:2192
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1502
+#: lxc/info.go:619 lxc/storage_volume.go:1504
 msgid "Snapshots:"
 msgstr ""
 
@@ -6251,21 +6270,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:703
+#: lxc/storage_volume.go:707
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:791
+#: lxc/storage_volume.go:795
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:516
+#: lxc/storage_volume.go:520
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:524
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -6328,22 +6347,22 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1747 lxc/warning.go:216
+#: lxc/storage_volume.go:1749 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1262
+#: lxc/file.go:1286
 #, fuzzy
 msgid "Target path and --listen flag cannot be used together"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/file.go:1256
+#: lxc/file.go:1280
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6353,16 +6372,16 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:181
+#: lxc/move.go:186
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:219 lxc/move.go:240
+#: lxc/move.go:224 lxc/move.go:245
 #, fuzzy
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/move.go:193
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -6370,17 +6389,17 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:185
+#: lxc/move.go:190
 #, fuzzy
 msgid "The --storage flag can't be used with --target"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/move.go:189
+#: lxc/move.go:194
 #, fuzzy
 msgid "The --target-project flag can't be used with --target"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/move.go:205
+#: lxc/move.go:210
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -6402,7 +6421,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:439
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6455,7 +6474,7 @@ msgstr "Nome de membro do cluster"
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: lxc/network_forward.go:462
+#: lxc/network_forward.go:470
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr "Nome de membro do cluster"
@@ -6495,12 +6514,12 @@ msgstr "Nome de membro do cluster"
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: lxc/storage_volume.go:1340
+#: lxc/storage_volume.go:1342
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: lxc/storage_volume.go:1317
+#: lxc/storage_volume.go:1319
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6515,12 +6534,12 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:309
+#: lxc/move.go:314
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
-#: lxc/storage_volume.go:989
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
+#: lxc/storage_volume.go:991
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6550,7 +6569,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr "A importação de diretório não está disponível nessa plataforma"
 
-#: lxc/main.go:298
+#: lxc/main.go:307
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6574,11 +6593,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:437
+#: lxc/init.go:441
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:440
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6586,7 +6605,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:412
+#: lxc/main.go:421
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6597,7 +6616,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1489
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6612,7 +6631,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1864
+#: lxc/storage_volume.go:1866
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6620,7 +6639,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6637,7 +6656,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:327
+#: lxc/copy.go:382 lxc/move.go:332
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "Editar arquivos no container"
@@ -6681,7 +6700,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1472
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6703,13 +6722,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1752
+#: lxc/project.go:995 lxc/storage_volume.go:1754
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1751
+#: lxc/storage.go:724 lxc/storage_volume.go:1753
 msgid "USED BY"
 msgstr ""
 
@@ -6722,7 +6741,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:411
+#: lxc/file.go:423
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6737,12 +6756,12 @@ msgstr "Adicionar novos servidores remoto"
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1483
+#: lxc/file.go:1507
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1791
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6753,7 +6772,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1029
+#: lxc/file.go:1049
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6788,7 +6807,7 @@ msgstr "Não pode fornecer um nome para a imagem de destino"
 msgid "Unset device configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/image.go:1728 lxc/image.go:1729
+#: lxc/image.go:1729 lxc/image.go:1730
 #, fuzzy
 msgid "Unset image properties"
 msgstr "Editar propriedades da imagem"
@@ -6807,12 +6826,12 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:598
+#: lxc/network_forward.go:606
 #, fuzzy
 msgid "Unset network forward configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/network_forward.go:599
+#: lxc/network_forward.go:607
 #, fuzzy
 msgid "Unset network forward keys"
 msgstr "Criar novas redes"
@@ -6865,7 +6884,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6877,7 +6896,7 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:602
+#: lxc/network_forward.go:610
 #, fuzzy
 msgid "Unset the key as a network forward property"
 msgstr "Criar novas redes"
@@ -6924,7 +6943,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2381
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6932,7 +6951,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:248
+#: lxc/storage_volume.go:250
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6970,12 +6989,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr "Editar arquivos no container"
 
-#: lxc/storage_volume.go:1485
+#: lxc/storage_volume.go:1487
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Criado: %s"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2652
+#: lxc/export.go:42 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -7042,7 +7061,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1576
+#: lxc/storage_volume.go:1578
 msgid "Volume Only"
 msgstr ""
 
@@ -7093,7 +7112,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:293 lxc/move.go:369
+#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -7101,13 +7120,14 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:909
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:282
+#: lxc/storage_volume.go:912
 #, fuzzy
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
+msgstr "Criar perfis"
+
+#: lxc/storage_volume.go:284
+#, fuzzy
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr "Criar perfis"
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
@@ -7142,7 +7162,7 @@ msgstr "Criar perfis"
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:174
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
@@ -7205,7 +7225,7 @@ msgstr "Editar templates de arquivo do container"
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/image_alias.go:104
+#: lxc/image_alias.go:121
 msgid "[<remote>:]<alias>"
 msgstr ""
 
@@ -7213,7 +7233,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/image_alias.go:252
+#: lxc/image_alias.go:285
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
@@ -7275,16 +7295,16 @@ msgstr "Editar templates de arquivo do container"
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr "Criar perfis"
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1600 lxc/image.go:1727
+#: lxc/image.go:1601 lxc/image.go:1728
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/image.go:1664
+#: lxc/image.go:1665
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr "Editar templates de arquivo do container"
@@ -7306,7 +7326,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1443
+#: lxc/image.go:334 lxc/image.go:1444
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7381,7 +7401,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:376
+#: lxc/file.go:380
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -7394,12 +7414,12 @@ msgstr "Editar templates de arquivo do container"
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:454
+#: lxc/file.go:466
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1226
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr "Editar templates de arquivo do container"
@@ -7472,8 +7492,8 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:644
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:179
+#: lxc/network_forward.go:177 lxc/network_forward.go:652
+#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
 #: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address>"
@@ -7491,13 +7511,13 @@ msgid ""
 "[<target_port(s)>]"
 msgstr "Criar perfis"
 
-#: lxc/network_forward.go:402 lxc/network_forward.go:597
+#: lxc/network_forward.go:410 lxc/network_forward.go:605
 #: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr "Criar perfis"
 
-#: lxc/network_forward.go:487 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr "Criar perfis"
@@ -7509,13 +7529,13 @@ msgid ""
 "<backend_name>[,<backend_name>...]"
 msgstr "Criar perfis"
 
-#: lxc/network_forward.go:887
+#: lxc/network_forward.go:895
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:968 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -7576,7 +7596,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2811
+#: lxc/storage_volume.go:2813
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "Criar perfis"
@@ -7616,73 +7636,74 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1958
+#: lxc/storage_volume.go:1960
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:806
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:167
-#, fuzzy
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
-msgstr "Criar perfis"
-
-#: lxc/storage_volume.go:2562
+#: lxc/storage_volume.go:2564
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2645
+#: lxc/storage_volume.go:2647
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2428
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:610
+#: lxc/storage_volume.go:614
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:718
+#: lxc/storage_volume.go:722
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:2364
+#: lxc/storage_volume.go:810
+#, fuzzy
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
+msgstr "Criar perfis"
+
+#: lxc/storage_volume.go:167
+#, fuzzy
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
+msgstr "Criar perfis"
+
+#: lxc/storage_volume.go:2366
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2087
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2245
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1234
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:1858
+#: lxc/storage_volume.go:1860
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:392
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr "Criar perfis"
@@ -7800,7 +7821,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1603
 #, fuzzy
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr "Criar perfis"
@@ -7966,20 +7987,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1230
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:470
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:691
+#: lxc/file.go:704
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -8280,7 +8301,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:618
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -8288,13 +8309,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2817
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2432
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -8328,16 +8349,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1396
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1331
+#: lxc/file.go:1355
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1284
+#: lxc/file.go:1308
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-07 15:11-0700\n"
+"POT-Creation-Date: 2025-01-10 14:44-0600\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -78,7 +78,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:1041
+#: lxc/storage_volume.go:1043
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -378,7 +378,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что только конфигурация может быть изменена."
 
-#: lxc/network_forward.go:667
+#: lxc/network_forward.go:675
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the network forward.\n"
@@ -687,12 +687,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1157
+#: lxc/file.go:1177
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1047
+#: lxc/file.go:1067
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -728,7 +728,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:65
+#: lxc/init.go:146 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -782,7 +782,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:687
+#: lxc/file.go:700
 #, fuzzy
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
@@ -803,7 +803,7 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr "ПСЕВДОНИМ"
 
@@ -939,7 +939,7 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:888 lxc/network_forward.go:889
+#: lxc/network_forward.go:896 lxc/network_forward.go:897
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -990,7 +990,7 @@ msgstr ""
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
+#: lxc/image_alias.go:101 lxc/image_alias.go:156 lxc/image_alias.go:320
 msgid "Alias name missing"
 msgstr ""
 
@@ -1003,7 +1003,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr "Псевдонимы:"
 
-#: lxc/storage_volume.go:1607
+#: lxc/storage_volume.go:1609
 #, fuzzy
 msgid "All projects"
 msgstr "Доступные команды:"
@@ -1036,7 +1036,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -1061,13 +1061,27 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168 lxc/storage_volume.go:169
+#: lxc/storage_volume.go:168
 #, fuzzy
 msgid "Attach new storage volumes to instances"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:169
+msgid ""
+"Attach new storage volumes to instances\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
+msgstr ""
+
+#: lxc/storage_volume.go:285
 msgid "Attach new storage volumes to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:286
+msgid ""
+"Attach new storage volumes to profiles\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
 #: lxc/console.go:39
@@ -1119,16 +1133,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/storage_volume.go:2719
+#: lxc/storage_volume.go:2721
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/export.go:192 lxc/storage_volume.go:2796
+#: lxc/export.go:192 lxc/storage_volume.go:2798
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1538
+#: lxc/info.go:666 lxc/storage_volume.go:1540
 msgid "Backups:"
 msgstr ""
 
@@ -1137,19 +1151,19 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
+#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:326
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
 #, fuzzy, c-format
 msgid "Bad key=value pair: %q"
 msgstr "Имя контейнера: %s"
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1192,7 +1206,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr "ОБЩЕЕ ИМЯ"
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1752
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1246,7 +1260,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1254,7 +1268,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:562
+#: lxc/file.go:575
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1279,11 +1293,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:768
+#: lxc/file.go:790
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1296,12 +1310,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:493
+#: lxc/storage_volume.go:497
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:447
+#: lxc/storage_volume.go:451
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1412,9 +1426,9 @@ msgstr ""
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:497 lxc/network_forward.go:649
-#: lxc/network_forward.go:803 lxc/network_forward.go:892
-#: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
+#: lxc/network_forward.go:505 lxc/network_forward.go:657
+#: lxc/network_forward.go:811 lxc/network_forward.go:900
+#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
 #: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
 #: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
@@ -1426,14 +1440,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
-#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
-#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
-#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
+#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
 msgid "Cluster member name"
 msgstr ""
 
@@ -1449,7 +1463,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1608
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr "Столбцы"
@@ -1489,21 +1503,21 @@ msgstr ""
 #: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
-#: lxc/network_acl.go:698 lxc/network_forward.go:767
+#: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
-#: lxc/storage_volume.go:1199
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
+#: lxc/storage_volume.go:1201
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:620
+#: lxc/storage_volume.go:624
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1478
+#: lxc/storage_volume.go:1480
 #, fuzzy, c-format
 msgid "Content type: %s"
 msgstr "Авто-обновление: %s"
@@ -1566,7 +1580,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 #, fuzzy
 msgid "Copy storage volumes"
 msgstr "Копирование образа: %s"
@@ -1575,12 +1589,12 @@ msgstr "Копирование образа: %s"
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1594,7 +1608,7 @@ msgstr "Копирование образа: %s"
 msgid "Copying the image: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:519
 #, fuzzy, c-format
 msgid "Copying the storage volume: %s"
 msgstr "Копирование образа: %s"
@@ -1692,7 +1706,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:462 lxc/file.go:696
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1739,7 +1753,7 @@ msgstr "Копирование образа: %s"
 msgid "Create new custom storage buckets"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
 #, fuzzy
 msgid "Create new custom storage volumes"
 msgstr "Копирование образа: %s"
@@ -1800,12 +1814,12 @@ msgstr "Копирование образа: %s"
 msgid "Create the instance with no profiles applied"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:182
+#: lxc/init.go:186
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1815,7 +1829,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 #, fuzzy
 msgid "Creating the instance"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -1830,13 +1844,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1749
+#: lxc/storage_volume.go:1751
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1856,7 +1870,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2653
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1890,7 +1904,7 @@ msgstr "Копирование образа: %s"
 msgid "Delete identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:106 lxc/image_alias.go:107
+#: lxc/image_alias.go:123 lxc/image_alias.go:124
 msgid "Delete image aliases"
 msgstr ""
 
@@ -1917,7 +1931,7 @@ msgstr "Копирование образа: %s"
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:799 lxc/network_forward.go:800
+#: lxc/network_forward.go:807 lxc/network_forward.go:808
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1961,7 +1975,7 @@ msgstr "Копирование образа: %s"
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
+#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
 #, fuzzy
 msgid "Delete storage volumes"
 msgstr "Копирование образа: %s"
@@ -2004,13 +2018,13 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
-#: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
-#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
+#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
+#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
+#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
@@ -2024,10 +2038,10 @@ msgstr ""
 #: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:404 lxc/network_forward.go:489
-#: lxc/network_forward.go:599 lxc/network_forward.go:646
-#: lxc/network_forward.go:800 lxc/network_forward.go:874
-#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_forward.go:412 lxc/network_forward.go:497
+#: lxc/network_forward.go:607 lxc/network_forward.go:654
+#: lxc/network_forward.go:808 lxc/network_forward.go:882
+#: lxc/network_forward.go:897 lxc/network_forward.go:982
 #: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
 #: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
 #: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
@@ -2067,27 +2081,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
-#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
-#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
-#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
-#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
-#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
-#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
-#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1465
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Копирование образа: %s"
@@ -2100,12 +2114,12 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
 #, fuzzy
 msgid "Detach storage volumes from instances"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
+#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2155,7 +2169,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:403
+#: lxc/init.go:407
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2167,7 +2181,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1216
+#: lxc/file.go:1236
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2270,7 +2284,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:377 lxc/file.go:378
+#: lxc/file.go:381 lxc/file.go:382
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2314,7 +2328,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:653 lxc/network_forward.go:654
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -2359,7 +2373,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2367,7 +2381,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1785
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2421,11 +2435,11 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
-#: lxc/network_acl.go:524 lxc/network_forward.go:572
+#: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
+#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Копирование образа: %s"
@@ -2436,11 +2450,11 @@ msgid "Error unsetting properties: %v"
 msgstr "Копирование образа: %s"
 
 #: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
-#: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
+#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
-#: lxc/storage_volume.go:2210
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
+#: lxc/storage_volume.go:2212
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2486,8 +2500,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
+#: lxc/storage_volume.go:1577
 msgid "Expires at"
 msgstr ""
 
@@ -2512,7 +2526,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 #, fuzzy
 msgid "Export custom storage volume"
 msgstr "Копирование образа: %s"
@@ -2527,12 +2541,12 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Export instances as backup tarballs."
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/storage_volume.go:2650
+#: lxc/storage_volume.go:2652
 #, fuzzy
 msgid "Export the volume without its snapshots"
 msgstr "Копирование образа: %s"
 
-#: lxc/export.go:152 lxc/storage_volume.go:2779
+#: lxc/export.go:152 lxc/storage_volume.go:2781
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Копирование образа: %s"
@@ -2551,7 +2565,7 @@ msgid "FILENAME"
 msgstr ""
 
 #: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
-#: lxc/image_alias.go:235
+#: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2559,12 +2573,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1467
+#: lxc/file.go:1491
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1490
+#: lxc/file.go:1514
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2579,12 +2593,12 @@ msgstr "Копирование образа: %s"
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Копирование образа: %s"
 
-#: lxc/file.go:1517
+#: lxc/file.go:1541
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1326
 #, fuzzy, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr "Копирование образа: %s"
@@ -2614,7 +2628,7 @@ msgstr "Копирование образа: %s"
 msgid "Failed fetching fingerprint %q: %w"
 msgstr "Копирование образа: %s"
 
-#: lxc/file.go:1423
+#: lxc/file.go:1447
 #, fuzzy, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr "Принять сертификат"
@@ -2629,7 +2643,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr "Копирование образа: %s"
 
-#: lxc/file.go:1428
+#: lxc/file.go:1452
 #, fuzzy, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr "Принять сертификат"
@@ -2639,12 +2653,12 @@ msgstr "Принять сертификат"
 msgid "Failed starting command: %w"
 msgstr "Принять сертификат"
 
-#: lxc/file.go:1328
+#: lxc/file.go:1352
 #, fuzzy, c-format
 msgid "Failed starting sshfs: %w"
 msgstr "Принять сертификат"
 
-#: lxc/file.go:1455
+#: lxc/file.go:1479
 #, fuzzy, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr "Принять сертификат"
@@ -2658,7 +2672,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr "Принять сертификат"
 
-#: lxc/move.go:304 lxc/move.go:380
+#: lxc/move.go:309 lxc/move.go:385
 #, fuzzy, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr "Копирование образа: %s"
@@ -2683,7 +2697,7 @@ msgstr "Копирование образа: %s"
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1440
+#: lxc/file.go:1464
 #, fuzzy, c-format
 msgid "Failed to listen for connection: %w"
 msgstr "Принять сертификат"
@@ -2698,7 +2712,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr "Принять сертификат"
 
-#: lxc/file.go:1042
+#: lxc/file.go:1062
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2786,14 +2800,14 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1625 lxc/warning.go:94
+#: lxc/storage_volume.go:1627 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2862,7 +2876,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1602
+#: lxc/image.go:1602 lxc/image.go:1603
 msgid "Get image properties"
 msgstr ""
 
@@ -2878,7 +2892,7 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:414
 #, fuzzy
 msgid "Get the key as a network forward property"
 msgstr "Копирование образа: %s"
@@ -2925,7 +2939,7 @@ msgstr "Копирование образа: %s"
 msgid "Get the key as a storage property"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1249
+#: lxc/storage_volume.go:1251
 #, fuzzy
 msgid "Get the key as a storage volume property"
 msgstr "Копирование образа: %s"
@@ -2955,7 +2969,7 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:403 lxc/network_forward.go:404
+#: lxc/network_forward.go:411 lxc/network_forward.go:412
 #, fuzzy
 msgid "Get values for network forward configuration keys"
 msgstr "Копирование образа: %s"
@@ -2997,11 +3011,11 @@ msgstr "Копирование образа: %s"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:476
+#: lxc/storage_volume.go:480
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -3042,22 +3056,22 @@ msgstr "Псевдонимы:"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1540
+#: lxc/file.go:1564
 #, fuzzy, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/file.go:1529
+#: lxc/file.go:1553
 #, fuzzy, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/file.go:1352
+#: lxc/file.go:1376
 #, fuzzy, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/file.go:1362
+#: lxc/file.go:1386
 #, fuzzy, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -3130,11 +3144,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:415
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3144,7 +3158,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2437
+#: lxc/storage_volume.go:2439
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3157,7 +3171,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/image.go:1517
+#: lxc/image.go:1518
 msgid "Image already up to date."
 msgstr ""
 
@@ -3173,11 +3187,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1472
+#: lxc/image.go:364 lxc/image.go:1473
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1698
+#: lxc/image.go:444 lxc/image.go:1699
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -3187,7 +3201,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1515
+#: lxc/image.go:1516
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3195,7 +3209,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2815
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3203,7 +3217,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2814
 #, fuzzy
 msgid "Import custom storage volumes"
 msgstr "Копирование образа: %s"
@@ -3228,11 +3242,11 @@ msgstr "Копирование образа: %s"
 msgid "Import instance backups"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2822
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2894
+#: lxc/storage_volume.go:2896
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -3259,11 +3273,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr "Имя контейнера: %s"
 
-#: lxc/file.go:1354
+#: lxc/file.go:1378
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1531
+#: lxc/file.go:1555
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3273,7 +3287,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr "Имя контейнера является обязательным"
 
-#: lxc/init.go:414
+#: lxc/init.go:418
 #, fuzzy, c-format
 msgid "Instance name is: %s"
 msgstr "Имя контейнера: %s"
@@ -3283,7 +3297,7 @@ msgstr "Имя контейнера: %s"
 msgid "Instance name must be specified"
 msgstr "Имя контейнера: %s"
 
-#: lxc/file.go:1274
+#: lxc/file.go:1298
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3335,7 +3349,7 @@ msgstr "Имя контейнера: %s"
 msgid "Invalid instance name: %s"
 msgstr "Имя контейнера: %s"
 
-#: lxc/file.go:1269
+#: lxc/file.go:1293
 #, fuzzy, c-format
 msgid "Invalid instance path: %q"
 msgstr "Имя контейнера: %s"
@@ -3361,24 +3375,24 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2023
+#: lxc/move.go:153 lxc/storage_volume.go:2025
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "Нельзя использовать '/' в имени снимка"
 
-#: lxc/move.go:144
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2019
+#: lxc/storage_volume.go:2021
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:509
+#: lxc/main.go:518
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:353
+#: lxc/file.go:357
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3388,19 +3402,19 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
-#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
+#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Имя контейнера: %s"
 
-#: lxc/file.go:535
+#: lxc/file.go:548
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:717
+#: lxc/file.go:185 lxc/file.go:739
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3437,7 +3451,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3468,12 +3482,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:176
+#: lxc/init.go:180
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:174
+#: lxc/init.go:178
 #, fuzzy
 msgid "Launching the instance"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -3580,11 +3594,11 @@ msgstr "Псевдонимы:"
 msgid "List identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:151
+#: lxc/image_alias.go:176
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:177
 msgid ""
 "List image aliases\n"
 "\n"
@@ -3758,12 +3772,12 @@ msgstr "Копирование образа: %s"
 msgid "List storage buckets"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1605
 #, fuzzy
 msgid "List storage volumes"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1610
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3823,7 +3837,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1481
+#: lxc/info.go:489 lxc/storage_volume.go:1483
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4020,7 +4034,7 @@ msgstr "Копирование образа: %s"
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:873 lxc/network_forward.go:874
+#: lxc/network_forward.go:881 lxc/network_forward.go:882
 #, fuzzy
 msgid "Manage network forward ports"
 msgstr "Копирование образа: %s"
@@ -4186,12 +4200,12 @@ msgstr " Использование памяти:"
 msgid "Memory:"
 msgstr " Использование памяти:"
 
-#: lxc/move.go:322 lxc/move.go:435
+#: lxc/move.go:327 lxc/move.go:440
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:347 lxc/move.go:440
+#: lxc/move.go:352 lxc/move.go:445
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4265,10 +4279,10 @@ msgstr "Имя контейнера: %s"
 msgid "Missing key name"
 msgstr "Имя контейнера: %s"
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:449
-#: lxc/network_forward.go:534 lxc/network_forward.go:709
-#: lxc/network_forward.go:840 lxc/network_forward.go:933
-#: lxc/network_forward.go:1015 lxc/network_load_balancer.go:221
+#: lxc/network_forward.go:219 lxc/network_forward.go:457
+#: lxc/network_forward.go:542 lxc/network_forward.go:717
+#: lxc/network_forward.go:848 lxc/network_forward.go:945
+#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
 #: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
 #: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
 #: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
@@ -4295,10 +4309,10 @@ msgstr "Имя контейнера: %s"
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
 #: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
 #: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:284 lxc/network_forward.go:445
-#: lxc/network_forward.go:530 lxc/network_forward.go:705
-#: lxc/network_forward.go:836 lxc/network_forward.go:929
-#: lxc/network_forward.go:1011 lxc/network_load_balancer.go:131
+#: lxc/network_forward.go:292 lxc/network_forward.go:453
+#: lxc/network_forward.go:538 lxc/network_forward.go:713
+#: lxc/network_forward.go:844 lxc/network_forward.go:941
+#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
 #: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
 #: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
 #: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
@@ -4337,13 +4351,13 @@ msgstr "Имя контейнера: %s"
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
-#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
-#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
-#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
+#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
+#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
+#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
+#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
 msgid "Missing pool name"
 msgstr ""
 
@@ -4363,17 +4377,17 @@ msgstr "Имя контейнера: %s"
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
+#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
 #, fuzzy
 msgid "Missing source volume name"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1411
+#: lxc/storage_volume.go:1413
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Копирование образа: %s"
 
-#: lxc/file.go:820
+#: lxc/file.go:842
 msgid "Missing target directory"
 msgstr ""
 
@@ -4407,16 +4421,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
-#: lxc/storage_volume.go:975
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
+#: lxc/storage_volume.go:977
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:507
+#: lxc/file.go:520
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1207 lxc/file.go:1208
+#: lxc/file.go:1227 lxc/file.go:1228
 #, fuzzy
 msgid "Mount files from instances"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -4446,7 +4460,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
 #, fuzzy
 msgid "Move storage volumes between pools"
 msgstr "Копирование образа: %s"
@@ -4455,16 +4469,16 @@ msgstr "Копирование образа: %s"
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1869
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 #, fuzzy, c-format
 msgid "Moving the storage volume: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_forward.go:1059 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4486,7 +4500,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
 msgid "NAME"
 msgstr ""
 
@@ -4538,8 +4552,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
-#: lxc/storage_volume.go:1573
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Name"
 msgstr ""
 
@@ -4547,7 +4561,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4602,12 +4616,12 @@ msgstr " Использование сети:"
 msgid "Network Zone %s deleted"
 msgstr " Использование сети:"
 
-#: lxc/network_forward.go:386
+#: lxc/network_forward.go:394
 #, fuzzy, c-format
 msgid "Network forward %s created"
 msgstr " Использование сети:"
 
-#: lxc/network_forward.go:857
+#: lxc/network_forward.go:865
 #, fuzzy, c-format
 msgid "Network forward %s deleted"
 msgstr " Использование сети:"
@@ -4693,7 +4707,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
+#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
 #, fuzzy
 msgid "No device found for this storage volume"
 msgstr "Копирование образа: %s"
@@ -4702,7 +4716,7 @@ msgstr "Копирование образа: %s"
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1070 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4714,11 +4728,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4732,7 +4746,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2035
+#: lxc/storage_volume.go:2037
 #, fuzzy
 msgid "Not a snapshot name"
 msgstr "Нельзя использовать '/' в имени снимка"
@@ -4741,16 +4755,21 @@ msgstr "Нельзя использовать '/' в имени снимка"
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
-#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
-msgid "Only \"custom\" volumes can be attached to instances"
+#: lxc/storage_volume.go:216
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2701
+#: lxc/storage_volume.go:348
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:2703
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2500
+#: lxc/storage_volume.go:2502
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4762,7 +4781,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1431
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4775,7 +4794,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1577
+#: lxc/info.go:705 lxc/storage_volume.go:1579
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4805,7 +4824,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1767
+#: lxc/storage_volume.go:1769
 msgid "POOL"
 msgstr ""
 
@@ -4822,7 +4841,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167
-#: lxc/storage_volume.go:1773 lxc/warning.go:213
+#: lxc/storage_volume.go:1775 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4846,7 +4865,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:367
+#: lxc/main.go:376
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Пароль администратора для %s: "
@@ -4885,7 +4904,7 @@ msgstr "Авто-обновление: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1332
+#: lxc/file.go:1356
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4893,12 +4912,12 @@ msgstr ""
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
-#: lxc/network_acl.go:699 lxc/network_forward.go:768
+#: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
-#: lxc/storage_volume.go:1200
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
+#: lxc/storage_volume.go:1202
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -5011,11 +5030,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1649
+#: lxc/image.go:1650
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -5029,7 +5048,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1238
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5045,7 +5064,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5066,7 +5085,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1017
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5075,7 +5094,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2094
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5088,7 +5107,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2370
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5119,20 +5138,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/file.go:455 lxc/file.go:456
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:638 lxc/file.go:989
+#: lxc/file.go:651 lxc/file.go:1009
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:688 lxc/file.go:689
+#: lxc/file.go:701 lxc/file.go:702
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:923 lxc/file.go:1089
+#: lxc/file.go:943 lxc/file.go:1109
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -5141,7 +5160,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5172,16 +5191,16 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Rebuild instances"
 msgstr "Псевдонимы:"
 
-#: lxc/file.go:463 lxc/file.go:695
+#: lxc/file.go:475 lxc/file.go:708
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:403
 #, fuzzy
 msgid "Refresh and update the existing storage volume copies"
 msgstr "Копирование образа: %s"
 
-#: lxc/image.go:1444 lxc/image.go:1445
+#: lxc/image.go:1445 lxc/image.go:1446
 #, fuzzy
 msgid "Refresh images"
 msgstr "Копирование образа: %s"
@@ -5191,7 +5210,7 @@ msgstr "Копирование образа: %s"
 msgid "Refreshing instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/image.go:1481
+#: lxc/image.go:1482
 #, fuzzy, c-format
 msgid "Refreshing the image: %s"
 msgstr "Копирование образа: %s"
@@ -5271,7 +5290,7 @@ msgstr "Копирование образа: %s"
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:971 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -5310,7 +5329,7 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:969 lxc/network_forward.go:970
+#: lxc/network_forward.go:981 lxc/network_forward.go:982
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -5348,8 +5367,8 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
-#: lxc/image_alias.go:255
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:287
+#: lxc/image_alias.go:288
 msgid "Rename aliases"
 msgstr ""
 
@@ -5388,17 +5407,17 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1962
 #, fuzzy
 msgid "Rename storage volumes"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1961
 #, fuzzy
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
+#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5453,7 +5472,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
 #, fuzzy
 msgid "Restore storage volume snapshots"
 msgstr "Копирование образа: %s"
@@ -5471,7 +5490,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:361
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5523,12 +5542,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1460
+#: lxc/file.go:1484
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1461
+#: lxc/file.go:1485
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5606,7 +5625,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Set a cluster member's configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/file.go:1217
+#: lxc/file.go:1237
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5632,7 +5651,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1665 lxc/image.go:1666
+#: lxc/image.go:1666 lxc/image.go:1667
 msgid "Set image properties"
 msgstr ""
 
@@ -5675,12 +5694,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:488
+#: lxc/network_forward.go:496
 #, fuzzy
 msgid "Set network forward keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_forward.go:489
+#: lxc/network_forward.go:497
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5789,11 +5808,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2088
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2089
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5810,7 +5829,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:698
+#: lxc/file.go:711
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5818,7 +5837,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:699
+#: lxc/file.go:712
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5826,7 +5845,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:710
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5838,7 +5857,7 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:504
 #, fuzzy
 msgid "Set the key as a network forward property"
 msgstr "Копирование образа: %s"
@@ -5885,7 +5904,7 @@ msgstr "Копирование образа: %s"
 msgid "Set the key as a storage property"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2105
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "Копирование образа: %s"
@@ -5894,7 +5913,7 @@ msgstr "Копирование образа: %s"
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1215
+#: lxc/file.go:1235
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5954,7 +5973,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1535 lxc/image.go:1536
+#: lxc/image.go:1536 lxc/image.go:1537
 msgid "Show image properties"
 msgstr ""
 
@@ -5976,7 +5995,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:271 lxc/main.go:272
+#: lxc/main.go:280 lxc/main.go:281
 msgid "Show less common commands"
 msgstr ""
 
@@ -6049,11 +6068,11 @@ msgstr "Копирование образа: %s"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
 #, fuzzy
 msgid "Show storage volume state information"
 msgstr "Копирование образа: %s"
@@ -6125,16 +6144,16 @@ msgstr "Авто-обновление: %s"
 msgid "Size: %s"
 msgstr "Авто-обновление: %s"
 
-#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
 #, fuzzy
 msgid "Snapshot storage volumes"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:2190
+#: lxc/storage_volume.go:2192
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1502
+#: lxc/info.go:619 lxc/storage_volume.go:1504
 msgid "Snapshots:"
 msgstr ""
 
@@ -6242,21 +6261,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:703
+#: lxc/storage_volume.go:707
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:791
+#: lxc/storage_volume.go:795
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:516
+#: lxc/storage_volume.go:520
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:524
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -6319,21 +6338,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1747 lxc/warning.go:216
+#: lxc/storage_volume.go:1749 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1262
+#: lxc/file.go:1286
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1256
+#: lxc/file.go:1280
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6343,15 +6362,15 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:181
+#: lxc/move.go:186
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:219 lxc/move.go:240
+#: lxc/move.go:224 lxc/move.go:245
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:193
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -6359,15 +6378,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:185
+#: lxc/move.go:190
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:189
+#: lxc/move.go:194
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:210
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -6389,7 +6408,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:439
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6442,7 +6461,7 @@ msgstr "Копирование образа: %s"
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_forward.go:462
+#: lxc/network_forward.go:470
 #, fuzzy, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr "Копирование образа: %s"
@@ -6482,12 +6501,12 @@ msgstr "Копирование образа: %s"
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1340
+#: lxc/storage_volume.go:1342
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1317
+#: lxc/storage_volume.go:1319
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6502,12 +6521,12 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:309
+#: lxc/move.go:314
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
-#: lxc/storage_volume.go:989
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
+#: lxc/storage_volume.go:991
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6536,7 +6555,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:298
+#: lxc/main.go:307
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6560,11 +6579,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:437
+#: lxc/init.go:441
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:440
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6572,7 +6591,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:412
+#: lxc/main.go:421
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6583,7 +6602,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1489
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Авто-обновление: %s"
@@ -6598,7 +6617,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1864
+#: lxc/storage_volume.go:1866
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6606,7 +6625,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6623,7 +6642,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:327
+#: lxc/copy.go:382 lxc/move.go:332
 #, fuzzy, c-format
 msgid "Transferring instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -6666,7 +6685,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1472
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6688,13 +6707,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1752
+#: lxc/project.go:995 lxc/storage_volume.go:1754
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1751
+#: lxc/storage.go:724 lxc/storage_volume.go:1753
 msgid "USED BY"
 msgstr ""
 
@@ -6707,7 +6726,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:411
+#: lxc/file.go:423
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6721,12 +6740,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1483
+#: lxc/file.go:1507
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1791
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6737,7 +6756,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1029
+#: lxc/file.go:1049
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6770,7 +6789,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1728 lxc/image.go:1729
+#: lxc/image.go:1729 lxc/image.go:1730
 msgid "Unset image properties"
 msgstr ""
 
@@ -6786,12 +6805,12 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:598
+#: lxc/network_forward.go:606
 #, fuzzy
 msgid "Unset network forward configuration keys"
 msgstr "Копирование образа: %s"
 
-#: lxc/network_forward.go:599
+#: lxc/network_forward.go:607
 #, fuzzy
 msgid "Unset network forward keys"
 msgstr "Копирование образа: %s"
@@ -6843,7 +6862,7 @@ msgstr "Копирование образа: %s"
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6855,7 +6874,7 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:602
+#: lxc/network_forward.go:610
 #, fuzzy
 msgid "Unset the key as a network forward property"
 msgstr "Копирование образа: %s"
@@ -6903,7 +6922,7 @@ msgstr "Копирование образа: %s"
 msgid "Unset the key as a storage property"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2381
 #, fuzzy
 msgid "Unset the key as a storage volume property"
 msgstr "Копирование образа: %s"
@@ -6912,7 +6931,7 @@ msgstr "Копирование образа: %s"
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:248
+#: lxc/storage_volume.go:250
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6950,12 +6969,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1485
+#: lxc/storage_volume.go:1487
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Авто-обновление: %s"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2652
+#: lxc/export.go:42 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -7022,7 +7041,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1576
+#: lxc/storage_volume.go:1578
 msgid "Volume Only"
 msgstr ""
 
@@ -7073,7 +7092,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:293 lxc/move.go:369
+#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -7081,17 +7100,17 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:909
+#: lxc/storage_volume.go:912
 #, fuzzy
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 "Изменение состояния одного или нескольких контейнеров %s.\n"
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:282
+#: lxc/storage_volume.go:284
 #, fuzzy
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 "Изменение состояния одного или нескольких контейнеров %s.\n"
 "\n"
@@ -7150,7 +7169,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:174
 #, fuzzy
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
@@ -7251,7 +7270,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image_alias.go:104
+#: lxc/image_alias.go:121
 #, fuzzy
 msgid "[<remote>:]<alias>"
 msgstr ""
@@ -7267,7 +7286,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image_alias.go:252
+#: lxc/image_alias.go:285
 #, fuzzy
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
@@ -7357,7 +7376,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr ""
@@ -7365,7 +7384,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:1600 lxc/image.go:1727
+#: lxc/image.go:1601 lxc/image.go:1728
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr ""
@@ -7373,7 +7392,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:1664
+#: lxc/image.go:1665
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
@@ -7413,7 +7432,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:334 lxc/image.go:1443
+#: lxc/image.go:334 lxc/image.go:1444
 #, fuzzy
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
@@ -7552,7 +7571,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:376
+#: lxc/file.go:380
 #, fuzzy
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
@@ -7576,7 +7595,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:454
+#: lxc/file.go:466
 #, fuzzy
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
@@ -7585,7 +7604,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:1206
+#: lxc/file.go:1226
 #, fuzzy
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
@@ -7717,8 +7736,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:644
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:179
+#: lxc/network_forward.go:177 lxc/network_forward.go:652
+#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
 #: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address>"
@@ -7745,7 +7764,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:402 lxc/network_forward.go:597
+#: lxc/network_forward.go:410 lxc/network_forward.go:605
 #: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>"
@@ -7754,7 +7773,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:487 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
@@ -7772,13 +7791,13 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network_forward.go:887
+#: lxc/network_forward.go:895
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:968 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
 #, fuzzy
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
@@ -7885,7 +7904,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2811
+#: lxc/storage_volume.go:2813
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
@@ -7952,7 +7971,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1958
+#: lxc/storage_volume.go:1960
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
@@ -7962,23 +7981,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:806
-#, fuzzy
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
-msgstr ""
-"Изменение состояния одного или нескольких контейнеров %s.\n"
-"\n"
-"lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
-
-#: lxc/storage_volume.go:167
-#, fuzzy
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
-msgstr ""
-"Изменение состояния одного или нескольких контейнеров %s.\n"
-"\n"
-"lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
-
-#: lxc/storage_volume.go:2562
+#: lxc/storage_volume.go:2564
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
@@ -7986,7 +7989,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2645
+#: lxc/storage_volume.go:2647
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
@@ -7994,7 +7997,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2428
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
@@ -8002,7 +8005,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:610
+#: lxc/storage_volume.go:614
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
@@ -8010,7 +8013,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:718
+#: lxc/storage_volume.go:722
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
@@ -8018,7 +8021,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
@@ -8026,7 +8029,23 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2364
+#: lxc/storage_volume.go:810
+#, fuzzy
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
+msgstr ""
+"Изменение состояния одного или нескольких контейнеров %s.\n"
+"\n"
+"lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
+
+#: lxc/storage_volume.go:167
+#, fuzzy
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
+msgstr ""
+"Изменение состояния одного или нескольких контейнеров %s.\n"
+"\n"
+"lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
+
+#: lxc/storage_volume.go:2366
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
@@ -8034,7 +8053,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2087
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
@@ -8042,7 +8061,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2245
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
@@ -8050,7 +8069,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1234
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
@@ -8058,7 +8077,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1858
+#: lxc/storage_volume.go:1860
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -8066,7 +8085,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:392
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -8276,7 +8295,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1603
 #, fuzzy
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
@@ -8454,20 +8473,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1230
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:470
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:691
+#: lxc/file.go:704
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -8768,7 +8787,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:618
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -8776,13 +8795,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2817
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2432
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -8816,16 +8835,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1396
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1331
+#: lxc/file.go:1355
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1284
+#: lxc/file.go:1308
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-07 15:11-0700\n"
+"POT-Creation-Date: 2025-01-10 14:44-0600\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1041
+#: lxc/storage_volume.go:1043
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:667
+#: lxc/network_forward.go:675
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,12 +430,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1157
+#: lxc/file.go:1177
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1047
+#: lxc/file.go:1067
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -471,7 +471,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:65
+#: lxc/init.go:146 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:687
+#: lxc/file.go:700
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -541,7 +541,7 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
@@ -672,7 +672,7 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:888 lxc/network_forward.go:889
+#: lxc/network_forward.go:896 lxc/network_forward.go:897
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -722,7 +722,7 @@ msgstr ""
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
+#: lxc/image_alias.go:101 lxc/image_alias.go:156 lxc/image_alias.go:320
 msgid "Alias name missing"
 msgstr ""
 
@@ -735,7 +735,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1607
+#: lxc/storage_volume.go:1609
 msgid "All projects"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -790,12 +790,26 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168 lxc/storage_volume.go:169
+#: lxc/storage_volume.go:168
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:169
+msgid ""
+"Attach new storage volumes to instances\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
+msgstr ""
+
+#: lxc/storage_volume.go:285
 msgid "Attach new storage volumes to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:286
+msgid ""
+"Attach new storage volumes to profiles\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
 #: lxc/console.go:39
@@ -846,16 +860,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2719
+#: lxc/storage_volume.go:2721
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2796
+#: lxc/export.go:192 lxc/storage_volume.go:2798
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1538
+#: lxc/info.go:666 lxc/storage_volume.go:1540
 msgid "Backups:"
 msgstr ""
 
@@ -864,19 +878,19 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
+#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:326
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -919,7 +933,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1752
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -971,7 +985,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -979,7 +993,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:562
+#: lxc/file.go:575
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1004,11 +1018,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:768
+#: lxc/file.go:790
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1021,12 +1035,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:493
+#: lxc/storage_volume.go:497
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:447
+#: lxc/storage_volume.go:451
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1132,9 +1146,9 @@ msgstr ""
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:497 lxc/network_forward.go:649
-#: lxc/network_forward.go:803 lxc/network_forward.go:892
-#: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
+#: lxc/network_forward.go:505 lxc/network_forward.go:657
+#: lxc/network_forward.go:811 lxc/network_forward.go:900
+#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
 #: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
 #: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
@@ -1146,14 +1160,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
-#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
-#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
-#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
+#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
 msgid "Cluster member name"
 msgstr ""
 
@@ -1169,7 +1183,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1608
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1209,21 +1223,21 @@ msgstr ""
 #: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
-#: lxc/network_acl.go:698 lxc/network_forward.go:767
+#: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
-#: lxc/storage_volume.go:1199
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
+#: lxc/storage_volume.go:1201
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:620
+#: lxc/storage_volume.go:624
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1478
+#: lxc/storage_volume.go:1480
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1285,7 +1299,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1293,12 +1307,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1311,7 +1325,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1406,7 +1420,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:462 lxc/file.go:696
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1446,7 +1460,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1498,12 +1512,12 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:182
+#: lxc/init.go:186
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1513,7 +1527,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 msgid "Creating the instance"
 msgstr ""
 
@@ -1527,13 +1541,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1749
+#: lxc/storage_volume.go:1751
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1553,7 +1567,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2653
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1585,7 +1599,7 @@ msgstr ""
 msgid "Delete identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:106 lxc/image_alias.go:107
+#: lxc/image_alias.go:123 lxc/image_alias.go:124
 msgid "Delete image aliases"
 msgstr ""
 
@@ -1609,7 +1623,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:799 lxc/network_forward.go:800
+#: lxc/network_forward.go:807 lxc/network_forward.go:808
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1649,7 +1663,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
+#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1691,13 +1705,13 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
-#: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
-#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
+#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
+#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
+#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
@@ -1711,10 +1725,10 @@ msgstr ""
 #: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:404 lxc/network_forward.go:489
-#: lxc/network_forward.go:599 lxc/network_forward.go:646
-#: lxc/network_forward.go:800 lxc/network_forward.go:874
-#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_forward.go:412 lxc/network_forward.go:497
+#: lxc/network_forward.go:607 lxc/network_forward.go:654
+#: lxc/network_forward.go:808 lxc/network_forward.go:882
+#: lxc/network_forward.go:897 lxc/network_forward.go:982
 #: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
 #: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
 #: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
@@ -1754,27 +1768,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
-#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
-#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
-#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
-#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
-#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
-#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
-#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1465
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1786,11 +1800,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
+#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1840,7 +1854,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:403
+#: lxc/init.go:407
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1852,7 +1866,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1216
+#: lxc/file.go:1236
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1948,7 +1962,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:377 lxc/file.go:378
+#: lxc/file.go:381 lxc/file.go:382
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1988,7 +2002,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:653 lxc/network_forward.go:654
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -2028,7 +2042,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2036,7 +2050,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1785
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2090,11 +2104,11 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
-#: lxc/network_acl.go:524 lxc/network_forward.go:572
+#: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
+#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2105,11 +2119,11 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
-#: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
+#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
-#: lxc/storage_volume.go:2210
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
+#: lxc/storage_volume.go:2212
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2151,8 +2165,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
+#: lxc/storage_volume.go:1577
 msgid "Expires at"
 msgstr ""
 
@@ -2176,7 +2190,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2188,11 +2202,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2650
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2779
+#: lxc/export.go:152 lxc/storage_volume.go:2781
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2211,7 +2225,7 @@ msgid "FILENAME"
 msgstr ""
 
 #: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
-#: lxc/image_alias.go:235
+#: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2219,12 +2233,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1467
+#: lxc/file.go:1491
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1490
+#: lxc/file.go:1514
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2239,12 +2253,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1517
+#: lxc/file.go:1541
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1326
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2274,7 +2288,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1423
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2289,7 +2303,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1428
+#: lxc/file.go:1452
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2299,12 +2313,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1352
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1455
+#: lxc/file.go:1479
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2318,7 +2332,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:304 lxc/move.go:380
+#: lxc/move.go:309 lxc/move.go:385
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2343,7 +2357,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1440
+#: lxc/file.go:1464
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2358,7 +2372,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1042
+#: lxc/file.go:1062
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2445,14 +2459,14 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1625 lxc/warning.go:94
+#: lxc/storage_volume.go:1627 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2520,7 +2534,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1602
+#: lxc/image.go:1602 lxc/image.go:1603
 msgid "Get image properties"
 msgstr ""
 
@@ -2536,7 +2550,7 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:414
 msgid "Get the key as a network forward property"
 msgstr ""
 
@@ -2576,7 +2590,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1249
+#: lxc/storage_volume.go:1251
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2604,7 +2618,7 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:403 lxc/network_forward.go:404
+#: lxc/network_forward.go:411 lxc/network_forward.go:412
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
@@ -2640,11 +2654,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:476
+#: lxc/storage_volume.go:480
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2684,22 +2698,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1540
+#: lxc/file.go:1564
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1529
+#: lxc/file.go:1553
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1376
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1362
+#: lxc/file.go:1386
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2772,11 +2786,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:415
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2786,7 +2800,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2437
+#: lxc/storage_volume.go:2439
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2798,7 +2812,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1517
+#: lxc/image.go:1518
 msgid "Image already up to date."
 msgstr ""
 
@@ -2814,11 +2828,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1472
+#: lxc/image.go:364 lxc/image.go:1473
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1698
+#: lxc/image.go:444 lxc/image.go:1699
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2828,7 +2842,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1515
+#: lxc/image.go:1516
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2836,7 +2850,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2815
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2844,7 +2858,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2814
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2866,11 +2880,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2822
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2894
+#: lxc/storage_volume.go:2896
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2896,11 +2910,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1378
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1531
+#: lxc/file.go:1555
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2909,7 +2923,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:414
+#: lxc/init.go:418
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2918,7 +2932,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1298
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2970,7 +2984,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1293
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2996,23 +3010,23 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2023
+#: lxc/move.go:153 lxc/storage_volume.go:2025
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:144
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2019
+#: lxc/storage_volume.go:2021
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:509
+#: lxc/main.go:518
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:353
+#: lxc/file.go:357
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3022,18 +3036,18 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
-#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
+#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:535
+#: lxc/file.go:548
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:717
+#: lxc/file.go:185 lxc/file.go:739
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3070,7 +3084,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3101,12 +3115,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:176
+#: lxc/init.go:180
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:174
+#: lxc/init.go:178
 msgid "Launching the instance"
 msgstr ""
 
@@ -3204,11 +3218,11 @@ msgstr ""
 msgid "List identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:151
+#: lxc/image_alias.go:176
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:177
 msgid ""
 "List image aliases\n"
 "\n"
@@ -3375,11 +3389,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1605
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1610
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3438,7 +3452,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1481
+#: lxc/info.go:489 lxc/storage_volume.go:1483
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3624,7 +3638,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:873 lxc/network_forward.go:874
+#: lxc/network_forward.go:881 lxc/network_forward.go:882
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -3770,12 +3784,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:322 lxc/move.go:435
+#: lxc/move.go:327 lxc/move.go:440
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:347 lxc/move.go:440
+#: lxc/move.go:352 lxc/move.go:445
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3840,10 +3854,10 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:449
-#: lxc/network_forward.go:534 lxc/network_forward.go:709
-#: lxc/network_forward.go:840 lxc/network_forward.go:933
-#: lxc/network_forward.go:1015 lxc/network_load_balancer.go:221
+#: lxc/network_forward.go:219 lxc/network_forward.go:457
+#: lxc/network_forward.go:542 lxc/network_forward.go:717
+#: lxc/network_forward.go:848 lxc/network_forward.go:945
+#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
 #: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
 #: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
 #: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
@@ -3868,10 +3882,10 @@ msgstr ""
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
 #: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
 #: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:284 lxc/network_forward.go:445
-#: lxc/network_forward.go:530 lxc/network_forward.go:705
-#: lxc/network_forward.go:836 lxc/network_forward.go:929
-#: lxc/network_forward.go:1011 lxc/network_load_balancer.go:131
+#: lxc/network_forward.go:292 lxc/network_forward.go:453
+#: lxc/network_forward.go:538 lxc/network_forward.go:713
+#: lxc/network_forward.go:844 lxc/network_forward.go:941
+#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
 #: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
 #: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
 #: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
@@ -3907,13 +3921,13 @@ msgstr ""
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
-#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
-#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
-#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
+#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
+#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
+#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
+#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
 msgid "Missing pool name"
 msgstr ""
 
@@ -3932,15 +3946,15 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
+#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1411
+#: lxc/storage_volume.go:1413
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:820
+#: lxc/file.go:842
 msgid "Missing target directory"
 msgstr ""
 
@@ -3973,16 +3987,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
-#: lxc/storage_volume.go:975
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
+#: lxc/storage_volume.go:977
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:507
+#: lxc/file.go:520
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1207 lxc/file.go:1208
+#: lxc/file.go:1227 lxc/file.go:1228
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4011,7 +4025,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4019,16 +4033,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1869
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1059 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4050,7 +4064,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
 msgid "NAME"
 msgstr ""
 
@@ -4102,8 +4116,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
-#: lxc/storage_volume.go:1573
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Name"
 msgstr ""
 
@@ -4111,7 +4125,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4166,12 +4180,12 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:386
+#: lxc/network_forward.go:394
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:857
+#: lxc/network_forward.go:865
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -4255,7 +4269,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
+#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4263,7 +4277,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1070 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4275,11 +4289,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4293,7 +4307,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2035
+#: lxc/storage_volume.go:2037
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4301,16 +4315,21 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
-#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
-msgid "Only \"custom\" volumes can be attached to instances"
+#: lxc/storage_volume.go:216
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2701
+#: lxc/storage_volume.go:348
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:2703
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2500
+#: lxc/storage_volume.go:2502
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4322,7 +4341,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1431
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4335,7 +4354,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1577
+#: lxc/info.go:705 lxc/storage_volume.go:1579
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4365,7 +4384,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1767
+#: lxc/storage_volume.go:1769
 msgid "POOL"
 msgstr ""
 
@@ -4382,7 +4401,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167
-#: lxc/storage_volume.go:1773 lxc/warning.go:213
+#: lxc/storage_volume.go:1775 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4406,7 +4425,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:367
+#: lxc/main.go:376
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4444,7 +4463,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1332
+#: lxc/file.go:1356
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4452,12 +4471,12 @@ msgstr ""
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
-#: lxc/network_acl.go:699 lxc/network_forward.go:768
+#: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
-#: lxc/storage_volume.go:1200
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
+#: lxc/storage_volume.go:1202
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4570,11 +4589,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1649
+#: lxc/image.go:1650
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4588,7 +4607,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1238
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4604,7 +4623,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4625,7 +4644,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1017
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4634,7 +4653,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2094
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4647,7 +4666,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2370
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4678,20 +4697,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:455 lxc/file.go:456
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:638 lxc/file.go:989
+#: lxc/file.go:651 lxc/file.go:1009
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:688 lxc/file.go:689
+#: lxc/file.go:701 lxc/file.go:702
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:923 lxc/file.go:1089
+#: lxc/file.go:943 lxc/file.go:1109
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4700,7 +4719,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4729,15 +4748,15 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:463 lxc/file.go:695
+#: lxc/file.go:475 lxc/file.go:708
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1444 lxc/image.go:1445
+#: lxc/image.go:1445 lxc/image.go:1446
 msgid "Refresh images"
 msgstr ""
 
@@ -4746,7 +4765,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1481
+#: lxc/image.go:1482
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4823,7 +4842,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:971 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4859,7 +4878,7 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:969 lxc/network_forward.go:970
+#: lxc/network_forward.go:981 lxc/network_forward.go:982
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -4895,8 +4914,8 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
-#: lxc/image_alias.go:255
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:287
+#: lxc/image_alias.go:288
 msgid "Rename aliases"
 msgstr ""
 
@@ -4932,15 +4951,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1962
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
+#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4992,7 +5011,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5009,7 +5028,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:361
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5058,12 +5077,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1460
+#: lxc/file.go:1484
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1461
+#: lxc/file.go:1485
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5139,7 +5158,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1217
+#: lxc/file.go:1237
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5165,7 +5184,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1665 lxc/image.go:1666
+#: lxc/image.go:1666 lxc/image.go:1667
 msgid "Set image properties"
 msgstr ""
 
@@ -5208,11 +5227,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:488
+#: lxc/network_forward.go:496
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:489
+#: lxc/network_forward.go:497
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5316,11 +5335,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2088
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2089
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5337,7 +5356,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:698
+#: lxc/file.go:711
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5345,7 +5364,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:699
+#: lxc/file.go:712
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5353,7 +5372,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:710
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5365,7 +5384,7 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:504
 msgid "Set the key as a network forward property"
 msgstr ""
 
@@ -5405,7 +5424,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2105
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5413,7 +5432,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1215
+#: lxc/file.go:1235
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5470,7 +5489,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1535 lxc/image.go:1536
+#: lxc/image.go:1536 lxc/image.go:1537
 msgid "Show image properties"
 msgstr ""
 
@@ -5490,7 +5509,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:271 lxc/main.go:272
+#: lxc/main.go:280 lxc/main.go:281
 msgid "Show less common commands"
 msgstr ""
 
@@ -5554,11 +5573,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5626,15 +5645,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2190
+#: lxc/storage_volume.go:2192
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1502
+#: lxc/info.go:619 lxc/storage_volume.go:1504
 msgid "Snapshots:"
 msgstr ""
 
@@ -5739,21 +5758,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:703
+#: lxc/storage_volume.go:707
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:791
+#: lxc/storage_volume.go:795
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:516
+#: lxc/storage_volume.go:520
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:524
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5815,21 +5834,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1747 lxc/warning.go:216
+#: lxc/storage_volume.go:1749 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1262
+#: lxc/file.go:1286
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1256
+#: lxc/file.go:1280
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5839,15 +5858,15 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:181
+#: lxc/move.go:186
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:219 lxc/move.go:240
+#: lxc/move.go:224 lxc/move.go:245
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:193
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5855,15 +5874,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:185
+#: lxc/move.go:190
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:189
+#: lxc/move.go:194
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:210
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5885,7 +5904,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:439
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5938,7 +5957,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:462
+#: lxc/network_forward.go:470
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -5978,12 +5997,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1340
+#: lxc/storage_volume.go:1342
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1317
+#: lxc/storage_volume.go:1319
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -5998,12 +6017,12 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:309
+#: lxc/move.go:314
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
-#: lxc/storage_volume.go:989
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
+#: lxc/storage_volume.go:991
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6031,7 +6050,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:298
+#: lxc/main.go:307
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6055,11 +6074,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:437
+#: lxc/init.go:441
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:440
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6067,7 +6086,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:412
+#: lxc/main.go:421
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6078,7 +6097,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1489
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6093,7 +6112,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1864
+#: lxc/storage_volume.go:1866
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6101,7 +6120,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6118,7 +6137,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:327
+#: lxc/copy.go:382 lxc/move.go:332
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6160,7 +6179,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1472
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6182,13 +6201,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1752
+#: lxc/project.go:995 lxc/storage_volume.go:1754
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1751
+#: lxc/storage.go:724 lxc/storage_volume.go:1753
 msgid "USED BY"
 msgstr ""
 
@@ -6201,7 +6220,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:411
+#: lxc/file.go:423
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6215,12 +6234,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1483
+#: lxc/file.go:1507
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1791
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6231,7 +6250,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1029
+#: lxc/file.go:1049
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6262,7 +6281,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1728 lxc/image.go:1729
+#: lxc/image.go:1729 lxc/image.go:1730
 msgid "Unset image properties"
 msgstr ""
 
@@ -6278,11 +6297,11 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:598
+#: lxc/network_forward.go:606
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:599
+#: lxc/network_forward.go:607
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -6326,7 +6345,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6338,7 +6357,7 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:602
+#: lxc/network_forward.go:610
 msgid "Unset the key as a network forward property"
 msgstr ""
 
@@ -6378,7 +6397,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2381
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6386,7 +6405,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:248
+#: lxc/storage_volume.go:250
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6422,12 +6441,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1485
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2652
+#: lxc/export.go:42 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6494,7 +6513,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1576
+#: lxc/storage_volume.go:1578
 msgid "Volume Only"
 msgstr ""
 
@@ -6545,7 +6564,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:293 lxc/move.go:369
+#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6553,12 +6572,12 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:909
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:912
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:282
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:284
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
@@ -6590,7 +6609,7 @@ msgstr ""
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:174
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
@@ -6643,7 +6662,7 @@ msgstr ""
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: lxc/image_alias.go:104
+#: lxc/image_alias.go:121
 msgid "[<remote>:]<alias>"
 msgstr ""
 
@@ -6651,7 +6670,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/image_alias.go:252
+#: lxc/image_alias.go:285
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
@@ -6705,15 +6724,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1600 lxc/image.go:1727
+#: lxc/image.go:1601 lxc/image.go:1728
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1664
+#: lxc/image.go:1665
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6733,7 +6752,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1443
+#: lxc/image.go:334 lxc/image.go:1444
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6804,7 +6823,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:376
+#: lxc/file.go:380
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -6816,12 +6835,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:454
+#: lxc/file.go:466
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1226
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6889,8 +6908,8 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:644
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:179
+#: lxc/network_forward.go:177 lxc/network_forward.go:652
+#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
 #: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
@@ -6905,12 +6924,12 @@ msgid ""
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:402 lxc/network_forward.go:597
+#: lxc/network_forward.go:410 lxc/network_forward.go:605
 #: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
@@ -6920,13 +6939,13 @@ msgid ""
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:887
+#: lxc/network_forward.go:895
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:968 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -6981,7 +7000,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2811
+#: lxc/storage_volume.go:2813
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7016,65 +7035,65 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1958
+#: lxc/storage_volume.go:1960
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:806
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:167
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
-msgstr ""
-
-#: lxc/storage_volume.go:2562
+#: lxc/storage_volume.go:2564
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2645
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2428
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:610
+#: lxc/storage_volume.go:614
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:718
+#: lxc/storage_volume.go:722
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2364
+#: lxc/storage_volume.go:810
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
+msgstr ""
+
+#: lxc/storage_volume.go:167
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
+msgstr ""
+
+#: lxc/storage_volume.go:2366
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2087
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2245
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1234
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1858
+#: lxc/storage_volume.go:1860
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7180,7 +7199,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1603
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7342,20 +7361,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1230
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:470
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:691
+#: lxc/file.go:704
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7656,7 +7675,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:618
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7664,13 +7683,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2817
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2432
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7704,16 +7723,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1396
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1331
+#: lxc/file.go:1355
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1284
+#: lxc/file.go:1308
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-07 15:11-0700\n"
+"POT-Creation-Date: 2025-01-10 14:44-0600\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -50,7 +50,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1041
+#: lxc/storage_volume.go:1043
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -255,7 +255,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:667
+#: lxc/network_forward.go:675
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -431,12 +431,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1157
+#: lxc/file.go:1177
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1047
+#: lxc/file.go:1067
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -472,7 +472,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:65
+#: lxc/init.go:146 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -525,7 +525,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:687
+#: lxc/file.go:700
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -542,7 +542,7 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
@@ -673,7 +673,7 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:888 lxc/network_forward.go:889
+#: lxc/network_forward.go:896 lxc/network_forward.go:897
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
+#: lxc/image_alias.go:101 lxc/image_alias.go:156 lxc/image_alias.go:320
 msgid "Alias name missing"
 msgstr ""
 
@@ -736,7 +736,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1607
+#: lxc/storage_volume.go:1609
 msgid "All projects"
 msgstr ""
 
@@ -767,7 +767,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -791,12 +791,26 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168 lxc/storage_volume.go:169
+#: lxc/storage_volume.go:168
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:169
+msgid ""
+"Attach new storage volumes to instances\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
+msgstr ""
+
+#: lxc/storage_volume.go:285
 msgid "Attach new storage volumes to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:286
+msgid ""
+"Attach new storage volumes to profiles\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
 #: lxc/console.go:39
@@ -847,16 +861,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2719
+#: lxc/storage_volume.go:2721
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2796
+#: lxc/export.go:192 lxc/storage_volume.go:2798
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1538
+#: lxc/info.go:666 lxc/storage_volume.go:1540
 msgid "Backups:"
 msgstr ""
 
@@ -865,19 +879,19 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
+#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:326
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -920,7 +934,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1752
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -972,7 +986,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -980,7 +994,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:562
+#: lxc/file.go:575
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1005,11 +1019,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:768
+#: lxc/file.go:790
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1022,12 +1036,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:493
+#: lxc/storage_volume.go:497
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:447
+#: lxc/storage_volume.go:451
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1133,9 +1147,9 @@ msgstr ""
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:497 lxc/network_forward.go:649
-#: lxc/network_forward.go:803 lxc/network_forward.go:892
-#: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
+#: lxc/network_forward.go:505 lxc/network_forward.go:657
+#: lxc/network_forward.go:811 lxc/network_forward.go:900
+#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
 #: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
 #: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
@@ -1147,14 +1161,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
-#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
-#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
-#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
+#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
 msgid "Cluster member name"
 msgstr ""
 
@@ -1170,7 +1184,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1608
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1210,21 +1224,21 @@ msgstr ""
 #: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
-#: lxc/network_acl.go:698 lxc/network_forward.go:767
+#: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
-#: lxc/storage_volume.go:1199
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
+#: lxc/storage_volume.go:1201
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:620
+#: lxc/storage_volume.go:624
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1478
+#: lxc/storage_volume.go:1480
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1286,7 +1300,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1294,12 +1308,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1312,7 +1326,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1407,7 +1421,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:462 lxc/file.go:696
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1447,7 +1461,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1499,12 +1513,12 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:182
+#: lxc/init.go:186
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1514,7 +1528,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 msgid "Creating the instance"
 msgstr ""
 
@@ -1528,13 +1542,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1749
+#: lxc/storage_volume.go:1751
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1554,7 +1568,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2653
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1586,7 +1600,7 @@ msgstr ""
 msgid "Delete identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:106 lxc/image_alias.go:107
+#: lxc/image_alias.go:123 lxc/image_alias.go:124
 msgid "Delete image aliases"
 msgstr ""
 
@@ -1610,7 +1624,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:799 lxc/network_forward.go:800
+#: lxc/network_forward.go:807 lxc/network_forward.go:808
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1650,7 +1664,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
+#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1692,13 +1706,13 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
-#: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
-#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
+#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
+#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
+#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
@@ -1712,10 +1726,10 @@ msgstr ""
 #: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:404 lxc/network_forward.go:489
-#: lxc/network_forward.go:599 lxc/network_forward.go:646
-#: lxc/network_forward.go:800 lxc/network_forward.go:874
-#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_forward.go:412 lxc/network_forward.go:497
+#: lxc/network_forward.go:607 lxc/network_forward.go:654
+#: lxc/network_forward.go:808 lxc/network_forward.go:882
+#: lxc/network_forward.go:897 lxc/network_forward.go:982
 #: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
 #: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
 #: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
@@ -1755,27 +1769,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
-#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
-#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
-#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
-#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
-#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
-#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
-#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1465
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1787,11 +1801,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
+#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1841,7 +1855,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:403
+#: lxc/init.go:407
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1853,7 +1867,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1216
+#: lxc/file.go:1236
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1949,7 +1963,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:377 lxc/file.go:378
+#: lxc/file.go:381 lxc/file.go:382
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1989,7 +2003,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:653 lxc/network_forward.go:654
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -2029,7 +2043,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2037,7 +2051,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1785
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2091,11 +2105,11 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
-#: lxc/network_acl.go:524 lxc/network_forward.go:572
+#: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
+#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2106,11 +2120,11 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
-#: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
+#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
-#: lxc/storage_volume.go:2210
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
+#: lxc/storage_volume.go:2212
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2152,8 +2166,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
+#: lxc/storage_volume.go:1577
 msgid "Expires at"
 msgstr ""
 
@@ -2177,7 +2191,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2189,11 +2203,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2650
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2779
+#: lxc/export.go:152 lxc/storage_volume.go:2781
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2212,7 +2226,7 @@ msgid "FILENAME"
 msgstr ""
 
 #: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
-#: lxc/image_alias.go:235
+#: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2220,12 +2234,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1467
+#: lxc/file.go:1491
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1490
+#: lxc/file.go:1514
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2240,12 +2254,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1517
+#: lxc/file.go:1541
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1326
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2275,7 +2289,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1423
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2290,7 +2304,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1428
+#: lxc/file.go:1452
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2300,12 +2314,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1352
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1455
+#: lxc/file.go:1479
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2319,7 +2333,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:304 lxc/move.go:380
+#: lxc/move.go:309 lxc/move.go:385
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2344,7 +2358,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1440
+#: lxc/file.go:1464
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2359,7 +2373,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1042
+#: lxc/file.go:1062
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2446,14 +2460,14 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1625 lxc/warning.go:94
+#: lxc/storage_volume.go:1627 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2521,7 +2535,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1602
+#: lxc/image.go:1602 lxc/image.go:1603
 msgid "Get image properties"
 msgstr ""
 
@@ -2537,7 +2551,7 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:414
 msgid "Get the key as a network forward property"
 msgstr ""
 
@@ -2577,7 +2591,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1249
+#: lxc/storage_volume.go:1251
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2605,7 +2619,7 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:403 lxc/network_forward.go:404
+#: lxc/network_forward.go:411 lxc/network_forward.go:412
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
@@ -2641,11 +2655,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:476
+#: lxc/storage_volume.go:480
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2685,22 +2699,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1540
+#: lxc/file.go:1564
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1529
+#: lxc/file.go:1553
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1376
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1362
+#: lxc/file.go:1386
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2773,11 +2787,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:415
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2787,7 +2801,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2437
+#: lxc/storage_volume.go:2439
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2799,7 +2813,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1517
+#: lxc/image.go:1518
 msgid "Image already up to date."
 msgstr ""
 
@@ -2815,11 +2829,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1472
+#: lxc/image.go:364 lxc/image.go:1473
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1698
+#: lxc/image.go:444 lxc/image.go:1699
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2829,7 +2843,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1515
+#: lxc/image.go:1516
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2837,7 +2851,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2815
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2845,7 +2859,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2814
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2867,11 +2881,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2822
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2894
+#: lxc/storage_volume.go:2896
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2897,11 +2911,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1378
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1531
+#: lxc/file.go:1555
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2910,7 +2924,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:414
+#: lxc/init.go:418
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2919,7 +2933,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1298
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2971,7 +2985,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1293
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2997,23 +3011,23 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2023
+#: lxc/move.go:153 lxc/storage_volume.go:2025
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:144
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2019
+#: lxc/storage_volume.go:2021
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:509
+#: lxc/main.go:518
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:353
+#: lxc/file.go:357
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3023,18 +3037,18 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
-#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
+#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:535
+#: lxc/file.go:548
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:717
+#: lxc/file.go:185 lxc/file.go:739
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3071,7 +3085,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3102,12 +3116,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:176
+#: lxc/init.go:180
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:174
+#: lxc/init.go:178
 msgid "Launching the instance"
 msgstr ""
 
@@ -3205,11 +3219,11 @@ msgstr ""
 msgid "List identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:151
+#: lxc/image_alias.go:176
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:177
 msgid ""
 "List image aliases\n"
 "\n"
@@ -3376,11 +3390,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1605
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1610
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3439,7 +3453,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1481
+#: lxc/info.go:489 lxc/storage_volume.go:1483
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3625,7 +3639,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:873 lxc/network_forward.go:874
+#: lxc/network_forward.go:881 lxc/network_forward.go:882
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -3771,12 +3785,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:322 lxc/move.go:435
+#: lxc/move.go:327 lxc/move.go:440
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:347 lxc/move.go:440
+#: lxc/move.go:352 lxc/move.go:445
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3841,10 +3855,10 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:449
-#: lxc/network_forward.go:534 lxc/network_forward.go:709
-#: lxc/network_forward.go:840 lxc/network_forward.go:933
-#: lxc/network_forward.go:1015 lxc/network_load_balancer.go:221
+#: lxc/network_forward.go:219 lxc/network_forward.go:457
+#: lxc/network_forward.go:542 lxc/network_forward.go:717
+#: lxc/network_forward.go:848 lxc/network_forward.go:945
+#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
 #: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
 #: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
 #: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
@@ -3869,10 +3883,10 @@ msgstr ""
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
 #: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
 #: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:284 lxc/network_forward.go:445
-#: lxc/network_forward.go:530 lxc/network_forward.go:705
-#: lxc/network_forward.go:836 lxc/network_forward.go:929
-#: lxc/network_forward.go:1011 lxc/network_load_balancer.go:131
+#: lxc/network_forward.go:292 lxc/network_forward.go:453
+#: lxc/network_forward.go:538 lxc/network_forward.go:713
+#: lxc/network_forward.go:844 lxc/network_forward.go:941
+#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
 #: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
 #: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
 #: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
@@ -3908,13 +3922,13 @@ msgstr ""
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
-#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
-#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
-#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
+#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
+#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
+#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
+#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
 msgid "Missing pool name"
 msgstr ""
 
@@ -3933,15 +3947,15 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
+#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1411
+#: lxc/storage_volume.go:1413
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:820
+#: lxc/file.go:842
 msgid "Missing target directory"
 msgstr ""
 
@@ -3974,16 +3988,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
-#: lxc/storage_volume.go:975
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
+#: lxc/storage_volume.go:977
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:507
+#: lxc/file.go:520
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1207 lxc/file.go:1208
+#: lxc/file.go:1227 lxc/file.go:1228
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4012,7 +4026,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4020,16 +4034,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1869
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1059 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4051,7 +4065,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
 msgid "NAME"
 msgstr ""
 
@@ -4103,8 +4117,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
-#: lxc/storage_volume.go:1573
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Name"
 msgstr ""
 
@@ -4112,7 +4126,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4167,12 +4181,12 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:386
+#: lxc/network_forward.go:394
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:857
+#: lxc/network_forward.go:865
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -4256,7 +4270,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
+#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4264,7 +4278,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1070 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4276,11 +4290,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4294,7 +4308,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2035
+#: lxc/storage_volume.go:2037
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4302,16 +4316,21 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
-#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
-msgid "Only \"custom\" volumes can be attached to instances"
+#: lxc/storage_volume.go:216
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2701
+#: lxc/storage_volume.go:348
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:2703
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2500
+#: lxc/storage_volume.go:2502
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4323,7 +4342,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1431
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4336,7 +4355,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1577
+#: lxc/info.go:705 lxc/storage_volume.go:1579
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4366,7 +4385,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1767
+#: lxc/storage_volume.go:1769
 msgid "POOL"
 msgstr ""
 
@@ -4383,7 +4402,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167
-#: lxc/storage_volume.go:1773 lxc/warning.go:213
+#: lxc/storage_volume.go:1775 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4407,7 +4426,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:367
+#: lxc/main.go:376
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4445,7 +4464,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1332
+#: lxc/file.go:1356
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4453,12 +4472,12 @@ msgstr ""
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
-#: lxc/network_acl.go:699 lxc/network_forward.go:768
+#: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
-#: lxc/storage_volume.go:1200
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
+#: lxc/storage_volume.go:1202
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4571,11 +4590,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1649
+#: lxc/image.go:1650
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4589,7 +4608,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1238
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4605,7 +4624,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4626,7 +4645,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1017
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4635,7 +4654,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2094
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4648,7 +4667,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2370
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4679,20 +4698,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:455 lxc/file.go:456
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:638 lxc/file.go:989
+#: lxc/file.go:651 lxc/file.go:1009
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:688 lxc/file.go:689
+#: lxc/file.go:701 lxc/file.go:702
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:923 lxc/file.go:1089
+#: lxc/file.go:943 lxc/file.go:1109
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4701,7 +4720,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4730,15 +4749,15 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:463 lxc/file.go:695
+#: lxc/file.go:475 lxc/file.go:708
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1444 lxc/image.go:1445
+#: lxc/image.go:1445 lxc/image.go:1446
 msgid "Refresh images"
 msgstr ""
 
@@ -4747,7 +4766,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1481
+#: lxc/image.go:1482
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4824,7 +4843,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:971 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4860,7 +4879,7 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:969 lxc/network_forward.go:970
+#: lxc/network_forward.go:981 lxc/network_forward.go:982
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -4896,8 +4915,8 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
-#: lxc/image_alias.go:255
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:287
+#: lxc/image_alias.go:288
 msgid "Rename aliases"
 msgstr ""
 
@@ -4933,15 +4952,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1962
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
+#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4993,7 +5012,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5010,7 +5029,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:361
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5059,12 +5078,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1460
+#: lxc/file.go:1484
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1461
+#: lxc/file.go:1485
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5140,7 +5159,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1217
+#: lxc/file.go:1237
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5166,7 +5185,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1665 lxc/image.go:1666
+#: lxc/image.go:1666 lxc/image.go:1667
 msgid "Set image properties"
 msgstr ""
 
@@ -5209,11 +5228,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:488
+#: lxc/network_forward.go:496
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:489
+#: lxc/network_forward.go:497
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5317,11 +5336,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2088
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2089
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5338,7 +5357,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:698
+#: lxc/file.go:711
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5346,7 +5365,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:699
+#: lxc/file.go:712
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5354,7 +5373,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:710
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5366,7 +5385,7 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:504
 msgid "Set the key as a network forward property"
 msgstr ""
 
@@ -5406,7 +5425,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2105
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5414,7 +5433,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1215
+#: lxc/file.go:1235
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5471,7 +5490,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1535 lxc/image.go:1536
+#: lxc/image.go:1536 lxc/image.go:1537
 msgid "Show image properties"
 msgstr ""
 
@@ -5491,7 +5510,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:271 lxc/main.go:272
+#: lxc/main.go:280 lxc/main.go:281
 msgid "Show less common commands"
 msgstr ""
 
@@ -5555,11 +5574,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5627,15 +5646,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2190
+#: lxc/storage_volume.go:2192
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1502
+#: lxc/info.go:619 lxc/storage_volume.go:1504
 msgid "Snapshots:"
 msgstr ""
 
@@ -5740,21 +5759,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:703
+#: lxc/storage_volume.go:707
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:791
+#: lxc/storage_volume.go:795
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:516
+#: lxc/storage_volume.go:520
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:524
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5816,21 +5835,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1747 lxc/warning.go:216
+#: lxc/storage_volume.go:1749 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1262
+#: lxc/file.go:1286
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1256
+#: lxc/file.go:1280
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5840,15 +5859,15 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:181
+#: lxc/move.go:186
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:219 lxc/move.go:240
+#: lxc/move.go:224 lxc/move.go:245
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:193
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5856,15 +5875,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:185
+#: lxc/move.go:190
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:189
+#: lxc/move.go:194
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:210
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5886,7 +5905,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:439
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5939,7 +5958,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:462
+#: lxc/network_forward.go:470
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -5979,12 +5998,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1340
+#: lxc/storage_volume.go:1342
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1317
+#: lxc/storage_volume.go:1319
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -5999,12 +6018,12 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:309
+#: lxc/move.go:314
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
-#: lxc/storage_volume.go:989
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
+#: lxc/storage_volume.go:991
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6032,7 +6051,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:298
+#: lxc/main.go:307
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6056,11 +6075,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:437
+#: lxc/init.go:441
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:440
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6068,7 +6087,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:412
+#: lxc/main.go:421
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6079,7 +6098,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1489
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6094,7 +6113,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1864
+#: lxc/storage_volume.go:1866
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6102,7 +6121,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6119,7 +6138,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:327
+#: lxc/copy.go:382 lxc/move.go:332
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6161,7 +6180,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1472
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6183,13 +6202,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1752
+#: lxc/project.go:995 lxc/storage_volume.go:1754
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1751
+#: lxc/storage.go:724 lxc/storage_volume.go:1753
 msgid "USED BY"
 msgstr ""
 
@@ -6202,7 +6221,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:411
+#: lxc/file.go:423
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6216,12 +6235,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1483
+#: lxc/file.go:1507
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1791
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6232,7 +6251,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1029
+#: lxc/file.go:1049
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6263,7 +6282,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1728 lxc/image.go:1729
+#: lxc/image.go:1729 lxc/image.go:1730
 msgid "Unset image properties"
 msgstr ""
 
@@ -6279,11 +6298,11 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:598
+#: lxc/network_forward.go:606
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:599
+#: lxc/network_forward.go:607
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -6327,7 +6346,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6339,7 +6358,7 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:602
+#: lxc/network_forward.go:610
 msgid "Unset the key as a network forward property"
 msgstr ""
 
@@ -6379,7 +6398,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2381
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6387,7 +6406,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:248
+#: lxc/storage_volume.go:250
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6423,12 +6442,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1485
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2652
+#: lxc/export.go:42 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6495,7 +6514,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1576
+#: lxc/storage_volume.go:1578
 msgid "Volume Only"
 msgstr ""
 
@@ -6546,7 +6565,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:293 lxc/move.go:369
+#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6554,12 +6573,12 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:909
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:912
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:282
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:284
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
@@ -6591,7 +6610,7 @@ msgstr ""
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:174
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
@@ -6644,7 +6663,7 @@ msgstr ""
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: lxc/image_alias.go:104
+#: lxc/image_alias.go:121
 msgid "[<remote>:]<alias>"
 msgstr ""
 
@@ -6652,7 +6671,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/image_alias.go:252
+#: lxc/image_alias.go:285
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
@@ -6706,15 +6725,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1600 lxc/image.go:1727
+#: lxc/image.go:1601 lxc/image.go:1728
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1664
+#: lxc/image.go:1665
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6734,7 +6753,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1443
+#: lxc/image.go:334 lxc/image.go:1444
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6805,7 +6824,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:376
+#: lxc/file.go:380
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -6817,12 +6836,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:454
+#: lxc/file.go:466
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1226
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6890,8 +6909,8 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:644
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:179
+#: lxc/network_forward.go:177 lxc/network_forward.go:652
+#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
 #: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
@@ -6906,12 +6925,12 @@ msgid ""
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:402 lxc/network_forward.go:597
+#: lxc/network_forward.go:410 lxc/network_forward.go:605
 #: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
@@ -6921,13 +6940,13 @@ msgid ""
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:887
+#: lxc/network_forward.go:895
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:968 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -6982,7 +7001,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2811
+#: lxc/storage_volume.go:2813
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7017,65 +7036,65 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1958
+#: lxc/storage_volume.go:1960
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:806
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:167
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
-msgstr ""
-
-#: lxc/storage_volume.go:2562
+#: lxc/storage_volume.go:2564
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2645
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2428
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:610
+#: lxc/storage_volume.go:614
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:718
+#: lxc/storage_volume.go:722
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2364
+#: lxc/storage_volume.go:810
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
+msgstr ""
+
+#: lxc/storage_volume.go:167
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
+msgstr ""
+
+#: lxc/storage_volume.go:2366
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2087
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2245
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1234
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1858
+#: lxc/storage_volume.go:1860
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7181,7 +7200,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1603
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7343,20 +7362,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1230
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:470
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:691
+#: lxc/file.go:704
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7657,7 +7676,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:618
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7665,13 +7684,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2817
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2432
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7705,16 +7724,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1396
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1331
+#: lxc/file.go:1355
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1284
+#: lxc/file.go:1308
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-07 15:11-0700\n"
+"POT-Creation-Date: 2025-01-10 14:44-0600\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -50,7 +50,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1041
+#: lxc/storage_volume.go:1043
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -255,7 +255,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:667
+#: lxc/network_forward.go:675
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -431,12 +431,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1157
+#: lxc/file.go:1177
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1047
+#: lxc/file.go:1067
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -472,7 +472,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:65
+#: lxc/init.go:146 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -525,7 +525,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:687
+#: lxc/file.go:700
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -542,7 +542,7 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
@@ -673,7 +673,7 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:888 lxc/network_forward.go:889
+#: lxc/network_forward.go:896 lxc/network_forward.go:897
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
+#: lxc/image_alias.go:101 lxc/image_alias.go:156 lxc/image_alias.go:320
 msgid "Alias name missing"
 msgstr ""
 
@@ -736,7 +736,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1607
+#: lxc/storage_volume.go:1609
 msgid "All projects"
 msgstr ""
 
@@ -767,7 +767,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -791,12 +791,26 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168 lxc/storage_volume.go:169
+#: lxc/storage_volume.go:168
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:169
+msgid ""
+"Attach new storage volumes to instances\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
+msgstr ""
+
+#: lxc/storage_volume.go:285
 msgid "Attach new storage volumes to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:286
+msgid ""
+"Attach new storage volumes to profiles\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
 #: lxc/console.go:39
@@ -847,16 +861,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2719
+#: lxc/storage_volume.go:2721
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2796
+#: lxc/export.go:192 lxc/storage_volume.go:2798
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1538
+#: lxc/info.go:666 lxc/storage_volume.go:1540
 msgid "Backups:"
 msgstr ""
 
@@ -865,19 +879,19 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
+#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:326
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -920,7 +934,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1752
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -972,7 +986,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -980,7 +994,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:562
+#: lxc/file.go:575
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1005,11 +1019,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:768
+#: lxc/file.go:790
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1022,12 +1036,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:493
+#: lxc/storage_volume.go:497
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:447
+#: lxc/storage_volume.go:451
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1133,9 +1147,9 @@ msgstr ""
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:497 lxc/network_forward.go:649
-#: lxc/network_forward.go:803 lxc/network_forward.go:892
-#: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
+#: lxc/network_forward.go:505 lxc/network_forward.go:657
+#: lxc/network_forward.go:811 lxc/network_forward.go:900
+#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
 #: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
 #: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
@@ -1147,14 +1161,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
-#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
-#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
-#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
+#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
 msgid "Cluster member name"
 msgstr ""
 
@@ -1170,7 +1184,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1608
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1210,21 +1224,21 @@ msgstr ""
 #: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
-#: lxc/network_acl.go:698 lxc/network_forward.go:767
+#: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
-#: lxc/storage_volume.go:1199
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
+#: lxc/storage_volume.go:1201
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:620
+#: lxc/storage_volume.go:624
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1478
+#: lxc/storage_volume.go:1480
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1286,7 +1300,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1294,12 +1308,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1312,7 +1326,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1407,7 +1421,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:462 lxc/file.go:696
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1447,7 +1461,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1499,12 +1513,12 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:182
+#: lxc/init.go:186
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1514,7 +1528,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 msgid "Creating the instance"
 msgstr ""
 
@@ -1528,13 +1542,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1749
+#: lxc/storage_volume.go:1751
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1554,7 +1568,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2653
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1586,7 +1600,7 @@ msgstr ""
 msgid "Delete identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:106 lxc/image_alias.go:107
+#: lxc/image_alias.go:123 lxc/image_alias.go:124
 msgid "Delete image aliases"
 msgstr ""
 
@@ -1610,7 +1624,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:799 lxc/network_forward.go:800
+#: lxc/network_forward.go:807 lxc/network_forward.go:808
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1650,7 +1664,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
+#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1692,13 +1706,13 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
-#: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
-#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
+#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
+#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
+#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
@@ -1712,10 +1726,10 @@ msgstr ""
 #: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:404 lxc/network_forward.go:489
-#: lxc/network_forward.go:599 lxc/network_forward.go:646
-#: lxc/network_forward.go:800 lxc/network_forward.go:874
-#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_forward.go:412 lxc/network_forward.go:497
+#: lxc/network_forward.go:607 lxc/network_forward.go:654
+#: lxc/network_forward.go:808 lxc/network_forward.go:882
+#: lxc/network_forward.go:897 lxc/network_forward.go:982
 #: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
 #: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
 #: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
@@ -1755,27 +1769,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
-#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
-#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
-#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
-#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
-#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
-#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
-#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1465
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1787,11 +1801,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
+#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1841,7 +1855,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:403
+#: lxc/init.go:407
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1853,7 +1867,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1216
+#: lxc/file.go:1236
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1949,7 +1963,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:377 lxc/file.go:378
+#: lxc/file.go:381 lxc/file.go:382
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1989,7 +2003,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:653 lxc/network_forward.go:654
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -2029,7 +2043,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2037,7 +2051,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1785
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2091,11 +2105,11 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
-#: lxc/network_acl.go:524 lxc/network_forward.go:572
+#: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
+#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2106,11 +2120,11 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
-#: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
+#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
-#: lxc/storage_volume.go:2210
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
+#: lxc/storage_volume.go:2212
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2152,8 +2166,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
+#: lxc/storage_volume.go:1577
 msgid "Expires at"
 msgstr ""
 
@@ -2177,7 +2191,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2189,11 +2203,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2650
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2779
+#: lxc/export.go:152 lxc/storage_volume.go:2781
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2212,7 +2226,7 @@ msgid "FILENAME"
 msgstr ""
 
 #: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
-#: lxc/image_alias.go:235
+#: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2220,12 +2234,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1467
+#: lxc/file.go:1491
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1490
+#: lxc/file.go:1514
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2240,12 +2254,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1517
+#: lxc/file.go:1541
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1326
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2275,7 +2289,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1423
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2290,7 +2304,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1428
+#: lxc/file.go:1452
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2300,12 +2314,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1352
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1455
+#: lxc/file.go:1479
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2319,7 +2333,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:304 lxc/move.go:380
+#: lxc/move.go:309 lxc/move.go:385
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2344,7 +2358,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1440
+#: lxc/file.go:1464
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2359,7 +2373,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1042
+#: lxc/file.go:1062
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2446,14 +2460,14 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1625 lxc/warning.go:94
+#: lxc/storage_volume.go:1627 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2521,7 +2535,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1602
+#: lxc/image.go:1602 lxc/image.go:1603
 msgid "Get image properties"
 msgstr ""
 
@@ -2537,7 +2551,7 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:414
 msgid "Get the key as a network forward property"
 msgstr ""
 
@@ -2577,7 +2591,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1249
+#: lxc/storage_volume.go:1251
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2605,7 +2619,7 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:403 lxc/network_forward.go:404
+#: lxc/network_forward.go:411 lxc/network_forward.go:412
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
@@ -2641,11 +2655,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:476
+#: lxc/storage_volume.go:480
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2685,22 +2699,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1540
+#: lxc/file.go:1564
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1529
+#: lxc/file.go:1553
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1376
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1362
+#: lxc/file.go:1386
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2773,11 +2787,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:415
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2787,7 +2801,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2437
+#: lxc/storage_volume.go:2439
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2799,7 +2813,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1517
+#: lxc/image.go:1518
 msgid "Image already up to date."
 msgstr ""
 
@@ -2815,11 +2829,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1472
+#: lxc/image.go:364 lxc/image.go:1473
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1698
+#: lxc/image.go:444 lxc/image.go:1699
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2829,7 +2843,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1515
+#: lxc/image.go:1516
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2837,7 +2851,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2815
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2845,7 +2859,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2814
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2867,11 +2881,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2822
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2894
+#: lxc/storage_volume.go:2896
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2897,11 +2911,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1378
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1531
+#: lxc/file.go:1555
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2910,7 +2924,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:414
+#: lxc/init.go:418
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2919,7 +2933,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1298
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2971,7 +2985,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1293
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2997,23 +3011,23 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2023
+#: lxc/move.go:153 lxc/storage_volume.go:2025
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:144
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2019
+#: lxc/storage_volume.go:2021
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:509
+#: lxc/main.go:518
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:353
+#: lxc/file.go:357
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3023,18 +3037,18 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
-#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
+#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:535
+#: lxc/file.go:548
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:717
+#: lxc/file.go:185 lxc/file.go:739
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3071,7 +3085,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3102,12 +3116,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:176
+#: lxc/init.go:180
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:174
+#: lxc/init.go:178
 msgid "Launching the instance"
 msgstr ""
 
@@ -3205,11 +3219,11 @@ msgstr ""
 msgid "List identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:151
+#: lxc/image_alias.go:176
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:177
 msgid ""
 "List image aliases\n"
 "\n"
@@ -3376,11 +3390,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1605
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1610
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3439,7 +3453,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1481
+#: lxc/info.go:489 lxc/storage_volume.go:1483
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3625,7 +3639,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:873 lxc/network_forward.go:874
+#: lxc/network_forward.go:881 lxc/network_forward.go:882
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -3771,12 +3785,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:322 lxc/move.go:435
+#: lxc/move.go:327 lxc/move.go:440
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:347 lxc/move.go:440
+#: lxc/move.go:352 lxc/move.go:445
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3841,10 +3855,10 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:449
-#: lxc/network_forward.go:534 lxc/network_forward.go:709
-#: lxc/network_forward.go:840 lxc/network_forward.go:933
-#: lxc/network_forward.go:1015 lxc/network_load_balancer.go:221
+#: lxc/network_forward.go:219 lxc/network_forward.go:457
+#: lxc/network_forward.go:542 lxc/network_forward.go:717
+#: lxc/network_forward.go:848 lxc/network_forward.go:945
+#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
 #: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
 #: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
 #: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
@@ -3869,10 +3883,10 @@ msgstr ""
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
 #: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
 #: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:284 lxc/network_forward.go:445
-#: lxc/network_forward.go:530 lxc/network_forward.go:705
-#: lxc/network_forward.go:836 lxc/network_forward.go:929
-#: lxc/network_forward.go:1011 lxc/network_load_balancer.go:131
+#: lxc/network_forward.go:292 lxc/network_forward.go:453
+#: lxc/network_forward.go:538 lxc/network_forward.go:713
+#: lxc/network_forward.go:844 lxc/network_forward.go:941
+#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
 #: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
 #: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
 #: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
@@ -3908,13 +3922,13 @@ msgstr ""
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
-#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
-#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
-#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
+#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
+#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
+#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
+#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
 msgid "Missing pool name"
 msgstr ""
 
@@ -3933,15 +3947,15 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
+#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1411
+#: lxc/storage_volume.go:1413
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:820
+#: lxc/file.go:842
 msgid "Missing target directory"
 msgstr ""
 
@@ -3974,16 +3988,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
-#: lxc/storage_volume.go:975
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
+#: lxc/storage_volume.go:977
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:507
+#: lxc/file.go:520
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1207 lxc/file.go:1208
+#: lxc/file.go:1227 lxc/file.go:1228
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4012,7 +4026,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4020,16 +4034,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1869
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1059 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4051,7 +4065,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
 msgid "NAME"
 msgstr ""
 
@@ -4103,8 +4117,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
-#: lxc/storage_volume.go:1573
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Name"
 msgstr ""
 
@@ -4112,7 +4126,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4167,12 +4181,12 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:386
+#: lxc/network_forward.go:394
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:857
+#: lxc/network_forward.go:865
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -4256,7 +4270,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
+#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4264,7 +4278,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1070 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4276,11 +4290,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4294,7 +4308,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2035
+#: lxc/storage_volume.go:2037
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4302,16 +4316,21 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
-#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
-msgid "Only \"custom\" volumes can be attached to instances"
+#: lxc/storage_volume.go:216
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2701
+#: lxc/storage_volume.go:348
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:2703
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2500
+#: lxc/storage_volume.go:2502
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4323,7 +4342,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1431
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4336,7 +4355,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1577
+#: lxc/info.go:705 lxc/storage_volume.go:1579
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4366,7 +4385,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1767
+#: lxc/storage_volume.go:1769
 msgid "POOL"
 msgstr ""
 
@@ -4383,7 +4402,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167
-#: lxc/storage_volume.go:1773 lxc/warning.go:213
+#: lxc/storage_volume.go:1775 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4407,7 +4426,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:367
+#: lxc/main.go:376
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4445,7 +4464,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1332
+#: lxc/file.go:1356
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4453,12 +4472,12 @@ msgstr ""
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
-#: lxc/network_acl.go:699 lxc/network_forward.go:768
+#: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
-#: lxc/storage_volume.go:1200
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
+#: lxc/storage_volume.go:1202
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4571,11 +4590,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1649
+#: lxc/image.go:1650
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4589,7 +4608,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1238
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4605,7 +4624,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4626,7 +4645,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1017
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4635,7 +4654,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2094
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4648,7 +4667,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2370
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4679,20 +4698,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:455 lxc/file.go:456
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:638 lxc/file.go:989
+#: lxc/file.go:651 lxc/file.go:1009
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:688 lxc/file.go:689
+#: lxc/file.go:701 lxc/file.go:702
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:923 lxc/file.go:1089
+#: lxc/file.go:943 lxc/file.go:1109
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4701,7 +4720,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4730,15 +4749,15 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:463 lxc/file.go:695
+#: lxc/file.go:475 lxc/file.go:708
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1444 lxc/image.go:1445
+#: lxc/image.go:1445 lxc/image.go:1446
 msgid "Refresh images"
 msgstr ""
 
@@ -4747,7 +4766,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1481
+#: lxc/image.go:1482
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4824,7 +4843,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:971 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4860,7 +4879,7 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:969 lxc/network_forward.go:970
+#: lxc/network_forward.go:981 lxc/network_forward.go:982
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -4896,8 +4915,8 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
-#: lxc/image_alias.go:255
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:287
+#: lxc/image_alias.go:288
 msgid "Rename aliases"
 msgstr ""
 
@@ -4933,15 +4952,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1962
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
+#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4993,7 +5012,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5010,7 +5029,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:361
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5059,12 +5078,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1460
+#: lxc/file.go:1484
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1461
+#: lxc/file.go:1485
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5140,7 +5159,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1217
+#: lxc/file.go:1237
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5166,7 +5185,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1665 lxc/image.go:1666
+#: lxc/image.go:1666 lxc/image.go:1667
 msgid "Set image properties"
 msgstr ""
 
@@ -5209,11 +5228,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:488
+#: lxc/network_forward.go:496
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:489
+#: lxc/network_forward.go:497
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5317,11 +5336,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2088
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2089
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5338,7 +5357,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:698
+#: lxc/file.go:711
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5346,7 +5365,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:699
+#: lxc/file.go:712
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5354,7 +5373,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:710
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5366,7 +5385,7 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:504
 msgid "Set the key as a network forward property"
 msgstr ""
 
@@ -5406,7 +5425,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2105
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5414,7 +5433,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1215
+#: lxc/file.go:1235
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5471,7 +5490,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1535 lxc/image.go:1536
+#: lxc/image.go:1536 lxc/image.go:1537
 msgid "Show image properties"
 msgstr ""
 
@@ -5491,7 +5510,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:271 lxc/main.go:272
+#: lxc/main.go:280 lxc/main.go:281
 msgid "Show less common commands"
 msgstr ""
 
@@ -5555,11 +5574,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5627,15 +5646,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2190
+#: lxc/storage_volume.go:2192
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1502
+#: lxc/info.go:619 lxc/storage_volume.go:1504
 msgid "Snapshots:"
 msgstr ""
 
@@ -5740,21 +5759,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:703
+#: lxc/storage_volume.go:707
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:791
+#: lxc/storage_volume.go:795
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:516
+#: lxc/storage_volume.go:520
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:524
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5816,21 +5835,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1747 lxc/warning.go:216
+#: lxc/storage_volume.go:1749 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1262
+#: lxc/file.go:1286
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1256
+#: lxc/file.go:1280
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5840,15 +5859,15 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:181
+#: lxc/move.go:186
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:219 lxc/move.go:240
+#: lxc/move.go:224 lxc/move.go:245
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:193
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5856,15 +5875,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:185
+#: lxc/move.go:190
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:189
+#: lxc/move.go:194
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:210
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5886,7 +5905,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:439
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5939,7 +5958,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:462
+#: lxc/network_forward.go:470
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -5979,12 +5998,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1340
+#: lxc/storage_volume.go:1342
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1317
+#: lxc/storage_volume.go:1319
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -5999,12 +6018,12 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:309
+#: lxc/move.go:314
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
-#: lxc/storage_volume.go:989
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
+#: lxc/storage_volume.go:991
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6032,7 +6051,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:298
+#: lxc/main.go:307
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6056,11 +6075,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:437
+#: lxc/init.go:441
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:440
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6068,7 +6087,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:412
+#: lxc/main.go:421
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6079,7 +6098,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1489
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6094,7 +6113,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1864
+#: lxc/storage_volume.go:1866
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6102,7 +6121,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6119,7 +6138,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:327
+#: lxc/copy.go:382 lxc/move.go:332
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6161,7 +6180,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1472
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6183,13 +6202,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1752
+#: lxc/project.go:995 lxc/storage_volume.go:1754
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1751
+#: lxc/storage.go:724 lxc/storage_volume.go:1753
 msgid "USED BY"
 msgstr ""
 
@@ -6202,7 +6221,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:411
+#: lxc/file.go:423
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6216,12 +6235,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1483
+#: lxc/file.go:1507
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1791
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6232,7 +6251,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1029
+#: lxc/file.go:1049
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6263,7 +6282,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1728 lxc/image.go:1729
+#: lxc/image.go:1729 lxc/image.go:1730
 msgid "Unset image properties"
 msgstr ""
 
@@ -6279,11 +6298,11 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:598
+#: lxc/network_forward.go:606
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:599
+#: lxc/network_forward.go:607
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -6327,7 +6346,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6339,7 +6358,7 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:602
+#: lxc/network_forward.go:610
 msgid "Unset the key as a network forward property"
 msgstr ""
 
@@ -6379,7 +6398,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2381
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6387,7 +6406,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:248
+#: lxc/storage_volume.go:250
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6423,12 +6442,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1485
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2652
+#: lxc/export.go:42 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6495,7 +6514,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1576
+#: lxc/storage_volume.go:1578
 msgid "Volume Only"
 msgstr ""
 
@@ -6546,7 +6565,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:293 lxc/move.go:369
+#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6554,12 +6573,12 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:909
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:912
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:282
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:284
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
@@ -6591,7 +6610,7 @@ msgstr ""
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:174
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
@@ -6644,7 +6663,7 @@ msgstr ""
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: lxc/image_alias.go:104
+#: lxc/image_alias.go:121
 msgid "[<remote>:]<alias>"
 msgstr ""
 
@@ -6652,7 +6671,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/image_alias.go:252
+#: lxc/image_alias.go:285
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
@@ -6706,15 +6725,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1600 lxc/image.go:1727
+#: lxc/image.go:1601 lxc/image.go:1728
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1664
+#: lxc/image.go:1665
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6734,7 +6753,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1443
+#: lxc/image.go:334 lxc/image.go:1444
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6805,7 +6824,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:376
+#: lxc/file.go:380
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -6817,12 +6836,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:454
+#: lxc/file.go:466
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1226
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6890,8 +6909,8 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:644
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:179
+#: lxc/network_forward.go:177 lxc/network_forward.go:652
+#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
 #: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
@@ -6906,12 +6925,12 @@ msgid ""
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:402 lxc/network_forward.go:597
+#: lxc/network_forward.go:410 lxc/network_forward.go:605
 #: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
@@ -6921,13 +6940,13 @@ msgid ""
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:887
+#: lxc/network_forward.go:895
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:968 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -6982,7 +7001,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2811
+#: lxc/storage_volume.go:2813
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7017,65 +7036,65 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1958
+#: lxc/storage_volume.go:1960
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:806
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:167
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
-msgstr ""
-
-#: lxc/storage_volume.go:2562
+#: lxc/storage_volume.go:2564
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2645
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2428
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:610
+#: lxc/storage_volume.go:614
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:718
+#: lxc/storage_volume.go:722
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2364
+#: lxc/storage_volume.go:810
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
+msgstr ""
+
+#: lxc/storage_volume.go:167
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
+msgstr ""
+
+#: lxc/storage_volume.go:2366
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2087
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2245
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1234
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1858
+#: lxc/storage_volume.go:1860
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7181,7 +7200,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1603
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7343,20 +7362,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1230
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:470
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:691
+#: lxc/file.go:704
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7657,7 +7676,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:618
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7665,13 +7684,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2817
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2432
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7705,16 +7724,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1396
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1331
+#: lxc/file.go:1355
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1284
+#: lxc/file.go:1308
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-07 15:11-0700\n"
+"POT-Creation-Date: 2025-01-10 14:44-0600\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1041
+#: lxc/storage_volume.go:1043
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:667
+#: lxc/network_forward.go:675
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,12 +430,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1157
+#: lxc/file.go:1177
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1047
+#: lxc/file.go:1067
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -471,7 +471,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:65
+#: lxc/init.go:146 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:687
+#: lxc/file.go:700
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -541,7 +541,7 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
@@ -672,7 +672,7 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:888 lxc/network_forward.go:889
+#: lxc/network_forward.go:896 lxc/network_forward.go:897
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -722,7 +722,7 @@ msgstr ""
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
+#: lxc/image_alias.go:101 lxc/image_alias.go:156 lxc/image_alias.go:320
 msgid "Alias name missing"
 msgstr ""
 
@@ -735,7 +735,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1607
+#: lxc/storage_volume.go:1609
 msgid "All projects"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -790,12 +790,26 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168 lxc/storage_volume.go:169
+#: lxc/storage_volume.go:168
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:169
+msgid ""
+"Attach new storage volumes to instances\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
+msgstr ""
+
+#: lxc/storage_volume.go:285
 msgid "Attach new storage volumes to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:286
+msgid ""
+"Attach new storage volumes to profiles\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
 #: lxc/console.go:39
@@ -846,16 +860,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2719
+#: lxc/storage_volume.go:2721
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2796
+#: lxc/export.go:192 lxc/storage_volume.go:2798
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1538
+#: lxc/info.go:666 lxc/storage_volume.go:1540
 msgid "Backups:"
 msgstr ""
 
@@ -864,19 +878,19 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
+#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:326
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -919,7 +933,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1752
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -971,7 +985,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -979,7 +993,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:562
+#: lxc/file.go:575
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1004,11 +1018,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:768
+#: lxc/file.go:790
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1021,12 +1035,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:493
+#: lxc/storage_volume.go:497
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:447
+#: lxc/storage_volume.go:451
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1132,9 +1146,9 @@ msgstr ""
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:497 lxc/network_forward.go:649
-#: lxc/network_forward.go:803 lxc/network_forward.go:892
-#: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
+#: lxc/network_forward.go:505 lxc/network_forward.go:657
+#: lxc/network_forward.go:811 lxc/network_forward.go:900
+#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
 #: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
 #: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
@@ -1146,14 +1160,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
-#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
-#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
-#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
+#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
 msgid "Cluster member name"
 msgstr ""
 
@@ -1169,7 +1183,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1608
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1209,21 +1223,21 @@ msgstr ""
 #: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
-#: lxc/network_acl.go:698 lxc/network_forward.go:767
+#: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
-#: lxc/storage_volume.go:1199
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
+#: lxc/storage_volume.go:1201
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:620
+#: lxc/storage_volume.go:624
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1478
+#: lxc/storage_volume.go:1480
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1285,7 +1299,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1293,12 +1307,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1311,7 +1325,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1406,7 +1420,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:462 lxc/file.go:696
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1446,7 +1460,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1498,12 +1512,12 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:182
+#: lxc/init.go:186
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1513,7 +1527,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 msgid "Creating the instance"
 msgstr ""
 
@@ -1527,13 +1541,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1749
+#: lxc/storage_volume.go:1751
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1553,7 +1567,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2653
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1585,7 +1599,7 @@ msgstr ""
 msgid "Delete identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:106 lxc/image_alias.go:107
+#: lxc/image_alias.go:123 lxc/image_alias.go:124
 msgid "Delete image aliases"
 msgstr ""
 
@@ -1609,7 +1623,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:799 lxc/network_forward.go:800
+#: lxc/network_forward.go:807 lxc/network_forward.go:808
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1649,7 +1663,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
+#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1691,13 +1705,13 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
-#: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
-#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
+#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
+#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
+#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
@@ -1711,10 +1725,10 @@ msgstr ""
 #: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:404 lxc/network_forward.go:489
-#: lxc/network_forward.go:599 lxc/network_forward.go:646
-#: lxc/network_forward.go:800 lxc/network_forward.go:874
-#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_forward.go:412 lxc/network_forward.go:497
+#: lxc/network_forward.go:607 lxc/network_forward.go:654
+#: lxc/network_forward.go:808 lxc/network_forward.go:882
+#: lxc/network_forward.go:897 lxc/network_forward.go:982
 #: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
 #: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
 #: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
@@ -1754,27 +1768,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
-#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
-#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
-#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
-#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
-#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
-#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
-#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1465
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1786,11 +1800,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
+#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1840,7 +1854,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:403
+#: lxc/init.go:407
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1852,7 +1866,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1216
+#: lxc/file.go:1236
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1948,7 +1962,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:377 lxc/file.go:378
+#: lxc/file.go:381 lxc/file.go:382
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1988,7 +2002,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:653 lxc/network_forward.go:654
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -2028,7 +2042,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2036,7 +2050,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1785
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2090,11 +2104,11 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
-#: lxc/network_acl.go:524 lxc/network_forward.go:572
+#: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
+#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2105,11 +2119,11 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
-#: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
+#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
-#: lxc/storage_volume.go:2210
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
+#: lxc/storage_volume.go:2212
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2151,8 +2165,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
+#: lxc/storage_volume.go:1577
 msgid "Expires at"
 msgstr ""
 
@@ -2176,7 +2190,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2188,11 +2202,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2650
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2779
+#: lxc/export.go:152 lxc/storage_volume.go:2781
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2211,7 +2225,7 @@ msgid "FILENAME"
 msgstr ""
 
 #: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
-#: lxc/image_alias.go:235
+#: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2219,12 +2233,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1467
+#: lxc/file.go:1491
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1490
+#: lxc/file.go:1514
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2239,12 +2253,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1517
+#: lxc/file.go:1541
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1326
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2274,7 +2288,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1423
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2289,7 +2303,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1428
+#: lxc/file.go:1452
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2299,12 +2313,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1352
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1455
+#: lxc/file.go:1479
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2318,7 +2332,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:304 lxc/move.go:380
+#: lxc/move.go:309 lxc/move.go:385
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2343,7 +2357,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1440
+#: lxc/file.go:1464
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2358,7 +2372,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1042
+#: lxc/file.go:1062
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2445,14 +2459,14 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1625 lxc/warning.go:94
+#: lxc/storage_volume.go:1627 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2520,7 +2534,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1602
+#: lxc/image.go:1602 lxc/image.go:1603
 msgid "Get image properties"
 msgstr ""
 
@@ -2536,7 +2550,7 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:414
 msgid "Get the key as a network forward property"
 msgstr ""
 
@@ -2576,7 +2590,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1249
+#: lxc/storage_volume.go:1251
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2604,7 +2618,7 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:403 lxc/network_forward.go:404
+#: lxc/network_forward.go:411 lxc/network_forward.go:412
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
@@ -2640,11 +2654,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:476
+#: lxc/storage_volume.go:480
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2684,22 +2698,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1540
+#: lxc/file.go:1564
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1529
+#: lxc/file.go:1553
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1376
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1362
+#: lxc/file.go:1386
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2772,11 +2786,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:415
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2786,7 +2800,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2437
+#: lxc/storage_volume.go:2439
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2798,7 +2812,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1517
+#: lxc/image.go:1518
 msgid "Image already up to date."
 msgstr ""
 
@@ -2814,11 +2828,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1472
+#: lxc/image.go:364 lxc/image.go:1473
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1698
+#: lxc/image.go:444 lxc/image.go:1699
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2828,7 +2842,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1515
+#: lxc/image.go:1516
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2836,7 +2850,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2815
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2844,7 +2858,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2814
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2866,11 +2880,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2822
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2894
+#: lxc/storage_volume.go:2896
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2896,11 +2910,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1378
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1531
+#: lxc/file.go:1555
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2909,7 +2923,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:414
+#: lxc/init.go:418
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2918,7 +2932,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1298
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2970,7 +2984,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1293
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2996,23 +3010,23 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2023
+#: lxc/move.go:153 lxc/storage_volume.go:2025
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:144
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2019
+#: lxc/storage_volume.go:2021
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:509
+#: lxc/main.go:518
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:353
+#: lxc/file.go:357
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3022,18 +3036,18 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
-#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
+#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:535
+#: lxc/file.go:548
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:717
+#: lxc/file.go:185 lxc/file.go:739
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3070,7 +3084,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3101,12 +3115,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:176
+#: lxc/init.go:180
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:174
+#: lxc/init.go:178
 msgid "Launching the instance"
 msgstr ""
 
@@ -3204,11 +3218,11 @@ msgstr ""
 msgid "List identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:151
+#: lxc/image_alias.go:176
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:177
 msgid ""
 "List image aliases\n"
 "\n"
@@ -3375,11 +3389,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1605
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1610
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3438,7 +3452,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1481
+#: lxc/info.go:489 lxc/storage_volume.go:1483
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3624,7 +3638,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:873 lxc/network_forward.go:874
+#: lxc/network_forward.go:881 lxc/network_forward.go:882
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -3770,12 +3784,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:322 lxc/move.go:435
+#: lxc/move.go:327 lxc/move.go:440
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:347 lxc/move.go:440
+#: lxc/move.go:352 lxc/move.go:445
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3840,10 +3854,10 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:449
-#: lxc/network_forward.go:534 lxc/network_forward.go:709
-#: lxc/network_forward.go:840 lxc/network_forward.go:933
-#: lxc/network_forward.go:1015 lxc/network_load_balancer.go:221
+#: lxc/network_forward.go:219 lxc/network_forward.go:457
+#: lxc/network_forward.go:542 lxc/network_forward.go:717
+#: lxc/network_forward.go:848 lxc/network_forward.go:945
+#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
 #: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
 #: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
 #: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
@@ -3868,10 +3882,10 @@ msgstr ""
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
 #: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
 #: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:284 lxc/network_forward.go:445
-#: lxc/network_forward.go:530 lxc/network_forward.go:705
-#: lxc/network_forward.go:836 lxc/network_forward.go:929
-#: lxc/network_forward.go:1011 lxc/network_load_balancer.go:131
+#: lxc/network_forward.go:292 lxc/network_forward.go:453
+#: lxc/network_forward.go:538 lxc/network_forward.go:713
+#: lxc/network_forward.go:844 lxc/network_forward.go:941
+#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
 #: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
 #: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
 #: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
@@ -3907,13 +3921,13 @@ msgstr ""
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
-#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
-#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
-#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
+#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
+#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
+#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
+#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
 msgid "Missing pool name"
 msgstr ""
 
@@ -3932,15 +3946,15 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
+#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1411
+#: lxc/storage_volume.go:1413
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:820
+#: lxc/file.go:842
 msgid "Missing target directory"
 msgstr ""
 
@@ -3973,16 +3987,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
-#: lxc/storage_volume.go:975
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
+#: lxc/storage_volume.go:977
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:507
+#: lxc/file.go:520
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1207 lxc/file.go:1208
+#: lxc/file.go:1227 lxc/file.go:1228
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4011,7 +4025,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4019,16 +4033,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1869
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1059 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4050,7 +4064,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
 msgid "NAME"
 msgstr ""
 
@@ -4102,8 +4116,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
-#: lxc/storage_volume.go:1573
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Name"
 msgstr ""
 
@@ -4111,7 +4125,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4166,12 +4180,12 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:386
+#: lxc/network_forward.go:394
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:857
+#: lxc/network_forward.go:865
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -4255,7 +4269,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
+#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4263,7 +4277,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1070 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4275,11 +4289,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4293,7 +4307,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2035
+#: lxc/storage_volume.go:2037
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4301,16 +4315,21 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
-#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
-msgid "Only \"custom\" volumes can be attached to instances"
+#: lxc/storage_volume.go:216
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2701
+#: lxc/storage_volume.go:348
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:2703
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2500
+#: lxc/storage_volume.go:2502
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4322,7 +4341,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1431
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4335,7 +4354,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1577
+#: lxc/info.go:705 lxc/storage_volume.go:1579
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4365,7 +4384,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1767
+#: lxc/storage_volume.go:1769
 msgid "POOL"
 msgstr ""
 
@@ -4382,7 +4401,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167
-#: lxc/storage_volume.go:1773 lxc/warning.go:213
+#: lxc/storage_volume.go:1775 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4406,7 +4425,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:367
+#: lxc/main.go:376
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4444,7 +4463,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1332
+#: lxc/file.go:1356
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4452,12 +4471,12 @@ msgstr ""
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
-#: lxc/network_acl.go:699 lxc/network_forward.go:768
+#: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
-#: lxc/storage_volume.go:1200
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
+#: lxc/storage_volume.go:1202
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4570,11 +4589,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1649
+#: lxc/image.go:1650
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4588,7 +4607,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1238
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4604,7 +4623,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4625,7 +4644,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1017
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4634,7 +4653,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2094
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4647,7 +4666,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2370
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4678,20 +4697,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:455 lxc/file.go:456
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:638 lxc/file.go:989
+#: lxc/file.go:651 lxc/file.go:1009
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:688 lxc/file.go:689
+#: lxc/file.go:701 lxc/file.go:702
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:923 lxc/file.go:1089
+#: lxc/file.go:943 lxc/file.go:1109
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4700,7 +4719,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4729,15 +4748,15 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:463 lxc/file.go:695
+#: lxc/file.go:475 lxc/file.go:708
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1444 lxc/image.go:1445
+#: lxc/image.go:1445 lxc/image.go:1446
 msgid "Refresh images"
 msgstr ""
 
@@ -4746,7 +4765,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1481
+#: lxc/image.go:1482
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4823,7 +4842,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:971 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4859,7 +4878,7 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:969 lxc/network_forward.go:970
+#: lxc/network_forward.go:981 lxc/network_forward.go:982
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -4895,8 +4914,8 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
-#: lxc/image_alias.go:255
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:287
+#: lxc/image_alias.go:288
 msgid "Rename aliases"
 msgstr ""
 
@@ -4932,15 +4951,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1962
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
+#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4992,7 +5011,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5009,7 +5028,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:361
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5058,12 +5077,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1460
+#: lxc/file.go:1484
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1461
+#: lxc/file.go:1485
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5139,7 +5158,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1217
+#: lxc/file.go:1237
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5165,7 +5184,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1665 lxc/image.go:1666
+#: lxc/image.go:1666 lxc/image.go:1667
 msgid "Set image properties"
 msgstr ""
 
@@ -5208,11 +5227,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:488
+#: lxc/network_forward.go:496
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:489
+#: lxc/network_forward.go:497
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5316,11 +5335,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2088
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2089
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5337,7 +5356,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:698
+#: lxc/file.go:711
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5345,7 +5364,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:699
+#: lxc/file.go:712
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5353,7 +5372,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:710
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5365,7 +5384,7 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:504
 msgid "Set the key as a network forward property"
 msgstr ""
 
@@ -5405,7 +5424,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2105
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5413,7 +5432,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1215
+#: lxc/file.go:1235
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5470,7 +5489,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1535 lxc/image.go:1536
+#: lxc/image.go:1536 lxc/image.go:1537
 msgid "Show image properties"
 msgstr ""
 
@@ -5490,7 +5509,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:271 lxc/main.go:272
+#: lxc/main.go:280 lxc/main.go:281
 msgid "Show less common commands"
 msgstr ""
 
@@ -5554,11 +5573,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5626,15 +5645,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2190
+#: lxc/storage_volume.go:2192
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1502
+#: lxc/info.go:619 lxc/storage_volume.go:1504
 msgid "Snapshots:"
 msgstr ""
 
@@ -5739,21 +5758,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:703
+#: lxc/storage_volume.go:707
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:791
+#: lxc/storage_volume.go:795
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:516
+#: lxc/storage_volume.go:520
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:524
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5815,21 +5834,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1747 lxc/warning.go:216
+#: lxc/storage_volume.go:1749 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1262
+#: lxc/file.go:1286
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1256
+#: lxc/file.go:1280
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5839,15 +5858,15 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:181
+#: lxc/move.go:186
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:219 lxc/move.go:240
+#: lxc/move.go:224 lxc/move.go:245
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:193
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5855,15 +5874,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:185
+#: lxc/move.go:190
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:189
+#: lxc/move.go:194
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:210
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5885,7 +5904,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:439
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5938,7 +5957,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:462
+#: lxc/network_forward.go:470
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -5978,12 +5997,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1340
+#: lxc/storage_volume.go:1342
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1317
+#: lxc/storage_volume.go:1319
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -5998,12 +6017,12 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:309
+#: lxc/move.go:314
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
-#: lxc/storage_volume.go:989
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
+#: lxc/storage_volume.go:991
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6031,7 +6050,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:298
+#: lxc/main.go:307
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6055,11 +6074,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:437
+#: lxc/init.go:441
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:440
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6067,7 +6086,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:412
+#: lxc/main.go:421
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6078,7 +6097,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1489
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6093,7 +6112,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1864
+#: lxc/storage_volume.go:1866
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6101,7 +6120,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6118,7 +6137,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:327
+#: lxc/copy.go:382 lxc/move.go:332
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6160,7 +6179,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1472
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6182,13 +6201,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1752
+#: lxc/project.go:995 lxc/storage_volume.go:1754
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1751
+#: lxc/storage.go:724 lxc/storage_volume.go:1753
 msgid "USED BY"
 msgstr ""
 
@@ -6201,7 +6220,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:411
+#: lxc/file.go:423
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6215,12 +6234,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1483
+#: lxc/file.go:1507
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1791
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6231,7 +6250,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1029
+#: lxc/file.go:1049
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6262,7 +6281,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1728 lxc/image.go:1729
+#: lxc/image.go:1729 lxc/image.go:1730
 msgid "Unset image properties"
 msgstr ""
 
@@ -6278,11 +6297,11 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:598
+#: lxc/network_forward.go:606
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:599
+#: lxc/network_forward.go:607
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -6326,7 +6345,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6338,7 +6357,7 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:602
+#: lxc/network_forward.go:610
 msgid "Unset the key as a network forward property"
 msgstr ""
 
@@ -6378,7 +6397,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2381
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6386,7 +6405,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:248
+#: lxc/storage_volume.go:250
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6422,12 +6441,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1485
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2652
+#: lxc/export.go:42 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6494,7 +6513,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1576
+#: lxc/storage_volume.go:1578
 msgid "Volume Only"
 msgstr ""
 
@@ -6545,7 +6564,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:293 lxc/move.go:369
+#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6553,12 +6572,12 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:909
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:912
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:282
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:284
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
@@ -6590,7 +6609,7 @@ msgstr ""
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:174
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
@@ -6643,7 +6662,7 @@ msgstr ""
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: lxc/image_alias.go:104
+#: lxc/image_alias.go:121
 msgid "[<remote>:]<alias>"
 msgstr ""
 
@@ -6651,7 +6670,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/image_alias.go:252
+#: lxc/image_alias.go:285
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
@@ -6705,15 +6724,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1600 lxc/image.go:1727
+#: lxc/image.go:1601 lxc/image.go:1728
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1664
+#: lxc/image.go:1665
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6733,7 +6752,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1443
+#: lxc/image.go:334 lxc/image.go:1444
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6804,7 +6823,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:376
+#: lxc/file.go:380
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -6816,12 +6835,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:454
+#: lxc/file.go:466
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1226
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6889,8 +6908,8 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:644
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:179
+#: lxc/network_forward.go:177 lxc/network_forward.go:652
+#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
 #: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
@@ -6905,12 +6924,12 @@ msgid ""
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:402 lxc/network_forward.go:597
+#: lxc/network_forward.go:410 lxc/network_forward.go:605
 #: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
@@ -6920,13 +6939,13 @@ msgid ""
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:887
+#: lxc/network_forward.go:895
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:968 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -6981,7 +7000,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2811
+#: lxc/storage_volume.go:2813
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7016,65 +7035,65 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1958
+#: lxc/storage_volume.go:1960
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:806
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:167
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
-msgstr ""
-
-#: lxc/storage_volume.go:2562
+#: lxc/storage_volume.go:2564
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2645
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2428
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:610
+#: lxc/storage_volume.go:614
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:718
+#: lxc/storage_volume.go:722
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2364
+#: lxc/storage_volume.go:810
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
+msgstr ""
+
+#: lxc/storage_volume.go:167
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
+msgstr ""
+
+#: lxc/storage_volume.go:2366
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2087
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2245
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1234
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1858
+#: lxc/storage_volume.go:1860
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7180,7 +7199,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1603
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7342,20 +7361,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1230
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:470
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:691
+#: lxc/file.go:704
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7656,7 +7675,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:618
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7664,13 +7683,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2817
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2432
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7704,16 +7723,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1396
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1331
+#: lxc/file.go:1355
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1284
+#: lxc/file.go:1308
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-07 15:11-0700\n"
+"POT-Creation-Date: 2025-01-10 14:44-0600\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1041
+#: lxc/storage_volume.go:1043
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:667
+#: lxc/network_forward.go:675
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,12 +430,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1157
+#: lxc/file.go:1177
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1047
+#: lxc/file.go:1067
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -471,7 +471,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:65
+#: lxc/init.go:146 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:687
+#: lxc/file.go:700
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -541,7 +541,7 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
@@ -672,7 +672,7 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:888 lxc/network_forward.go:889
+#: lxc/network_forward.go:896 lxc/network_forward.go:897
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -722,7 +722,7 @@ msgstr ""
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
+#: lxc/image_alias.go:101 lxc/image_alias.go:156 lxc/image_alias.go:320
 msgid "Alias name missing"
 msgstr ""
 
@@ -735,7 +735,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1607
+#: lxc/storage_volume.go:1609
 msgid "All projects"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -790,12 +790,26 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168 lxc/storage_volume.go:169
+#: lxc/storage_volume.go:168
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:169
+msgid ""
+"Attach new storage volumes to instances\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
+msgstr ""
+
+#: lxc/storage_volume.go:285
 msgid "Attach new storage volumes to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:286
+msgid ""
+"Attach new storage volumes to profiles\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
 #: lxc/console.go:39
@@ -846,16 +860,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2719
+#: lxc/storage_volume.go:2721
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2796
+#: lxc/export.go:192 lxc/storage_volume.go:2798
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1538
+#: lxc/info.go:666 lxc/storage_volume.go:1540
 msgid "Backups:"
 msgstr ""
 
@@ -864,19 +878,19 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
+#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:326
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -919,7 +933,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1752
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -971,7 +985,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -979,7 +993,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:562
+#: lxc/file.go:575
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1004,11 +1018,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:768
+#: lxc/file.go:790
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1021,12 +1035,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:493
+#: lxc/storage_volume.go:497
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:447
+#: lxc/storage_volume.go:451
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1132,9 +1146,9 @@ msgstr ""
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:497 lxc/network_forward.go:649
-#: lxc/network_forward.go:803 lxc/network_forward.go:892
-#: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
+#: lxc/network_forward.go:505 lxc/network_forward.go:657
+#: lxc/network_forward.go:811 lxc/network_forward.go:900
+#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
 #: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
 #: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
@@ -1146,14 +1160,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
-#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
-#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
-#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
+#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
 msgid "Cluster member name"
 msgstr ""
 
@@ -1169,7 +1183,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1608
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1209,21 +1223,21 @@ msgstr ""
 #: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
-#: lxc/network_acl.go:698 lxc/network_forward.go:767
+#: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
-#: lxc/storage_volume.go:1199
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
+#: lxc/storage_volume.go:1201
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:620
+#: lxc/storage_volume.go:624
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1478
+#: lxc/storage_volume.go:1480
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1285,7 +1299,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1293,12 +1307,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1311,7 +1325,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1406,7 +1420,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:462 lxc/file.go:696
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1446,7 +1460,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1498,12 +1512,12 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:182
+#: lxc/init.go:186
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1513,7 +1527,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 msgid "Creating the instance"
 msgstr ""
 
@@ -1527,13 +1541,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1749
+#: lxc/storage_volume.go:1751
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1553,7 +1567,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2653
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1585,7 +1599,7 @@ msgstr ""
 msgid "Delete identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:106 lxc/image_alias.go:107
+#: lxc/image_alias.go:123 lxc/image_alias.go:124
 msgid "Delete image aliases"
 msgstr ""
 
@@ -1609,7 +1623,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:799 lxc/network_forward.go:800
+#: lxc/network_forward.go:807 lxc/network_forward.go:808
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1649,7 +1663,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
+#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1691,13 +1705,13 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
-#: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
-#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
+#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
+#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
+#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
@@ -1711,10 +1725,10 @@ msgstr ""
 #: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:404 lxc/network_forward.go:489
-#: lxc/network_forward.go:599 lxc/network_forward.go:646
-#: lxc/network_forward.go:800 lxc/network_forward.go:874
-#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_forward.go:412 lxc/network_forward.go:497
+#: lxc/network_forward.go:607 lxc/network_forward.go:654
+#: lxc/network_forward.go:808 lxc/network_forward.go:882
+#: lxc/network_forward.go:897 lxc/network_forward.go:982
 #: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
 #: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
 #: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
@@ -1754,27 +1768,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
-#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
-#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
-#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
-#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
-#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
-#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
-#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1465
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1786,11 +1800,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
+#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1840,7 +1854,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:403
+#: lxc/init.go:407
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1852,7 +1866,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1216
+#: lxc/file.go:1236
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1948,7 +1962,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:377 lxc/file.go:378
+#: lxc/file.go:381 lxc/file.go:382
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1988,7 +2002,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:653 lxc/network_forward.go:654
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -2028,7 +2042,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2036,7 +2050,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1785
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2090,11 +2104,11 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
-#: lxc/network_acl.go:524 lxc/network_forward.go:572
+#: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
+#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2105,11 +2119,11 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
-#: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
+#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
-#: lxc/storage_volume.go:2210
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
+#: lxc/storage_volume.go:2212
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2151,8 +2165,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
+#: lxc/storage_volume.go:1577
 msgid "Expires at"
 msgstr ""
 
@@ -2176,7 +2190,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2188,11 +2202,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2650
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2779
+#: lxc/export.go:152 lxc/storage_volume.go:2781
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2211,7 +2225,7 @@ msgid "FILENAME"
 msgstr ""
 
 #: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
-#: lxc/image_alias.go:235
+#: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2219,12 +2233,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1467
+#: lxc/file.go:1491
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1490
+#: lxc/file.go:1514
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2239,12 +2253,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1517
+#: lxc/file.go:1541
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1326
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2274,7 +2288,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1423
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2289,7 +2303,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1428
+#: lxc/file.go:1452
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2299,12 +2313,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1352
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1455
+#: lxc/file.go:1479
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2318,7 +2332,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:304 lxc/move.go:380
+#: lxc/move.go:309 lxc/move.go:385
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2343,7 +2357,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1440
+#: lxc/file.go:1464
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2358,7 +2372,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1042
+#: lxc/file.go:1062
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2445,14 +2459,14 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1625 lxc/warning.go:94
+#: lxc/storage_volume.go:1627 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2520,7 +2534,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1602
+#: lxc/image.go:1602 lxc/image.go:1603
 msgid "Get image properties"
 msgstr ""
 
@@ -2536,7 +2550,7 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:414
 msgid "Get the key as a network forward property"
 msgstr ""
 
@@ -2576,7 +2590,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1249
+#: lxc/storage_volume.go:1251
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2604,7 +2618,7 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:403 lxc/network_forward.go:404
+#: lxc/network_forward.go:411 lxc/network_forward.go:412
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
@@ -2640,11 +2654,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:476
+#: lxc/storage_volume.go:480
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2684,22 +2698,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1540
+#: lxc/file.go:1564
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1529
+#: lxc/file.go:1553
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1376
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1362
+#: lxc/file.go:1386
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2772,11 +2786,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:415
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2786,7 +2800,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2437
+#: lxc/storage_volume.go:2439
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2798,7 +2812,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1517
+#: lxc/image.go:1518
 msgid "Image already up to date."
 msgstr ""
 
@@ -2814,11 +2828,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1472
+#: lxc/image.go:364 lxc/image.go:1473
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1698
+#: lxc/image.go:444 lxc/image.go:1699
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2828,7 +2842,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1515
+#: lxc/image.go:1516
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2836,7 +2850,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2815
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2844,7 +2858,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2814
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2866,11 +2880,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2822
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2894
+#: lxc/storage_volume.go:2896
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2896,11 +2910,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1378
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1531
+#: lxc/file.go:1555
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2909,7 +2923,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:414
+#: lxc/init.go:418
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2918,7 +2932,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1298
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2970,7 +2984,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1293
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2996,23 +3010,23 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2023
+#: lxc/move.go:153 lxc/storage_volume.go:2025
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:144
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2019
+#: lxc/storage_volume.go:2021
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:509
+#: lxc/main.go:518
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:353
+#: lxc/file.go:357
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3022,18 +3036,18 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
-#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
+#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:535
+#: lxc/file.go:548
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:717
+#: lxc/file.go:185 lxc/file.go:739
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3070,7 +3084,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3101,12 +3115,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:176
+#: lxc/init.go:180
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:174
+#: lxc/init.go:178
 msgid "Launching the instance"
 msgstr ""
 
@@ -3204,11 +3218,11 @@ msgstr ""
 msgid "List identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:151
+#: lxc/image_alias.go:176
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:177
 msgid ""
 "List image aliases\n"
 "\n"
@@ -3375,11 +3389,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1605
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1610
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3438,7 +3452,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1481
+#: lxc/info.go:489 lxc/storage_volume.go:1483
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3624,7 +3638,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:873 lxc/network_forward.go:874
+#: lxc/network_forward.go:881 lxc/network_forward.go:882
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -3770,12 +3784,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:322 lxc/move.go:435
+#: lxc/move.go:327 lxc/move.go:440
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:347 lxc/move.go:440
+#: lxc/move.go:352 lxc/move.go:445
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3840,10 +3854,10 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:449
-#: lxc/network_forward.go:534 lxc/network_forward.go:709
-#: lxc/network_forward.go:840 lxc/network_forward.go:933
-#: lxc/network_forward.go:1015 lxc/network_load_balancer.go:221
+#: lxc/network_forward.go:219 lxc/network_forward.go:457
+#: lxc/network_forward.go:542 lxc/network_forward.go:717
+#: lxc/network_forward.go:848 lxc/network_forward.go:945
+#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
 #: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
 #: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
 #: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
@@ -3868,10 +3882,10 @@ msgstr ""
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
 #: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
 #: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:284 lxc/network_forward.go:445
-#: lxc/network_forward.go:530 lxc/network_forward.go:705
-#: lxc/network_forward.go:836 lxc/network_forward.go:929
-#: lxc/network_forward.go:1011 lxc/network_load_balancer.go:131
+#: lxc/network_forward.go:292 lxc/network_forward.go:453
+#: lxc/network_forward.go:538 lxc/network_forward.go:713
+#: lxc/network_forward.go:844 lxc/network_forward.go:941
+#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
 #: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
 #: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
 #: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
@@ -3907,13 +3921,13 @@ msgstr ""
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
-#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
-#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
-#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
+#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
+#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
+#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
+#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
 msgid "Missing pool name"
 msgstr ""
 
@@ -3932,15 +3946,15 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
+#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1411
+#: lxc/storage_volume.go:1413
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:820
+#: lxc/file.go:842
 msgid "Missing target directory"
 msgstr ""
 
@@ -3973,16 +3987,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
-#: lxc/storage_volume.go:975
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
+#: lxc/storage_volume.go:977
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:507
+#: lxc/file.go:520
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1207 lxc/file.go:1208
+#: lxc/file.go:1227 lxc/file.go:1228
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4011,7 +4025,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4019,16 +4033,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1869
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1059 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4050,7 +4064,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
 msgid "NAME"
 msgstr ""
 
@@ -4102,8 +4116,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
-#: lxc/storage_volume.go:1573
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Name"
 msgstr ""
 
@@ -4111,7 +4125,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4166,12 +4180,12 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:386
+#: lxc/network_forward.go:394
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:857
+#: lxc/network_forward.go:865
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -4255,7 +4269,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
+#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4263,7 +4277,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1070 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4275,11 +4289,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4293,7 +4307,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2035
+#: lxc/storage_volume.go:2037
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4301,16 +4315,21 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
-#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
-msgid "Only \"custom\" volumes can be attached to instances"
+#: lxc/storage_volume.go:216
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2701
+#: lxc/storage_volume.go:348
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:2703
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2500
+#: lxc/storage_volume.go:2502
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4322,7 +4341,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1431
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4335,7 +4354,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1577
+#: lxc/info.go:705 lxc/storage_volume.go:1579
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4365,7 +4384,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1767
+#: lxc/storage_volume.go:1769
 msgid "POOL"
 msgstr ""
 
@@ -4382,7 +4401,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167
-#: lxc/storage_volume.go:1773 lxc/warning.go:213
+#: lxc/storage_volume.go:1775 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4406,7 +4425,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:367
+#: lxc/main.go:376
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4444,7 +4463,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1332
+#: lxc/file.go:1356
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4452,12 +4471,12 @@ msgstr ""
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
-#: lxc/network_acl.go:699 lxc/network_forward.go:768
+#: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
-#: lxc/storage_volume.go:1200
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
+#: lxc/storage_volume.go:1202
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4570,11 +4589,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1649
+#: lxc/image.go:1650
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4588,7 +4607,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1238
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4604,7 +4623,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4625,7 +4644,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1017
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4634,7 +4653,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2094
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4647,7 +4666,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2370
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4678,20 +4697,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:455 lxc/file.go:456
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:638 lxc/file.go:989
+#: lxc/file.go:651 lxc/file.go:1009
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:688 lxc/file.go:689
+#: lxc/file.go:701 lxc/file.go:702
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:923 lxc/file.go:1089
+#: lxc/file.go:943 lxc/file.go:1109
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4700,7 +4719,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4729,15 +4748,15 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:463 lxc/file.go:695
+#: lxc/file.go:475 lxc/file.go:708
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1444 lxc/image.go:1445
+#: lxc/image.go:1445 lxc/image.go:1446
 msgid "Refresh images"
 msgstr ""
 
@@ -4746,7 +4765,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1481
+#: lxc/image.go:1482
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4823,7 +4842,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:971 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4859,7 +4878,7 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:969 lxc/network_forward.go:970
+#: lxc/network_forward.go:981 lxc/network_forward.go:982
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -4895,8 +4914,8 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
-#: lxc/image_alias.go:255
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:287
+#: lxc/image_alias.go:288
 msgid "Rename aliases"
 msgstr ""
 
@@ -4932,15 +4951,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1962
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
+#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4992,7 +5011,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5009,7 +5028,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:361
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5058,12 +5077,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1460
+#: lxc/file.go:1484
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1461
+#: lxc/file.go:1485
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5139,7 +5158,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1217
+#: lxc/file.go:1237
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5165,7 +5184,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1665 lxc/image.go:1666
+#: lxc/image.go:1666 lxc/image.go:1667
 msgid "Set image properties"
 msgstr ""
 
@@ -5208,11 +5227,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:488
+#: lxc/network_forward.go:496
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:489
+#: lxc/network_forward.go:497
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5316,11 +5335,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2088
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2089
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5337,7 +5356,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:698
+#: lxc/file.go:711
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5345,7 +5364,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:699
+#: lxc/file.go:712
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5353,7 +5372,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:710
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5365,7 +5384,7 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:504
 msgid "Set the key as a network forward property"
 msgstr ""
 
@@ -5405,7 +5424,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2105
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5413,7 +5432,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1215
+#: lxc/file.go:1235
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5470,7 +5489,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1535 lxc/image.go:1536
+#: lxc/image.go:1536 lxc/image.go:1537
 msgid "Show image properties"
 msgstr ""
 
@@ -5490,7 +5509,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:271 lxc/main.go:272
+#: lxc/main.go:280 lxc/main.go:281
 msgid "Show less common commands"
 msgstr ""
 
@@ -5554,11 +5573,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5626,15 +5645,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2190
+#: lxc/storage_volume.go:2192
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1502
+#: lxc/info.go:619 lxc/storage_volume.go:1504
 msgid "Snapshots:"
 msgstr ""
 
@@ -5739,21 +5758,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:703
+#: lxc/storage_volume.go:707
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:791
+#: lxc/storage_volume.go:795
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:516
+#: lxc/storage_volume.go:520
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:524
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5815,21 +5834,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1747 lxc/warning.go:216
+#: lxc/storage_volume.go:1749 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1262
+#: lxc/file.go:1286
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1256
+#: lxc/file.go:1280
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5839,15 +5858,15 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:181
+#: lxc/move.go:186
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:219 lxc/move.go:240
+#: lxc/move.go:224 lxc/move.go:245
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:193
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5855,15 +5874,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:185
+#: lxc/move.go:190
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:189
+#: lxc/move.go:194
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:210
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5885,7 +5904,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:439
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5938,7 +5957,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:462
+#: lxc/network_forward.go:470
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -5978,12 +5997,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1340
+#: lxc/storage_volume.go:1342
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1317
+#: lxc/storage_volume.go:1319
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -5998,12 +6017,12 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:309
+#: lxc/move.go:314
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
-#: lxc/storage_volume.go:989
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
+#: lxc/storage_volume.go:991
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6031,7 +6050,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:298
+#: lxc/main.go:307
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6055,11 +6074,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:437
+#: lxc/init.go:441
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:440
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6067,7 +6086,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:412
+#: lxc/main.go:421
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6078,7 +6097,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1489
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6093,7 +6112,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1864
+#: lxc/storage_volume.go:1866
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6101,7 +6120,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6118,7 +6137,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:327
+#: lxc/copy.go:382 lxc/move.go:332
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6160,7 +6179,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1472
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6182,13 +6201,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1752
+#: lxc/project.go:995 lxc/storage_volume.go:1754
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1751
+#: lxc/storage.go:724 lxc/storage_volume.go:1753
 msgid "USED BY"
 msgstr ""
 
@@ -6201,7 +6220,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:411
+#: lxc/file.go:423
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6215,12 +6234,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1483
+#: lxc/file.go:1507
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1791
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6231,7 +6250,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1029
+#: lxc/file.go:1049
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6262,7 +6281,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1728 lxc/image.go:1729
+#: lxc/image.go:1729 lxc/image.go:1730
 msgid "Unset image properties"
 msgstr ""
 
@@ -6278,11 +6297,11 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:598
+#: lxc/network_forward.go:606
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:599
+#: lxc/network_forward.go:607
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -6326,7 +6345,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6338,7 +6357,7 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:602
+#: lxc/network_forward.go:610
 msgid "Unset the key as a network forward property"
 msgstr ""
 
@@ -6378,7 +6397,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2381
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6386,7 +6405,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:248
+#: lxc/storage_volume.go:250
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6422,12 +6441,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1485
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2652
+#: lxc/export.go:42 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6494,7 +6513,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1576
+#: lxc/storage_volume.go:1578
 msgid "Volume Only"
 msgstr ""
 
@@ -6545,7 +6564,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:293 lxc/move.go:369
+#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6553,12 +6572,12 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:909
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:912
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:282
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:284
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
@@ -6590,7 +6609,7 @@ msgstr ""
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:174
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
@@ -6643,7 +6662,7 @@ msgstr ""
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: lxc/image_alias.go:104
+#: lxc/image_alias.go:121
 msgid "[<remote>:]<alias>"
 msgstr ""
 
@@ -6651,7 +6670,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/image_alias.go:252
+#: lxc/image_alias.go:285
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
@@ -6705,15 +6724,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1600 lxc/image.go:1727
+#: lxc/image.go:1601 lxc/image.go:1728
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1664
+#: lxc/image.go:1665
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6733,7 +6752,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1443
+#: lxc/image.go:334 lxc/image.go:1444
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6804,7 +6823,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:376
+#: lxc/file.go:380
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -6816,12 +6835,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:454
+#: lxc/file.go:466
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1226
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6889,8 +6908,8 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:644
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:179
+#: lxc/network_forward.go:177 lxc/network_forward.go:652
+#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
 #: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
@@ -6905,12 +6924,12 @@ msgid ""
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:402 lxc/network_forward.go:597
+#: lxc/network_forward.go:410 lxc/network_forward.go:605
 #: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
@@ -6920,13 +6939,13 @@ msgid ""
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:887
+#: lxc/network_forward.go:895
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:968 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -6981,7 +7000,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2811
+#: lxc/storage_volume.go:2813
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7016,65 +7035,65 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1958
+#: lxc/storage_volume.go:1960
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:806
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:167
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
-msgstr ""
-
-#: lxc/storage_volume.go:2562
+#: lxc/storage_volume.go:2564
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2645
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2428
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:610
+#: lxc/storage_volume.go:614
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:718
+#: lxc/storage_volume.go:722
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2364
+#: lxc/storage_volume.go:810
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
+msgstr ""
+
+#: lxc/storage_volume.go:167
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
+msgstr ""
+
+#: lxc/storage_volume.go:2366
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2087
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2245
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1234
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1858
+#: lxc/storage_volume.go:1860
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7180,7 +7199,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1603
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7342,20 +7361,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1230
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:470
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:691
+#: lxc/file.go:704
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7656,7 +7675,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:618
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7664,13 +7683,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2817
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2432
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7704,16 +7723,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1396
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1331
+#: lxc/file.go:1355
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1284
+#: lxc/file.go:1308
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/th.po
+++ b/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-07 15:11-0700\n"
+"POT-Creation-Date: 2025-01-10 14:44-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -46,7 +46,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1041
+#: lxc/storage_volume.go:1043
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -251,7 +251,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:667
+#: lxc/network_forward.go:675
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -427,12 +427,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1157
+#: lxc/file.go:1177
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1047
+#: lxc/file.go:1067
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -468,7 +468,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:65
+#: lxc/init.go:146 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -521,7 +521,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:687
+#: lxc/file.go:700
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -538,7 +538,7 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
@@ -669,7 +669,7 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:888 lxc/network_forward.go:889
+#: lxc/network_forward.go:896 lxc/network_forward.go:897
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -719,7 +719,7 @@ msgstr ""
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
+#: lxc/image_alias.go:101 lxc/image_alias.go:156 lxc/image_alias.go:320
 msgid "Alias name missing"
 msgstr ""
 
@@ -732,7 +732,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1607
+#: lxc/storage_volume.go:1609
 msgid "All projects"
 msgstr ""
 
@@ -763,7 +763,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -787,12 +787,26 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168 lxc/storage_volume.go:169
+#: lxc/storage_volume.go:168
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:169
+msgid ""
+"Attach new storage volumes to instances\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
+msgstr ""
+
+#: lxc/storage_volume.go:285
 msgid "Attach new storage volumes to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:286
+msgid ""
+"Attach new storage volumes to profiles\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
 #: lxc/console.go:39
@@ -843,16 +857,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2719
+#: lxc/storage_volume.go:2721
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2796
+#: lxc/export.go:192 lxc/storage_volume.go:2798
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1538
+#: lxc/info.go:666 lxc/storage_volume.go:1540
 msgid "Backups:"
 msgstr ""
 
@@ -861,19 +875,19 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
+#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:326
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -916,7 +930,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1752
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -968,7 +982,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -976,7 +990,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:562
+#: lxc/file.go:575
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1001,11 +1015,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:768
+#: lxc/file.go:790
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1018,12 +1032,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:493
+#: lxc/storage_volume.go:497
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:447
+#: lxc/storage_volume.go:451
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1129,9 +1143,9 @@ msgstr ""
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:497 lxc/network_forward.go:649
-#: lxc/network_forward.go:803 lxc/network_forward.go:892
-#: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
+#: lxc/network_forward.go:505 lxc/network_forward.go:657
+#: lxc/network_forward.go:811 lxc/network_forward.go:900
+#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
 #: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
 #: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
@@ -1143,14 +1157,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
-#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
-#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
-#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
+#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
 msgid "Cluster member name"
 msgstr ""
 
@@ -1166,7 +1180,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1608
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1206,21 +1220,21 @@ msgstr ""
 #: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
-#: lxc/network_acl.go:698 lxc/network_forward.go:767
+#: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
-#: lxc/storage_volume.go:1199
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
+#: lxc/storage_volume.go:1201
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:620
+#: lxc/storage_volume.go:624
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1478
+#: lxc/storage_volume.go:1480
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1282,7 +1296,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1290,12 +1304,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1308,7 +1322,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1403,7 +1417,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:462 lxc/file.go:696
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1443,7 +1457,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1495,12 +1509,12 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:182
+#: lxc/init.go:186
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1510,7 +1524,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 msgid "Creating the instance"
 msgstr ""
 
@@ -1524,13 +1538,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1749
+#: lxc/storage_volume.go:1751
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1550,7 +1564,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2653
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1582,7 +1596,7 @@ msgstr ""
 msgid "Delete identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:106 lxc/image_alias.go:107
+#: lxc/image_alias.go:123 lxc/image_alias.go:124
 msgid "Delete image aliases"
 msgstr ""
 
@@ -1606,7 +1620,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:799 lxc/network_forward.go:800
+#: lxc/network_forward.go:807 lxc/network_forward.go:808
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1646,7 +1660,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
+#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1688,13 +1702,13 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
-#: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
-#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
+#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
+#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
+#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
@@ -1708,10 +1722,10 @@ msgstr ""
 #: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:404 lxc/network_forward.go:489
-#: lxc/network_forward.go:599 lxc/network_forward.go:646
-#: lxc/network_forward.go:800 lxc/network_forward.go:874
-#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_forward.go:412 lxc/network_forward.go:497
+#: lxc/network_forward.go:607 lxc/network_forward.go:654
+#: lxc/network_forward.go:808 lxc/network_forward.go:882
+#: lxc/network_forward.go:897 lxc/network_forward.go:982
 #: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
 #: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
 #: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
@@ -1751,27 +1765,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
-#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
-#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
-#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
-#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
-#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
-#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
-#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1465
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1783,11 +1797,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
+#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1837,7 +1851,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:403
+#: lxc/init.go:407
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1849,7 +1863,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1216
+#: lxc/file.go:1236
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1945,7 +1959,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:377 lxc/file.go:378
+#: lxc/file.go:381 lxc/file.go:382
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1985,7 +1999,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:653 lxc/network_forward.go:654
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -2025,7 +2039,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2033,7 +2047,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1785
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2087,11 +2101,11 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
-#: lxc/network_acl.go:524 lxc/network_forward.go:572
+#: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
+#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2102,11 +2116,11 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
-#: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
+#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
-#: lxc/storage_volume.go:2210
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
+#: lxc/storage_volume.go:2212
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2148,8 +2162,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
+#: lxc/storage_volume.go:1577
 msgid "Expires at"
 msgstr ""
 
@@ -2173,7 +2187,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2185,11 +2199,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2650
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2779
+#: lxc/export.go:152 lxc/storage_volume.go:2781
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2208,7 +2222,7 @@ msgid "FILENAME"
 msgstr ""
 
 #: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
-#: lxc/image_alias.go:235
+#: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2216,12 +2230,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1467
+#: lxc/file.go:1491
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1490
+#: lxc/file.go:1514
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2236,12 +2250,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1517
+#: lxc/file.go:1541
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1326
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2271,7 +2285,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1423
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2286,7 +2300,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1428
+#: lxc/file.go:1452
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2296,12 +2310,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1352
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1455
+#: lxc/file.go:1479
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2315,7 +2329,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:304 lxc/move.go:380
+#: lxc/move.go:309 lxc/move.go:385
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2340,7 +2354,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1440
+#: lxc/file.go:1464
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2355,7 +2369,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1042
+#: lxc/file.go:1062
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2442,14 +2456,14 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1625 lxc/warning.go:94
+#: lxc/storage_volume.go:1627 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2517,7 +2531,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1602
+#: lxc/image.go:1602 lxc/image.go:1603
 msgid "Get image properties"
 msgstr ""
 
@@ -2533,7 +2547,7 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:414
 msgid "Get the key as a network forward property"
 msgstr ""
 
@@ -2573,7 +2587,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1249
+#: lxc/storage_volume.go:1251
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2601,7 +2615,7 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:403 lxc/network_forward.go:404
+#: lxc/network_forward.go:411 lxc/network_forward.go:412
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
@@ -2637,11 +2651,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:476
+#: lxc/storage_volume.go:480
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2681,22 +2695,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1540
+#: lxc/file.go:1564
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1529
+#: lxc/file.go:1553
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1376
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1362
+#: lxc/file.go:1386
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2769,11 +2783,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:415
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2783,7 +2797,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2437
+#: lxc/storage_volume.go:2439
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2795,7 +2809,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1517
+#: lxc/image.go:1518
 msgid "Image already up to date."
 msgstr ""
 
@@ -2811,11 +2825,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1472
+#: lxc/image.go:364 lxc/image.go:1473
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1698
+#: lxc/image.go:444 lxc/image.go:1699
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2825,7 +2839,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1515
+#: lxc/image.go:1516
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2833,7 +2847,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2815
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2841,7 +2855,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2814
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2863,11 +2877,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2822
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2894
+#: lxc/storage_volume.go:2896
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2893,11 +2907,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1378
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1531
+#: lxc/file.go:1555
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2906,7 +2920,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:414
+#: lxc/init.go:418
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2915,7 +2929,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1298
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2967,7 +2981,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1293
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2993,23 +3007,23 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2023
+#: lxc/move.go:153 lxc/storage_volume.go:2025
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:144
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2019
+#: lxc/storage_volume.go:2021
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:509
+#: lxc/main.go:518
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:353
+#: lxc/file.go:357
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3019,18 +3033,18 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
-#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
+#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:535
+#: lxc/file.go:548
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:717
+#: lxc/file.go:185 lxc/file.go:739
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3067,7 +3081,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3098,12 +3112,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:176
+#: lxc/init.go:180
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:174
+#: lxc/init.go:178
 msgid "Launching the instance"
 msgstr ""
 
@@ -3201,11 +3215,11 @@ msgstr ""
 msgid "List identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:151
+#: lxc/image_alias.go:176
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:177
 msgid ""
 "List image aliases\n"
 "\n"
@@ -3372,11 +3386,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1605
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1610
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3435,7 +3449,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1481
+#: lxc/info.go:489 lxc/storage_volume.go:1483
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3621,7 +3635,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:873 lxc/network_forward.go:874
+#: lxc/network_forward.go:881 lxc/network_forward.go:882
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -3767,12 +3781,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:322 lxc/move.go:435
+#: lxc/move.go:327 lxc/move.go:440
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:347 lxc/move.go:440
+#: lxc/move.go:352 lxc/move.go:445
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3837,10 +3851,10 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:449
-#: lxc/network_forward.go:534 lxc/network_forward.go:709
-#: lxc/network_forward.go:840 lxc/network_forward.go:933
-#: lxc/network_forward.go:1015 lxc/network_load_balancer.go:221
+#: lxc/network_forward.go:219 lxc/network_forward.go:457
+#: lxc/network_forward.go:542 lxc/network_forward.go:717
+#: lxc/network_forward.go:848 lxc/network_forward.go:945
+#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
 #: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
 #: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
 #: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
@@ -3865,10 +3879,10 @@ msgstr ""
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
 #: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
 #: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:284 lxc/network_forward.go:445
-#: lxc/network_forward.go:530 lxc/network_forward.go:705
-#: lxc/network_forward.go:836 lxc/network_forward.go:929
-#: lxc/network_forward.go:1011 lxc/network_load_balancer.go:131
+#: lxc/network_forward.go:292 lxc/network_forward.go:453
+#: lxc/network_forward.go:538 lxc/network_forward.go:713
+#: lxc/network_forward.go:844 lxc/network_forward.go:941
+#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
 #: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
 #: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
 #: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
@@ -3904,13 +3918,13 @@ msgstr ""
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
-#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
-#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
-#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
+#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
+#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
+#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
+#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
 msgid "Missing pool name"
 msgstr ""
 
@@ -3929,15 +3943,15 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
+#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1411
+#: lxc/storage_volume.go:1413
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:820
+#: lxc/file.go:842
 msgid "Missing target directory"
 msgstr ""
 
@@ -3970,16 +3984,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
-#: lxc/storage_volume.go:975
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
+#: lxc/storage_volume.go:977
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:507
+#: lxc/file.go:520
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1207 lxc/file.go:1208
+#: lxc/file.go:1227 lxc/file.go:1228
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4008,7 +4022,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4016,16 +4030,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1869
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1059 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4047,7 +4061,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
 msgid "NAME"
 msgstr ""
 
@@ -4099,8 +4113,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
-#: lxc/storage_volume.go:1573
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Name"
 msgstr ""
 
@@ -4108,7 +4122,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4163,12 +4177,12 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:386
+#: lxc/network_forward.go:394
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:857
+#: lxc/network_forward.go:865
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -4252,7 +4266,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
+#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4260,7 +4274,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1070 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4272,11 +4286,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4290,7 +4304,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2035
+#: lxc/storage_volume.go:2037
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4298,16 +4312,21 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
-#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
-msgid "Only \"custom\" volumes can be attached to instances"
+#: lxc/storage_volume.go:216
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2701
+#: lxc/storage_volume.go:348
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:2703
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2500
+#: lxc/storage_volume.go:2502
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4319,7 +4338,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1431
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4332,7 +4351,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1577
+#: lxc/info.go:705 lxc/storage_volume.go:1579
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4362,7 +4381,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1767
+#: lxc/storage_volume.go:1769
 msgid "POOL"
 msgstr ""
 
@@ -4379,7 +4398,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167
-#: lxc/storage_volume.go:1773 lxc/warning.go:213
+#: lxc/storage_volume.go:1775 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4403,7 +4422,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:367
+#: lxc/main.go:376
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4441,7 +4460,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1332
+#: lxc/file.go:1356
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4449,12 +4468,12 @@ msgstr ""
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
-#: lxc/network_acl.go:699 lxc/network_forward.go:768
+#: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
-#: lxc/storage_volume.go:1200
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
+#: lxc/storage_volume.go:1202
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4567,11 +4586,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1649
+#: lxc/image.go:1650
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4585,7 +4604,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1238
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4601,7 +4620,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4622,7 +4641,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1017
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4631,7 +4650,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2094
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4644,7 +4663,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2370
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4675,20 +4694,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:455 lxc/file.go:456
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:638 lxc/file.go:989
+#: lxc/file.go:651 lxc/file.go:1009
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:688 lxc/file.go:689
+#: lxc/file.go:701 lxc/file.go:702
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:923 lxc/file.go:1089
+#: lxc/file.go:943 lxc/file.go:1109
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4697,7 +4716,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4726,15 +4745,15 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:463 lxc/file.go:695
+#: lxc/file.go:475 lxc/file.go:708
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1444 lxc/image.go:1445
+#: lxc/image.go:1445 lxc/image.go:1446
 msgid "Refresh images"
 msgstr ""
 
@@ -4743,7 +4762,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1481
+#: lxc/image.go:1482
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4820,7 +4839,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:971 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4856,7 +4875,7 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:969 lxc/network_forward.go:970
+#: lxc/network_forward.go:981 lxc/network_forward.go:982
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -4892,8 +4911,8 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
-#: lxc/image_alias.go:255
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:287
+#: lxc/image_alias.go:288
 msgid "Rename aliases"
 msgstr ""
 
@@ -4929,15 +4948,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1962
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
+#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4989,7 +5008,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5006,7 +5025,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:361
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5055,12 +5074,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1460
+#: lxc/file.go:1484
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1461
+#: lxc/file.go:1485
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5136,7 +5155,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1217
+#: lxc/file.go:1237
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5162,7 +5181,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1665 lxc/image.go:1666
+#: lxc/image.go:1666 lxc/image.go:1667
 msgid "Set image properties"
 msgstr ""
 
@@ -5205,11 +5224,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:488
+#: lxc/network_forward.go:496
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:489
+#: lxc/network_forward.go:497
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5313,11 +5332,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2088
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2089
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5334,7 +5353,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:698
+#: lxc/file.go:711
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5342,7 +5361,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:699
+#: lxc/file.go:712
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5350,7 +5369,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:710
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5362,7 +5381,7 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:504
 msgid "Set the key as a network forward property"
 msgstr ""
 
@@ -5402,7 +5421,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2105
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5410,7 +5429,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1215
+#: lxc/file.go:1235
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5467,7 +5486,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1535 lxc/image.go:1536
+#: lxc/image.go:1536 lxc/image.go:1537
 msgid "Show image properties"
 msgstr ""
 
@@ -5487,7 +5506,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:271 lxc/main.go:272
+#: lxc/main.go:280 lxc/main.go:281
 msgid "Show less common commands"
 msgstr ""
 
@@ -5551,11 +5570,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5623,15 +5642,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2190
+#: lxc/storage_volume.go:2192
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1502
+#: lxc/info.go:619 lxc/storage_volume.go:1504
 msgid "Snapshots:"
 msgstr ""
 
@@ -5736,21 +5755,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:703
+#: lxc/storage_volume.go:707
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:791
+#: lxc/storage_volume.go:795
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:516
+#: lxc/storage_volume.go:520
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:524
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5812,21 +5831,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1747 lxc/warning.go:216
+#: lxc/storage_volume.go:1749 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1262
+#: lxc/file.go:1286
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1256
+#: lxc/file.go:1280
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5836,15 +5855,15 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:181
+#: lxc/move.go:186
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:219 lxc/move.go:240
+#: lxc/move.go:224 lxc/move.go:245
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:193
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5852,15 +5871,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:185
+#: lxc/move.go:190
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:189
+#: lxc/move.go:194
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:210
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5882,7 +5901,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:439
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5935,7 +5954,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:462
+#: lxc/network_forward.go:470
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -5975,12 +5994,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1340
+#: lxc/storage_volume.go:1342
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1317
+#: lxc/storage_volume.go:1319
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -5995,12 +6014,12 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:309
+#: lxc/move.go:314
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
-#: lxc/storage_volume.go:989
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
+#: lxc/storage_volume.go:991
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6028,7 +6047,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:298
+#: lxc/main.go:307
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6052,11 +6071,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:437
+#: lxc/init.go:441
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:440
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6064,7 +6083,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:412
+#: lxc/main.go:421
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6075,7 +6094,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1489
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6090,7 +6109,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1864
+#: lxc/storage_volume.go:1866
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6098,7 +6117,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6115,7 +6134,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:327
+#: lxc/copy.go:382 lxc/move.go:332
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6157,7 +6176,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1472
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6179,13 +6198,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1752
+#: lxc/project.go:995 lxc/storage_volume.go:1754
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1751
+#: lxc/storage.go:724 lxc/storage_volume.go:1753
 msgid "USED BY"
 msgstr ""
 
@@ -6198,7 +6217,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:411
+#: lxc/file.go:423
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6212,12 +6231,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1483
+#: lxc/file.go:1507
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1791
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6228,7 +6247,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1029
+#: lxc/file.go:1049
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6259,7 +6278,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1728 lxc/image.go:1729
+#: lxc/image.go:1729 lxc/image.go:1730
 msgid "Unset image properties"
 msgstr ""
 
@@ -6275,11 +6294,11 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:598
+#: lxc/network_forward.go:606
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:599
+#: lxc/network_forward.go:607
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -6323,7 +6342,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6335,7 +6354,7 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:602
+#: lxc/network_forward.go:610
 msgid "Unset the key as a network forward property"
 msgstr ""
 
@@ -6375,7 +6394,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2381
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6383,7 +6402,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:248
+#: lxc/storage_volume.go:250
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6419,12 +6438,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1485
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2652
+#: lxc/export.go:42 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6491,7 +6510,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1576
+#: lxc/storage_volume.go:1578
 msgid "Volume Only"
 msgstr ""
 
@@ -6542,7 +6561,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:293 lxc/move.go:369
+#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6550,12 +6569,12 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:909
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:912
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:282
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:284
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
@@ -6587,7 +6606,7 @@ msgstr ""
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:174
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
@@ -6640,7 +6659,7 @@ msgstr ""
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: lxc/image_alias.go:104
+#: lxc/image_alias.go:121
 msgid "[<remote>:]<alias>"
 msgstr ""
 
@@ -6648,7 +6667,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/image_alias.go:252
+#: lxc/image_alias.go:285
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
@@ -6702,15 +6721,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1600 lxc/image.go:1727
+#: lxc/image.go:1601 lxc/image.go:1728
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1664
+#: lxc/image.go:1665
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6730,7 +6749,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1443
+#: lxc/image.go:334 lxc/image.go:1444
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6801,7 +6820,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:376
+#: lxc/file.go:380
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -6813,12 +6832,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:454
+#: lxc/file.go:466
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1226
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6886,8 +6905,8 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:644
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:179
+#: lxc/network_forward.go:177 lxc/network_forward.go:652
+#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
 #: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
@@ -6902,12 +6921,12 @@ msgid ""
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:402 lxc/network_forward.go:597
+#: lxc/network_forward.go:410 lxc/network_forward.go:605
 #: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
@@ -6917,13 +6936,13 @@ msgid ""
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:887
+#: lxc/network_forward.go:895
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:968 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -6978,7 +6997,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2811
+#: lxc/storage_volume.go:2813
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7013,65 +7032,65 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1958
+#: lxc/storage_volume.go:1960
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:806
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:167
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
-msgstr ""
-
-#: lxc/storage_volume.go:2562
+#: lxc/storage_volume.go:2564
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2645
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2428
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:610
+#: lxc/storage_volume.go:614
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:718
+#: lxc/storage_volume.go:722
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2364
+#: lxc/storage_volume.go:810
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
+msgstr ""
+
+#: lxc/storage_volume.go:167
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
+msgstr ""
+
+#: lxc/storage_volume.go:2366
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2087
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2245
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1234
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1858
+#: lxc/storage_volume.go:1860
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7177,7 +7196,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1603
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7339,20 +7358,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1230
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:470
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:691
+#: lxc/file.go:704
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7653,7 +7672,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:618
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7661,13 +7680,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2817
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2432
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7701,16 +7720,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1396
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1331
+#: lxc/file.go:1355
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1284
+#: lxc/file.go:1308
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-07 15:11-0700\n"
+"POT-Creation-Date: 2025-01-10 14:44-0600\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1041
+#: lxc/storage_volume.go:1043
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:667
+#: lxc/network_forward.go:675
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,12 +430,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1157
+#: lxc/file.go:1177
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1047
+#: lxc/file.go:1067
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -471,7 +471,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:65
+#: lxc/init.go:146 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:687
+#: lxc/file.go:700
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -541,7 +541,7 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
@@ -672,7 +672,7 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:888 lxc/network_forward.go:889
+#: lxc/network_forward.go:896 lxc/network_forward.go:897
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -722,7 +722,7 @@ msgstr ""
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
+#: lxc/image_alias.go:101 lxc/image_alias.go:156 lxc/image_alias.go:320
 msgid "Alias name missing"
 msgstr ""
 
@@ -735,7 +735,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1607
+#: lxc/storage_volume.go:1609
 msgid "All projects"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -790,12 +790,26 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168 lxc/storage_volume.go:169
+#: lxc/storage_volume.go:168
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:169
+msgid ""
+"Attach new storage volumes to instances\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
+msgstr ""
+
+#: lxc/storage_volume.go:285
 msgid "Attach new storage volumes to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:286
+msgid ""
+"Attach new storage volumes to profiles\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
 #: lxc/console.go:39
@@ -846,16 +860,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2719
+#: lxc/storage_volume.go:2721
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2796
+#: lxc/export.go:192 lxc/storage_volume.go:2798
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1538
+#: lxc/info.go:666 lxc/storage_volume.go:1540
 msgid "Backups:"
 msgstr ""
 
@@ -864,19 +878,19 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
+#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:326
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -919,7 +933,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1752
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -971,7 +985,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -979,7 +993,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:562
+#: lxc/file.go:575
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1004,11 +1018,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:768
+#: lxc/file.go:790
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1021,12 +1035,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:493
+#: lxc/storage_volume.go:497
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:447
+#: lxc/storage_volume.go:451
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1132,9 +1146,9 @@ msgstr ""
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:497 lxc/network_forward.go:649
-#: lxc/network_forward.go:803 lxc/network_forward.go:892
-#: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
+#: lxc/network_forward.go:505 lxc/network_forward.go:657
+#: lxc/network_forward.go:811 lxc/network_forward.go:900
+#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
 #: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
 #: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
@@ -1146,14 +1160,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
-#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
-#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
-#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
+#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
 msgid "Cluster member name"
 msgstr ""
 
@@ -1169,7 +1183,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1608
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1209,21 +1223,21 @@ msgstr ""
 #: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
-#: lxc/network_acl.go:698 lxc/network_forward.go:767
+#: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
-#: lxc/storage_volume.go:1199
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
+#: lxc/storage_volume.go:1201
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:620
+#: lxc/storage_volume.go:624
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1478
+#: lxc/storage_volume.go:1480
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1285,7 +1299,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1293,12 +1307,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1311,7 +1325,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1406,7 +1420,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:462 lxc/file.go:696
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1446,7 +1460,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1498,12 +1512,12 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:182
+#: lxc/init.go:186
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1513,7 +1527,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 msgid "Creating the instance"
 msgstr ""
 
@@ -1527,13 +1541,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1749
+#: lxc/storage_volume.go:1751
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1553,7 +1567,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2653
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1585,7 +1599,7 @@ msgstr ""
 msgid "Delete identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:106 lxc/image_alias.go:107
+#: lxc/image_alias.go:123 lxc/image_alias.go:124
 msgid "Delete image aliases"
 msgstr ""
 
@@ -1609,7 +1623,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:799 lxc/network_forward.go:800
+#: lxc/network_forward.go:807 lxc/network_forward.go:808
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1649,7 +1663,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
+#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1691,13 +1705,13 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
-#: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
-#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
+#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
+#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
+#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
@@ -1711,10 +1725,10 @@ msgstr ""
 #: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:404 lxc/network_forward.go:489
-#: lxc/network_forward.go:599 lxc/network_forward.go:646
-#: lxc/network_forward.go:800 lxc/network_forward.go:874
-#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_forward.go:412 lxc/network_forward.go:497
+#: lxc/network_forward.go:607 lxc/network_forward.go:654
+#: lxc/network_forward.go:808 lxc/network_forward.go:882
+#: lxc/network_forward.go:897 lxc/network_forward.go:982
 #: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
 #: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
 #: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
@@ -1754,27 +1768,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
-#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
-#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
-#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
-#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
-#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
-#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
-#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1465
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1786,11 +1800,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
+#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1840,7 +1854,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:403
+#: lxc/init.go:407
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1852,7 +1866,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1216
+#: lxc/file.go:1236
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1948,7 +1962,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:377 lxc/file.go:378
+#: lxc/file.go:381 lxc/file.go:382
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1988,7 +2002,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:653 lxc/network_forward.go:654
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -2028,7 +2042,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2036,7 +2050,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1785
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2090,11 +2104,11 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
-#: lxc/network_acl.go:524 lxc/network_forward.go:572
+#: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
+#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2105,11 +2119,11 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
-#: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
+#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
-#: lxc/storage_volume.go:2210
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
+#: lxc/storage_volume.go:2212
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2151,8 +2165,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
+#: lxc/storage_volume.go:1577
 msgid "Expires at"
 msgstr ""
 
@@ -2176,7 +2190,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2188,11 +2202,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2650
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2779
+#: lxc/export.go:152 lxc/storage_volume.go:2781
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2211,7 +2225,7 @@ msgid "FILENAME"
 msgstr ""
 
 #: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
-#: lxc/image_alias.go:235
+#: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2219,12 +2233,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1467
+#: lxc/file.go:1491
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1490
+#: lxc/file.go:1514
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2239,12 +2253,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1517
+#: lxc/file.go:1541
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1326
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2274,7 +2288,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1423
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2289,7 +2303,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1428
+#: lxc/file.go:1452
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2299,12 +2313,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1352
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1455
+#: lxc/file.go:1479
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2318,7 +2332,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:304 lxc/move.go:380
+#: lxc/move.go:309 lxc/move.go:385
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2343,7 +2357,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1440
+#: lxc/file.go:1464
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2358,7 +2372,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1042
+#: lxc/file.go:1062
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2445,14 +2459,14 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1625 lxc/warning.go:94
+#: lxc/storage_volume.go:1627 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2520,7 +2534,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1602
+#: lxc/image.go:1602 lxc/image.go:1603
 msgid "Get image properties"
 msgstr ""
 
@@ -2536,7 +2550,7 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:414
 msgid "Get the key as a network forward property"
 msgstr ""
 
@@ -2576,7 +2590,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1249
+#: lxc/storage_volume.go:1251
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2604,7 +2618,7 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:403 lxc/network_forward.go:404
+#: lxc/network_forward.go:411 lxc/network_forward.go:412
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
@@ -2640,11 +2654,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:476
+#: lxc/storage_volume.go:480
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2684,22 +2698,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1540
+#: lxc/file.go:1564
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1529
+#: lxc/file.go:1553
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1376
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1362
+#: lxc/file.go:1386
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2772,11 +2786,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:415
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2786,7 +2800,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2437
+#: lxc/storage_volume.go:2439
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2798,7 +2812,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1517
+#: lxc/image.go:1518
 msgid "Image already up to date."
 msgstr ""
 
@@ -2814,11 +2828,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1472
+#: lxc/image.go:364 lxc/image.go:1473
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1698
+#: lxc/image.go:444 lxc/image.go:1699
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2828,7 +2842,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1515
+#: lxc/image.go:1516
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2836,7 +2850,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2815
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2844,7 +2858,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2814
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2866,11 +2880,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2822
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2894
+#: lxc/storage_volume.go:2896
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2896,11 +2910,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1378
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1531
+#: lxc/file.go:1555
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2909,7 +2923,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:414
+#: lxc/init.go:418
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2918,7 +2932,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1298
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2970,7 +2984,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1293
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2996,23 +3010,23 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2023
+#: lxc/move.go:153 lxc/storage_volume.go:2025
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:144
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2019
+#: lxc/storage_volume.go:2021
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:509
+#: lxc/main.go:518
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:353
+#: lxc/file.go:357
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3022,18 +3036,18 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
-#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
+#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:535
+#: lxc/file.go:548
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:717
+#: lxc/file.go:185 lxc/file.go:739
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3070,7 +3084,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3101,12 +3115,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:176
+#: lxc/init.go:180
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:174
+#: lxc/init.go:178
 msgid "Launching the instance"
 msgstr ""
 
@@ -3204,11 +3218,11 @@ msgstr ""
 msgid "List identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:151
+#: lxc/image_alias.go:176
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:177
 msgid ""
 "List image aliases\n"
 "\n"
@@ -3375,11 +3389,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1605
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1610
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3438,7 +3452,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1481
+#: lxc/info.go:489 lxc/storage_volume.go:1483
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3624,7 +3638,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:873 lxc/network_forward.go:874
+#: lxc/network_forward.go:881 lxc/network_forward.go:882
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -3770,12 +3784,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:322 lxc/move.go:435
+#: lxc/move.go:327 lxc/move.go:440
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:347 lxc/move.go:440
+#: lxc/move.go:352 lxc/move.go:445
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3840,10 +3854,10 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:449
-#: lxc/network_forward.go:534 lxc/network_forward.go:709
-#: lxc/network_forward.go:840 lxc/network_forward.go:933
-#: lxc/network_forward.go:1015 lxc/network_load_balancer.go:221
+#: lxc/network_forward.go:219 lxc/network_forward.go:457
+#: lxc/network_forward.go:542 lxc/network_forward.go:717
+#: lxc/network_forward.go:848 lxc/network_forward.go:945
+#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
 #: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
 #: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
 #: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
@@ -3868,10 +3882,10 @@ msgstr ""
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
 #: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
 #: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:284 lxc/network_forward.go:445
-#: lxc/network_forward.go:530 lxc/network_forward.go:705
-#: lxc/network_forward.go:836 lxc/network_forward.go:929
-#: lxc/network_forward.go:1011 lxc/network_load_balancer.go:131
+#: lxc/network_forward.go:292 lxc/network_forward.go:453
+#: lxc/network_forward.go:538 lxc/network_forward.go:713
+#: lxc/network_forward.go:844 lxc/network_forward.go:941
+#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
 #: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
 #: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
 #: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
@@ -3907,13 +3921,13 @@ msgstr ""
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
-#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
-#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
-#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
+#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
+#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
+#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
+#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
 msgid "Missing pool name"
 msgstr ""
 
@@ -3932,15 +3946,15 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
+#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1411
+#: lxc/storage_volume.go:1413
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:820
+#: lxc/file.go:842
 msgid "Missing target directory"
 msgstr ""
 
@@ -3973,16 +3987,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
-#: lxc/storage_volume.go:975
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
+#: lxc/storage_volume.go:977
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:507
+#: lxc/file.go:520
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1207 lxc/file.go:1208
+#: lxc/file.go:1227 lxc/file.go:1228
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4011,7 +4025,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4019,16 +4033,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1869
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1059 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4050,7 +4064,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
 msgid "NAME"
 msgstr ""
 
@@ -4102,8 +4116,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
-#: lxc/storage_volume.go:1573
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Name"
 msgstr ""
 
@@ -4111,7 +4125,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4166,12 +4180,12 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:386
+#: lxc/network_forward.go:394
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:857
+#: lxc/network_forward.go:865
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -4255,7 +4269,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
+#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4263,7 +4277,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1070 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4275,11 +4289,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4293,7 +4307,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2035
+#: lxc/storage_volume.go:2037
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4301,16 +4315,21 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
-#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
-msgid "Only \"custom\" volumes can be attached to instances"
+#: lxc/storage_volume.go:216
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2701
+#: lxc/storage_volume.go:348
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:2703
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2500
+#: lxc/storage_volume.go:2502
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4322,7 +4341,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1431
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4335,7 +4354,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1577
+#: lxc/info.go:705 lxc/storage_volume.go:1579
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4365,7 +4384,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1767
+#: lxc/storage_volume.go:1769
 msgid "POOL"
 msgstr ""
 
@@ -4382,7 +4401,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167
-#: lxc/storage_volume.go:1773 lxc/warning.go:213
+#: lxc/storage_volume.go:1775 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4406,7 +4425,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:367
+#: lxc/main.go:376
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4444,7 +4463,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1332
+#: lxc/file.go:1356
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4452,12 +4471,12 @@ msgstr ""
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
-#: lxc/network_acl.go:699 lxc/network_forward.go:768
+#: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
-#: lxc/storage_volume.go:1200
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
+#: lxc/storage_volume.go:1202
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4570,11 +4589,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1649
+#: lxc/image.go:1650
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4588,7 +4607,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1238
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4604,7 +4623,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4625,7 +4644,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1017
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4634,7 +4653,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2094
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4647,7 +4666,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2370
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4678,20 +4697,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:455 lxc/file.go:456
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:638 lxc/file.go:989
+#: lxc/file.go:651 lxc/file.go:1009
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:688 lxc/file.go:689
+#: lxc/file.go:701 lxc/file.go:702
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:923 lxc/file.go:1089
+#: lxc/file.go:943 lxc/file.go:1109
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4700,7 +4719,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4729,15 +4748,15 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:463 lxc/file.go:695
+#: lxc/file.go:475 lxc/file.go:708
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1444 lxc/image.go:1445
+#: lxc/image.go:1445 lxc/image.go:1446
 msgid "Refresh images"
 msgstr ""
 
@@ -4746,7 +4765,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1481
+#: lxc/image.go:1482
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4823,7 +4842,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:971 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4859,7 +4878,7 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:969 lxc/network_forward.go:970
+#: lxc/network_forward.go:981 lxc/network_forward.go:982
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -4895,8 +4914,8 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
-#: lxc/image_alias.go:255
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:287
+#: lxc/image_alias.go:288
 msgid "Rename aliases"
 msgstr ""
 
@@ -4932,15 +4951,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1962
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
+#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4992,7 +5011,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5009,7 +5028,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:361
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5058,12 +5077,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1460
+#: lxc/file.go:1484
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1461
+#: lxc/file.go:1485
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5139,7 +5158,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1217
+#: lxc/file.go:1237
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5165,7 +5184,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1665 lxc/image.go:1666
+#: lxc/image.go:1666 lxc/image.go:1667
 msgid "Set image properties"
 msgstr ""
 
@@ -5208,11 +5227,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:488
+#: lxc/network_forward.go:496
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:489
+#: lxc/network_forward.go:497
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5316,11 +5335,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2088
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2089
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5337,7 +5356,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:698
+#: lxc/file.go:711
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5345,7 +5364,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:699
+#: lxc/file.go:712
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5353,7 +5372,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:710
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5365,7 +5384,7 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:504
 msgid "Set the key as a network forward property"
 msgstr ""
 
@@ -5405,7 +5424,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2105
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5413,7 +5432,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1215
+#: lxc/file.go:1235
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5470,7 +5489,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1535 lxc/image.go:1536
+#: lxc/image.go:1536 lxc/image.go:1537
 msgid "Show image properties"
 msgstr ""
 
@@ -5490,7 +5509,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:271 lxc/main.go:272
+#: lxc/main.go:280 lxc/main.go:281
 msgid "Show less common commands"
 msgstr ""
 
@@ -5554,11 +5573,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5626,15 +5645,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2190
+#: lxc/storage_volume.go:2192
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1502
+#: lxc/info.go:619 lxc/storage_volume.go:1504
 msgid "Snapshots:"
 msgstr ""
 
@@ -5739,21 +5758,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:703
+#: lxc/storage_volume.go:707
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:791
+#: lxc/storage_volume.go:795
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:516
+#: lxc/storage_volume.go:520
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:524
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5815,21 +5834,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1747 lxc/warning.go:216
+#: lxc/storage_volume.go:1749 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1262
+#: lxc/file.go:1286
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1256
+#: lxc/file.go:1280
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5839,15 +5858,15 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:181
+#: lxc/move.go:186
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:219 lxc/move.go:240
+#: lxc/move.go:224 lxc/move.go:245
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:193
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5855,15 +5874,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:185
+#: lxc/move.go:190
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:189
+#: lxc/move.go:194
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:210
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5885,7 +5904,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:439
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5938,7 +5957,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:462
+#: lxc/network_forward.go:470
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -5978,12 +5997,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1340
+#: lxc/storage_volume.go:1342
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1317
+#: lxc/storage_volume.go:1319
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -5998,12 +6017,12 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:309
+#: lxc/move.go:314
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
-#: lxc/storage_volume.go:989
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
+#: lxc/storage_volume.go:991
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6031,7 +6050,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:298
+#: lxc/main.go:307
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6055,11 +6074,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:437
+#: lxc/init.go:441
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:440
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6067,7 +6086,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:412
+#: lxc/main.go:421
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6078,7 +6097,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1489
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6093,7 +6112,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1864
+#: lxc/storage_volume.go:1866
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6101,7 +6120,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6118,7 +6137,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:327
+#: lxc/copy.go:382 lxc/move.go:332
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6160,7 +6179,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1472
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6182,13 +6201,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1752
+#: lxc/project.go:995 lxc/storage_volume.go:1754
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1751
+#: lxc/storage.go:724 lxc/storage_volume.go:1753
 msgid "USED BY"
 msgstr ""
 
@@ -6201,7 +6220,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:411
+#: lxc/file.go:423
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6215,12 +6234,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1483
+#: lxc/file.go:1507
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1791
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6231,7 +6250,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1029
+#: lxc/file.go:1049
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6262,7 +6281,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1728 lxc/image.go:1729
+#: lxc/image.go:1729 lxc/image.go:1730
 msgid "Unset image properties"
 msgstr ""
 
@@ -6278,11 +6297,11 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:598
+#: lxc/network_forward.go:606
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:599
+#: lxc/network_forward.go:607
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -6326,7 +6345,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6338,7 +6357,7 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:602
+#: lxc/network_forward.go:610
 msgid "Unset the key as a network forward property"
 msgstr ""
 
@@ -6378,7 +6397,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2381
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6386,7 +6405,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:248
+#: lxc/storage_volume.go:250
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6422,12 +6441,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1485
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2652
+#: lxc/export.go:42 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6494,7 +6513,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1576
+#: lxc/storage_volume.go:1578
 msgid "Volume Only"
 msgstr ""
 
@@ -6545,7 +6564,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:293 lxc/move.go:369
+#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6553,12 +6572,12 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:909
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:912
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:282
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:284
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
@@ -6590,7 +6609,7 @@ msgstr ""
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:174
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
@@ -6643,7 +6662,7 @@ msgstr ""
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: lxc/image_alias.go:104
+#: lxc/image_alias.go:121
 msgid "[<remote>:]<alias>"
 msgstr ""
 
@@ -6651,7 +6670,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/image_alias.go:252
+#: lxc/image_alias.go:285
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
@@ -6705,15 +6724,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1600 lxc/image.go:1727
+#: lxc/image.go:1601 lxc/image.go:1728
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1664
+#: lxc/image.go:1665
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6733,7 +6752,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1443
+#: lxc/image.go:334 lxc/image.go:1444
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6804,7 +6823,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:376
+#: lxc/file.go:380
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -6816,12 +6835,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:454
+#: lxc/file.go:466
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1226
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6889,8 +6908,8 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:644
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:179
+#: lxc/network_forward.go:177 lxc/network_forward.go:652
+#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
 #: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
@@ -6905,12 +6924,12 @@ msgid ""
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:402 lxc/network_forward.go:597
+#: lxc/network_forward.go:410 lxc/network_forward.go:605
 #: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
@@ -6920,13 +6939,13 @@ msgid ""
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:887
+#: lxc/network_forward.go:895
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:968 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -6981,7 +7000,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2811
+#: lxc/storage_volume.go:2813
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7016,65 +7035,65 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1958
+#: lxc/storage_volume.go:1960
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:806
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:167
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
-msgstr ""
-
-#: lxc/storage_volume.go:2562
+#: lxc/storage_volume.go:2564
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2645
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2428
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:610
+#: lxc/storage_volume.go:614
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:718
+#: lxc/storage_volume.go:722
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2364
+#: lxc/storage_volume.go:810
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
+msgstr ""
+
+#: lxc/storage_volume.go:167
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
+msgstr ""
+
+#: lxc/storage_volume.go:2366
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2087
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2245
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1234
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1858
+#: lxc/storage_volume.go:1860
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7180,7 +7199,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1603
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7342,20 +7361,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1230
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:470
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:691
+#: lxc/file.go:704
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7656,7 +7675,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:618
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7664,13 +7683,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2817
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2432
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7704,16 +7723,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1396
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1331
+#: lxc/file.go:1355
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1284
+#: lxc/file.go:1308
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-07 15:11-0700\n"
+"POT-Creation-Date: 2025-01-10 14:44-0600\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1041
+#: lxc/storage_volume.go:1043
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:667
+#: lxc/network_forward.go:675
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,12 +430,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1157
+#: lxc/file.go:1177
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1047
+#: lxc/file.go:1067
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -471,7 +471,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:65
+#: lxc/init.go:146 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:687
+#: lxc/file.go:700
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -541,7 +541,7 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
@@ -672,7 +672,7 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:888 lxc/network_forward.go:889
+#: lxc/network_forward.go:896 lxc/network_forward.go:897
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -722,7 +722,7 @@ msgstr ""
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
+#: lxc/image_alias.go:101 lxc/image_alias.go:156 lxc/image_alias.go:320
 msgid "Alias name missing"
 msgstr ""
 
@@ -735,7 +735,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1607
+#: lxc/storage_volume.go:1609
 msgid "All projects"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -790,12 +790,26 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168 lxc/storage_volume.go:169
+#: lxc/storage_volume.go:168
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:169
+msgid ""
+"Attach new storage volumes to instances\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
+msgstr ""
+
+#: lxc/storage_volume.go:285
 msgid "Attach new storage volumes to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:286
+msgid ""
+"Attach new storage volumes to profiles\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
 #: lxc/console.go:39
@@ -846,16 +860,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2719
+#: lxc/storage_volume.go:2721
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2796
+#: lxc/export.go:192 lxc/storage_volume.go:2798
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1538
+#: lxc/info.go:666 lxc/storage_volume.go:1540
 msgid "Backups:"
 msgstr ""
 
@@ -864,19 +878,19 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
+#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:326
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -919,7 +933,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1752
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -971,7 +985,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -979,7 +993,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:562
+#: lxc/file.go:575
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1004,11 +1018,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:768
+#: lxc/file.go:790
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1021,12 +1035,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:493
+#: lxc/storage_volume.go:497
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:447
+#: lxc/storage_volume.go:451
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1132,9 +1146,9 @@ msgstr ""
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:497 lxc/network_forward.go:649
-#: lxc/network_forward.go:803 lxc/network_forward.go:892
-#: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
+#: lxc/network_forward.go:505 lxc/network_forward.go:657
+#: lxc/network_forward.go:811 lxc/network_forward.go:900
+#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
 #: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
 #: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
@@ -1146,14 +1160,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
-#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
-#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
-#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
+#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
 msgid "Cluster member name"
 msgstr ""
 
@@ -1169,7 +1183,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1608
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1209,21 +1223,21 @@ msgstr ""
 #: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
-#: lxc/network_acl.go:698 lxc/network_forward.go:767
+#: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
-#: lxc/storage_volume.go:1199
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
+#: lxc/storage_volume.go:1201
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:620
+#: lxc/storage_volume.go:624
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1478
+#: lxc/storage_volume.go:1480
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1285,7 +1299,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1293,12 +1307,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1311,7 +1325,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1406,7 +1420,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:462 lxc/file.go:696
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1446,7 +1460,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1498,12 +1512,12 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:182
+#: lxc/init.go:186
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1513,7 +1527,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 msgid "Creating the instance"
 msgstr ""
 
@@ -1527,13 +1541,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1749
+#: lxc/storage_volume.go:1751
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1553,7 +1567,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2653
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1585,7 +1599,7 @@ msgstr ""
 msgid "Delete identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:106 lxc/image_alias.go:107
+#: lxc/image_alias.go:123 lxc/image_alias.go:124
 msgid "Delete image aliases"
 msgstr ""
 
@@ -1609,7 +1623,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:799 lxc/network_forward.go:800
+#: lxc/network_forward.go:807 lxc/network_forward.go:808
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1649,7 +1663,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
+#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1691,13 +1705,13 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
-#: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
-#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
+#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
+#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
+#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
@@ -1711,10 +1725,10 @@ msgstr ""
 #: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:404 lxc/network_forward.go:489
-#: lxc/network_forward.go:599 lxc/network_forward.go:646
-#: lxc/network_forward.go:800 lxc/network_forward.go:874
-#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_forward.go:412 lxc/network_forward.go:497
+#: lxc/network_forward.go:607 lxc/network_forward.go:654
+#: lxc/network_forward.go:808 lxc/network_forward.go:882
+#: lxc/network_forward.go:897 lxc/network_forward.go:982
 #: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
 #: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
 #: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
@@ -1754,27 +1768,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
-#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
-#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
-#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
-#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
-#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
-#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
-#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1465
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1786,11 +1800,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
+#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1840,7 +1854,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:403
+#: lxc/init.go:407
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1852,7 +1866,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1216
+#: lxc/file.go:1236
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1948,7 +1962,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:377 lxc/file.go:378
+#: lxc/file.go:381 lxc/file.go:382
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1988,7 +2002,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:653 lxc/network_forward.go:654
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -2028,7 +2042,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2036,7 +2050,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1785
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2090,11 +2104,11 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
-#: lxc/network_acl.go:524 lxc/network_forward.go:572
+#: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
+#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2105,11 +2119,11 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
-#: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
+#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
-#: lxc/storage_volume.go:2210
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
+#: lxc/storage_volume.go:2212
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2151,8 +2165,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
+#: lxc/storage_volume.go:1577
 msgid "Expires at"
 msgstr ""
 
@@ -2176,7 +2190,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2188,11 +2202,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2650
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2779
+#: lxc/export.go:152 lxc/storage_volume.go:2781
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2211,7 +2225,7 @@ msgid "FILENAME"
 msgstr ""
 
 #: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
-#: lxc/image_alias.go:235
+#: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2219,12 +2233,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1467
+#: lxc/file.go:1491
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1490
+#: lxc/file.go:1514
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2239,12 +2253,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1517
+#: lxc/file.go:1541
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1326
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2274,7 +2288,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1423
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2289,7 +2303,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1428
+#: lxc/file.go:1452
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2299,12 +2313,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1352
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1455
+#: lxc/file.go:1479
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2318,7 +2332,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:304 lxc/move.go:380
+#: lxc/move.go:309 lxc/move.go:385
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2343,7 +2357,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1440
+#: lxc/file.go:1464
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2358,7 +2372,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1042
+#: lxc/file.go:1062
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2445,14 +2459,14 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1625 lxc/warning.go:94
+#: lxc/storage_volume.go:1627 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2520,7 +2534,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1602
+#: lxc/image.go:1602 lxc/image.go:1603
 msgid "Get image properties"
 msgstr ""
 
@@ -2536,7 +2550,7 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:414
 msgid "Get the key as a network forward property"
 msgstr ""
 
@@ -2576,7 +2590,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1249
+#: lxc/storage_volume.go:1251
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2604,7 +2618,7 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:403 lxc/network_forward.go:404
+#: lxc/network_forward.go:411 lxc/network_forward.go:412
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
@@ -2640,11 +2654,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:476
+#: lxc/storage_volume.go:480
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2684,22 +2698,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1540
+#: lxc/file.go:1564
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1529
+#: lxc/file.go:1553
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1376
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1362
+#: lxc/file.go:1386
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2772,11 +2786,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:415
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2786,7 +2800,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2437
+#: lxc/storage_volume.go:2439
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2798,7 +2812,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1517
+#: lxc/image.go:1518
 msgid "Image already up to date."
 msgstr ""
 
@@ -2814,11 +2828,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1472
+#: lxc/image.go:364 lxc/image.go:1473
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1698
+#: lxc/image.go:444 lxc/image.go:1699
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2828,7 +2842,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1515
+#: lxc/image.go:1516
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2836,7 +2850,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2815
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2844,7 +2858,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2814
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2866,11 +2880,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2822
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2894
+#: lxc/storage_volume.go:2896
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2896,11 +2910,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1378
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1531
+#: lxc/file.go:1555
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2909,7 +2923,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:414
+#: lxc/init.go:418
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2918,7 +2932,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1298
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2970,7 +2984,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1293
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2996,23 +3010,23 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2023
+#: lxc/move.go:153 lxc/storage_volume.go:2025
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:144
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2019
+#: lxc/storage_volume.go:2021
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:509
+#: lxc/main.go:518
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:353
+#: lxc/file.go:357
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3022,18 +3036,18 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
-#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
+#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:535
+#: lxc/file.go:548
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:717
+#: lxc/file.go:185 lxc/file.go:739
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3070,7 +3084,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3101,12 +3115,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:176
+#: lxc/init.go:180
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:174
+#: lxc/init.go:178
 msgid "Launching the instance"
 msgstr ""
 
@@ -3204,11 +3218,11 @@ msgstr ""
 msgid "List identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:151
+#: lxc/image_alias.go:176
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:177
 msgid ""
 "List image aliases\n"
 "\n"
@@ -3375,11 +3389,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1605
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1610
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3438,7 +3452,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1481
+#: lxc/info.go:489 lxc/storage_volume.go:1483
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3624,7 +3638,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:873 lxc/network_forward.go:874
+#: lxc/network_forward.go:881 lxc/network_forward.go:882
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -3770,12 +3784,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:322 lxc/move.go:435
+#: lxc/move.go:327 lxc/move.go:440
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:347 lxc/move.go:440
+#: lxc/move.go:352 lxc/move.go:445
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3840,10 +3854,10 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:449
-#: lxc/network_forward.go:534 lxc/network_forward.go:709
-#: lxc/network_forward.go:840 lxc/network_forward.go:933
-#: lxc/network_forward.go:1015 lxc/network_load_balancer.go:221
+#: lxc/network_forward.go:219 lxc/network_forward.go:457
+#: lxc/network_forward.go:542 lxc/network_forward.go:717
+#: lxc/network_forward.go:848 lxc/network_forward.go:945
+#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
 #: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
 #: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
 #: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
@@ -3868,10 +3882,10 @@ msgstr ""
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
 #: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
 #: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:284 lxc/network_forward.go:445
-#: lxc/network_forward.go:530 lxc/network_forward.go:705
-#: lxc/network_forward.go:836 lxc/network_forward.go:929
-#: lxc/network_forward.go:1011 lxc/network_load_balancer.go:131
+#: lxc/network_forward.go:292 lxc/network_forward.go:453
+#: lxc/network_forward.go:538 lxc/network_forward.go:713
+#: lxc/network_forward.go:844 lxc/network_forward.go:941
+#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
 #: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
 #: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
 #: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
@@ -3907,13 +3921,13 @@ msgstr ""
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
-#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
-#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
-#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
+#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
+#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
+#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
+#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
 msgid "Missing pool name"
 msgstr ""
 
@@ -3932,15 +3946,15 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
+#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1411
+#: lxc/storage_volume.go:1413
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:820
+#: lxc/file.go:842
 msgid "Missing target directory"
 msgstr ""
 
@@ -3973,16 +3987,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
-#: lxc/storage_volume.go:975
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
+#: lxc/storage_volume.go:977
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:507
+#: lxc/file.go:520
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1207 lxc/file.go:1208
+#: lxc/file.go:1227 lxc/file.go:1228
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4011,7 +4025,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4019,16 +4033,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1869
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1059 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4050,7 +4064,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
 msgid "NAME"
 msgstr ""
 
@@ -4102,8 +4116,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
-#: lxc/storage_volume.go:1573
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Name"
 msgstr ""
 
@@ -4111,7 +4125,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4166,12 +4180,12 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:386
+#: lxc/network_forward.go:394
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:857
+#: lxc/network_forward.go:865
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -4255,7 +4269,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
+#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4263,7 +4277,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1070 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4275,11 +4289,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4293,7 +4307,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2035
+#: lxc/storage_volume.go:2037
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4301,16 +4315,21 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
-#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
-msgid "Only \"custom\" volumes can be attached to instances"
+#: lxc/storage_volume.go:216
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2701
+#: lxc/storage_volume.go:348
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:2703
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2500
+#: lxc/storage_volume.go:2502
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4322,7 +4341,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1431
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4335,7 +4354,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1577
+#: lxc/info.go:705 lxc/storage_volume.go:1579
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4365,7 +4384,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1767
+#: lxc/storage_volume.go:1769
 msgid "POOL"
 msgstr ""
 
@@ -4382,7 +4401,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167
-#: lxc/storage_volume.go:1773 lxc/warning.go:213
+#: lxc/storage_volume.go:1775 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4406,7 +4425,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:367
+#: lxc/main.go:376
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4444,7 +4463,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1332
+#: lxc/file.go:1356
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4452,12 +4471,12 @@ msgstr ""
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
-#: lxc/network_acl.go:699 lxc/network_forward.go:768
+#: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
-#: lxc/storage_volume.go:1200
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
+#: lxc/storage_volume.go:1202
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4570,11 +4589,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1649
+#: lxc/image.go:1650
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4588,7 +4607,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1238
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4604,7 +4623,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4625,7 +4644,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1017
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4634,7 +4653,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2094
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4647,7 +4666,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2370
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4678,20 +4697,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:455 lxc/file.go:456
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:638 lxc/file.go:989
+#: lxc/file.go:651 lxc/file.go:1009
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:688 lxc/file.go:689
+#: lxc/file.go:701 lxc/file.go:702
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:923 lxc/file.go:1089
+#: lxc/file.go:943 lxc/file.go:1109
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4700,7 +4719,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4729,15 +4748,15 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:463 lxc/file.go:695
+#: lxc/file.go:475 lxc/file.go:708
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1444 lxc/image.go:1445
+#: lxc/image.go:1445 lxc/image.go:1446
 msgid "Refresh images"
 msgstr ""
 
@@ -4746,7 +4765,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1481
+#: lxc/image.go:1482
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4823,7 +4842,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:971 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4859,7 +4878,7 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:969 lxc/network_forward.go:970
+#: lxc/network_forward.go:981 lxc/network_forward.go:982
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -4895,8 +4914,8 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
-#: lxc/image_alias.go:255
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:287
+#: lxc/image_alias.go:288
 msgid "Rename aliases"
 msgstr ""
 
@@ -4932,15 +4951,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1962
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
+#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4992,7 +5011,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5009,7 +5028,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:361
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5058,12 +5077,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1460
+#: lxc/file.go:1484
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1461
+#: lxc/file.go:1485
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5139,7 +5158,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1217
+#: lxc/file.go:1237
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5165,7 +5184,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1665 lxc/image.go:1666
+#: lxc/image.go:1666 lxc/image.go:1667
 msgid "Set image properties"
 msgstr ""
 
@@ -5208,11 +5227,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:488
+#: lxc/network_forward.go:496
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:489
+#: lxc/network_forward.go:497
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5316,11 +5335,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2088
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2089
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5337,7 +5356,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:698
+#: lxc/file.go:711
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5345,7 +5364,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:699
+#: lxc/file.go:712
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5353,7 +5372,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:710
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5365,7 +5384,7 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:504
 msgid "Set the key as a network forward property"
 msgstr ""
 
@@ -5405,7 +5424,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2105
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5413,7 +5432,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1215
+#: lxc/file.go:1235
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5470,7 +5489,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1535 lxc/image.go:1536
+#: lxc/image.go:1536 lxc/image.go:1537
 msgid "Show image properties"
 msgstr ""
 
@@ -5490,7 +5509,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:271 lxc/main.go:272
+#: lxc/main.go:280 lxc/main.go:281
 msgid "Show less common commands"
 msgstr ""
 
@@ -5554,11 +5573,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5626,15 +5645,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2190
+#: lxc/storage_volume.go:2192
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1502
+#: lxc/info.go:619 lxc/storage_volume.go:1504
 msgid "Snapshots:"
 msgstr ""
 
@@ -5739,21 +5758,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:703
+#: lxc/storage_volume.go:707
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:791
+#: lxc/storage_volume.go:795
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:516
+#: lxc/storage_volume.go:520
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:524
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5815,21 +5834,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1747 lxc/warning.go:216
+#: lxc/storage_volume.go:1749 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1262
+#: lxc/file.go:1286
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1256
+#: lxc/file.go:1280
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5839,15 +5858,15 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:181
+#: lxc/move.go:186
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:219 lxc/move.go:240
+#: lxc/move.go:224 lxc/move.go:245
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:193
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5855,15 +5874,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:185
+#: lxc/move.go:190
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:189
+#: lxc/move.go:194
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:210
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5885,7 +5904,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:439
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5938,7 +5957,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:462
+#: lxc/network_forward.go:470
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -5978,12 +5997,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1340
+#: lxc/storage_volume.go:1342
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1317
+#: lxc/storage_volume.go:1319
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -5998,12 +6017,12 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:309
+#: lxc/move.go:314
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
-#: lxc/storage_volume.go:989
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
+#: lxc/storage_volume.go:991
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6031,7 +6050,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:298
+#: lxc/main.go:307
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6055,11 +6074,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:437
+#: lxc/init.go:441
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:440
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6067,7 +6086,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:412
+#: lxc/main.go:421
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6078,7 +6097,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1489
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6093,7 +6112,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1864
+#: lxc/storage_volume.go:1866
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6101,7 +6120,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6118,7 +6137,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:327
+#: lxc/copy.go:382 lxc/move.go:332
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6160,7 +6179,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1472
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6182,13 +6201,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1752
+#: lxc/project.go:995 lxc/storage_volume.go:1754
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1751
+#: lxc/storage.go:724 lxc/storage_volume.go:1753
 msgid "USED BY"
 msgstr ""
 
@@ -6201,7 +6220,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:411
+#: lxc/file.go:423
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6215,12 +6234,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1483
+#: lxc/file.go:1507
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1791
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6231,7 +6250,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1029
+#: lxc/file.go:1049
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6262,7 +6281,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1728 lxc/image.go:1729
+#: lxc/image.go:1729 lxc/image.go:1730
 msgid "Unset image properties"
 msgstr ""
 
@@ -6278,11 +6297,11 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:598
+#: lxc/network_forward.go:606
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:599
+#: lxc/network_forward.go:607
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -6326,7 +6345,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6338,7 +6357,7 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:602
+#: lxc/network_forward.go:610
 msgid "Unset the key as a network forward property"
 msgstr ""
 
@@ -6378,7 +6397,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2381
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6386,7 +6405,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:248
+#: lxc/storage_volume.go:250
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6422,12 +6441,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1485
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2652
+#: lxc/export.go:42 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6494,7 +6513,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1576
+#: lxc/storage_volume.go:1578
 msgid "Volume Only"
 msgstr ""
 
@@ -6545,7 +6564,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:293 lxc/move.go:369
+#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6553,12 +6572,12 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:909
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:912
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:282
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:284
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
@@ -6590,7 +6609,7 @@ msgstr ""
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:174
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
@@ -6643,7 +6662,7 @@ msgstr ""
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: lxc/image_alias.go:104
+#: lxc/image_alias.go:121
 msgid "[<remote>:]<alias>"
 msgstr ""
 
@@ -6651,7 +6670,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/image_alias.go:252
+#: lxc/image_alias.go:285
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
@@ -6705,15 +6724,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1600 lxc/image.go:1727
+#: lxc/image.go:1601 lxc/image.go:1728
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1664
+#: lxc/image.go:1665
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6733,7 +6752,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1443
+#: lxc/image.go:334 lxc/image.go:1444
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6804,7 +6823,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:376
+#: lxc/file.go:380
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -6816,12 +6835,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:454
+#: lxc/file.go:466
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1226
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6889,8 +6908,8 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:644
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:179
+#: lxc/network_forward.go:177 lxc/network_forward.go:652
+#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
 #: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
@@ -6905,12 +6924,12 @@ msgid ""
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:402 lxc/network_forward.go:597
+#: lxc/network_forward.go:410 lxc/network_forward.go:605
 #: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
@@ -6920,13 +6939,13 @@ msgid ""
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:887
+#: lxc/network_forward.go:895
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:968 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -6981,7 +7000,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2811
+#: lxc/storage_volume.go:2813
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7016,65 +7035,65 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1958
+#: lxc/storage_volume.go:1960
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:806
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:167
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
-msgstr ""
-
-#: lxc/storage_volume.go:2562
+#: lxc/storage_volume.go:2564
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2645
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2428
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:610
+#: lxc/storage_volume.go:614
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:718
+#: lxc/storage_volume.go:722
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2364
+#: lxc/storage_volume.go:810
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
+msgstr ""
+
+#: lxc/storage_volume.go:167
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
+msgstr ""
+
+#: lxc/storage_volume.go:2366
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2087
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2245
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1234
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1858
+#: lxc/storage_volume.go:1860
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7180,7 +7199,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1603
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7342,20 +7361,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1230
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:470
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:691
+#: lxc/file.go:704
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7656,7 +7675,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:618
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7664,13 +7683,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2817
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2432
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7704,16 +7723,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1396
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1331
+#: lxc/file.go:1355
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1284
+#: lxc/file.go:1308
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-07 15:11-0700\n"
+"POT-Creation-Date: 2025-01-10 14:44-0600\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1041
+#: lxc/storage_volume.go:1043
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:667
+#: lxc/network_forward.go:675
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,12 +430,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1157
+#: lxc/file.go:1177
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1047
+#: lxc/file.go:1067
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -471,7 +471,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:65
+#: lxc/init.go:146 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:687
+#: lxc/file.go:700
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -541,7 +541,7 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
@@ -672,7 +672,7 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:888 lxc/network_forward.go:889
+#: lxc/network_forward.go:896 lxc/network_forward.go:897
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -722,7 +722,7 @@ msgstr ""
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
+#: lxc/image_alias.go:101 lxc/image_alias.go:156 lxc/image_alias.go:320
 msgid "Alias name missing"
 msgstr ""
 
@@ -735,7 +735,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1607
+#: lxc/storage_volume.go:1609
 msgid "All projects"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -790,12 +790,26 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168 lxc/storage_volume.go:169
+#: lxc/storage_volume.go:168
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:169
+msgid ""
+"Attach new storage volumes to instances\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
+msgstr ""
+
+#: lxc/storage_volume.go:285
 msgid "Attach new storage volumes to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:286
+msgid ""
+"Attach new storage volumes to profiles\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
 #: lxc/console.go:39
@@ -846,16 +860,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2719
+#: lxc/storage_volume.go:2721
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2796
+#: lxc/export.go:192 lxc/storage_volume.go:2798
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1538
+#: lxc/info.go:666 lxc/storage_volume.go:1540
 msgid "Backups:"
 msgstr ""
 
@@ -864,19 +878,19 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
+#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:326
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -919,7 +933,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1752
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -971,7 +985,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -979,7 +993,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:562
+#: lxc/file.go:575
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1004,11 +1018,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:768
+#: lxc/file.go:790
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1021,12 +1035,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:493
+#: lxc/storage_volume.go:497
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:447
+#: lxc/storage_volume.go:451
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1132,9 +1146,9 @@ msgstr ""
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:497 lxc/network_forward.go:649
-#: lxc/network_forward.go:803 lxc/network_forward.go:892
-#: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
+#: lxc/network_forward.go:505 lxc/network_forward.go:657
+#: lxc/network_forward.go:811 lxc/network_forward.go:900
+#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
 #: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
 #: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
@@ -1146,14 +1160,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
-#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
-#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
-#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
+#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
 msgid "Cluster member name"
 msgstr ""
 
@@ -1169,7 +1183,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1608
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1209,21 +1223,21 @@ msgstr ""
 #: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
-#: lxc/network_acl.go:698 lxc/network_forward.go:767
+#: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
-#: lxc/storage_volume.go:1199
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
+#: lxc/storage_volume.go:1201
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:620
+#: lxc/storage_volume.go:624
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1478
+#: lxc/storage_volume.go:1480
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1285,7 +1299,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1293,12 +1307,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1311,7 +1325,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1406,7 +1420,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:462 lxc/file.go:696
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1446,7 +1460,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1498,12 +1512,12 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:182
+#: lxc/init.go:186
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1513,7 +1527,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 msgid "Creating the instance"
 msgstr ""
 
@@ -1527,13 +1541,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1749
+#: lxc/storage_volume.go:1751
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1553,7 +1567,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2653
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1585,7 +1599,7 @@ msgstr ""
 msgid "Delete identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:106 lxc/image_alias.go:107
+#: lxc/image_alias.go:123 lxc/image_alias.go:124
 msgid "Delete image aliases"
 msgstr ""
 
@@ -1609,7 +1623,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:799 lxc/network_forward.go:800
+#: lxc/network_forward.go:807 lxc/network_forward.go:808
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1649,7 +1663,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
+#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1691,13 +1705,13 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
-#: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
-#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
+#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
+#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
+#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
@@ -1711,10 +1725,10 @@ msgstr ""
 #: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:404 lxc/network_forward.go:489
-#: lxc/network_forward.go:599 lxc/network_forward.go:646
-#: lxc/network_forward.go:800 lxc/network_forward.go:874
-#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_forward.go:412 lxc/network_forward.go:497
+#: lxc/network_forward.go:607 lxc/network_forward.go:654
+#: lxc/network_forward.go:808 lxc/network_forward.go:882
+#: lxc/network_forward.go:897 lxc/network_forward.go:982
 #: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
 #: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
 #: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
@@ -1754,27 +1768,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
-#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
-#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
-#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
-#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
-#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
-#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
-#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1465
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1786,11 +1800,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
+#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1840,7 +1854,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:403
+#: lxc/init.go:407
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1852,7 +1866,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1216
+#: lxc/file.go:1236
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1948,7 +1962,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:377 lxc/file.go:378
+#: lxc/file.go:381 lxc/file.go:382
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1988,7 +2002,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:653 lxc/network_forward.go:654
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -2028,7 +2042,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2036,7 +2050,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1785
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2090,11 +2104,11 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
-#: lxc/network_acl.go:524 lxc/network_forward.go:572
+#: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
+#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2105,11 +2119,11 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
-#: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
+#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
-#: lxc/storage_volume.go:2210
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
+#: lxc/storage_volume.go:2212
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2151,8 +2165,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
+#: lxc/storage_volume.go:1577
 msgid "Expires at"
 msgstr ""
 
@@ -2176,7 +2190,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2188,11 +2202,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2650
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2779
+#: lxc/export.go:152 lxc/storage_volume.go:2781
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2211,7 +2225,7 @@ msgid "FILENAME"
 msgstr ""
 
 #: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
-#: lxc/image_alias.go:235
+#: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2219,12 +2233,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1467
+#: lxc/file.go:1491
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1490
+#: lxc/file.go:1514
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2239,12 +2253,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1517
+#: lxc/file.go:1541
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1326
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2274,7 +2288,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1423
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2289,7 +2303,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1428
+#: lxc/file.go:1452
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2299,12 +2313,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1352
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1455
+#: lxc/file.go:1479
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2318,7 +2332,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:304 lxc/move.go:380
+#: lxc/move.go:309 lxc/move.go:385
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2343,7 +2357,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1440
+#: lxc/file.go:1464
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2358,7 +2372,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1042
+#: lxc/file.go:1062
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2445,14 +2459,14 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1625 lxc/warning.go:94
+#: lxc/storage_volume.go:1627 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2520,7 +2534,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1602
+#: lxc/image.go:1602 lxc/image.go:1603
 msgid "Get image properties"
 msgstr ""
 
@@ -2536,7 +2550,7 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:414
 msgid "Get the key as a network forward property"
 msgstr ""
 
@@ -2576,7 +2590,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1249
+#: lxc/storage_volume.go:1251
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2604,7 +2618,7 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:403 lxc/network_forward.go:404
+#: lxc/network_forward.go:411 lxc/network_forward.go:412
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
@@ -2640,11 +2654,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:476
+#: lxc/storage_volume.go:480
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2684,22 +2698,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1540
+#: lxc/file.go:1564
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1529
+#: lxc/file.go:1553
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1376
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1362
+#: lxc/file.go:1386
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2772,11 +2786,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:415
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2786,7 +2800,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2437
+#: lxc/storage_volume.go:2439
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2798,7 +2812,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1517
+#: lxc/image.go:1518
 msgid "Image already up to date."
 msgstr ""
 
@@ -2814,11 +2828,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1472
+#: lxc/image.go:364 lxc/image.go:1473
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1698
+#: lxc/image.go:444 lxc/image.go:1699
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2828,7 +2842,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1515
+#: lxc/image.go:1516
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2836,7 +2850,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2815
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2844,7 +2858,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2814
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2866,11 +2880,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2822
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2894
+#: lxc/storage_volume.go:2896
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2896,11 +2910,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1378
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1531
+#: lxc/file.go:1555
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2909,7 +2923,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:414
+#: lxc/init.go:418
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2918,7 +2932,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1298
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2970,7 +2984,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1293
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2996,23 +3010,23 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2023
+#: lxc/move.go:153 lxc/storage_volume.go:2025
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:144
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2019
+#: lxc/storage_volume.go:2021
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:509
+#: lxc/main.go:518
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:353
+#: lxc/file.go:357
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3022,18 +3036,18 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
-#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
+#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:535
+#: lxc/file.go:548
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:717
+#: lxc/file.go:185 lxc/file.go:739
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3070,7 +3084,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3101,12 +3115,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:176
+#: lxc/init.go:180
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:174
+#: lxc/init.go:178
 msgid "Launching the instance"
 msgstr ""
 
@@ -3204,11 +3218,11 @@ msgstr ""
 msgid "List identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:151
+#: lxc/image_alias.go:176
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:177
 msgid ""
 "List image aliases\n"
 "\n"
@@ -3375,11 +3389,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1605
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1610
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3438,7 +3452,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1481
+#: lxc/info.go:489 lxc/storage_volume.go:1483
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3624,7 +3638,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:873 lxc/network_forward.go:874
+#: lxc/network_forward.go:881 lxc/network_forward.go:882
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -3770,12 +3784,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:322 lxc/move.go:435
+#: lxc/move.go:327 lxc/move.go:440
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:347 lxc/move.go:440
+#: lxc/move.go:352 lxc/move.go:445
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3840,10 +3854,10 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:449
-#: lxc/network_forward.go:534 lxc/network_forward.go:709
-#: lxc/network_forward.go:840 lxc/network_forward.go:933
-#: lxc/network_forward.go:1015 lxc/network_load_balancer.go:221
+#: lxc/network_forward.go:219 lxc/network_forward.go:457
+#: lxc/network_forward.go:542 lxc/network_forward.go:717
+#: lxc/network_forward.go:848 lxc/network_forward.go:945
+#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
 #: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
 #: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
 #: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
@@ -3868,10 +3882,10 @@ msgstr ""
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
 #: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
 #: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:284 lxc/network_forward.go:445
-#: lxc/network_forward.go:530 lxc/network_forward.go:705
-#: lxc/network_forward.go:836 lxc/network_forward.go:929
-#: lxc/network_forward.go:1011 lxc/network_load_balancer.go:131
+#: lxc/network_forward.go:292 lxc/network_forward.go:453
+#: lxc/network_forward.go:538 lxc/network_forward.go:713
+#: lxc/network_forward.go:844 lxc/network_forward.go:941
+#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
 #: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
 #: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
 #: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
@@ -3907,13 +3921,13 @@ msgstr ""
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
-#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
-#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
-#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
+#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
+#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
+#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
+#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
 msgid "Missing pool name"
 msgstr ""
 
@@ -3932,15 +3946,15 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
+#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1411
+#: lxc/storage_volume.go:1413
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:820
+#: lxc/file.go:842
 msgid "Missing target directory"
 msgstr ""
 
@@ -3973,16 +3987,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
-#: lxc/storage_volume.go:975
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
+#: lxc/storage_volume.go:977
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:507
+#: lxc/file.go:520
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1207 lxc/file.go:1208
+#: lxc/file.go:1227 lxc/file.go:1228
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4011,7 +4025,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4019,16 +4033,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1869
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1059 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4050,7 +4064,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
 msgid "NAME"
 msgstr ""
 
@@ -4102,8 +4116,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
-#: lxc/storage_volume.go:1573
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Name"
 msgstr ""
 
@@ -4111,7 +4125,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4166,12 +4180,12 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:386
+#: lxc/network_forward.go:394
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:857
+#: lxc/network_forward.go:865
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -4255,7 +4269,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
+#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4263,7 +4277,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1070 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4275,11 +4289,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4293,7 +4307,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2035
+#: lxc/storage_volume.go:2037
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4301,16 +4315,21 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
-#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
-msgid "Only \"custom\" volumes can be attached to instances"
+#: lxc/storage_volume.go:216
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2701
+#: lxc/storage_volume.go:348
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:2703
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2500
+#: lxc/storage_volume.go:2502
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4322,7 +4341,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1431
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4335,7 +4354,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1577
+#: lxc/info.go:705 lxc/storage_volume.go:1579
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4365,7 +4384,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1767
+#: lxc/storage_volume.go:1769
 msgid "POOL"
 msgstr ""
 
@@ -4382,7 +4401,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167
-#: lxc/storage_volume.go:1773 lxc/warning.go:213
+#: lxc/storage_volume.go:1775 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4406,7 +4425,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:367
+#: lxc/main.go:376
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4444,7 +4463,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1332
+#: lxc/file.go:1356
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4452,12 +4471,12 @@ msgstr ""
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
-#: lxc/network_acl.go:699 lxc/network_forward.go:768
+#: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
-#: lxc/storage_volume.go:1200
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
+#: lxc/storage_volume.go:1202
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4570,11 +4589,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1649
+#: lxc/image.go:1650
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4588,7 +4607,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1238
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4604,7 +4623,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4625,7 +4644,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1017
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4634,7 +4653,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2094
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4647,7 +4666,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2370
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4678,20 +4697,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:455 lxc/file.go:456
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:638 lxc/file.go:989
+#: lxc/file.go:651 lxc/file.go:1009
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:688 lxc/file.go:689
+#: lxc/file.go:701 lxc/file.go:702
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:923 lxc/file.go:1089
+#: lxc/file.go:943 lxc/file.go:1109
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4700,7 +4719,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4729,15 +4748,15 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:463 lxc/file.go:695
+#: lxc/file.go:475 lxc/file.go:708
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1444 lxc/image.go:1445
+#: lxc/image.go:1445 lxc/image.go:1446
 msgid "Refresh images"
 msgstr ""
 
@@ -4746,7 +4765,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1481
+#: lxc/image.go:1482
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4823,7 +4842,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:971 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4859,7 +4878,7 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:969 lxc/network_forward.go:970
+#: lxc/network_forward.go:981 lxc/network_forward.go:982
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -4895,8 +4914,8 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
-#: lxc/image_alias.go:255
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:287
+#: lxc/image_alias.go:288
 msgid "Rename aliases"
 msgstr ""
 
@@ -4932,15 +4951,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1962
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
+#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4992,7 +5011,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5009,7 +5028,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:361
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5058,12 +5077,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1460
+#: lxc/file.go:1484
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1461
+#: lxc/file.go:1485
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5139,7 +5158,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1217
+#: lxc/file.go:1237
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5165,7 +5184,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1665 lxc/image.go:1666
+#: lxc/image.go:1666 lxc/image.go:1667
 msgid "Set image properties"
 msgstr ""
 
@@ -5208,11 +5227,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:488
+#: lxc/network_forward.go:496
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:489
+#: lxc/network_forward.go:497
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5316,11 +5335,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2088
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2089
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5337,7 +5356,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:698
+#: lxc/file.go:711
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5345,7 +5364,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:699
+#: lxc/file.go:712
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5353,7 +5372,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:710
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5365,7 +5384,7 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:504
 msgid "Set the key as a network forward property"
 msgstr ""
 
@@ -5405,7 +5424,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2105
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5413,7 +5432,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1215
+#: lxc/file.go:1235
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5470,7 +5489,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1535 lxc/image.go:1536
+#: lxc/image.go:1536 lxc/image.go:1537
 msgid "Show image properties"
 msgstr ""
 
@@ -5490,7 +5509,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:271 lxc/main.go:272
+#: lxc/main.go:280 lxc/main.go:281
 msgid "Show less common commands"
 msgstr ""
 
@@ -5554,11 +5573,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5626,15 +5645,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2190
+#: lxc/storage_volume.go:2192
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1502
+#: lxc/info.go:619 lxc/storage_volume.go:1504
 msgid "Snapshots:"
 msgstr ""
 
@@ -5739,21 +5758,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:703
+#: lxc/storage_volume.go:707
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:791
+#: lxc/storage_volume.go:795
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:516
+#: lxc/storage_volume.go:520
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:524
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5815,21 +5834,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1747 lxc/warning.go:216
+#: lxc/storage_volume.go:1749 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1262
+#: lxc/file.go:1286
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1256
+#: lxc/file.go:1280
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5839,15 +5858,15 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:181
+#: lxc/move.go:186
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:219 lxc/move.go:240
+#: lxc/move.go:224 lxc/move.go:245
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:193
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5855,15 +5874,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:185
+#: lxc/move.go:190
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:189
+#: lxc/move.go:194
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:210
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5885,7 +5904,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:439
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5938,7 +5957,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:462
+#: lxc/network_forward.go:470
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -5978,12 +5997,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1340
+#: lxc/storage_volume.go:1342
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1317
+#: lxc/storage_volume.go:1319
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -5998,12 +6017,12 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:309
+#: lxc/move.go:314
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
-#: lxc/storage_volume.go:989
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
+#: lxc/storage_volume.go:991
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6031,7 +6050,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:298
+#: lxc/main.go:307
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6055,11 +6074,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:437
+#: lxc/init.go:441
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:440
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6067,7 +6086,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:412
+#: lxc/main.go:421
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6078,7 +6097,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1489
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6093,7 +6112,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1864
+#: lxc/storage_volume.go:1866
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6101,7 +6120,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6118,7 +6137,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:327
+#: lxc/copy.go:382 lxc/move.go:332
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6160,7 +6179,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1472
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6182,13 +6201,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1752
+#: lxc/project.go:995 lxc/storage_volume.go:1754
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1751
+#: lxc/storage.go:724 lxc/storage_volume.go:1753
 msgid "USED BY"
 msgstr ""
 
@@ -6201,7 +6220,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:411
+#: lxc/file.go:423
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6215,12 +6234,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1483
+#: lxc/file.go:1507
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1791
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6231,7 +6250,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1029
+#: lxc/file.go:1049
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6262,7 +6281,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1728 lxc/image.go:1729
+#: lxc/image.go:1729 lxc/image.go:1730
 msgid "Unset image properties"
 msgstr ""
 
@@ -6278,11 +6297,11 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:598
+#: lxc/network_forward.go:606
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:599
+#: lxc/network_forward.go:607
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -6326,7 +6345,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6338,7 +6357,7 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:602
+#: lxc/network_forward.go:610
 msgid "Unset the key as a network forward property"
 msgstr ""
 
@@ -6378,7 +6397,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2381
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6386,7 +6405,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:248
+#: lxc/storage_volume.go:250
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6422,12 +6441,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1485
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2652
+#: lxc/export.go:42 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6494,7 +6513,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1576
+#: lxc/storage_volume.go:1578
 msgid "Volume Only"
 msgstr ""
 
@@ -6545,7 +6564,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:293 lxc/move.go:369
+#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6553,12 +6572,12 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:909
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:912
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:282
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:284
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
@@ -6590,7 +6609,7 @@ msgstr ""
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:174
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
@@ -6643,7 +6662,7 @@ msgstr ""
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: lxc/image_alias.go:104
+#: lxc/image_alias.go:121
 msgid "[<remote>:]<alias>"
 msgstr ""
 
@@ -6651,7 +6670,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/image_alias.go:252
+#: lxc/image_alias.go:285
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
@@ -6705,15 +6724,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1600 lxc/image.go:1727
+#: lxc/image.go:1601 lxc/image.go:1728
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1664
+#: lxc/image.go:1665
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6733,7 +6752,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1443
+#: lxc/image.go:334 lxc/image.go:1444
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6804,7 +6823,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:376
+#: lxc/file.go:380
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -6816,12 +6835,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:454
+#: lxc/file.go:466
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1226
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6889,8 +6908,8 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:644
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:179
+#: lxc/network_forward.go:177 lxc/network_forward.go:652
+#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
 #: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
@@ -6905,12 +6924,12 @@ msgid ""
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:402 lxc/network_forward.go:597
+#: lxc/network_forward.go:410 lxc/network_forward.go:605
 #: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
@@ -6920,13 +6939,13 @@ msgid ""
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:887
+#: lxc/network_forward.go:895
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:968 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -6981,7 +7000,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2811
+#: lxc/storage_volume.go:2813
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7016,65 +7035,65 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1958
+#: lxc/storage_volume.go:1960
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:806
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:167
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
-msgstr ""
-
-#: lxc/storage_volume.go:2562
+#: lxc/storage_volume.go:2564
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2645
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2428
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:610
+#: lxc/storage_volume.go:614
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:718
+#: lxc/storage_volume.go:722
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2364
+#: lxc/storage_volume.go:810
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
+msgstr ""
+
+#: lxc/storage_volume.go:167
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
+msgstr ""
+
+#: lxc/storage_volume.go:2366
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2087
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2245
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1234
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1858
+#: lxc/storage_volume.go:1860
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7180,7 +7199,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1603
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7342,20 +7361,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1230
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:470
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:691
+#: lxc/file.go:704
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7656,7 +7675,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:618
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7664,13 +7683,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2817
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2432
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7704,16 +7723,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1396
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1331
+#: lxc/file.go:1355
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1284
+#: lxc/file.go:1308
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-07 15:11-0700\n"
+"POT-Creation-Date: 2025-01-10 14:44-0600\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -50,7 +50,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1041
+#: lxc/storage_volume.go:1043
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -255,7 +255,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:667
+#: lxc/network_forward.go:675
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -431,12 +431,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1157
+#: lxc/file.go:1177
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1047
+#: lxc/file.go:1067
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -472,7 +472,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:65
+#: lxc/init.go:146 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -525,7 +525,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:687
+#: lxc/file.go:700
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -542,7 +542,7 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
@@ -673,7 +673,7 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:888 lxc/network_forward.go:889
+#: lxc/network_forward.go:896 lxc/network_forward.go:897
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -723,7 +723,7 @@ msgstr ""
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
+#: lxc/image_alias.go:101 lxc/image_alias.go:156 lxc/image_alias.go:320
 msgid "Alias name missing"
 msgstr ""
 
@@ -736,7 +736,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1607
+#: lxc/storage_volume.go:1609
 msgid "All projects"
 msgstr ""
 
@@ -767,7 +767,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -791,12 +791,26 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168 lxc/storage_volume.go:169
+#: lxc/storage_volume.go:168
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:169
+msgid ""
+"Attach new storage volumes to instances\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
+msgstr ""
+
+#: lxc/storage_volume.go:285
 msgid "Attach new storage volumes to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:286
+msgid ""
+"Attach new storage volumes to profiles\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
 #: lxc/console.go:39
@@ -847,16 +861,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2719
+#: lxc/storage_volume.go:2721
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2796
+#: lxc/export.go:192 lxc/storage_volume.go:2798
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1538
+#: lxc/info.go:666 lxc/storage_volume.go:1540
 msgid "Backups:"
 msgstr ""
 
@@ -865,19 +879,19 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
+#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:326
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -920,7 +934,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1752
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -972,7 +986,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -980,7 +994,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:562
+#: lxc/file.go:575
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1005,11 +1019,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:768
+#: lxc/file.go:790
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1022,12 +1036,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:493
+#: lxc/storage_volume.go:497
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:447
+#: lxc/storage_volume.go:451
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1133,9 +1147,9 @@ msgstr ""
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:497 lxc/network_forward.go:649
-#: lxc/network_forward.go:803 lxc/network_forward.go:892
-#: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
+#: lxc/network_forward.go:505 lxc/network_forward.go:657
+#: lxc/network_forward.go:811 lxc/network_forward.go:900
+#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
 #: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
 #: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
@@ -1147,14 +1161,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
-#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
-#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
-#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
+#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
 msgid "Cluster member name"
 msgstr ""
 
@@ -1170,7 +1184,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1608
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1210,21 +1224,21 @@ msgstr ""
 #: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
-#: lxc/network_acl.go:698 lxc/network_forward.go:767
+#: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
-#: lxc/storage_volume.go:1199
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
+#: lxc/storage_volume.go:1201
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:620
+#: lxc/storage_volume.go:624
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1478
+#: lxc/storage_volume.go:1480
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1286,7 +1300,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1294,12 +1308,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1312,7 +1326,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1407,7 +1421,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:462 lxc/file.go:696
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1447,7 +1461,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1499,12 +1513,12 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:182
+#: lxc/init.go:186
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1514,7 +1528,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 msgid "Creating the instance"
 msgstr ""
 
@@ -1528,13 +1542,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1749
+#: lxc/storage_volume.go:1751
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1554,7 +1568,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2653
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1586,7 +1600,7 @@ msgstr ""
 msgid "Delete identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:106 lxc/image_alias.go:107
+#: lxc/image_alias.go:123 lxc/image_alias.go:124
 msgid "Delete image aliases"
 msgstr ""
 
@@ -1610,7 +1624,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:799 lxc/network_forward.go:800
+#: lxc/network_forward.go:807 lxc/network_forward.go:808
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1650,7 +1664,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
+#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1692,13 +1706,13 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
-#: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
-#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
+#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
+#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
+#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
@@ -1712,10 +1726,10 @@ msgstr ""
 #: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:404 lxc/network_forward.go:489
-#: lxc/network_forward.go:599 lxc/network_forward.go:646
-#: lxc/network_forward.go:800 lxc/network_forward.go:874
-#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_forward.go:412 lxc/network_forward.go:497
+#: lxc/network_forward.go:607 lxc/network_forward.go:654
+#: lxc/network_forward.go:808 lxc/network_forward.go:882
+#: lxc/network_forward.go:897 lxc/network_forward.go:982
 #: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
 #: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
 #: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
@@ -1755,27 +1769,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
-#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
-#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
-#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
-#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
-#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
-#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
-#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1465
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1787,11 +1801,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
+#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1841,7 +1855,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:403
+#: lxc/init.go:407
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1853,7 +1867,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1216
+#: lxc/file.go:1236
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1949,7 +1963,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:377 lxc/file.go:378
+#: lxc/file.go:381 lxc/file.go:382
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1989,7 +2003,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:653 lxc/network_forward.go:654
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -2029,7 +2043,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2037,7 +2051,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1785
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2091,11 +2105,11 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
-#: lxc/network_acl.go:524 lxc/network_forward.go:572
+#: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
+#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2106,11 +2120,11 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
-#: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
+#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
-#: lxc/storage_volume.go:2210
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
+#: lxc/storage_volume.go:2212
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2152,8 +2166,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
+#: lxc/storage_volume.go:1577
 msgid "Expires at"
 msgstr ""
 
@@ -2177,7 +2191,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2189,11 +2203,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2650
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2779
+#: lxc/export.go:152 lxc/storage_volume.go:2781
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2212,7 +2226,7 @@ msgid "FILENAME"
 msgstr ""
 
 #: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
-#: lxc/image_alias.go:235
+#: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2220,12 +2234,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1467
+#: lxc/file.go:1491
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1490
+#: lxc/file.go:1514
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2240,12 +2254,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1517
+#: lxc/file.go:1541
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1326
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2275,7 +2289,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1423
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2290,7 +2304,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1428
+#: lxc/file.go:1452
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2300,12 +2314,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1352
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1455
+#: lxc/file.go:1479
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2319,7 +2333,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:304 lxc/move.go:380
+#: lxc/move.go:309 lxc/move.go:385
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2344,7 +2358,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1440
+#: lxc/file.go:1464
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2359,7 +2373,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1042
+#: lxc/file.go:1062
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2446,14 +2460,14 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1625 lxc/warning.go:94
+#: lxc/storage_volume.go:1627 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2521,7 +2535,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1602
+#: lxc/image.go:1602 lxc/image.go:1603
 msgid "Get image properties"
 msgstr ""
 
@@ -2537,7 +2551,7 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:414
 msgid "Get the key as a network forward property"
 msgstr ""
 
@@ -2577,7 +2591,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1249
+#: lxc/storage_volume.go:1251
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2605,7 +2619,7 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:403 lxc/network_forward.go:404
+#: lxc/network_forward.go:411 lxc/network_forward.go:412
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
@@ -2641,11 +2655,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:476
+#: lxc/storage_volume.go:480
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2685,22 +2699,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1540
+#: lxc/file.go:1564
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1529
+#: lxc/file.go:1553
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1376
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1362
+#: lxc/file.go:1386
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2773,11 +2787,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:415
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2787,7 +2801,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2437
+#: lxc/storage_volume.go:2439
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2799,7 +2813,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1517
+#: lxc/image.go:1518
 msgid "Image already up to date."
 msgstr ""
 
@@ -2815,11 +2829,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1472
+#: lxc/image.go:364 lxc/image.go:1473
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1698
+#: lxc/image.go:444 lxc/image.go:1699
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2829,7 +2843,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1515
+#: lxc/image.go:1516
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2837,7 +2851,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2815
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2845,7 +2859,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2814
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2867,11 +2881,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2822
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2894
+#: lxc/storage_volume.go:2896
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2897,11 +2911,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1378
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1531
+#: lxc/file.go:1555
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2910,7 +2924,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:414
+#: lxc/init.go:418
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2919,7 +2933,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1298
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2971,7 +2985,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1293
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2997,23 +3011,23 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2023
+#: lxc/move.go:153 lxc/storage_volume.go:2025
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:144
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2019
+#: lxc/storage_volume.go:2021
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:509
+#: lxc/main.go:518
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:353
+#: lxc/file.go:357
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3023,18 +3037,18 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
-#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
+#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:535
+#: lxc/file.go:548
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:717
+#: lxc/file.go:185 lxc/file.go:739
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3071,7 +3085,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3102,12 +3116,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:176
+#: lxc/init.go:180
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:174
+#: lxc/init.go:178
 msgid "Launching the instance"
 msgstr ""
 
@@ -3205,11 +3219,11 @@ msgstr ""
 msgid "List identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:151
+#: lxc/image_alias.go:176
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:177
 msgid ""
 "List image aliases\n"
 "\n"
@@ -3376,11 +3390,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1605
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1610
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3439,7 +3453,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1481
+#: lxc/info.go:489 lxc/storage_volume.go:1483
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3625,7 +3639,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:873 lxc/network_forward.go:874
+#: lxc/network_forward.go:881 lxc/network_forward.go:882
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -3771,12 +3785,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:322 lxc/move.go:435
+#: lxc/move.go:327 lxc/move.go:440
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:347 lxc/move.go:440
+#: lxc/move.go:352 lxc/move.go:445
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3841,10 +3855,10 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:449
-#: lxc/network_forward.go:534 lxc/network_forward.go:709
-#: lxc/network_forward.go:840 lxc/network_forward.go:933
-#: lxc/network_forward.go:1015 lxc/network_load_balancer.go:221
+#: lxc/network_forward.go:219 lxc/network_forward.go:457
+#: lxc/network_forward.go:542 lxc/network_forward.go:717
+#: lxc/network_forward.go:848 lxc/network_forward.go:945
+#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
 #: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
 #: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
 #: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
@@ -3869,10 +3883,10 @@ msgstr ""
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
 #: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
 #: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:284 lxc/network_forward.go:445
-#: lxc/network_forward.go:530 lxc/network_forward.go:705
-#: lxc/network_forward.go:836 lxc/network_forward.go:929
-#: lxc/network_forward.go:1011 lxc/network_load_balancer.go:131
+#: lxc/network_forward.go:292 lxc/network_forward.go:453
+#: lxc/network_forward.go:538 lxc/network_forward.go:713
+#: lxc/network_forward.go:844 lxc/network_forward.go:941
+#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
 #: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
 #: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
 #: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
@@ -3908,13 +3922,13 @@ msgstr ""
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
-#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
-#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
-#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
+#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
+#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
+#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
+#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
 msgid "Missing pool name"
 msgstr ""
 
@@ -3933,15 +3947,15 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
+#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1411
+#: lxc/storage_volume.go:1413
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:820
+#: lxc/file.go:842
 msgid "Missing target directory"
 msgstr ""
 
@@ -3974,16 +3988,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
-#: lxc/storage_volume.go:975
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
+#: lxc/storage_volume.go:977
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:507
+#: lxc/file.go:520
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1207 lxc/file.go:1208
+#: lxc/file.go:1227 lxc/file.go:1228
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4012,7 +4026,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4020,16 +4034,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1869
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1059 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4051,7 +4065,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
 msgid "NAME"
 msgstr ""
 
@@ -4103,8 +4117,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
-#: lxc/storage_volume.go:1573
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Name"
 msgstr ""
 
@@ -4112,7 +4126,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4167,12 +4181,12 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:386
+#: lxc/network_forward.go:394
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:857
+#: lxc/network_forward.go:865
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -4256,7 +4270,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
+#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4264,7 +4278,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1070 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4276,11 +4290,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4294,7 +4308,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2035
+#: lxc/storage_volume.go:2037
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4302,16 +4316,21 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
-#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
-msgid "Only \"custom\" volumes can be attached to instances"
+#: lxc/storage_volume.go:216
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2701
+#: lxc/storage_volume.go:348
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:2703
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2500
+#: lxc/storage_volume.go:2502
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4323,7 +4342,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1431
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4336,7 +4355,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1577
+#: lxc/info.go:705 lxc/storage_volume.go:1579
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4366,7 +4385,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1767
+#: lxc/storage_volume.go:1769
 msgid "POOL"
 msgstr ""
 
@@ -4383,7 +4402,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167
-#: lxc/storage_volume.go:1773 lxc/warning.go:213
+#: lxc/storage_volume.go:1775 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4407,7 +4426,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:367
+#: lxc/main.go:376
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4445,7 +4464,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1332
+#: lxc/file.go:1356
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4453,12 +4472,12 @@ msgstr ""
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
-#: lxc/network_acl.go:699 lxc/network_forward.go:768
+#: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
-#: lxc/storage_volume.go:1200
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
+#: lxc/storage_volume.go:1202
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4571,11 +4590,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1649
+#: lxc/image.go:1650
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4589,7 +4608,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1238
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4605,7 +4624,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4626,7 +4645,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1017
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4635,7 +4654,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2094
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4648,7 +4667,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2370
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4679,20 +4698,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:455 lxc/file.go:456
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:638 lxc/file.go:989
+#: lxc/file.go:651 lxc/file.go:1009
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:688 lxc/file.go:689
+#: lxc/file.go:701 lxc/file.go:702
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:923 lxc/file.go:1089
+#: lxc/file.go:943 lxc/file.go:1109
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4701,7 +4720,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4730,15 +4749,15 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:463 lxc/file.go:695
+#: lxc/file.go:475 lxc/file.go:708
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1444 lxc/image.go:1445
+#: lxc/image.go:1445 lxc/image.go:1446
 msgid "Refresh images"
 msgstr ""
 
@@ -4747,7 +4766,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1481
+#: lxc/image.go:1482
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4824,7 +4843,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:971 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4860,7 +4879,7 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:969 lxc/network_forward.go:970
+#: lxc/network_forward.go:981 lxc/network_forward.go:982
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -4896,8 +4915,8 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
-#: lxc/image_alias.go:255
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:287
+#: lxc/image_alias.go:288
 msgid "Rename aliases"
 msgstr ""
 
@@ -4933,15 +4952,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1962
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
+#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4993,7 +5012,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5010,7 +5029,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:361
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5059,12 +5078,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1460
+#: lxc/file.go:1484
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1461
+#: lxc/file.go:1485
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5140,7 +5159,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1217
+#: lxc/file.go:1237
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5166,7 +5185,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1665 lxc/image.go:1666
+#: lxc/image.go:1666 lxc/image.go:1667
 msgid "Set image properties"
 msgstr ""
 
@@ -5209,11 +5228,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:488
+#: lxc/network_forward.go:496
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:489
+#: lxc/network_forward.go:497
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5317,11 +5336,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2088
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2089
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5338,7 +5357,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:698
+#: lxc/file.go:711
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5346,7 +5365,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:699
+#: lxc/file.go:712
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5354,7 +5373,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:710
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5366,7 +5385,7 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:504
 msgid "Set the key as a network forward property"
 msgstr ""
 
@@ -5406,7 +5425,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2105
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5414,7 +5433,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1215
+#: lxc/file.go:1235
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5471,7 +5490,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1535 lxc/image.go:1536
+#: lxc/image.go:1536 lxc/image.go:1537
 msgid "Show image properties"
 msgstr ""
 
@@ -5491,7 +5510,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:271 lxc/main.go:272
+#: lxc/main.go:280 lxc/main.go:281
 msgid "Show less common commands"
 msgstr ""
 
@@ -5555,11 +5574,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5627,15 +5646,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2190
+#: lxc/storage_volume.go:2192
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1502
+#: lxc/info.go:619 lxc/storage_volume.go:1504
 msgid "Snapshots:"
 msgstr ""
 
@@ -5740,21 +5759,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:703
+#: lxc/storage_volume.go:707
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:791
+#: lxc/storage_volume.go:795
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:516
+#: lxc/storage_volume.go:520
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:524
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5816,21 +5835,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1747 lxc/warning.go:216
+#: lxc/storage_volume.go:1749 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1262
+#: lxc/file.go:1286
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1256
+#: lxc/file.go:1280
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5840,15 +5859,15 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:181
+#: lxc/move.go:186
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:219 lxc/move.go:240
+#: lxc/move.go:224 lxc/move.go:245
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:193
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5856,15 +5875,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:185
+#: lxc/move.go:190
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:189
+#: lxc/move.go:194
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:210
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5886,7 +5905,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:439
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5939,7 +5958,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:462
+#: lxc/network_forward.go:470
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -5979,12 +5998,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1340
+#: lxc/storage_volume.go:1342
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1317
+#: lxc/storage_volume.go:1319
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -5999,12 +6018,12 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:309
+#: lxc/move.go:314
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
-#: lxc/storage_volume.go:989
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
+#: lxc/storage_volume.go:991
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6032,7 +6051,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:298
+#: lxc/main.go:307
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6056,11 +6075,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:437
+#: lxc/init.go:441
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:440
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6068,7 +6087,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:412
+#: lxc/main.go:421
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6079,7 +6098,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1489
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6094,7 +6113,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1864
+#: lxc/storage_volume.go:1866
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6102,7 +6121,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6119,7 +6138,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:327
+#: lxc/copy.go:382 lxc/move.go:332
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6161,7 +6180,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1472
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6183,13 +6202,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1752
+#: lxc/project.go:995 lxc/storage_volume.go:1754
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1751
+#: lxc/storage.go:724 lxc/storage_volume.go:1753
 msgid "USED BY"
 msgstr ""
 
@@ -6202,7 +6221,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:411
+#: lxc/file.go:423
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6216,12 +6235,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1483
+#: lxc/file.go:1507
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1791
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6232,7 +6251,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1029
+#: lxc/file.go:1049
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6263,7 +6282,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1728 lxc/image.go:1729
+#: lxc/image.go:1729 lxc/image.go:1730
 msgid "Unset image properties"
 msgstr ""
 
@@ -6279,11 +6298,11 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:598
+#: lxc/network_forward.go:606
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:599
+#: lxc/network_forward.go:607
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -6327,7 +6346,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6339,7 +6358,7 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:602
+#: lxc/network_forward.go:610
 msgid "Unset the key as a network forward property"
 msgstr ""
 
@@ -6379,7 +6398,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2381
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6387,7 +6406,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:248
+#: lxc/storage_volume.go:250
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6423,12 +6442,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1485
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2652
+#: lxc/export.go:42 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6495,7 +6514,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1576
+#: lxc/storage_volume.go:1578
 msgid "Volume Only"
 msgstr ""
 
@@ -6546,7 +6565,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:293 lxc/move.go:369
+#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6554,12 +6573,12 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:909
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:912
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:282
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:284
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
@@ -6591,7 +6610,7 @@ msgstr ""
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:174
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
@@ -6644,7 +6663,7 @@ msgstr ""
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: lxc/image_alias.go:104
+#: lxc/image_alias.go:121
 msgid "[<remote>:]<alias>"
 msgstr ""
 
@@ -6652,7 +6671,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/image_alias.go:252
+#: lxc/image_alias.go:285
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
@@ -6706,15 +6725,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1600 lxc/image.go:1727
+#: lxc/image.go:1601 lxc/image.go:1728
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1664
+#: lxc/image.go:1665
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6734,7 +6753,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1443
+#: lxc/image.go:334 lxc/image.go:1444
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6805,7 +6824,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:376
+#: lxc/file.go:380
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -6817,12 +6836,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:454
+#: lxc/file.go:466
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1226
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6890,8 +6909,8 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:644
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:179
+#: lxc/network_forward.go:177 lxc/network_forward.go:652
+#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
 #: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
@@ -6906,12 +6925,12 @@ msgid ""
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:402 lxc/network_forward.go:597
+#: lxc/network_forward.go:410 lxc/network_forward.go:605
 #: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
@@ -6921,13 +6940,13 @@ msgid ""
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:887
+#: lxc/network_forward.go:895
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:968 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -6982,7 +7001,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2811
+#: lxc/storage_volume.go:2813
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7017,65 +7036,65 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1958
+#: lxc/storage_volume.go:1960
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:806
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:167
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
-msgstr ""
-
-#: lxc/storage_volume.go:2562
+#: lxc/storage_volume.go:2564
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2645
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2428
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:610
+#: lxc/storage_volume.go:614
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:718
+#: lxc/storage_volume.go:722
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2364
+#: lxc/storage_volume.go:810
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
+msgstr ""
+
+#: lxc/storage_volume.go:167
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
+msgstr ""
+
+#: lxc/storage_volume.go:2366
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2087
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2245
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1234
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1858
+#: lxc/storage_volume.go:1860
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7181,7 +7200,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1603
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7343,20 +7362,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1230
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:470
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:691
+#: lxc/file.go:704
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7657,7 +7676,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:618
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7665,13 +7684,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2817
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2432
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7705,16 +7724,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1396
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1331
+#: lxc/file.go:1355
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1284
+#: lxc/file.go:1308
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-07 15:11-0700\n"
+"POT-Creation-Date: 2025-01-10 14:44-0600\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -73,7 +73,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:1041
+#: lxc/storage_volume.go:1043
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -339,7 +339,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:667
+#: lxc/network_forward.go:675
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -591,12 +591,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1157
+#: lxc/file.go:1177
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s 不是一个目录"
 
-#: lxc/file.go:1047
+#: lxc/file.go:1067
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -632,7 +632,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:65
+#: lxc/init.go:146 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -685,7 +685,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:687
+#: lxc/file.go:700
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -702,7 +702,7 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
@@ -833,7 +833,7 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:888 lxc/network_forward.go:889
+#: lxc/network_forward.go:896 lxc/network_forward.go:897
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -883,7 +883,7 @@ msgstr ""
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
+#: lxc/image_alias.go:101 lxc/image_alias.go:156 lxc/image_alias.go:320
 msgid "Alias name missing"
 msgstr ""
 
@@ -896,7 +896,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1607
+#: lxc/storage_volume.go:1609
 msgid "All projects"
 msgstr ""
 
@@ -927,7 +927,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -951,12 +951,26 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168 lxc/storage_volume.go:169
+#: lxc/storage_volume.go:168
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:169
+msgid ""
+"Attach new storage volumes to instances\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
+msgstr ""
+
+#: lxc/storage_volume.go:285
 msgid "Attach new storage volumes to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:286
+msgid ""
+"Attach new storage volumes to profiles\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
 #: lxc/console.go:39
@@ -1007,16 +1021,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2719
+#: lxc/storage_volume.go:2721
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2796
+#: lxc/export.go:192 lxc/storage_volume.go:2798
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1538
+#: lxc/info.go:666 lxc/storage_volume.go:1540
 msgid "Backups:"
 msgstr ""
 
@@ -1025,19 +1039,19 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
+#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:326
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1080,7 +1094,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1752
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1132,7 +1146,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -1140,7 +1154,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:562
+#: lxc/file.go:575
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1165,11 +1179,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:768
+#: lxc/file.go:790
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1182,12 +1196,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:493
+#: lxc/storage_volume.go:497
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:447
+#: lxc/storage_volume.go:451
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1293,9 +1307,9 @@ msgstr ""
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:497 lxc/network_forward.go:649
-#: lxc/network_forward.go:803 lxc/network_forward.go:892
-#: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
+#: lxc/network_forward.go:505 lxc/network_forward.go:657
+#: lxc/network_forward.go:811 lxc/network_forward.go:900
+#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
 #: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
 #: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
@@ -1307,14 +1321,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
-#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
-#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
-#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
+#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
 msgid "Cluster member name"
 msgstr ""
 
@@ -1330,7 +1344,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1608
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1370,21 +1384,21 @@ msgstr ""
 #: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
-#: lxc/network_acl.go:698 lxc/network_forward.go:767
+#: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
-#: lxc/storage_volume.go:1199
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
+#: lxc/storage_volume.go:1201
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:620
+#: lxc/storage_volume.go:624
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1478
+#: lxc/storage_volume.go:1480
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1446,7 +1460,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1454,12 +1468,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1472,7 +1486,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1567,7 +1581,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:462 lxc/file.go:696
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1607,7 +1621,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1659,12 +1673,12 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:182
+#: lxc/init.go:186
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1674,7 +1688,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 msgid "Creating the instance"
 msgstr ""
 
@@ -1688,13 +1702,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1749
+#: lxc/storage_volume.go:1751
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1714,7 +1728,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2653
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1746,7 +1760,7 @@ msgstr ""
 msgid "Delete identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:106 lxc/image_alias.go:107
+#: lxc/image_alias.go:123 lxc/image_alias.go:124
 msgid "Delete image aliases"
 msgstr ""
 
@@ -1770,7 +1784,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:799 lxc/network_forward.go:800
+#: lxc/network_forward.go:807 lxc/network_forward.go:808
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1810,7 +1824,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
+#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1852,13 +1866,13 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
-#: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
-#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
+#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
+#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
+#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
@@ -1872,10 +1886,10 @@ msgstr ""
 #: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:404 lxc/network_forward.go:489
-#: lxc/network_forward.go:599 lxc/network_forward.go:646
-#: lxc/network_forward.go:800 lxc/network_forward.go:874
-#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_forward.go:412 lxc/network_forward.go:497
+#: lxc/network_forward.go:607 lxc/network_forward.go:654
+#: lxc/network_forward.go:808 lxc/network_forward.go:882
+#: lxc/network_forward.go:897 lxc/network_forward.go:982
 #: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
 #: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
 #: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
@@ -1915,27 +1929,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
-#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
-#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
-#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
-#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
-#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
-#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
-#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1465
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1947,11 +1961,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
+#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2001,7 +2015,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:403
+#: lxc/init.go:407
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -2013,7 +2027,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1216
+#: lxc/file.go:1236
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -2109,7 +2123,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:377 lxc/file.go:378
+#: lxc/file.go:381 lxc/file.go:382
 msgid "Edit files in instances"
 msgstr ""
 
@@ -2149,7 +2163,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:653 lxc/network_forward.go:654
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -2189,7 +2203,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2197,7 +2211,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1785
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2251,11 +2265,11 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
-#: lxc/network_acl.go:524 lxc/network_forward.go:572
+#: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
+#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2266,11 +2280,11 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
-#: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
+#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
-#: lxc/storage_volume.go:2210
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
+#: lxc/storage_volume.go:2212
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2312,8 +2326,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
+#: lxc/storage_volume.go:1577
 msgid "Expires at"
 msgstr ""
 
@@ -2337,7 +2351,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2349,11 +2363,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2650
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2779
+#: lxc/export.go:152 lxc/storage_volume.go:2781
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2372,7 +2386,7 @@ msgid "FILENAME"
 msgstr ""
 
 #: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
-#: lxc/image_alias.go:235
+#: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2380,12 +2394,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1467
+#: lxc/file.go:1491
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1490
+#: lxc/file.go:1514
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2400,12 +2414,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1517
+#: lxc/file.go:1541
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1326
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2435,7 +2449,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1423
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2450,7 +2464,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1428
+#: lxc/file.go:1452
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2460,12 +2474,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1352
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1455
+#: lxc/file.go:1479
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2479,7 +2493,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:304 lxc/move.go:380
+#: lxc/move.go:309 lxc/move.go:385
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2504,7 +2518,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1440
+#: lxc/file.go:1464
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2519,7 +2533,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1042
+#: lxc/file.go:1062
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2606,14 +2620,14 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1625 lxc/warning.go:94
+#: lxc/storage_volume.go:1627 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2681,7 +2695,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1602
+#: lxc/image.go:1602 lxc/image.go:1603
 msgid "Get image properties"
 msgstr ""
 
@@ -2697,7 +2711,7 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:414
 msgid "Get the key as a network forward property"
 msgstr ""
 
@@ -2737,7 +2751,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1249
+#: lxc/storage_volume.go:1251
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2765,7 +2779,7 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:403 lxc/network_forward.go:404
+#: lxc/network_forward.go:411 lxc/network_forward.go:412
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
@@ -2801,11 +2815,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:476
+#: lxc/storage_volume.go:480
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2845,22 +2859,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1540
+#: lxc/file.go:1564
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1529
+#: lxc/file.go:1553
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1376
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1362
+#: lxc/file.go:1386
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2933,11 +2947,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:415
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2947,7 +2961,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2437
+#: lxc/storage_volume.go:2439
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2959,7 +2973,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1517
+#: lxc/image.go:1518
 msgid "Image already up to date."
 msgstr ""
 
@@ -2975,11 +2989,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1472
+#: lxc/image.go:364 lxc/image.go:1473
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1698
+#: lxc/image.go:444 lxc/image.go:1699
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2989,7 +3003,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1515
+#: lxc/image.go:1516
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2997,7 +3011,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2815
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3005,7 +3019,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2814
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -3027,11 +3041,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2822
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2894
+#: lxc/storage_volume.go:2896
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3057,11 +3071,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1378
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1531
+#: lxc/file.go:1555
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -3070,7 +3084,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:414
+#: lxc/init.go:418
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -3079,7 +3093,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1298
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -3131,7 +3145,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1293
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -3157,23 +3171,23 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2023
+#: lxc/move.go:153 lxc/storage_volume.go:2025
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:144
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2019
+#: lxc/storage_volume.go:2021
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:509
+#: lxc/main.go:518
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:353
+#: lxc/file.go:357
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3183,18 +3197,18 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
-#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
+#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:535
+#: lxc/file.go:548
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:717
+#: lxc/file.go:185 lxc/file.go:739
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3231,7 +3245,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3262,12 +3276,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:176
+#: lxc/init.go:180
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:174
+#: lxc/init.go:178
 msgid "Launching the instance"
 msgstr ""
 
@@ -3365,11 +3379,11 @@ msgstr ""
 msgid "List identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:151
+#: lxc/image_alias.go:176
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:177
 msgid ""
 "List image aliases\n"
 "\n"
@@ -3536,11 +3550,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1605
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1610
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3599,7 +3613,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1481
+#: lxc/info.go:489 lxc/storage_volume.go:1483
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3785,7 +3799,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:873 lxc/network_forward.go:874
+#: lxc/network_forward.go:881 lxc/network_forward.go:882
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -3931,12 +3945,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:322 lxc/move.go:435
+#: lxc/move.go:327 lxc/move.go:440
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:347 lxc/move.go:440
+#: lxc/move.go:352 lxc/move.go:445
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -4001,10 +4015,10 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:449
-#: lxc/network_forward.go:534 lxc/network_forward.go:709
-#: lxc/network_forward.go:840 lxc/network_forward.go:933
-#: lxc/network_forward.go:1015 lxc/network_load_balancer.go:221
+#: lxc/network_forward.go:219 lxc/network_forward.go:457
+#: lxc/network_forward.go:542 lxc/network_forward.go:717
+#: lxc/network_forward.go:848 lxc/network_forward.go:945
+#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
 #: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
 #: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
 #: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
@@ -4029,10 +4043,10 @@ msgstr ""
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
 #: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
 #: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:284 lxc/network_forward.go:445
-#: lxc/network_forward.go:530 lxc/network_forward.go:705
-#: lxc/network_forward.go:836 lxc/network_forward.go:929
-#: lxc/network_forward.go:1011 lxc/network_load_balancer.go:131
+#: lxc/network_forward.go:292 lxc/network_forward.go:453
+#: lxc/network_forward.go:538 lxc/network_forward.go:713
+#: lxc/network_forward.go:844 lxc/network_forward.go:941
+#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
 #: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
 #: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
 #: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
@@ -4068,13 +4082,13 @@ msgstr ""
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
-#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
-#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
-#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
+#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
+#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
+#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
+#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
 msgid "Missing pool name"
 msgstr ""
 
@@ -4093,15 +4107,15 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
+#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1411
+#: lxc/storage_volume.go:1413
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:820
+#: lxc/file.go:842
 msgid "Missing target directory"
 msgstr ""
 
@@ -4134,16 +4148,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
-#: lxc/storage_volume.go:975
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
+#: lxc/storage_volume.go:977
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:507
+#: lxc/file.go:520
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1207 lxc/file.go:1208
+#: lxc/file.go:1227 lxc/file.go:1228
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4172,7 +4186,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4180,16 +4194,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1869
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1059 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4211,7 +4225,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
 msgid "NAME"
 msgstr ""
 
@@ -4263,8 +4277,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
-#: lxc/storage_volume.go:1573
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Name"
 msgstr ""
 
@@ -4272,7 +4286,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4327,12 +4341,12 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:386
+#: lxc/network_forward.go:394
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:857
+#: lxc/network_forward.go:865
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -4416,7 +4430,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
+#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4424,7 +4438,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1070 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4436,11 +4450,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4454,7 +4468,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2035
+#: lxc/storage_volume.go:2037
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4462,16 +4476,21 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
-#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
-msgid "Only \"custom\" volumes can be attached to instances"
+#: lxc/storage_volume.go:216
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2701
+#: lxc/storage_volume.go:348
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:2703
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2500
+#: lxc/storage_volume.go:2502
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4483,7 +4502,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1431
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4496,7 +4515,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1577
+#: lxc/info.go:705 lxc/storage_volume.go:1579
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4526,7 +4545,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1767
+#: lxc/storage_volume.go:1769
 msgid "POOL"
 msgstr ""
 
@@ -4543,7 +4562,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167
-#: lxc/storage_volume.go:1773 lxc/warning.go:213
+#: lxc/storage_volume.go:1775 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4567,7 +4586,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:367
+#: lxc/main.go:376
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4605,7 +4624,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1332
+#: lxc/file.go:1356
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4613,12 +4632,12 @@ msgstr ""
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
-#: lxc/network_acl.go:699 lxc/network_forward.go:768
+#: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
-#: lxc/storage_volume.go:1200
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
+#: lxc/storage_volume.go:1202
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4731,11 +4750,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1649
+#: lxc/image.go:1650
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4749,7 +4768,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1238
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4765,7 +4784,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4786,7 +4805,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1017
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4795,7 +4814,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2094
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4808,7 +4827,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2370
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4839,20 +4858,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:455 lxc/file.go:456
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:638 lxc/file.go:989
+#: lxc/file.go:651 lxc/file.go:1009
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:688 lxc/file.go:689
+#: lxc/file.go:701 lxc/file.go:702
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:923 lxc/file.go:1089
+#: lxc/file.go:943 lxc/file.go:1109
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4861,7 +4880,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4890,15 +4909,15 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:463 lxc/file.go:695
+#: lxc/file.go:475 lxc/file.go:708
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1444 lxc/image.go:1445
+#: lxc/image.go:1445 lxc/image.go:1446
 msgid "Refresh images"
 msgstr ""
 
@@ -4907,7 +4926,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1481
+#: lxc/image.go:1482
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4984,7 +5003,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:971 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -5020,7 +5039,7 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:969 lxc/network_forward.go:970
+#: lxc/network_forward.go:981 lxc/network_forward.go:982
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -5056,8 +5075,8 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
-#: lxc/image_alias.go:255
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:287
+#: lxc/image_alias.go:288
 msgid "Rename aliases"
 msgstr ""
 
@@ -5093,15 +5112,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1962
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
+#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5153,7 +5172,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5170,7 +5189,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:361
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5219,12 +5238,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1460
+#: lxc/file.go:1484
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1461
+#: lxc/file.go:1485
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5300,7 +5319,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1217
+#: lxc/file.go:1237
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5326,7 +5345,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1665 lxc/image.go:1666
+#: lxc/image.go:1666 lxc/image.go:1667
 msgid "Set image properties"
 msgstr ""
 
@@ -5369,11 +5388,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:488
+#: lxc/network_forward.go:496
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:489
+#: lxc/network_forward.go:497
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5477,11 +5496,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2088
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2089
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5498,7 +5517,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:698
+#: lxc/file.go:711
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5506,7 +5525,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:699
+#: lxc/file.go:712
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5514,7 +5533,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:710
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5526,7 +5545,7 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:504
 msgid "Set the key as a network forward property"
 msgstr ""
 
@@ -5566,7 +5585,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2105
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5574,7 +5593,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1215
+#: lxc/file.go:1235
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5631,7 +5650,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1535 lxc/image.go:1536
+#: lxc/image.go:1536 lxc/image.go:1537
 msgid "Show image properties"
 msgstr ""
 
@@ -5651,7 +5670,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:271 lxc/main.go:272
+#: lxc/main.go:280 lxc/main.go:281
 msgid "Show less common commands"
 msgstr ""
 
@@ -5715,11 +5734,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5787,15 +5806,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2190
+#: lxc/storage_volume.go:2192
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1502
+#: lxc/info.go:619 lxc/storage_volume.go:1504
 msgid "Snapshots:"
 msgstr ""
 
@@ -5900,21 +5919,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:703
+#: lxc/storage_volume.go:707
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:791
+#: lxc/storage_volume.go:795
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:516
+#: lxc/storage_volume.go:520
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:524
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5976,21 +5995,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1747 lxc/warning.go:216
+#: lxc/storage_volume.go:1749 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1262
+#: lxc/file.go:1286
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1256
+#: lxc/file.go:1280
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -6000,15 +6019,15 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:181
+#: lxc/move.go:186
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:219 lxc/move.go:240
+#: lxc/move.go:224 lxc/move.go:245
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:193
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -6016,15 +6035,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:185
+#: lxc/move.go:190
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:189
+#: lxc/move.go:194
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:210
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -6046,7 +6065,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:439
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -6099,7 +6118,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:462
+#: lxc/network_forward.go:470
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -6139,12 +6158,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1340
+#: lxc/storage_volume.go:1342
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1317
+#: lxc/storage_volume.go:1319
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6159,12 +6178,12 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:309
+#: lxc/move.go:314
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
-#: lxc/storage_volume.go:989
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
+#: lxc/storage_volume.go:991
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6192,7 +6211,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:298
+#: lxc/main.go:307
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6216,11 +6235,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:437
+#: lxc/init.go:441
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:440
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6228,7 +6247,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:412
+#: lxc/main.go:421
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6239,7 +6258,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1489
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6254,7 +6273,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1864
+#: lxc/storage_volume.go:1866
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6262,7 +6281,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6279,7 +6298,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:327
+#: lxc/copy.go:382 lxc/move.go:332
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6321,7 +6340,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1472
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6343,13 +6362,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1752
+#: lxc/project.go:995 lxc/storage_volume.go:1754
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1751
+#: lxc/storage.go:724 lxc/storage_volume.go:1753
 msgid "USED BY"
 msgstr ""
 
@@ -6362,7 +6381,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:411
+#: lxc/file.go:423
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6376,12 +6395,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1483
+#: lxc/file.go:1507
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1791
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6392,7 +6411,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1029
+#: lxc/file.go:1049
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6423,7 +6442,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1728 lxc/image.go:1729
+#: lxc/image.go:1729 lxc/image.go:1730
 msgid "Unset image properties"
 msgstr ""
 
@@ -6439,11 +6458,11 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:598
+#: lxc/network_forward.go:606
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:599
+#: lxc/network_forward.go:607
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -6487,7 +6506,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6499,7 +6518,7 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:602
+#: lxc/network_forward.go:610
 msgid "Unset the key as a network forward property"
 msgstr ""
 
@@ -6539,7 +6558,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2381
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6547,7 +6566,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:248
+#: lxc/storage_volume.go:250
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6583,12 +6602,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1485
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2652
+#: lxc/export.go:42 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6655,7 +6674,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1576
+#: lxc/storage_volume.go:1578
 msgid "Volume Only"
 msgstr ""
 
@@ -6706,7 +6725,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:293 lxc/move.go:369
+#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6714,12 +6733,12 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:909
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:912
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:282
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:284
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
@@ -6751,7 +6770,7 @@ msgstr ""
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:174
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
@@ -6804,7 +6823,7 @@ msgstr ""
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: lxc/image_alias.go:104
+#: lxc/image_alias.go:121
 msgid "[<remote>:]<alias>"
 msgstr ""
 
@@ -6812,7 +6831,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/image_alias.go:252
+#: lxc/image_alias.go:285
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
@@ -6866,15 +6885,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1600 lxc/image.go:1727
+#: lxc/image.go:1601 lxc/image.go:1728
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1664
+#: lxc/image.go:1665
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6894,7 +6913,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1443
+#: lxc/image.go:334 lxc/image.go:1444
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6965,7 +6984,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:376
+#: lxc/file.go:380
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -6977,12 +6996,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:454
+#: lxc/file.go:466
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1226
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -7050,8 +7069,8 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:644
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:179
+#: lxc/network_forward.go:177 lxc/network_forward.go:652
+#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
 #: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
@@ -7066,12 +7085,12 @@ msgid ""
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:402 lxc/network_forward.go:597
+#: lxc/network_forward.go:410 lxc/network_forward.go:605
 #: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
@@ -7081,13 +7100,13 @@ msgid ""
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:887
+#: lxc/network_forward.go:895
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:968 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -7142,7 +7161,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2811
+#: lxc/storage_volume.go:2813
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7177,65 +7196,65 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1958
+#: lxc/storage_volume.go:1960
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:806
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:167
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
-msgstr ""
-
-#: lxc/storage_volume.go:2562
+#: lxc/storage_volume.go:2564
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2645
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2428
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:610
+#: lxc/storage_volume.go:614
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:718
+#: lxc/storage_volume.go:722
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2364
+#: lxc/storage_volume.go:810
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
+msgstr ""
+
+#: lxc/storage_volume.go:167
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
+msgstr ""
+
+#: lxc/storage_volume.go:2366
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2087
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2245
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1234
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1858
+#: lxc/storage_volume.go:1860
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7341,7 +7360,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1603
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7503,20 +7522,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1230
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:470
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:691
+#: lxc/file.go:704
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7817,7 +7836,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:618
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7825,13 +7844,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2817
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2432
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7865,16 +7884,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1396
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1331
+#: lxc/file.go:1355
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1284
+#: lxc/file.go:1308
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-07 15:11-0700\n"
+"POT-Creation-Date: 2025-01-10 14:44-0600\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1041
+#: lxc/storage_volume.go:1043
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -254,7 +254,7 @@ msgid ""
 "configuration keys can be changed."
 msgstr ""
 
-#: lxc/network_forward.go:667
+#: lxc/network_forward.go:675
 msgid ""
 "### This is a YAML representation of the network forward.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -430,12 +430,12 @@ msgstr ""
 msgid "%s (%s) (%d available)"
 msgstr ""
 
-#: lxc/file.go:1157
+#: lxc/file.go:1177
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
 
-#: lxc/file.go:1047
+#: lxc/file.go:1067
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -471,7 +471,7 @@ msgstr ""
 msgid "--console only works with a single instance"
 msgstr ""
 
-#: lxc/init.go:142 lxc/rebuild.go:65
+#: lxc/init.go:146 lxc/rebuild.go:65
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -524,7 +524,7 @@ msgstr ""
 msgid "<remote> <new-name>"
 msgstr ""
 
-#: lxc/file.go:687
+#: lxc/file.go:700
 msgid "<source path>... [<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -541,7 +541,7 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:267
 msgid "ALIAS"
 msgstr ""
 
@@ -672,7 +672,7 @@ msgstr ""
 msgid "Add permissions to groups"
 msgstr ""
 
-#: lxc/network_forward.go:888 lxc/network_forward.go:889
+#: lxc/network_forward.go:896 lxc/network_forward.go:897
 msgid "Add ports to a forward"
 msgstr ""
 
@@ -722,7 +722,7 @@ msgstr ""
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:84 lxc/image_alias.go:131 lxc/image_alias.go:279
+#: lxc/image_alias.go:101 lxc/image_alias.go:156 lxc/image_alias.go:320
 msgid "Alias name missing"
 msgstr ""
 
@@ -735,7 +735,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1607
+#: lxc/storage_volume.go:1609
 msgid "All projects"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "As neither could be found, the raw SPICE socket can be found at:"
 msgstr ""
 
-#: lxc/init.go:343 lxc/rebuild.go:131
+#: lxc/init.go:347 lxc/rebuild.go:131
 msgid "Asked for a VM but image is of type container"
 msgstr ""
 
@@ -790,12 +790,26 @@ msgstr ""
 msgid "Attach new network interfaces to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:168 lxc/storage_volume.go:169
+#: lxc/storage_volume.go:168
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:169
+msgid ""
+"Attach new storage volumes to instances\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
+msgstr ""
+
+#: lxc/storage_volume.go:285
 msgid "Attach new storage volumes to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:286
+msgid ""
+"Attach new storage volumes to profiles\n"
+"\n"
+"<type> must be one of \"custom\" or \"virtual-machine\""
 msgstr ""
 
 #: lxc/console.go:39
@@ -846,16 +860,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2719
+#: lxc/storage_volume.go:2721
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2796
+#: lxc/export.go:192 lxc/storage_volume.go:2798
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1538
+#: lxc/info.go:666 lxc/storage_volume.go:1540
 msgid "Backups:"
 msgstr ""
 
@@ -864,19 +878,19 @@ msgstr ""
 msgid "Bad device override syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
 
-#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:318
+#: lxc/network.go:366 lxc/network_acl.go:431 lxc/network_forward.go:326
 #: lxc/network_load_balancer.go:321 lxc/network_peer.go:309
 #: lxc/network_zone.go:384 lxc/network_zone.go:1071 lxc/storage_bucket.go:142
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:152 lxc/init.go:237 lxc/move.go:393 lxc/project.go:161
+#: lxc/copy.go:152 lxc/init.go:241 lxc/move.go:398 lxc/project.go:161
 #, c-format
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:690
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -919,7 +933,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1750
+#: lxc/storage_volume.go:1752
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -971,7 +985,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:130
+#: lxc/move.go:135
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -979,7 +993,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:562
+#: lxc/file.go:575
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -1004,11 +1018,11 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1762 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:768
+#: lxc/file.go:790
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -1021,12 +1035,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:493
+#: lxc/storage_volume.go:497
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:447
+#: lxc/storage_volume.go:451
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1132,9 +1146,9 @@ msgstr ""
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
 #: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
 #: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
-#: lxc/network_forward.go:497 lxc/network_forward.go:649
-#: lxc/network_forward.go:803 lxc/network_forward.go:892
-#: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
+#: lxc/network_forward.go:505 lxc/network_forward.go:657
+#: lxc/network_forward.go:811 lxc/network_forward.go:900
+#: lxc/network_forward.go:986 lxc/network_load_balancer.go:184
 #: lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484
 #: lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774
 #: lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938
@@ -1146,14 +1160,14 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
-#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
-#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
-#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
-#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
-#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
-#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
-#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:399
+#: lxc/storage_volume.go:623 lxc/storage_volume.go:728
+#: lxc/storage_volume.go:1024 lxc/storage_volume.go:1250
+#: lxc/storage_volume.go:1379 lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1965 lxc/storage_volume.go:2104
+#: lxc/storage_volume.go:2264 lxc/storage_volume.go:2380
+#: lxc/storage_volume.go:2441 lxc/storage_volume.go:2568
+#: lxc/storage_volume.go:2656 lxc/storage_volume.go:2820
 msgid "Cluster member name"
 msgstr ""
 
@@ -1169,7 +1183,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1608
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1209,21 +1223,21 @@ msgstr ""
 #: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
 #: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
-#: lxc/network_acl.go:698 lxc/network_forward.go:767
+#: lxc/network_acl.go:698 lxc/network_forward.go:775
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:639 lxc/network_zone.go:1334 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
-#: lxc/storage_volume.go:1199
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1169
+#: lxc/storage_volume.go:1201
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:620
+#: lxc/storage_volume.go:624
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1478
+#: lxc/storage_volume.go:1480
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1285,7 +1299,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
+#: lxc/storage_volume.go:394 lxc/storage_volume.go:395
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1293,12 +1307,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:401
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:402
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1311,7 +1325,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1406,7 +1420,7 @@ msgstr ""
 msgid "Create and start instances from images"
 msgstr ""
 
-#: lxc/file.go:143 lxc/file.go:462 lxc/file.go:696
+#: lxc/file.go:143 lxc/file.go:474 lxc/file.go:709
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -1446,7 +1460,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:615 lxc/storage_volume.go:616
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1498,12 +1512,12 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1494
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:182
+#: lxc/init.go:186
 #, c-format
 msgid "Creating %s"
 msgstr ""
@@ -1513,7 +1527,7 @@ msgstr ""
 msgid "Creating %s: %%s"
 msgstr ""
 
-#: lxc/init.go:180
+#: lxc/init.go:184
 msgid "Creating the instance"
 msgstr ""
 
@@ -1527,13 +1541,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
+#: lxc/image.go:1139 lxc/image_alias.go:270 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:162 lxc/network_zone.go:846 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1749
+#: lxc/storage_volume.go:1751
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1553,7 +1567,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2653
+#: lxc/storage_volume.go:2655
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1585,7 +1599,7 @@ msgstr ""
 msgid "Delete identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:106 lxc/image_alias.go:107
+#: lxc/image_alias.go:123 lxc/image_alias.go:124
 msgid "Delete image aliases"
 msgstr ""
 
@@ -1609,7 +1623,7 @@ msgstr ""
 msgid "Delete network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:799 lxc/network_forward.go:800
+#: lxc/network_forward.go:807 lxc/network_forward.go:808
 msgid "Delete network forwards"
 msgstr ""
 
@@ -1649,7 +1663,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
+#: lxc/storage_volume.go:724 lxc/storage_volume.go:725
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1691,13 +1705,13 @@ msgstr ""
 #: lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580
 #: lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32
 #: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135
-#: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
-#: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
+#: lxc/file.go:321 lxc/file.go:382 lxc/file.go:468 lxc/file.go:702
+#: lxc/file.go:1228 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
-#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
-#: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
-#: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
+#: lxc/image.go:1091 lxc/image.go:1446 lxc/image.go:1537 lxc/image.go:1603
+#: lxc/image.go:1667 lxc/image.go:1730 lxc/image_alias.go:24
+#: lxc/image_alias.go:60 lxc/image_alias.go:124 lxc/image_alias.go:177
+#: lxc/image_alias.go:288 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
@@ -1711,10 +1725,10 @@ msgstr ""
 #: lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53
 #: lxc/network_forward.go:33 lxc/network_forward.go:90
 #: lxc/network_forward.go:179 lxc/network_forward.go:256
-#: lxc/network_forward.go:404 lxc/network_forward.go:489
-#: lxc/network_forward.go:599 lxc/network_forward.go:646
-#: lxc/network_forward.go:800 lxc/network_forward.go:874
-#: lxc/network_forward.go:889 lxc/network_forward.go:970
+#: lxc/network_forward.go:412 lxc/network_forward.go:497
+#: lxc/network_forward.go:607 lxc/network_forward.go:654
+#: lxc/network_forward.go:808 lxc/network_forward.go:882
+#: lxc/network_forward.go:897 lxc/network_forward.go:982
 #: lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94
 #: lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258
 #: lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476
@@ -1754,27 +1768,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
-#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
-#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
-#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
-#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
-#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
-#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
-#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
-#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
-#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
-#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:286
+#: lxc/storage_volume.go:395 lxc/storage_volume.go:616
+#: lxc/storage_volume.go:725 lxc/storage_volume.go:812
+#: lxc/storage_volume.go:914 lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1236 lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1526 lxc/storage_volume.go:1610
+#: lxc/storage_volume.go:1863 lxc/storage_volume.go:1962
+#: lxc/storage_volume.go:2089 lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2368 lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2566 lxc/storage_volume.go:2649
+#: lxc/storage_volume.go:2815 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1465
+#: lxc/storage_volume.go:1467
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
+#: lxc/storage_volume.go:400 lxc/storage_volume.go:1868
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1786,11 +1800,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:811 lxc/storage_volume.go:812
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
+#: lxc/storage_volume.go:913 lxc/storage_volume.go:914
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1840,7 +1854,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:403
+#: lxc/init.go:407
 msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
@@ -1852,7 +1866,7 @@ msgstr ""
 msgid "Directory to run the command in (default /root)"
 msgstr ""
 
-#: lxc/file.go:1216
+#: lxc/file.go:1236
 msgid "Disable authentication when using SSH SFTP listener"
 msgstr ""
 
@@ -1948,7 +1962,7 @@ msgstr ""
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:377 lxc/file.go:378
+#: lxc/file.go:381 lxc/file.go:382
 msgid "Edit files in instances"
 msgstr ""
 
@@ -1988,7 +2002,7 @@ msgstr ""
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/network_forward.go:645 lxc/network_forward.go:646
+#: lxc/network_forward.go:653 lxc/network_forward.go:654
 msgid "Edit network forward configurations as YAML"
 msgstr ""
 
@@ -2028,7 +2042,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1014 lxc/storage_volume.go:1015
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2036,7 +2050,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1785
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2090,11 +2104,11 @@ msgid "Error retrieving aliases: %w"
 msgstr ""
 
 #: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
-#: lxc/network_acl.go:524 lxc/network_forward.go:572
+#: lxc/network_acl.go:524 lxc/network_forward.go:580
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:477 lxc/network_zone.go:1165 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
+#: lxc/storage_volume.go:2180 lxc/storage_volume.go:2218
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2105,11 +2119,11 @@ msgid "Error unsetting properties: %v"
 msgstr ""
 
 #: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
-#: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
+#: lxc/network_forward.go:574 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:471 lxc/network_zone.go:1159
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
-#: lxc/storage_volume.go:2210
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2174
+#: lxc/storage_volume.go:2212
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2151,8 +2165,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
-#: lxc/storage_volume.go:1575
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1527
+#: lxc/storage_volume.go:1577
 msgid "Expires at"
 msgstr ""
 
@@ -2176,7 +2190,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2648 lxc/storage_volume.go:2649
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2188,11 +2202,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2650
+#: lxc/storage_volume.go:2652
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2779
+#: lxc/export.go:152 lxc/storage_volume.go:2781
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2211,7 +2225,7 @@ msgid "FILENAME"
 msgstr ""
 
 #: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
-#: lxc/image_alias.go:235
+#: lxc/image_alias.go:268
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -2219,12 +2233,12 @@ msgstr ""
 msgid "FIRST SEEN"
 msgstr ""
 
-#: lxc/file.go:1467
+#: lxc/file.go:1491
 #, c-format
 msgid "Failed SSH handshake with client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1490
+#: lxc/file.go:1514
 #, c-format
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
@@ -2239,12 +2253,12 @@ msgstr ""
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/file.go:1517
+#: lxc/file.go:1541
 #, c-format
 msgid "Failed connecting to instance SFTP for client %q: %v"
 msgstr ""
 
-#: lxc/file.go:1302
+#: lxc/file.go:1326
 #, c-format
 msgid "Failed connecting to instance SFTP: %w"
 msgstr ""
@@ -2274,7 +2288,7 @@ msgstr ""
 msgid "Failed fetching fingerprint %q: %w"
 msgstr ""
 
-#: lxc/file.go:1423
+#: lxc/file.go:1447
 #, c-format
 msgid "Failed generating SSH host key: %w"
 msgstr ""
@@ -2289,7 +2303,7 @@ msgstr ""
 msgid "Failed loading profile %q: %w"
 msgstr ""
 
-#: lxc/file.go:1428
+#: lxc/file.go:1452
 #, c-format
 msgid "Failed parsing SSH host key: %w"
 msgstr ""
@@ -2299,12 +2313,12 @@ msgstr ""
 msgid "Failed starting command: %w"
 msgstr ""
 
-#: lxc/file.go:1328
+#: lxc/file.go:1352
 #, c-format
 msgid "Failed starting sshfs: %w"
 msgstr ""
 
-#: lxc/file.go:1455
+#: lxc/file.go:1479
 #, c-format
 msgid "Failed to accept incoming connection: %w"
 msgstr ""
@@ -2318,7 +2332,7 @@ msgstr ""
 msgid "Failed to close server cert file %q: %w"
 msgstr ""
 
-#: lxc/move.go:304 lxc/move.go:380
+#: lxc/move.go:309 lxc/move.go:385
 #, c-format
 msgid "Failed to connect to cluster member: %w"
 msgstr ""
@@ -2343,7 +2357,7 @@ msgstr ""
 msgid "Failed to find project: %w"
 msgstr ""
 
-#: lxc/file.go:1440
+#: lxc/file.go:1464
 #, c-format
 msgid "Failed to listen for connection: %w"
 msgstr ""
@@ -2358,7 +2372,7 @@ msgstr ""
 msgid "Failed to remove alias %s: %w"
 msgstr ""
 
-#: lxc/file.go:1042
+#: lxc/file.go:1062
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -2445,14 +2459,14 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/image.go:1118 lxc/image_alias.go:182 lxc/list.go:133 lxc/network.go:1010
 #: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:90 lxc/network_zone.go:788
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1625 lxc/warning.go:94
+#: lxc/storage_volume.go:1627 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2520,7 +2534,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1601 lxc/image.go:1602
+#: lxc/image.go:1602 lxc/image.go:1603
 msgid "Get image properties"
 msgstr ""
 
@@ -2536,7 +2550,7 @@ msgstr ""
 msgid "Get the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:406
+#: lxc/network_forward.go:414
 msgid "Get the key as a network forward property"
 msgstr ""
 
@@ -2576,7 +2590,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1249
+#: lxc/storage_volume.go:1251
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2604,7 +2618,7 @@ msgstr ""
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:403 lxc/network_forward.go:404
+#: lxc/network_forward.go:411 lxc/network_forward.go:412
 msgid "Get values for network forward configuration keys"
 msgstr ""
 
@@ -2640,11 +2654,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
+#: lxc/storage_volume.go:1235 lxc/storage_volume.go:1236
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:476
+#: lxc/storage_volume.go:480
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2684,22 +2698,22 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/file.go:1540
+#: lxc/file.go:1564
 #, c-format
 msgid "I/O copy from SSH to instance failed: %v"
 msgstr ""
 
-#: lxc/file.go:1529
+#: lxc/file.go:1553
 #, c-format
 msgid "I/O copy from instance to SSH failed: %v"
 msgstr ""
 
-#: lxc/file.go:1352
+#: lxc/file.go:1376
 #, c-format
 msgid "I/O copy from instance to sshfs failed: %v"
 msgstr ""
 
-#: lxc/file.go:1362
+#: lxc/file.go:1386
 #, c-format
 msgid "I/O copy from sshfs to instance failed: %v"
 msgstr ""
@@ -2772,11 +2786,11 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2440
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:406
+#: lxc/main.go:415
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2786,7 +2800,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2437
+#: lxc/storage_volume.go:2439
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2798,7 +2812,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1517
+#: lxc/image.go:1518
 msgid "Image already up to date."
 msgstr ""
 
@@ -2814,11 +2828,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1472
+#: lxc/image.go:364 lxc/image.go:1473
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1698
+#: lxc/image.go:444 lxc/image.go:1699
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2828,7 +2842,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1515
+#: lxc/image.go:1516
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2836,7 +2850,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2813
+#: lxc/storage_volume.go:2815
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2844,7 +2858,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2812
+#: lxc/storage_volume.go:2814
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2866,11 +2880,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2820
+#: lxc/storage_volume.go:2822
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2894
+#: lxc/storage_volume.go:2896
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2896,11 +2910,11 @@ msgstr ""
 msgid "Instance Only"
 msgstr ""
 
-#: lxc/file.go:1354
+#: lxc/file.go:1378
 msgid "Instance disconnected"
 msgstr ""
 
-#: lxc/file.go:1531
+#: lxc/file.go:1555
 #, c-format
 msgid "Instance disconnected for client %q"
 msgstr ""
@@ -2909,7 +2923,7 @@ msgstr ""
 msgid "Instance name is mandatory"
 msgstr ""
 
-#: lxc/init.go:414
+#: lxc/init.go:418
 #, c-format
 msgid "Instance name is: %s"
 msgstr ""
@@ -2918,7 +2932,7 @@ msgstr ""
 msgid "Instance name must be specified"
 msgstr ""
 
-#: lxc/file.go:1274
+#: lxc/file.go:1298
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
@@ -2970,7 +2984,7 @@ msgstr ""
 msgid "Invalid instance name: %s"
 msgstr ""
 
-#: lxc/file.go:1269
+#: lxc/file.go:1293
 #, c-format
 msgid "Invalid instance path: %q"
 msgstr ""
@@ -2996,23 +3010,23 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2023
+#: lxc/move.go:153 lxc/storage_volume.go:2025
 msgid "Invalid new snapshot name"
 msgstr ""
 
-#: lxc/move.go:144
+#: lxc/move.go:149
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2019
+#: lxc/storage_volume.go:2021
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:509
+#: lxc/main.go:518
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:353
+#: lxc/file.go:357
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -3022,18 +3036,18 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
-#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
-#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
+#: lxc/storage_volume.go:1083 lxc/storage_volume.go:1300
+#: lxc/storage_volume.go:1424 lxc/storage_volume.go:2010
+#: lxc/storage_volume.go:2157 lxc/storage_volume.go:2309
 msgid "Invalid snapshot name"
 msgstr ""
 
-#: lxc/file.go:535
+#: lxc/file.go:548
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:185 lxc/file.go:717
+#: lxc/file.go:185 lxc/file.go:739
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -3070,7 +3084,7 @@ msgstr ""
 
 #: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1758 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3101,12 +3115,12 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/init.go:176
+#: lxc/init.go:180
 #, c-format
 msgid "Launching %s"
 msgstr ""
 
-#: lxc/init.go:174
+#: lxc/init.go:178
 msgid "Launching the instance"
 msgstr ""
 
@@ -3204,11 +3218,11 @@ msgstr ""
 msgid "List identity provider groups"
 msgstr ""
 
-#: lxc/image_alias.go:151
+#: lxc/image_alias.go:176
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:152
+#: lxc/image_alias.go:177
 msgid ""
 "List image aliases\n"
 "\n"
@@ -3375,11 +3389,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1603
+#: lxc/storage_volume.go:1605
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1610
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3438,7 +3452,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1481
+#: lxc/info.go:489 lxc/storage_volume.go:1483
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3624,7 +3638,7 @@ msgstr ""
 msgid "Manage network ACLs"
 msgstr ""
 
-#: lxc/network_forward.go:873 lxc/network_forward.go:874
+#: lxc/network_forward.go:881 lxc/network_forward.go:882
 msgid "Manage network forward ports"
 msgstr ""
 
@@ -3770,12 +3784,12 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:322 lxc/move.go:435
+#: lxc/move.go:327 lxc/move.go:440
 #, c-format
 msgid "Migration API failure: %w"
 msgstr ""
 
-#: lxc/move.go:347 lxc/move.go:440
+#: lxc/move.go:352 lxc/move.go:445
 #, c-format
 msgid "Migration operation failure: %w"
 msgstr ""
@@ -3840,10 +3854,10 @@ msgstr ""
 msgid "Missing key name"
 msgstr ""
 
-#: lxc/network_forward.go:219 lxc/network_forward.go:449
-#: lxc/network_forward.go:534 lxc/network_forward.go:709
-#: lxc/network_forward.go:840 lxc/network_forward.go:933
-#: lxc/network_forward.go:1015 lxc/network_load_balancer.go:221
+#: lxc/network_forward.go:219 lxc/network_forward.go:457
+#: lxc/network_forward.go:542 lxc/network_forward.go:717
+#: lxc/network_forward.go:848 lxc/network_forward.go:945
+#: lxc/network_forward.go:1031 lxc/network_load_balancer.go:221
 #: lxc/network_load_balancer.go:436 lxc/network_load_balancer.go:521
 #: lxc/network_load_balancer.go:679 lxc/network_load_balancer.go:811
 #: lxc/network_load_balancer.go:899 lxc/network_load_balancer.go:975
@@ -3868,10 +3882,10 @@ msgstr ""
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
 #: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
 #: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
-#: lxc/network_forward.go:284 lxc/network_forward.go:445
-#: lxc/network_forward.go:530 lxc/network_forward.go:705
-#: lxc/network_forward.go:836 lxc/network_forward.go:929
-#: lxc/network_forward.go:1011 lxc/network_load_balancer.go:131
+#: lxc/network_forward.go:292 lxc/network_forward.go:453
+#: lxc/network_forward.go:538 lxc/network_forward.go:713
+#: lxc/network_forward.go:844 lxc/network_forward.go:941
+#: lxc/network_forward.go:1027 lxc/network_load_balancer.go:131
 #: lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286
 #: lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517
 #: lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807
@@ -3907,13 +3921,13 @@ msgstr ""
 #: lxc/storage_bucket.go:565 lxc/storage_bucket.go:657
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
-#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
-#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
-#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
-#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
+#: lxc/storage_bucket.go:1185 lxc/storage_volume.go:211
+#: lxc/storage_volume.go:328 lxc/storage_volume.go:654
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:852
+#: lxc/storage_volume.go:954 lxc/storage_volume.go:1072
+#: lxc/storage_volume.go:1289 lxc/storage_volume.go:1999
+#: lxc/storage_volume.go:2140 lxc/storage_volume.go:2298
+#: lxc/storage_volume.go:2489 lxc/storage_volume.go:2606
 msgid "Missing pool name"
 msgstr ""
 
@@ -3932,15 +3946,15 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
+#: lxc/storage_volume.go:443 lxc/storage_volume.go:1909
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1411
+#: lxc/storage_volume.go:1413
 msgid "Missing storage pool name"
 msgstr ""
 
-#: lxc/file.go:820
+#: lxc/file.go:842
 msgid "Missing target directory"
 msgstr ""
 
@@ -3973,16 +3987,16 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
-#: lxc/storage_volume.go:975
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:876
+#: lxc/storage_volume.go:977
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:507
+#: lxc/file.go:520
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/file.go:1207 lxc/file.go:1208
+#: lxc/file.go:1227 lxc/file.go:1228
 msgid "Mount files from instances"
 msgstr ""
 
@@ -4011,7 +4025,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
+#: lxc/storage_volume.go:1862 lxc/storage_volume.go:1863
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4019,16 +4033,16 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1867
+#: lxc/storage_volume.go:1869
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
 
-#: lxc/network_forward.go:1059 lxc/network_load_balancer.go:1206
+#: lxc/network_forward.go:1075 lxc/network_load_balancer.go:1206
 msgid "Multiple ports match. Use --force to remove them all"
 msgstr ""
 
@@ -4050,7 +4064,7 @@ msgstr ""
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:161
 #: lxc/network_zone.go:845 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1750
 msgid "NAME"
 msgstr ""
 
@@ -4102,8 +4116,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
-#: lxc/storage_volume.go:1573
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Name"
 msgstr ""
 
@@ -4111,7 +4125,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1465
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4166,12 +4180,12 @@ msgstr ""
 msgid "Network Zone %s deleted"
 msgstr ""
 
-#: lxc/network_forward.go:386
+#: lxc/network_forward.go:394
 #, c-format
 msgid "Network forward %s created"
 msgstr ""
 
-#: lxc/network_forward.go:857
+#: lxc/network_forward.go:865
 #, c-format
 msgid "Network forward %s deleted"
 msgstr ""
@@ -4255,7 +4269,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
+#: lxc/storage_volume.go:885 lxc/storage_volume.go:986
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4263,7 +4277,7 @@ msgstr ""
 msgid "No matching backend found"
 msgstr ""
 
-#: lxc/network_forward.go:1070 lxc/network_load_balancer.go:1217
+#: lxc/network_forward.go:1086 lxc/network_load_balancer.go:1217
 msgid "No matching port(s) found"
 msgstr ""
 
@@ -4275,11 +4289,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:457 lxc/storage_volume.go:1918
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:507 lxc/storage_volume.go:1929
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4293,7 +4307,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2035
+#: lxc/storage_volume.go:2037
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4301,16 +4315,21 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
-#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
-msgid "Only \"custom\" volumes can be attached to instances"
+#: lxc/storage_volume.go:216
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2701
+#: lxc/storage_volume.go:348
+msgid ""
+"Only \"custom\" and \"virtual-machine\" volumes can be attached to profiles"
+msgstr ""
+
+#: lxc/storage_volume.go:2703
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2500
+#: lxc/storage_volume.go:2502
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4322,7 +4341,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1429
+#: lxc/storage_volume.go:1431
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4335,7 +4354,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1577
+#: lxc/info.go:705 lxc/storage_volume.go:1579
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4365,7 +4384,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1767
+#: lxc/storage_volume.go:1769
 msgid "POOL"
 msgstr ""
 
@@ -4382,7 +4401,7 @@ msgid "PROFILES"
 msgstr ""
 
 #: lxc/image.go:1140 lxc/list.go:567 lxc/network_zone.go:167
-#: lxc/storage_volume.go:1773 lxc/warning.go:213
+#: lxc/storage_volume.go:1775 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4406,7 +4425,7 @@ msgstr ""
 msgid "Partitions:"
 msgstr ""
 
-#: lxc/main.go:367
+#: lxc/main.go:376
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -4444,7 +4463,7 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/file.go:1332
+#: lxc/file.go:1356
 msgid "Press ctrl+c to finish"
 msgstr ""
 
@@ -4452,12 +4471,12 @@ msgstr ""
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
-#: lxc/network_acl.go:699 lxc/network_forward.go:768
+#: lxc/network_acl.go:699 lxc/network_forward.go:776
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:640 lxc/network_zone.go:1335 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
-#: lxc/storage_volume.go:1200
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1170
+#: lxc/storage_volume.go:1202
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4570,11 +4589,11 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1649
+#: lxc/image.go:1650
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1367
+#: lxc/storage_volume.go:1369
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4588,7 +4607,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1236
+#: lxc/storage_volume.go:1238
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4604,7 +4623,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2247
+#: lxc/storage_volume.go:2249
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4625,7 +4644,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1015
+#: lxc/storage_volume.go:1017
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4634,7 +4653,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2094
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4647,7 +4666,7 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2370
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4678,20 +4697,20 @@ msgstr ""
 msgid "Publishing instance: %s"
 msgstr ""
 
-#: lxc/file.go:455 lxc/file.go:456
+#: lxc/file.go:467 lxc/file.go:468
 msgid "Pull files from instances"
 msgstr ""
 
-#: lxc/file.go:638 lxc/file.go:989
+#: lxc/file.go:651 lxc/file.go:1009
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:688 lxc/file.go:689
+#: lxc/file.go:701 lxc/file.go:702
 msgid "Push files into instances"
 msgstr ""
 
-#: lxc/file.go:923 lxc/file.go:1089
+#: lxc/file.go:943 lxc/file.go:1109
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -4700,7 +4719,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1540
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4729,15 +4748,15 @@ msgstr ""
 msgid "Rebuild instances"
 msgstr ""
 
-#: lxc/file.go:463 lxc/file.go:695
+#: lxc/file.go:475 lxc/file.go:708
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:403
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1444 lxc/image.go:1445
+#: lxc/image.go:1445 lxc/image.go:1446
 msgid "Refresh images"
 msgstr ""
 
@@ -4746,7 +4765,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1481
+#: lxc/image.go:1482
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4823,7 +4842,7 @@ msgstr ""
 msgid "Remove aliases"
 msgstr ""
 
-#: lxc/network_forward.go:971 lxc/network_load_balancer.go:1122
+#: lxc/network_forward.go:983 lxc/network_load_balancer.go:1122
 msgid "Remove all ports that match"
 msgstr ""
 
@@ -4859,7 +4878,7 @@ msgstr ""
 msgid "Remove permissions from groups"
 msgstr ""
 
-#: lxc/network_forward.go:969 lxc/network_forward.go:970
+#: lxc/network_forward.go:981 lxc/network_forward.go:982
 msgid "Remove ports from a forward"
 msgstr ""
 
@@ -4895,8 +4914,8 @@ msgstr ""
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:254
-#: lxc/image_alias.go:255
+#: lxc/alias.go:158 lxc/alias.go:159 lxc/image_alias.go:287
+#: lxc/image_alias.go:288
 msgid "Rename aliases"
 msgstr ""
 
@@ -4932,15 +4951,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:1962
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1959
+#: lxc/storage_volume.go:1961
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
+#: lxc/storage_volume.go:2050 lxc/storage_volume.go:2070
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4992,7 +5011,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
+#: lxc/storage_volume.go:2565 lxc/storage_volume.go:2566
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5009,7 +5028,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:357
+#: lxc/init.go:361
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -5058,12 +5077,12 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/file.go:1460
+#: lxc/file.go:1484
 #, c-format
 msgid "SSH client connected %q"
 msgstr ""
 
-#: lxc/file.go:1461
+#: lxc/file.go:1485
 #, c-format
 msgid "SSH client disconnected %q"
 msgstr ""
@@ -5139,7 +5158,7 @@ msgstr ""
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
-#: lxc/file.go:1217
+#: lxc/file.go:1237
 msgid "Set authentication user when using SSH SFTP listener"
 msgstr ""
 
@@ -5165,7 +5184,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1665 lxc/image.go:1666
+#: lxc/image.go:1666 lxc/image.go:1667
 msgid "Set image properties"
 msgstr ""
 
@@ -5208,11 +5227,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/network_forward.go:488
+#: lxc/network_forward.go:496
 msgid "Set network forward keys"
 msgstr ""
 
-#: lxc/network_forward.go:489
+#: lxc/network_forward.go:497
 msgid ""
 "Set network forward keys\n"
 "\n"
@@ -5316,11 +5335,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2086
+#: lxc/storage_volume.go:2088
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2087
+#: lxc/storage_volume.go:2089
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5337,7 +5356,7 @@ msgstr ""
 msgid "Set the file's gid on create"
 msgstr ""
 
-#: lxc/file.go:698
+#: lxc/file.go:711
 msgid "Set the file's gid on push"
 msgstr ""
 
@@ -5345,7 +5364,7 @@ msgstr ""
 msgid "Set the file's perms on create"
 msgstr ""
 
-#: lxc/file.go:699
+#: lxc/file.go:712
 msgid "Set the file's perms on push"
 msgstr ""
 
@@ -5353,7 +5372,7 @@ msgstr ""
 msgid "Set the file's uid on create"
 msgstr ""
 
-#: lxc/file.go:697
+#: lxc/file.go:710
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -5365,7 +5384,7 @@ msgstr ""
 msgid "Set the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:496
+#: lxc/network_forward.go:504
 msgid "Set the key as a network forward property"
 msgstr ""
 
@@ -5405,7 +5424,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2103
+#: lxc/storage_volume.go:2105
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5413,7 +5432,7 @@ msgstr ""
 msgid "Set the key as an instance property"
 msgstr ""
 
-#: lxc/file.go:1215
+#: lxc/file.go:1235
 msgid "Setup SSH SFTP listener on address:port instead of mounting"
 msgstr ""
 
@@ -5470,7 +5489,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1535 lxc/image.go:1536
+#: lxc/image.go:1536 lxc/image.go:1537
 msgid "Show image properties"
 msgstr ""
 
@@ -5490,7 +5509,7 @@ msgstr ""
 msgid "Show instance or server information"
 msgstr ""
 
-#: lxc/main.go:271 lxc/main.go:272
+#: lxc/main.go:280 lxc/main.go:281
 msgid "Show less common commands"
 msgstr ""
 
@@ -5554,11 +5573,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2246 lxc/storage_volume.go:2247
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1367
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5626,15 +5645,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2429 lxc/storage_volume.go:2430
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2190
+#: lxc/storage_volume.go:2192
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1502
+#: lxc/info.go:619 lxc/storage_volume.go:1504
 msgid "Snapshots:"
 msgstr ""
 
@@ -5739,21 +5758,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:703
+#: lxc/storage_volume.go:707
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:791
+#: lxc/storage_volume.go:795
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:516
+#: lxc/storage_volume.go:520
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:520
+#: lxc/storage_volume.go:524
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5815,21 +5834,21 @@ msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/image_alias.go:269 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1747 lxc/warning.go:216
+#: lxc/storage_volume.go:1749 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1576
 msgid "Taken at"
 msgstr ""
 
-#: lxc/file.go:1262
+#: lxc/file.go:1286
 msgid "Target path and --listen flag cannot be used together"
 msgstr ""
 
-#: lxc/file.go:1256
+#: lxc/file.go:1280
 msgid "Target path must be a directory"
 msgstr ""
 
@@ -5839,15 +5858,15 @@ msgid ""
 "trust token"
 msgstr ""
 
-#: lxc/move.go:181
+#: lxc/move.go:186
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:219 lxc/move.go:240
+#: lxc/move.go:224 lxc/move.go:245
 msgid "The --mode flag can't be used with --storage or --target-project"
 msgstr ""
 
-#: lxc/move.go:193
+#: lxc/move.go:198
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
@@ -5855,15 +5874,15 @@ msgstr ""
 msgid "The --show-log flag is only supported for by 'console' output type"
 msgstr ""
 
-#: lxc/move.go:185
+#: lxc/move.go:190
 msgid "The --storage flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:189
+#: lxc/move.go:194
 msgid "The --target-project flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:205
+#: lxc/move.go:210
 msgid "The destination LXD server is not clustered"
 msgstr ""
 
@@ -5885,7 +5904,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:435
+#: lxc/init.go:439
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -5938,7 +5957,7 @@ msgstr ""
 msgid "The property %q does not exist on the network ACL %q: %v"
 msgstr ""
 
-#: lxc/network_forward.go:462
+#: lxc/network_forward.go:470
 #, c-format
 msgid "The property %q does not exist on the network forward %q: %v"
 msgstr ""
@@ -5978,12 +5997,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1340
+#: lxc/storage_volume.go:1342
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1317
+#: lxc/storage_volume.go:1319
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -5998,12 +6017,12 @@ msgstr ""
 msgid "The server doesn't implement the newer v2 resources API"
 msgstr ""
 
-#: lxc/move.go:309
+#: lxc/move.go:314
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
-#: lxc/storage_volume.go:989
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:890
+#: lxc/storage_volume.go:991
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6031,7 +6050,7 @@ msgstr ""
 msgid "This LXD server is not available on the network"
 msgstr ""
 
-#: lxc/main.go:298
+#: lxc/main.go:307
 msgid ""
 "This client hasn't been configured to use a remote LXD server yet.\n"
 "As your platform can't run native Linux instances, you must connect to a "
@@ -6055,11 +6074,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:437
+#: lxc/init.go:441
 msgid "To attach a network to an instance, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:436
+#: lxc/init.go:440
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -6067,7 +6086,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:412
+#: lxc/main.go:421
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6078,7 +6097,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1487
+#: lxc/storage_volume.go:1489
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6093,7 +6112,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1864
+#: lxc/storage_volume.go:1866
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6101,7 +6120,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:394
+#: lxc/storage_volume.go:398
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6118,7 +6137,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/copy.go:382 lxc/move.go:327
+#: lxc/copy.go:382 lxc/move.go:332
 #, c-format
 msgid "Transferring instance: %s"
 msgstr ""
@@ -6160,7 +6179,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1472
+#: lxc/storage_volume.go:1474
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6182,13 +6201,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1752
+#: lxc/project.go:995 lxc/storage_volume.go:1754
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:163 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1751
+#: lxc/storage.go:724 lxc/storage_volume.go:1753
 msgid "USED BY"
 msgstr ""
 
@@ -6201,7 +6220,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:411
+#: lxc/file.go:423
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -6215,12 +6234,12 @@ msgstr ""
 msgid "Unknown certificate type %q"
 msgstr ""
 
-#: lxc/file.go:1483
+#: lxc/file.go:1507
 #, c-format
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1791
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6231,7 +6250,7 @@ msgstr ""
 msgid "Unknown console type %q"
 msgstr ""
 
-#: lxc/file.go:1029
+#: lxc/file.go:1049
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -6262,7 +6281,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1728 lxc/image.go:1729
+#: lxc/image.go:1729 lxc/image.go:1730
 msgid "Unset image properties"
 msgstr ""
 
@@ -6278,11 +6297,11 @@ msgstr ""
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:598
+#: lxc/network_forward.go:606
 msgid "Unset network forward configuration keys"
 msgstr ""
 
-#: lxc/network_forward.go:599
+#: lxc/network_forward.go:607
 msgid "Unset network forward keys"
 msgstr ""
 
@@ -6326,7 +6345,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
+#: lxc/storage_volume.go:2367 lxc/storage_volume.go:2368
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6338,7 +6357,7 @@ msgstr ""
 msgid "Unset the key as a network ACL property"
 msgstr ""
 
-#: lxc/network_forward.go:602
+#: lxc/network_forward.go:610
 msgid "Unset the key as a network forward property"
 msgstr ""
 
@@ -6378,7 +6397,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2379
+#: lxc/storage_volume.go:2381
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6386,7 +6405,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:248
+#: lxc/storage_volume.go:250
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6422,12 +6441,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1485
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2652
+#: lxc/export.go:42 lxc/storage_volume.go:2654
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6494,7 +6513,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1576
+#: lxc/storage_volume.go:1578
 msgid "Volume Only"
 msgstr ""
 
@@ -6545,7 +6564,7 @@ msgstr ""
 msgid "You must specify a destination instance name"
 msgstr ""
 
-#: lxc/copy.go:98 lxc/move.go:293 lxc/move.go:369
+#: lxc/copy.go:98 lxc/move.go:298 lxc/move.go:374
 msgid "You must specify a source instance name"
 msgstr ""
 
@@ -6553,12 +6572,12 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:909
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
+#: lxc/storage_volume.go:912
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:282
-msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
+#: lxc/storage_volume.go:284
+msgid "[<remote:>]<pool> [<type>/]<volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
@@ -6590,7 +6609,7 @@ msgstr ""
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:174
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
@@ -6643,7 +6662,7 @@ msgstr ""
 msgid "[<remote>:]<Zone> [key=value...]"
 msgstr ""
 
-#: lxc/image_alias.go:104
+#: lxc/image_alias.go:121
 msgid "[<remote>:]<alias>"
 msgstr ""
 
@@ -6651,7 +6670,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/image_alias.go:252
+#: lxc/image_alias.go:285
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
@@ -6705,15 +6724,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1535
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1600 lxc/image.go:1727
+#: lxc/image.go:1601 lxc/image.go:1728
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1664
+#: lxc/image.go:1665
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6733,7 +6752,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1443
+#: lxc/image.go:334 lxc/image.go:1444
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -6804,7 +6823,7 @@ msgstr ""
 msgid "[<remote>:]<instance> [target] [--instance-only] [--optimized-storage]"
 msgstr ""
 
-#: lxc/file.go:376
+#: lxc/file.go:380
 msgid "[<remote>:]<instance>/<path>"
 msgstr ""
 
@@ -6816,12 +6835,12 @@ msgstr ""
 msgid "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...]"
 msgstr ""
 
-#: lxc/file.go:454
+#: lxc/file.go:466
 msgid ""
 "[<remote>:]<instance>/<path> [[<remote>:]<instance>/<path>...] <target path>"
 msgstr ""
 
-#: lxc/file.go:1206
+#: lxc/file.go:1226
 msgid "[<remote>:]<instance>[/<path>] [<target path>]"
 msgstr ""
 
@@ -6889,8 +6908,8 @@ msgstr ""
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/network_forward.go:177 lxc/network_forward.go:644
-#: lxc/network_forward.go:797 lxc/network_load_balancer.go:179
+#: lxc/network_forward.go:177 lxc/network_forward.go:652
+#: lxc/network_forward.go:805 lxc/network_load_balancer.go:179
 #: lxc/network_load_balancer.go:614 lxc/network_load_balancer.go:768
 msgid "[<remote>:]<network> <listen_address>"
 msgstr ""
@@ -6905,12 +6924,12 @@ msgid ""
 "[<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:402 lxc/network_forward.go:597
+#: lxc/network_forward.go:410 lxc/network_forward.go:605
 #: lxc/network_load_balancer.go:406 lxc/network_load_balancer.go:584
 msgid "[<remote>:]<network> <listen_address> <key>"
 msgstr ""
 
-#: lxc/network_forward.go:487 lxc/network_load_balancer.go:474
+#: lxc/network_forward.go:495 lxc/network_load_balancer.go:474
 msgid "[<remote>:]<network> <listen_address> <key>=<value>..."
 msgstr ""
 
@@ -6920,13 +6939,13 @@ msgid ""
 "<backend_name>[,<backend_name>...]"
 msgstr ""
 
-#: lxc/network_forward.go:887
+#: lxc/network_forward.go:895
 msgid ""
 "[<remote>:]<network> <listen_address> <protocol> <listen_port(s)> "
 "<target_address> [<target_port(s)>]"
 msgstr ""
 
-#: lxc/network_forward.go:968 lxc/network_load_balancer.go:1119
+#: lxc/network_forward.go:980 lxc/network_load_balancer.go:1119
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
@@ -6981,7 +7000,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2811
+#: lxc/storage_volume.go:2813
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7016,65 +7035,65 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1958
+#: lxc/storage_volume.go:1960
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:806
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
-msgstr ""
-
-#: lxc/storage_volume.go:167
-msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
-msgstr ""
-
-#: lxc/storage_volume.go:2562
+#: lxc/storage_volume.go:2564
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2645
+#: lxc/storage_volume.go:2647
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2428
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:610
+#: lxc/storage_volume.go:614
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:718
+#: lxc/storage_volume.go:722
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
+#: lxc/storage_volume.go:1013 lxc/storage_volume.go:1365
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2364
+#: lxc/storage_volume.go:810
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>]"
+msgstr ""
+
+#: lxc/storage_volume.go:167
+msgid "[<remote>:]<pool> [<type>/]<volume> <instance> [<device name>] [<path>]"
+msgstr ""
+
+#: lxc/storage_volume.go:2366
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2085
+#: lxc/storage_volume.go:2087
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2243
+#: lxc/storage_volume.go:2245
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1232
+#: lxc/storage_volume.go:1234
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1858
+#: lxc/storage_volume.go:1860
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:388
+#: lxc/storage_volume.go:392
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7180,7 +7199,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1601
+#: lxc/storage_volume.go:1603
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7342,20 +7361,20 @@ msgid ""
 "\t   To create a symlink /bar in instance foo whose target is baz."
 msgstr ""
 
-#: lxc/file.go:1210
+#: lxc/file.go:1230
 msgid ""
 "lxc file mount foo/root fooroot\n"
 "   To mount /root from the instance foo onto the local fooroot directory."
 msgstr ""
 
-#: lxc/file.go:458
+#: lxc/file.go:470
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the instance and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:691
+#: lxc/file.go:704
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the instance \"foo\"."
@@ -7656,7 +7675,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:614
+#: lxc/storage_volume.go:618
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7664,13 +7683,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2815
+#: lxc/storage_volume.go:2817
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2430
+#: lxc/storage_volume.go:2432
 msgid ""
 "lxc storage volume snapshot default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -7704,16 +7723,16 @@ msgstr ""
 msgid "space used"
 msgstr ""
 
-#: lxc/file.go:1372
+#: lxc/file.go:1396
 msgid "sshfs has stopped"
 msgstr ""
 
-#: lxc/file.go:1331
+#: lxc/file.go:1355
 #, c-format
 msgid "sshfs mounting %q on %q"
 msgstr ""
 
-#: lxc/file.go:1284
+#: lxc/file.go:1308
 msgid "sshfs not found. Try SSH SFTP mode using the --listen flag"
 msgstr ""
 

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -430,6 +430,7 @@ var APIExtensions = []string{
 	"storage_ceph_osd_pool_size",
 	"network_get_target",
 	"network_zones_all_projects",
+	"instance_root_volume_attachment",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
Includes commits from #14491 

This PR enables attaching a virtual machine's root storage volume to another virtual machine via a disk device:
```
# vm2 yaml
...
devices:
  v1-root:
    type: disk
    pool: default
    source: virtual-machine/vm1
```

This has some constraints because simultaneous access to storage volumes with content-type `block` is unsafe:
- `vm1`'s root volume can be attached to exactly one other instance if `vm1` has `security.protection.start: true`
- `vm1`'s root volume can be attached to any number of other instances if the storage volume `virtual-machine/vm1` has `security.shared: true`

`security.protection.start` is recommended for interactive use; e.g. a user temporarily needs to access a bricked machine's root volume to fix it or recover data. `security.shared` can be used if more than one running instance must have access to the block volume.

## TODO
- [x] Docs
- [x] [lxd-ci](https://github.com/canonical/lxd-ci/) tests to validate attachments to running VMs. [Done](https://github.com/canonical/lxd-ci/pull/366)
- [x] Bootorder bug (see comment) - current workaround is to hotplug disk devices to avoid UUID/LABEL collisions at boot time.