### PR TITLE
Simplify config validation

### DIFF
--- a/doc/metadata.txt
+++ b/doc/metadata.txt
@@ -1398,7 +1398,6 @@ This option specifies whether to use the HAProxy PROXY protocol to transmit send
 <!-- config group device-proxy-device-conf end -->
 <!-- config group device-tpm-device-conf start -->
 ```{config:option} path device-tpm-device-conf
-:condition: "containers"
 :required: "for containers"
 :shortdesc: "Path inside the container"
 :type: "string"
@@ -1406,7 +1405,6 @@ For example: `/dev/tpm0`
 ```
 
 ```{config:option} pathrm device-tpm-device-conf
-:condition: "containers"
 :required: "for containers"
 :shortdesc: "Resource manager path inside the container"
 :type: "string"

--- a/lxd/device/tpm.go
+++ b/lxd/device/tpm.go
@@ -43,7 +43,6 @@ func (d *tpm) validateConfig(instConf instance.ConfigReader) error {
 	// ---
 	//  type: string
 	//  required: for containers
-	//  condition: containers
 	//  shortdesc: Path inside the container
 
 	// lxdmeta:generate(entities=device-tpm; group=device-conf; key=pathrm)
@@ -51,7 +50,6 @@ func (d *tpm) validateConfig(instConf instance.ConfigReader) error {
 	// ---
 	//  type: string
 	//  required: for containers
-	//  condition: containers
 	//  shortdesc: Resource manager path inside the container
 	if instConf.Type() == instancetype.Container {
 		rules["path"] = validate.IsNotEmpty

--- a/lxd/device/tpm.go
+++ b/lxd/device/tpm.go
@@ -57,8 +57,8 @@ func (d *tpm) validateConfig(instConf instance.ConfigReader) error {
 		rules["path"] = validate.IsNotEmpty
 		rules["pathrm"] = validate.IsNotEmpty
 	} else {
-		rules["path"] = validate.Optional(validate.IsNotEmpty)
-		rules["pathrm"] = validate.Optional(validate.IsNotEmpty)
+		rules["path"] = validate.IsAny
+		rules["pathrm"] = validate.IsAny
 	}
 
 	err := d.config.Validate(rules)

--- a/lxd/device/usb.go
+++ b/lxd/device/usb.go
@@ -62,7 +62,7 @@ func (d *usb) validateConfig(instConf instance.ConfigReader) error {
 		// ---
 		//  type: string
 		//  shortdesc: The serial number of the USB device
-		"serial": validate.Optional(validate.IsAny),
+		"serial": validate.IsAny,
 
 		// lxdmeta:generate(entities=device-unix-usb; group=device-conf; key=busnum)
 		//

--- a/lxd/instance/instancetype/instance.go
+++ b/lxd/instance/instancetype/instance.go
@@ -1057,7 +1057,7 @@ var InstanceConfigKeysVM = map[string]func(value string) error{
 	//  liveupdate: no
 	//  condition: virtual machine
 	//  shortdesc: The guest owner's `base64`-encoded Diffie-Hellman key
-	"security.sev.session.dh": validate.Optional(validate.IsAny),
+	"security.sev.session.dh": validate.IsAny,
 
 	// lxdmeta:generate(entities=instance; group=security; key=security.sev.session.data)
 	//
@@ -1067,7 +1067,7 @@ var InstanceConfigKeysVM = map[string]func(value string) error{
 	//  liveupdate: no
 	//  condition: virtual machine
 	//  shortdesc: The guest owner's `base64`-encoded session blob
-	"security.sev.session.data": validate.Optional(validate.IsAny),
+	"security.sev.session.data": validate.IsAny,
 
 	// lxdmeta:generate(entities=instance; group=miscellaneous; key=user.*)
 	// User keys can be used in search.

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -1605,7 +1605,6 @@
 				"keys": [
 					{
 						"path": {
-							"condition": "containers",
 							"longdesc": "For example: `/dev/tpm0`",
 							"required": "for containers",
 							"shortdesc": "Path inside the container",
@@ -1614,7 +1613,6 @@
 					},
 					{
 						"pathrm": {
-							"condition": "containers",
 							"longdesc": "For example: `/dev/tpmrm0`",
 							"required": "for containers",
 							"shortdesc": "Resource manager path inside the container",

--- a/lxd/network/driver_common.go
+++ b/lxd/network/driver_common.go
@@ -610,7 +610,7 @@ func (n *common) bgpValidationRules(config map[string]string) (map[string]func(v
 		case "asn":
 			rules[k] = validate.Optional(validate.IsInRange(1, 4294967294))
 		case "password":
-			rules[k] = validate.Optional(validate.IsAny)
+			rules[k] = validate.IsAny
 		case "holdtime":
 			rules[k] = validate.Optional(validate.IsInRange(9, 65535))
 		}

--- a/lxd/storage/drivers/driver_cephobject.go
+++ b/lxd/storage/drivers/driver_cephobject.go
@@ -126,7 +126,7 @@ func (d *cephobject) Validate(config map[string]string) error {
 		// ---
 		//  type: string
 		//  shortdesc: Prefix to add to bucket names in Ceph
-		"cephobject.bucket.name_prefix": validate.Optional(validate.IsAny),
+		"cephobject.bucket.name_prefix": validate.IsAny,
 		// lxdmeta:generate(entities=storage-cephobject; group=pool-conf; key=volatile.pool.pristine)
 		//
 		// ---

--- a/lxd/storage/drivers/driver_powerflex.go
+++ b/lxd/storage/drivers/driver_powerflex.go
@@ -230,7 +230,7 @@ func (d *powerflex) Validate(config map[string]string) error {
 		// ---
 		//  type: string
 		//  shortdesc: Name of the PowerFlex protection domain
-		"powerflex.domain": validate.Optional(validate.IsAny),
+		"powerflex.domain": validate.IsAny,
 		// lxdmeta:generate(entities=storage-powerflex; group=pool-conf; key=powerflex.mode)
 		// The mode gets discovered automatically if the system provides the necessary kernel modules.
 		// This can be either `nvme` or `sdc`.


### PR DESCRIPTION
`validate.Optional()` checks if the provided value is not empty before calling the other validator.

As such, `validate.Optional(validate.IsNotEmpty)` is conceptually the same as `validate.IsAny`.

Also, since `validate.IsAny` accepts anything, using, `validate.Optional(validate.IsAny)` is conceptually the same as `validate.IsAny`.