### PR TITLE
lxd/storage: Remove `security.shared` from cephfs keys

### DIFF
--- a/doc/metadata.txt
+++ b/doc/metadata.txt
@@ -5090,15 +5090,6 @@ when creating a missing OSD pool.
 
 <!-- config group storage-cephfs-pool-conf end -->
 <!-- config group storage-cephfs-volume-conf start -->
-```{config:option} security.shared storage-cephfs-volume-conf
-:condition: "custom block volume"
-:defaultdesc: "same as `volume.security.shared` or `false`"
-:shortdesc: "Enable volume sharing"
-:type: "bool"
-Enabling this option allows sharing the volume across multiple instances despite the possibility of data loss.
-
-```
-
 ```{config:option} security.shifted storage-cephfs-volume-conf
 :condition: "custom volume"
 :defaultdesc: "same as `volume.security.shifted` or `false`"

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -5736,15 +5736,6 @@
 			"volume-conf": {
 				"keys": [
 					{
-						"security.shared": {
-							"condition": "custom block volume",
-							"defaultdesc": "same as `volume.security.shared` or `false`",
-							"longdesc": "Enabling this option allows sharing the volume across multiple instances despite the possibility of data loss.\n",
-							"shortdesc": "Enable volume sharing",
-							"type": "bool"
-						}
-					},
-					{
 						"security.shifted": {
 							"condition": "custom volume",
 							"defaultdesc": "same as `volume.security.shifted` or `false`",

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -539,7 +539,7 @@ func poolAndVolumeCommonRules(vol *drivers.Volume) map[string]func(string) error
 
 	// security.shared is only relevant for custom block volumes.
 	if vol == nil || (vol.Type() == drivers.VolumeTypeCustom && vol.ContentType() == drivers.ContentTypeBlock) {
-		// lxdmeta:generate(entities=storage-btrfs,storage-cephfs,storage-ceph,storage-dir,storage-lvm,storage-zfs,storage-powerflex; group=volume-conf; key=security.shared)
+		// lxdmeta:generate(entities=storage-btrfs,storage-ceph,storage-dir,storage-lvm,storage-zfs,storage-powerflex; group=volume-conf; key=security.shared)
 		// Enabling this option allows sharing the volume across multiple instances despite the possibility of data loss.
 		//
 		// ---


### PR DESCRIPTION
cephfs does not support block volumes, thus `security.shared` does not apply to it.

Closes https://github.com/canonical/lxd/issues/14534