### PR TITLE
test/suites: Check that a restricted client certificate cannot view server configuration

### DIFF
--- a/test/suites/tls_restrictions.sh
+++ b/test/suites/tls_restrictions.sh
@@ -27,6 +27,12 @@ test_tls_restrictions() {
   # Apply restrictions
   lxc config trust show "${FINGERPRINT}" | sed -e "s/restricted: false/restricted: true/" | lxc config trust edit "${FINGERPRINT}"
 
+  # Confirm client with restricted certificate cannot see server configuration.
+  lxc config set user.foo bar
+  [ "$(lxc_remote query localhost:/1.0 | jq '.config | length')" = 0 ]
+  [ "$(lxc_remote query localhost:/1.0 | jq -r '.config."user.foo"')" = "null" ]
+  lxc config unset user.foo
+
   # Confirm no project visible when none listed
   [ "$(lxc_remote project list localhost: --format csv | wc -l)" = 0 ]
 


### PR DESCRIPTION
This check is already performed in the `authorization` suite but isn't actually being performed in the `tls_restrictions` suite. We do already have unit tests that show that a restricted client certificate does not have `can_edit` on `server` (required for viewing server configuration), but this is a good thing to triple check.