### PR TITLE
Storage: Per project image and backup storage options

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2535,3 +2535,7 @@ Adds a new {config:option}`device-unix-hotplug-device-conf:ownership.inherit` co
 ## `unix_device_hotplug_subsystem_device_option`
 
 Adds a new {config:option}`device-unix-hotplug-device-conf:subsystem` configuration option for `unix-hotplug` devices. This adds support for detecting `unix-hotplug` devices by subsystem, and can be used in conjunction with {config:option}`device-unix-hotplug-device-conf:productid` and {config:option}`device-unix-hotplug-device-conf:vendorid`.
+
+## `project_daemon_storage`
+This introduces two new configuration keys `storage.images_volume` and `storage.backups_volume` to the project level to allow for a storage volume
+on an existing pool be used for storing the project-wide images and backups artifacts.

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -636,14 +636,14 @@ func doAPI10Update(d *Daemon, r *http.Request, req api.ServerPut, patch bool) re
 
 		// Validate the storage volumes
 		if nodeValues["storage.backups_volume"] != nil && nodeValues["storage.backups_volume"] != newNodeConfig.StorageBackupsVolume() {
-			err := daemonStorageValidate(s, nodeValues["storage.backups_volume"].(string))
+			err := daemonStorageValidate(s, api.ProjectDefaultName, nodeValues["storage.backups_volume"].(string))
 			if err != nil {
 				return fmt.Errorf("Failed validation of %q: %w", "storage.backups_volume", err)
 			}
 		}
 
 		if nodeValues["storage.images_volume"] != nil && nodeValues["storage.images_volume"] != newNodeConfig.StorageImagesVolume() {
-			err := daemonStorageValidate(s, nodeValues["storage.images_volume"].(string))
+			err := daemonStorageValidate(s, api.ProjectDefaultName, nodeValues["storage.images_volume"].(string))
 			if err != nil {
 				return fmt.Errorf("Failed validation of %q: %w", "storage.images_volume", err)
 			}
@@ -939,7 +939,7 @@ func doAPI10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 
 	value, ok = nodeChanged["storage.backups_volume"]
 	if ok {
-		err := daemonStorageMove(s, "backups", value)
+		err := daemonStorageMove(s, "backups", api.ProjectDefaultName, value, true)
 		if err != nil {
 			return err
 		}
@@ -947,7 +947,7 @@ func doAPI10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 
 	value, ok = nodeChanged["storage.images_volume"]
 	if ok {
-		err := daemonStorageMove(s, "images", value)
+		err := daemonStorageMove(s, "images", api.ProjectDefaultName, value, true)
 		if err != nil {
 			return err
 		}

--- a/lxd/backup.go
+++ b/lxd/backup.go
@@ -101,7 +101,7 @@ func backupCreate(s *state.State, args db.InstanceBackup, sourceInst instance.In
 	}
 
 	// Create the target path if needed.
-	backupsPath := shared.VarPath("backups", "instances", project.Instance(sourceInst.Project().Name, sourceInst.Name()))
+	backupsPath := shared.VarPath("backups", fmt.Sprintf("project_%s", op.Project()), "instances", project.Instance(sourceInst.Project().Name, sourceInst.Name()))
 	if !shared.PathExists(backupsPath) {
 		err := os.MkdirAll(backupsPath, 0700)
 		if err != nil {
@@ -111,7 +111,7 @@ func backupCreate(s *state.State, args db.InstanceBackup, sourceInst instance.In
 		revert.Add(func() { _ = os.Remove(backupsPath) })
 	}
 
-	target := shared.VarPath("backups", "instances", project.Instance(sourceInst.Project().Name, b.Name()))
+	target := shared.VarPath("backups", fmt.Sprintf("project_%s", op.Project()), "instances", project.Instance(sourceInst.Project().Name, b.Name()))
 
 	// Setup the tarball writer.
 	l.Debug("Opening backup tarball for writing", logger.Ctx{"path": target})
@@ -373,7 +373,7 @@ func pruneExpiredInstanceBackups(ctx context.Context, s *state.State) error {
 		}
 
 		instBackup := backup.NewInstanceBackup(s, inst, b.ID, b.Name, b.CreationDate, b.ExpiryDate, b.InstanceOnly, b.OptimizedStorage)
-		err = instBackup.Delete()
+		err = instBackup.Delete(inst.Project().Name)
 		if err != nil {
 			return fmt.Errorf("Error deleting instance backup %q: %w", b.Name, err)
 		}
@@ -437,7 +437,7 @@ func volumeBackupCreate(s *state.State, args db.StoragePoolVolumeBackup, project
 	}
 
 	// Create the target path if needed.
-	backupsPath := shared.VarPath("backups", "custom", pool.Name(), project.StorageVolume(projectName, volumeName))
+	backupsPath := shared.VarPath("backups", fmt.Sprintf("project_%s", projectName), "custom", pool.Name(), project.StorageVolume(projectName, volumeName))
 	if !shared.PathExists(backupsPath) {
 		err := os.MkdirAll(backupsPath, 0700)
 		if err != nil {
@@ -447,7 +447,7 @@ func volumeBackupCreate(s *state.State, args db.StoragePoolVolumeBackup, project
 		revert.Add(func() { _ = os.Remove(backupsPath) })
 	}
 
-	target := shared.VarPath("backups", "custom", pool.Name(), project.StorageVolume(projectName, backupRow.Name))
+	target := shared.VarPath("backups", fmt.Sprintf("project_%s", projectName), "custom", pool.Name(), project.StorageVolume(projectName, backupRow.Name))
 
 	// Setup the tarball writer.
 	l.Debug("Opening backup tarball for writing", logger.Ctx{"path": target})

--- a/lxd/backup/backup_instance.go
+++ b/lxd/backup/backup_instance.go
@@ -2,6 +2,7 @@ package backup
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strings"
 	"time"
@@ -58,17 +59,17 @@ func (b *InstanceBackup) Instance() Instance {
 }
 
 // Rename renames an instance backup.
-func (b *InstanceBackup) Rename(newName string) error {
-	oldBackupPath := shared.VarPath("backups", "instances", project.Instance(b.instance.Project().Name, b.name))
-	newBackupPath := shared.VarPath("backups", "instances", project.Instance(b.instance.Project().Name, newName))
+func (b *InstanceBackup) Rename(newName string, projectName string) error {
+	oldBackupPath := shared.VarPath("backups", fmt.Sprintf("project_%s", projectName), "instances", project.Instance(b.instance.Project().Name, b.name))
+	newBackupPath := shared.VarPath("backups", fmt.Sprintf("project_%s", projectName), "instances", project.Instance(b.instance.Project().Name, newName))
 
 	// Extract the old and new parent backup paths from the old and new backup names rather than use
 	// instance.Name() as this may be in flux if the instance itself is being renamed, whereas the relevant
 	// instance name is encoded into the backup names.
 	oldParentName, _, _ := api.GetParentAndSnapshotName(b.name)
-	oldParentBackupsPath := shared.VarPath("backups", "instances", project.Instance(b.instance.Project().Name, oldParentName))
+	oldParentBackupsPath := shared.VarPath("backups", fmt.Sprintf("project_%s", projectName), "instances", project.Instance(b.instance.Project().Name, oldParentName))
 	newParentName, _, _ := api.GetParentAndSnapshotName(newName)
-	newParentBackupsPath := shared.VarPath("backups", "instances", project.Instance(b.instance.Project().Name, newParentName))
+	newParentBackupsPath := shared.VarPath("backups", fmt.Sprintf("project_%s", projectName), "instances", project.Instance(b.instance.Project().Name, newParentName))
 
 	// Create the new backup path if doesn't exist.
 	if !shared.PathExists(newParentBackupsPath) {
@@ -108,8 +109,8 @@ func (b *InstanceBackup) Rename(newName string) error {
 }
 
 // Delete removes an instance backup.
-func (b *InstanceBackup) Delete() error {
-	backupPath := shared.VarPath("backups", "instances", project.Instance(b.instance.Project().Name, b.name))
+func (b *InstanceBackup) Delete(projectName string) error {
+	backupPath := shared.VarPath("backups", fmt.Sprintf("project_%s", projectName), "instances", project.Instance(b.instance.Project().Name, b.name))
 
 	// Delete the on-disk data.
 	if shared.PathExists(backupPath) {
@@ -120,7 +121,7 @@ func (b *InstanceBackup) Delete() error {
 	}
 
 	// Check if we can remove the instance directory.
-	backupsPath := shared.VarPath("backups", "instances", project.Instance(b.instance.Project().Name, b.instance.Name()))
+	backupsPath := shared.VarPath("backups", fmt.Sprintf("project_%s", projectName), "instances", project.Instance(b.instance.Project().Name, b.instance.Name()))
 	empty, _ := shared.PathIsEmpty(backupsPath)
 	if empty {
 		err := os.Remove(backupsPath)

--- a/lxd/backup/backup_volume.go
+++ b/lxd/backup/backup_volume.go
@@ -2,6 +2,7 @@ package backup
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strings"
 	"time"
@@ -54,16 +55,16 @@ func (b *VolumeBackup) OptimizedStorage() bool {
 
 // Rename renames a volume backup.
 func (b *VolumeBackup) Rename(newName string) error {
-	oldBackupPath := shared.VarPath("backups", "custom", b.poolName, project.StorageVolume(b.projectName, b.name))
-	newBackupPath := shared.VarPath("backups", "custom", b.poolName, project.StorageVolume(b.projectName, newName))
+	oldBackupPath := shared.VarPath("backups", fmt.Sprintf("project_%s", b.projectName), "custom", b.poolName, project.StorageVolume(b.projectName, b.name))
+	newBackupPath := shared.VarPath("backups", fmt.Sprintf("project_%s", b.projectName), "custom", b.poolName, project.StorageVolume(b.projectName, newName))
 
 	// Extract the old and new parent backup paths from the old and new backup names rather than use
 	// instance.Name() as this may be in flux if the instance itself is being renamed, whereas the relevant
 	// instance name is encoded into the backup names.
 	oldParentName, _, _ := api.GetParentAndSnapshotName(b.name)
-	oldParentBackupsPath := shared.VarPath("backups", "custom", b.poolName, project.StorageVolume(b.projectName, oldParentName))
+	oldParentBackupsPath := shared.VarPath("backups", fmt.Sprintf("project_%s", b.projectName), "custom", b.poolName, project.StorageVolume(b.projectName, oldParentName))
 	newParentName, _, _ := api.GetParentAndSnapshotName(newName)
-	newParentBackupsPath := shared.VarPath("backups", "custom", b.poolName, project.StorageVolume(b.projectName, newParentName))
+	newParentBackupsPath := shared.VarPath("backups", fmt.Sprintf("project_%s", b.projectName), "custom", b.poolName, project.StorageVolume(b.projectName, newParentName))
 
 	revert := revert.New()
 	defer revert.Fail()
@@ -107,7 +108,7 @@ func (b *VolumeBackup) Rename(newName string) error {
 
 // Delete removes a volume backup.
 func (b *VolumeBackup) Delete() error {
-	backupPath := shared.VarPath("backups", "custom", b.poolName, project.StorageVolume(b.projectName, b.name))
+	backupPath := shared.VarPath("backups", fmt.Sprintf("project_%s", b.projectName), "custom", b.poolName, project.StorageVolume(b.projectName, b.name))
 	// Delete the on-disk data.
 	if shared.PathExists(backupPath) {
 		err := os.RemoveAll(backupPath)
@@ -117,7 +118,7 @@ func (b *VolumeBackup) Delete() error {
 	}
 
 	// Check if we can remove the volume directory.
-	backupsPath := shared.VarPath("backups", "custom", b.poolName, project.StorageVolume(b.projectName, b.volumeName))
+	backupsPath := shared.VarPath("backups", fmt.Sprintf("project_%s", b.projectName), "custom", b.poolName, project.StorageVolume(b.projectName, b.volumeName))
 	empty, _ := shared.PathIsEmpty(backupsPath)
 	if empty {
 		err := os.Remove(backupsPath)

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1506,7 +1506,7 @@ func (d *Daemon) init() error {
 
 	// Mount any daemon storage volumes.
 	logger.Infof("Initializing daemon storage mounts")
-	err = daemonStorageMount(d.State())
+	err = daemonStorageMount(d.State(), api.ProjectDefaultName)
 	if err != nil {
 		return err
 	}
@@ -1974,7 +1974,7 @@ func (d *Daemon) Stop(ctx context.Context, sig os.Signal) error {
 		logger.Info("Stopping daemon storage volumes")
 		done := make(chan struct{})
 		go func() {
-			err := daemonStorageVolumesUnmount(s)
+			err := daemonStorageVolumesUnmount(s, api.ProjectDefaultName)
 			if err != nil {
 				logger.Error("Failed to unmount image and backup volumes", logger.Ctx{"err": err})
 			}

--- a/lxd/daemon_images.go
+++ b/lxd/daemon_images.go
@@ -321,7 +321,7 @@ func ImageDownload(r *http.Request, s *state.State, op *operations.Operation, ar
 	logger.Info("Downloading image", ctxMap)
 
 	// Cleanup any leftover from a past attempt
-	destDir := shared.VarPath("images")
+	destDir := shared.VarPath("images", fmt.Sprintf("project_%s", args.ProjectName))
 	destName := filepath.Join(destDir, fp)
 
 	failure := true
@@ -408,7 +408,7 @@ func ImageDownload(r *http.Request, s *state.State, op *operations.Operation, ar
 			ProgressHandler: progress,
 			Canceler:        canceler,
 			DeltaSourceRetriever: func(fingerprint string, file string) string {
-				path := shared.VarPath("images", fmt.Sprintf("%s.%s", fingerprint, file))
+				path := shared.VarPath("images", fmt.Sprintf("project_%s", args.ProjectName), fmt.Sprintf("%s.%s", fingerprint, file))
 				if shared.PathExists(path) {
 					return path
 				}

--- a/lxd/instance.go
+++ b/lxd/instance.go
@@ -77,7 +77,7 @@ func instanceImageTransfer(s *state.State, r *http.Request, projectName string, 
 
 	client = client.UseProject(projectName)
 
-	err = imageImportFromNode(filepath.Join(s.OS.VarDir, "images"), client, hash)
+	err = imageImportFromNode(filepath.Join(s.OS.VarDir, "images", fmt.Sprintf("project_%s", projectName)), client, hash)
 	if err != nil {
 		return err
 	}

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -3820,7 +3820,7 @@ func (d *lxc) delete(force bool) error {
 		}
 
 		for _, backup := range backups {
-			err = backup.Delete()
+			err = backup.Delete(d.project.Name)
 			if err != nil {
 				return err
 			}
@@ -4006,12 +4006,12 @@ func (d *lxc) Rename(newName string, applyTemplateTrigger bool) error {
 		backupName := strings.Split(oldName, "/")[1]
 		newName := fmt.Sprintf("%s/%s", newName, backupName)
 
-		err = b.Rename(newName)
+		err = b.Rename(newName, d.project.Name)
 		if err != nil {
 			return err
 		}
 
-		revert.Add(func() { _ = b.Rename(oldName) })
+		revert.Add(func() { _ = b.Rename(oldName, d.project.Name) })
 	}
 
 	// Invalidate the go-lxc cache.

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -5307,12 +5307,12 @@ func (d *qemu) Rename(newName string, applyTemplateTrigger bool) error {
 		backupName := strings.Split(oldName, "/")[1]
 		newName := fmt.Sprintf("%s/%s", newName, backupName)
 
-		err = b.Rename(newName)
+		err = b.Rename(newName, d.project.Name)
 		if err != nil {
 			return err
 		}
 
-		revert.Add(func() { _ = b.Rename(oldName) })
+		revert.Add(func() { _ = b.Rename(oldName, d.project.Name) })
 	}
 
 	// Update lease files.
@@ -6114,7 +6114,7 @@ func (d *qemu) delete(force bool) error {
 		}
 
 		for _, backup := range backups {
-			err = backup.Delete()
+			err = backup.Delete(d.project.Name)
 			if err != nil {
 				return err
 			}

--- a/lxd/instance_backup.go
+++ b/lxd/instance_backup.go
@@ -540,7 +540,7 @@ func instanceBackupPost(d *Daemon, r *http.Request) response.Response {
 	newName := name + shared.SnapshotDelimiter + req.Name
 
 	rename := func(op *operations.Operation) error {
-		err := backup.Rename(newName)
+		err := backup.Rename(newName, projectName)
 		if err != nil {
 			return err
 		}
@@ -629,7 +629,7 @@ func instanceBackupDelete(d *Daemon, r *http.Request) response.Response {
 	}
 
 	remove := func(op *operations.Operation) error {
-		err := backup.Delete()
+		err := backup.Delete(projectName)
 		if err != nil {
 			return err
 		}
@@ -714,7 +714,7 @@ func instanceBackupExportGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	ent := response.FileResponseEntry{
-		Path: shared.VarPath("backups", "instances", project.Instance(projectName, backup.Name())),
+		Path: shared.VarPath("backups", fmt.Sprintf("project_%s", projectName), "instances", project.Instance(projectName, backup.Name())),
 	}
 
 	s.Events.SendLifecycle(projectName, lifecycle.InstanceBackupRetrieved.Event(fullName, backup.Instance(), nil))

--- a/lxd/lifecycle/instance_backup.go
+++ b/lxd/lifecycle/instance_backup.go
@@ -1,6 +1,8 @@
 package lifecycle
 
 import (
+	"fmt"
+
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/version"
 )
@@ -20,7 +22,7 @@ const (
 func (a InstanceBackupAction) Event(fullBackupName string, inst instance, ctx map[string]any) api.EventLifecycle {
 	_, backupName, _ := api.GetParentAndSnapshotName(fullBackupName)
 
-	u := api.NewURL().Path(version.APIVersion, "instances", inst.Name(), "backups", backupName).Project(inst.Project().Name)
+	u := api.NewURL().Path(version.APIVersion, fmt.Sprintf("project_%s", inst.Project().Name), "instances", inst.Name(), "backups", backupName).Project(inst.Project().Name)
 
 	var requestor *api.EventLifecycleRequestor
 	if inst.Operation() != nil {

--- a/lxd/lifecycle/instance_log.go
+++ b/lxd/lifecycle/instance_log.go
@@ -1,6 +1,8 @@
 package lifecycle
 
 import (
+	"fmt"
+
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/version"
 )
@@ -16,7 +18,7 @@ const (
 
 // Event creates the lifecycle event for an action on an instance log.
 func (a InstanceLogAction) Event(file string, inst instance, requestor *api.EventLifecycleRequestor, ctx map[string]any) api.EventLifecycle {
-	u := api.NewURL().Path(version.APIVersion, "instances", inst.Name(), "backups", file).Project(inst.Project().Name)
+	u := api.NewURL().Path(version.APIVersion, fmt.Sprintf("project_%s", inst.Project().Name), "instances", inst.Name(), "backups", file).Project(inst.Project().Name)
 
 	return api.EventLifecycle{
 		Action:    string(a),

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -1795,7 +1795,7 @@ func (b *lxdBackend) imageFiller(fingerprint string, op *operations.Operation) f
 				}}
 		}
 
-		imageFile := shared.VarPath("images", fingerprint)
+		imageFile := shared.VarPath("images", fmt.Sprintf("project_%s", op.Project()), fingerprint)
 		return ImageUnpack(imageFile, vol, rootBlockPath, b.state.OS, allowUnsafeResize, tracker)
 	}
 }
@@ -2323,7 +2323,7 @@ func (b *lxdBackend) CreateInstanceFromMigration(inst instance.Instance, conn io
 				}
 
 				// Make sure that the image is available locally too (not guaranteed in clusters).
-				imageExists = err == nil && shared.PathExists(shared.VarPath("images", fingerprint))
+				imageExists = err == nil && shared.PathExists(shared.VarPath("images", fmt.Sprintf("project_%s", projectName), fingerprint))
 			}
 
 			if imageExists {
@@ -6195,7 +6195,7 @@ func (b *lxdBackend) DeleteCustomVolume(projectName string, volName string, op *
 	}
 
 	// Remove backups directory for volume.
-	backupsPath := shared.VarPath("backups", "custom", b.name, project.StorageVolume(projectName, volName))
+	backupsPath := shared.VarPath("backups", fmt.Sprintf("project_%s", projectName), "custom", b.name, project.StorageVolume(projectName, volName))
 	if shared.PathExists(backupsPath) {
 		err := os.RemoveAll(backupsPath)
 		if err != nil {

--- a/lxd/storage_volumes_backup.go
+++ b/lxd/storage_volumes_backup.go
@@ -795,7 +795,7 @@ func storagePoolVolumeTypeCustomBackupExportGet(d *Daemon, r *http.Request) resp
 	}
 
 	ent := response.FileResponseEntry{
-		Path: shared.VarPath("backups", "custom", details.pool.Name(), project.StorageVolume(effectiveProjectName, fullName)),
+		Path: shared.VarPath("backups", fmt.Sprintf("project_%s", effectiveProjectName), "custom", details.pool.Name(), project.StorageVolume(effectiveProjectName, fullName)),
 	}
 
 	s.Events.SendLifecycle(effectiveProjectName, lifecycle.StorageVolumeBackupRetrieved.Event(details.pool.Name(), details.volumeTypeName, fullName, effectiveProjectName, request.CreateRequestor(r), nil))

--- a/lxd/sys/fs.go
+++ b/lxd/sys/fs.go
@@ -32,6 +32,7 @@ func (s *OS) initDirs() error {
 	}{
 		{s.VarDir, 0711},
 		{filepath.Join(s.VarDir, "backups"), 0700},
+		{filepath.Join(s.VarDir, "backups", "daemon"), 0700},
 		{s.CacheDir, 0700},
 		// containers is 0711 because liblxc needs to traverse dir to get to each container.
 		{filepath.Join(s.VarDir, "containers"), 0711},
@@ -78,8 +79,8 @@ func (s *OS) initStorageDirs() error {
 		path string
 		mode os.FileMode
 	}{
-		{filepath.Join(s.VarDir, "backups", "custom"), 0700},
-		{filepath.Join(s.VarDir, "backups", "instances"), 0700},
+		{filepath.Join(s.VarDir, "backups", "daemon", "custom"), 0700},
+		{filepath.Join(s.VarDir, "backups", "daemon", "instances"), 0700},
 	}
 
 	for _, dir := range dirs {

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -427,6 +427,7 @@ var APIExtensions = []string{
 	"metadata_configuration_scope",
 	"unix_device_hotplug_ownership_inherit",
 	"unix_device_hotplug_subsystem_device_option",
+	"project_daemon_storage",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
This PR adds support for per-project image and backup storage options. We maintain the option to select storage options at the server level, and add a more fine-grained option to select this at the project level.

---

Overview: We currently support configuration of storage.backups_volume and storage.images_volume on the server level. We would like to make this option more granular by introducing the ability to configure it on a per-project basis. We will continue to support the server-level configuration, but project-level configuration will take priority.

If these options are configured on a given project, then all backup/image tarballs created for resources within said project will be stored in the selected volume. If not, then we will default to the config set at the server level (if any).

Implementation:
We will maintain support for `storage.[images,backups]_volume` on the server level, and add this config option at the project level. Users may specify `storage.images_volume` and `storage.backups_volume` at the project level, which will ensure images or backups for the given project are stored on the specified storage volume. These config keys can be changed, and data will move accordingly.

Images and backups will continue to be stored in the images and backups directory. However, we need some way to be able to store images and backups for a certain projects on a specified storage volume. We will follow the current pattern of using a symlink to the mountpoint of the specified volume. Special directories `backups/daemon` and `images/daemon` will be created, and will function exactly as the images and backups directories function now -- to store images and backups that are not project specific. If `storage.[images,backups]_volume` is set at the server level, then these will be symlinked to the selected volume's mountpoint. 

For each project that is created, directories `images/project_X` and `backups/project_X` will also be created, which will store images and backups for the given project. If `storage.[images,backups]_volume` is set at the project level, then the directory will be symlinked to the mountpoint of the selected storage volume. If not set on the project level, then the directory will be symlinked to `[images,backups]/daemon/project_X`. This follows the current implementation at the server level. When project-level `storage.[images,backups]_volume` is changed or unset, data is moved accordingly.