### PR TITLE
Storage: Add storage driver cache update to `storagePoolCreateLocal`

### DIFF
--- a/lxd/storage_pools_utils.go
+++ b/lxd/storage_pools_utils.go
@@ -147,6 +147,9 @@ func storagePoolCreateLocal(state *state.State, poolID int64, req api.StoragePoo
 		return nil, err
 	}
 
+	// Update the storage drivers cache in api_1.0.go.
+	storagePoolDriversCacheUpdate(state)
+
 	logger.Debug("Marked storage pool local status as created", logger.Ctx{"pool": req.Name})
 
 	revert.Success()


### PR DESCRIPTION
Fixes https://github.com/canonical/lxd/issues/14046.

This PR adds a storage driver cache update to `storagePoolCreateLocal`. `storagePoolCreateLocal` is called in `storagePoolsPostCluster` and whenever a `storagePoolPost` request is a cluster notification.