### PR TITLE
OpenFGA: Add request cache to the OpenFGA datastore

### DIFF
--- a/lxd/auth/drivers/openfga.go
+++ b/lxd/auth/drivers/openfga.go
@@ -84,10 +84,6 @@ func (e *embeddedOpenFGA) load(ctx context.Context, identityCache *identity.Cach
 		server.WithDatastore(opts.openfgaDatastore),
 		// Use our logger.
 		server.WithLogger(openfgaLogger{l: e.logger}),
-		// Set the max concurrency to 1 for both read and check requests.
-		// Our driver cannot perform concurrent reads.
-		server.WithMaxConcurrentReadsForListObjects(1),
-		server.WithMaxConcurrentReadsForCheck(1),
 		// Enable context propagation to the datastore so that the OpenFGA cache
 		// created for each request can be accessed from our OpenFGA datastore implementation.
 		server.WithContextPropagationToDatastore(true),

--- a/lxd/auth/drivers/openfga.go
+++ b/lxd/auth/drivers/openfga.go
@@ -88,6 +88,9 @@ func (e *embeddedOpenFGA) load(ctx context.Context, identityCache *identity.Cach
 		// Our driver cannot perform concurrent reads.
 		server.WithMaxConcurrentReadsForListObjects(1),
 		server.WithMaxConcurrentReadsForCheck(1),
+		// Enable context propagation to the datastore so that the OpenFGA cache
+		// created for each request can be accessed from our OpenFGA datastore implementation.
+		server.WithContextPropagationToDatastore(true),
 	}
 
 	e.server, err = server.NewServerWithOpts(openfgaServerOptions...)

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -754,6 +754,9 @@ func (d *Daemon) createCmd(restAPI *mux.Router, version string, c APIEndpoint) {
 			return
 		}
 
+		// Set OpenFGA cache in request context.
+		request.SetCtxValue(r, request.CtxOpenFGARequestCache, &openfga.RequestCache{})
+
 		// Dump full request JSON when in debug mode
 		if daemon.Debug && r.Method != "GET" && util.IsJSONRequest(r) {
 			newBody := &bytes.Buffer{}

--- a/lxd/request/const.go
+++ b/lxd/request/const.go
@@ -48,6 +48,9 @@ const (
 
 	// CtxMetricsCallbackFunc is a callback function that can be called to mark the request as completed for the API metrics.
 	CtxMetricsCallbackFunc CtxKey = "metrics_callback_function"
+
+	// CtxOpenFGARequestCache is used to set a cache for the OpenFGA datastore to improve driver performance on a per request basis.
+	CtxOpenFGARequestCache CtxKey = "openfga_request_cache"
 )
 
 // Headers.


### PR DESCRIPTION
This PR decrease the latency of API calls that are going through the OpenFGA fine-grained authorizer. Thanks to a per-request cache mechanism, we avoid calling the database when the cache key is present.

This work has been benchmarked and has been used in the following PR: https://github.com/canonical/lxd/pull/14476

[openfga_benchmark.pdf](https://github.com/user-attachments/files/17960500/openfga_benchmark.pdf)

The benchmarking script can be found at: https://paste.ubuntu.com/p/WCwsk6gSSK/ 