### PR TITLE
LXC: Fix `lxc image list` regression

### DIFF
--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -50,6 +50,8 @@ type ImageServer interface {
 	GetImages() (images []api.Image, err error)
 	GetImageFingerprints() (fingerprints []string, err error)
 	GetImagesWithFilter(filters []string) (images []api.Image, err error)
+	GetImagesAllProjects() (images []api.Image, err error)
+	GetImagesAllProjectsWithFilter(filters []string) (images []api.Image, err error)
 
 	GetImage(fingerprint string) (image *api.Image, ETag string, err error)
 	GetImageFile(fingerprint string, req ImageFileRequest) (resp *ImageFileResponse, err error)
@@ -243,8 +245,6 @@ type InstanceServer interface {
 	UpdateImageAlias(name string, alias api.ImageAliasesEntryPut, ETag string) (err error)
 	RenameImageAlias(name string, alias api.ImageAliasesEntryPost) (err error)
 	DeleteImageAlias(name string) (err error)
-	GetImagesAllProjects() (images []api.Image, err error)
-	GetImagesAllProjectsWithFilter(filters []string) (images []api.Image, err error)
 
 	// Network functions ("network" API extension)
 	GetNetworkNames() (names []string, err error)

--- a/client/simplestreams_images.go
+++ b/client/simplestreams_images.go
@@ -23,6 +23,11 @@ func (r *ProtocolSimpleStreams) GetImages() ([]api.Image, error) {
 	return r.ssClient.ListImages()
 }
 
+// GetImagesAllProjects returns a list of available images as Image structs.
+func (r *ProtocolSimpleStreams) GetImagesAllProjects() ([]api.Image, error) {
+	return r.GetImages()
+}
+
 // GetImageFingerprints returns a list of available image fingerprints.
 func (r *ProtocolSimpleStreams) GetImageFingerprints() ([]string, error) {
 	// Get all the images from simplestreams
@@ -43,6 +48,11 @@ func (r *ProtocolSimpleStreams) GetImageFingerprints() ([]string, error) {
 // GetImagesWithFilter returns a filtered list of available images as Image structs.
 func (r *ProtocolSimpleStreams) GetImagesWithFilter(filters []string) ([]api.Image, error) {
 	return nil, fmt.Errorf("GetImagesWithFilter is not supported by the simplestreams protocol")
+}
+
+// GetImagesAllProjectsWithFilter returns an error indicating compatibility with the simplestreams protocol.
+func (r *ProtocolSimpleStreams) GetImagesAllProjectsWithFilter(filters []string) ([]api.Image, error) {
+	return nil, fmt.Errorf("GetImagesAllProjectsWithFilter is not supported by the simplestreams protocol")
 }
 
 // GetImage returns an Image struct for the provided fingerprint.

--- a/lxc/image.go
+++ b/lxc/image.go
@@ -1353,11 +1353,6 @@ func (c *cmdImageList) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	d, err := c.global.conf.GetInstanceServer(remoteName)
-	if err != nil {
-		return err
-	}
-
 	// Process the filters
 	filters := []string{}
 	if name != "" {
@@ -1378,9 +1373,9 @@ func (c *cmdImageList) run(cmd *cobra.Command, args []string) error {
 
 	var allImages, images []api.Image
 	if c.flagAllProjects {
-		allImages, err = d.GetImagesAllProjectsWithFilter(serverFilters)
+		allImages, err = remoteServer.GetImagesAllProjectsWithFilter(serverFilters)
 		if err != nil {
-			allImages, err = d.GetImagesAllProjects()
+			allImages, err = remoteServer.GetImagesAllProjects()
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Fixes https://github.com/canonical/lxd/issues/14561 introduced with https://github.com/canonical/lxd/pull/14260.

This PR fixes a regression introduced with https://github.com/canonical/lxd/pull/14260 by adding `GetImagesAllProjects` and
`GetImagesAllProjectsWithFilter` functions to `client/simplestreams_images.go`, and moving their method signatures to
the `ImageServer` interface. While adding support for fetching images across all projects, we changed the logic in the `lxc image list` command to call different functions based on whether the `--all-projects` flag is passed in or not:

https://github.com/canonical/lxd/pull/14260/commits/1fae6e6d99d68538ae29f01937d4dfc8338bf923

This is fine, but we needed to add `simplestreams` protocol support as well to facilitate listing public images from remotes such as `images` and `ubuntu-minimal-daily`.

The actual bug comes from the following LOC: 

https://github.com/canonical/lxd/blob/4a3c4a343e4a9490105bd3da893f9892b86e01d8/lxc/image.go#L1356-L1359

Fetching from an instance server isn't applicable for `simplestreams` servers, so `GetImagesAllProjects` is never reached due to the error raised by `c.global.conf.GetInstanceServer`. Instead, we should fetch an image server before fetching images, hence why moving the new client functions method signatures to the `ImageServer` interface fixes the regression. 