### PR TITLE
Revert "github: only run CodeQL (go) on PRs and on weekly schedule"

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,6 +12,10 @@
 name: "CodeQL"
 
 on:
+  push:
+    branches:
+      - main
+      - stable-*
   pull_request:
     paths-ignore:
       - '.github/**'


### PR DESCRIPTION
This reverts commit 9ab852f8803c252949543b12d3c9bc7db8606fea as the GHA runners log those 2 warnings:

> 1 issue was detected with this workflow: Please specify an on.push hook to
> analyze and see code scanning alerts from the default branch on the Security
> tab.

> Unable to validate code scanning workflow: MissingPushHook