### PR TITLE
Network: Get fresh copy of global config when retrying network startup

### DIFF
--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -423,7 +423,7 @@ func clusterPutBootstrap(d *Daemon, r *http.Request, req api.ClusterPut) respons
 		}
 
 		// Restart the networks (to pickup forkdns and the like).
-		err = networkStartup(s)
+		err = networkStartup(d.State)
 		if err != nil {
 			return err
 		}
@@ -849,7 +849,7 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 
 		// Start up networks so any post-join changes can be applied now that we have a Node ID.
 		logger.Debug("Starting networks after cluster join")
-		err = networkStartup(s)
+		err = networkStartup(d.State)
 		if err != nil {
 			logger.Errorf("Failed starting networks: %v", err)
 		}
@@ -3471,7 +3471,7 @@ func restoreClusterMember(d *Daemon, r *http.Request) response.Response {
 		metadata := make(map[string]any)
 
 		// Restart the networks.
-		err = networkStartup(d.State())
+		err = networkStartup(d.State)
 		if err != nil {
 			return err
 		}

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1653,7 +1653,7 @@ func (d *Daemon) init() error {
 	if !d.db.Cluster.LocalNodeIsEvacuated() {
 		logger.Infof("Initializing networks")
 
-		err = networkStartup(d.State())
+		err = networkStartup(d.State)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This way a fresh copy of state can be retrieved on each iteration when
trying to start networks that couldn't be started on the first pass.

This helps in scenarios where the network couldn't be started due to
a problem with the server/cluster's global config that is rectified
and then the go routine running the retry mechanism needs to get an
updated copy of the global config before retrying starting the network.

Reorganises this function so that the scope of the initial setup attempt's
state variable is limited.