### PR TITLE
CLI: Improvements to `lxc config` and `lxc profile` shell completions

### DIFF
--- a/lxc/completion.go
+++ b/lxc/completion.go
@@ -512,9 +512,8 @@ func (g *cmdGlobal) cmpInstances(toComplete string) ([]string, cobra.ShellCompDi
 	}
 
 	if !strings.Contains(toComplete, ":") {
-		remotes, directives := g.cmpRemotes(false)
+		remotes, _ := g.cmpRemotes(false)
 		results = append(results, remotes...)
-		cmpDirectives |= directives
 	}
 
 	return results, cmpDirectives

--- a/lxc/config.go
+++ b/lxc/config.go
@@ -918,7 +918,8 @@ func (c *cmdConfigUnset) command() *cobra.Command {
 		}
 
 		if len(args) == 1 {
-			return c.global.cmpInstanceKeys(args[0])
+			// Only complete config keys which are currently set.
+			return c.global.cmpInstanceSetKeys(args[0])
 		}
 
 		return nil, cobra.ShellCompDirectiveNoFileComp

--- a/lxc/profile.go
+++ b/lxc/profile.go
@@ -932,7 +932,7 @@ For backward compatibility, a single configuration key may still be set with:
 		}
 
 		if len(args) == 1 {
-			return c.global.cmpInstanceAllKeys()
+			return c.global.cmpInstanceAllKeys(args[0])
 		}
 
 		return nil, cobra.ShellCompDirectiveNoFileComp


### PR DESCRIPTION
This PR includes updates to `lxc/completion.go`, improving the shell completion functionality for instance configuration keys. 

Summary of changes:
- Refactorings that improve performance and correctness;
- Updates `cmpInstanceKeys` and `cmpInstanceAllKeys` functions to use the metadata API (resolves https://github.com/canonical/lxd/issues/14537);
- Adds `cmpInstanceSetKeys` function for improved `lxc config unset` completions.