### PR TITLE
lxd: Get config for instance on offline cluster member

### DIFF
--- a/lxd/cluster/connect.go
+++ b/lxd/cluster/connect.go
@@ -34,7 +34,7 @@ func Connect(address string, networkCert *shared.CertInfo, serverCert *shared.Ce
 		defer cancel()
 		err := EventListenerWait(ctx, address)
 		if err != nil {
-			return nil, fmt.Errorf("Missing event connection with target cluster member")
+			return nil, api.StatusErrorf(http.StatusServiceUnavailable, "Missing event connection with target cluster member")
 		}
 	}
 

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -8141,6 +8141,11 @@ func (d *lxc) NextIdmap() (*idmap.IdmapSet, error) {
 
 // statusCode returns instance status code.
 func (d *lxc) statusCode() api.StatusCode {
+	// If instance is running on a remote cluster member, we cannot determine instance state.
+	if d.state.ServerName != d.Location() {
+		return api.Error
+	}
+
 	// Shortcut to avoid spamming liblxc during ongoing operations.
 	operationStatus := d.operationStatusCode()
 	if operationStatus != nil {

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -8234,6 +8234,11 @@ func (d *qemu) InitPID() int {
 }
 
 func (d *qemu) statusCode() api.StatusCode {
+	// If instance is running on a remote cluster member, we cannot determine instance state.
+	if d.state.ServerName != d.Location() {
+		return api.Error
+	}
+
 	// Shortcut to avoid spamming QMP during ongoing operations.
 	operationStatus := d.operationStatusCode()
 	if operationStatus != nil {

--- a/lxd/instance/instance_utils.go
+++ b/lxd/instance/instance_utils.go
@@ -421,6 +421,9 @@ func LoadFromBackup(s *state.State, projectName string, instancePath string) (In
 	instDBArgs.Config = backupConf.Container.ExpandedConfig
 	instDBArgs.Devices = deviceConfig.NewDevices(backupConf.Container.ExpandedDevices)
 
+	// Set Node field to local node.
+	instDBArgs.Node = s.ServerName
+
 	p := api.Project{
 		Name: backupConf.Container.Project,
 	}

--- a/lxd/instance_get.go
+++ b/lxd/instance_get.go
@@ -5,13 +5,13 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"strconv"
 
 	"github.com/gorilla/mux"
 
 	"github.com/canonical/lxd/lxd/instance"
 	"github.com/canonical/lxd/lxd/request"
 	"github.com/canonical/lxd/lxd/response"
+	"github.com/canonical/lxd/lxd/util"
 	"github.com/canonical/lxd/shared"
 )
 
@@ -117,12 +117,7 @@ func instanceGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Parse the recursion field
-	recursionStr := r.FormValue("recursion")
-
-	recursion, err := strconv.Atoi(recursionStr)
-	if err != nil {
-		recursion = 0
-	}
+	recursive := util.IsRecursionRequest(r)
 
 	// Handle requests targeted to a container on a different node
 	resp, err := forwardedResponseIfInstanceIsRemote(s, r, projectName, name, instanceType)
@@ -141,7 +136,7 @@ func instanceGet(d *Daemon, r *http.Request) response.Response {
 
 	var state any
 	var etag any
-	if recursion == 0 {
+	if !recursive {
 		state, etag, err = c.Render()
 	} else {
 		hostInterfaces, _ := net.Interfaces()

--- a/lxd/instances.go
+++ b/lxd/instances.go
@@ -433,6 +433,7 @@ func instancesOnDisk(s *state.State) ([]instance.Instance, error) {
 					Type:    instanceType,
 					Project: projectName,
 					Name:    instanceName,
+					Node:    s.ServerName, // Set Node field to local node.
 					Config:  make(map[string]string),
 				}
 

--- a/lxd/warnings.go
+++ b/lxd/warnings.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"strconv"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -23,6 +22,7 @@ import (
 	"github.com/canonical/lxd/lxd/response"
 	"github.com/canonical/lxd/lxd/state"
 	"github.com/canonical/lxd/lxd/task"
+	"github.com/canonical/lxd/lxd/util"
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/entity"
 	"github.com/canonical/lxd/shared/filter"
@@ -156,12 +156,7 @@ func filterWarnings(warnings []api.Warning, clauses *filter.ClauseSet) ([]api.Wa
 //	    $ref: "#/responses/InternalServerError"
 func warningsGet(d *Daemon, r *http.Request) response.Response {
 	// Parse the recursion field
-	recursionStr := r.FormValue("recursion")
-
-	recursion, err := strconv.Atoi(recursionStr)
-	if err != nil {
-		recursion = 0
-	}
+	recursive := util.IsRecursionRequest(r)
 
 	// Parse filter value
 	filterStr := r.FormValue("filter")
@@ -204,7 +199,7 @@ func warningsGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	var filters []api.Warning
-	if recursion == 0 {
+	if !recursive {
 		var resultList []string
 
 		filters, err = filterWarnings(warnings, clauses)

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -531,6 +531,12 @@ test_clustering_containers() {
   sleep 12
   LXD_DIR="${LXD_ONE_DIR}" lxc list | grep foo | grep -q ERROR
 
+  # For an instance on an offline member, we can get its config but not use recursion nor get instance state.
+  LXD_DIR="${LXD_ONE_DIR}" lxc config show foo
+  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxc query "/1.0/instances/foo" | jq '.status == "Error"')" = "true" ]
+  ! LXD_DIR="${LXD_ONE_DIR}" lxc query "/1.0/instances/foo?recursion=1" || false
+  ! LXD_DIR="${LXD_ONE_DIR}" lxc query "/1.0/instances/foo/state" || false
+
   # Start a container without specifying any target. It will be placed
   # on node1 since node2 is offline and both node1 and node3 have zero
   # containers, but node1 has a lower node ID.


### PR DESCRIPTION
If not using recursion on `GET /1.0/instances/:instanceName`, almost all the instance information used in the response comes from the database. So when forwarding the request is not possible, fallback to reading the instance info from the node being queried. The only change is the response is the instance state, that in this case would show as Error since we can't determine the state of a remote instance.
 
 closes https://github.com/canonical/lxd/issues/13698