### PR TITLE
LXC: Improve configuration key validation and add missing completions for `lxc config unset`

### DIFF
--- a/lxd/instance/instance_utils.go
+++ b/lxd/instance/instance_utils.go
@@ -144,6 +144,24 @@ func validConfigKey(os *sys.OS, key string, value string, instanceType instancet
 		return fmt.Errorf("%q requires a subkey", key)
 	}
 
+	// Validate the configuration key against instance type for containers and VMs.
+	// Ignore configuration keys with known prefixes since usage has already been validated, and ConfigKeyChecker validates keys syntactically.
+	if instanceType != instancetype.Any && !shared.StringHasPrefix(key, knownPrefixes...) && !strings.HasPrefix(key, instancetype.ConfigVolatilePrefix) {
+		// Ensure key is present in instance config key map based on type.
+		exists := false
+		switch instanceType {
+		case instancetype.VM:
+			_, exists = instancetype.InstanceConfigKeysVM[key]
+		case instancetype.Container:
+			_, exists = instancetype.InstanceConfigKeysContainer[key]
+		}
+
+		_, existsAny := instancetype.InstanceConfigKeysAny[key]
+		if !(exists || existsAny) {
+			return fmt.Errorf("%q isn't supported for %q", key, instanceType)
+		}
+	}
+
 	f, err := instancetype.ConfigKeyChecker(key, instanceType)
 	if err != nil {
 		return err
@@ -151,10 +169,6 @@ func validConfigKey(os *sys.OS, key string, value string, instanceType instancet
 
 	if err = f(value); err != nil {
 		return err
-	}
-
-	if strings.HasPrefix(key, "limits.kernel.") && instanceType == instancetype.VM {
-		return fmt.Errorf("%s isn't supported for VMs", key)
 	}
 
 	if key == "raw.lxc" {

--- a/lxd/instance/instancetype/instance.go
+++ b/lxd/instance/instancetype/instance.go
@@ -28,6 +28,12 @@ const (
 // ConfigVolatilePrefix indicates the prefix used for volatile config keys.
 const ConfigVolatilePrefix = "volatile."
 
+// ConfigKeyPrefixesAny indicates valid prefixes for configuration options.
+var ConfigKeyPrefixesAny = []string{"environment.", "user.", "image."}
+
+// ConfigKeyPrefixesContainer indicates valid prefixes for container configuration options.
+var ConfigKeyPrefixesContainer = []string{"linux.sysctl.", "limits.kernel."}
+
 // ValidName validates an instance name. There are different validation rules for instance snapshot names
 // so it takes an argument indicating whether the name is to be used for a snapshot or not.
 func ValidName(instanceName string, isSnapshot bool) error {

--- a/lxd/instance/instancetype/instance.go
+++ b/lxd/instance/instancetype/instance.go
@@ -1280,25 +1280,12 @@ func ConfigKeyChecker(key string, instanceType Type) (func(value string) error, 
 		}
 	}
 
-	if strings.HasPrefix(key, "environment.") {
+	if (instanceType == Any || instanceType == Container) && strings.HasPrefix(key, "linux.sysctl.") {
 		return validate.IsAny, nil
 	}
 
-	if strings.HasPrefix(key, "user.") {
-		return validate.IsAny, nil
-	}
-
-	if strings.HasPrefix(key, "image.") {
-		return validate.IsAny, nil
-	}
-
-	if strings.HasPrefix(key, "limits.kernel.") &&
-		(len(key) > len("limits.kernel.")) {
-		return validate.IsAny, nil
-	}
-
-	if (instanceType == Any || instanceType == Container) &&
-		strings.HasPrefix(key, "linux.sysctl.") {
+	knownPrefixes := append(ConfigKeyPrefixesAny, ConfigKeyPrefixesContainer...)
+	if shared.StringHasPrefix(key, knownPrefixes...) {
 		return validate.IsAny, nil
 	}
 

--- a/lxd/instance/instancetype/instance.go
+++ b/lxd/instance/instancetype/instance.go
@@ -1289,7 +1289,7 @@ func ConfigKeyChecker(key string, instanceType Type) (func(value string) error, 
 		return validate.IsAny, nil
 	}
 
-	return nil, fmt.Errorf("Unknown configuration key: %s", key)
+	return nil, fmt.Errorf("Unknown configuration key: %q", key)
 }
 
 // InstanceIncludeWhenCopying is used to decide whether to include a config item or not when copying an instance.


### PR DESCRIPTION
Fixes https://github.com/canonical/lxd/issues/14570.

This PR reworks configuration key validation in `validConfigKey`, in `lxd/instance/instance_utils.go`. The intent of the first two commits is to:
1. Validate keys that begin with a prefix, such as `user.*` and `linux.sysctl.*`; and
2. Validate keys based on their instance type.

For example, when attempting to set `linux.sysctl.*` for a VM instance, a meaningful error message should be shown indicating the key is not valid for VMs, rather than the generic `Unknown configuration key: <key>`.

This PR also expands the use of the new slices `instancetype.ConfigKeyPrefixesAny` and `instancetype.ConfigKeyPrefixesContainer` to contextually provide completions for prefixed config keys when running`lxc config unset`, based on instance type.