### PR TITLE
Introduce source type constants

### DIFF
--- a/client/lxd.go
+++ b/client/lxd.go
@@ -221,7 +221,7 @@ func lxdParseResponse(resp *http.Response) (*api.Response, string, error) {
 
 	// Handle errors
 	if response.Type == api.ErrorResponse {
-		return nil, "", api.StatusErrorf(resp.StatusCode, response.Error)
+		return nil, "", api.StatusErrorf(resp.StatusCode, "%s", response.Error)
 	}
 
 	return &response, etag, nil
@@ -354,7 +354,7 @@ func (r *ProtocolLXD) queryStruct(method string, path string, data any, ETag str
 
 	// Log the data
 	logger.Debugf("Got response struct from LXD")
-	logger.Debugf(logger.Pretty(target))
+	logger.Debug(logger.Pretty(target))
 
 	return etag, nil
 }
@@ -401,7 +401,7 @@ func (r *ProtocolLXD) queryOperation(method string, path string, data any, ETag 
 
 	// Log the data
 	logger.Debugf("Got operation from LXD")
-	logger.Debugf(logger.Pretty(op.Operation))
+	logger.Debug(logger.Pretty(op.Operation))
 
 	return &op, etag, nil
 }

--- a/client/lxd.go
+++ b/client/lxd.go
@@ -492,7 +492,7 @@ func (r *ProtocolLXD) getUnderlyingHTTPTransport() (*http.Transport, error) {
 // is also updated with the minimal source fields.
 func (r *ProtocolLXD) getSourceImageConnectionInfo(source ImageServer, image api.Image, instSrc *api.InstanceSource) (info *ConnectionInfo, err error) {
 	// Set the minimal source fields
-	instSrc.Type = "image"
+	instSrc.Type = api.SourceTypeImage
 
 	// Optimization for the local image case
 	if r.isSameServer(source) {

--- a/client/lxd_containers.go
+++ b/client/lxd_containers.go
@@ -424,7 +424,10 @@ func (r *ProtocolLXD) CopyContainer(source InstanceServer, container api.Contain
 
 		targetSecrets := map[string]string{}
 		for k, v := range opAPI.Metadata {
-			targetSecrets[k] = v.(string)
+			value, ok := v.(string)
+			if ok {
+				targetSecrets[k] = value
+			}
 		}
 
 		// Prepare the source request
@@ -452,7 +455,10 @@ func (r *ProtocolLXD) CopyContainer(source InstanceServer, container api.Contain
 
 	sourceSecrets := map[string]string{}
 	for k, v := range opAPI.Metadata {
-		sourceSecrets[k] = v.(string)
+		value, ok := v.(string)
+		if ok {
+			sourceSecrets[k] = value
+		}
 	}
 
 	// Relay mode migration
@@ -472,7 +478,10 @@ func (r *ProtocolLXD) CopyContainer(source InstanceServer, container api.Contain
 		// Extract the websockets
 		targetSecrets := map[string]string{}
 		for k, v := range targetOpAPI.Metadata {
-			targetSecrets[k] = v.(string)
+			value, ok := v.(string)
+			if ok {
+				targetSecrets[k] = value
+			}
 		}
 
 		// Launch the relay
@@ -651,11 +660,13 @@ func (r *ProtocolLXD) ExecContainer(containerName string, exec api.ContainerExec
 		// Parse the fds
 		fds := map[string]string{}
 
-		value, ok := opAPI.Metadata["fds"]
+		values, ok := opAPI.Metadata["fds"].(map[string]any)
 		if ok {
-			values := value.(map[string]any)
 			for k, v := range values {
-				fds[k] = v.(string)
+				fd, ok := v.(string)
+				if ok {
+					fds[k] = fd
+				}
 			}
 		}
 
@@ -1129,7 +1140,10 @@ func (r *ProtocolLXD) CopyContainerSnapshot(source InstanceServer, containerName
 
 		targetSecrets := map[string]string{}
 		for k, v := range opAPI.Metadata {
-			targetSecrets[k] = v.(string)
+			value, ok := v.(string)
+			if ok {
+				targetSecrets[k] = value
+			}
 		}
 
 		// Prepare the source request
@@ -1157,7 +1171,10 @@ func (r *ProtocolLXD) CopyContainerSnapshot(source InstanceServer, containerName
 
 	sourceSecrets := map[string]string{}
 	for k, v := range opAPI.Metadata {
-		sourceSecrets[k] = v.(string)
+		value, ok := v.(string)
+		if ok {
+			sourceSecrets[k] = value
+		}
 	}
 
 	// Relay mode migration
@@ -1177,7 +1194,10 @@ func (r *ProtocolLXD) CopyContainerSnapshot(source InstanceServer, containerName
 		// Extract the websockets
 		targetSecrets := map[string]string{}
 		for k, v := range targetOpAPI.Metadata {
-			targetSecrets[k] = v.(string)
+			value, ok := v.(string)
+			if ok {
+				targetSecrets[k] = value
+			}
 		}
 
 		// Launch the relay
@@ -1574,11 +1594,13 @@ func (r *ProtocolLXD) ConsoleContainer(containerName string, console api.Contain
 	// Parse the fds
 	fds := map[string]string{}
 
-	value, ok := opAPI.Metadata["fds"]
+	values, ok := opAPI.Metadata["fds"].(map[string]any)
 	if ok {
-		values := value.(map[string]any)
 		for k, v := range values {
-			fds[k] = v.(string)
+			fd, ok := v.(string)
+			if ok {
+				fds[k] = fd
+			}
 		}
 	}
 

--- a/client/lxd_containers.go
+++ b/client/lxd_containers.go
@@ -228,7 +228,7 @@ func (r *ProtocolLXD) tryCreateContainer(req api.ContainersPost, urls []string) 
 // CreateContainerFromImage is a convenience function to make it easier to create a container from an existing image.
 func (r *ProtocolLXD) CreateContainerFromImage(source ImageServer, image api.Image, req api.ContainersPost) (RemoteOperation, error) {
 	// Set the minimal source fields
-	req.Source.Type = "image"
+	req.Source.Type = api.SourceTypeImage
 
 	// Optimization for the local image case
 	if r.isSameServer(source) {
@@ -372,7 +372,7 @@ func (r *ProtocolLXD) CopyContainer(source InstanceServer, container api.Contain
 		}
 
 		// Local copy source fields
-		req.Source.Type = "copy"
+		req.Source.Type = api.SourceTypeCopy
 		req.Source.Source = container.Name
 
 		// Copy the container
@@ -411,7 +411,7 @@ func (r *ProtocolLXD) CopyContainer(source InstanceServer, container api.Contain
 		}
 
 		// Create the container
-		req.Source.Type = "migration"
+		req.Source.Type = api.SourceTypeMigration
 		req.Source.Mode = "push"
 		req.Source.Refresh = args.Refresh
 
@@ -458,7 +458,7 @@ func (r *ProtocolLXD) CopyContainer(source InstanceServer, container api.Contain
 	// Relay mode migration
 	if args != nil && args.Mode == "relay" {
 		// Push copy source fields
-		req.Source.Type = "migration"
+		req.Source.Type = api.SourceTypeMigration
 		req.Source.Mode = "push"
 
 		// Start the process
@@ -497,7 +497,7 @@ func (r *ProtocolLXD) CopyContainer(source InstanceServer, container api.Contain
 	}
 
 	// Pull mode migration
-	req.Source.Type = "migration"
+	req.Source.Type = api.SourceTypeMigration
 	req.Source.Mode = "pull"
 	req.Source.Operation = opAPI.ID
 	req.Source.Websockets = sourceSecrets
@@ -1075,7 +1075,7 @@ func (r *ProtocolLXD) CopyContainerSnapshot(source InstanceServer, containerName
 		}
 
 		// Local copy source fields
-		req.Source.Type = "copy"
+		req.Source.Type = api.SourceTypeCopy
 		req.Source.Source = fmt.Sprintf("%s/%s", cName, sName)
 
 		// Copy the container
@@ -1117,7 +1117,7 @@ func (r *ProtocolLXD) CopyContainerSnapshot(source InstanceServer, containerName
 		}
 
 		// Create the container
-		req.Source.Type = "migration"
+		req.Source.Type = api.SourceTypeMigration
 		req.Source.Mode = "push"
 
 		op, err := r.CreateContainer(req)
@@ -1163,7 +1163,7 @@ func (r *ProtocolLXD) CopyContainerSnapshot(source InstanceServer, containerName
 	// Relay mode migration
 	if args != nil && args.Mode == "relay" {
 		// Push copy source fields
-		req.Source.Type = "migration"
+		req.Source.Type = api.SourceTypeMigration
 		req.Source.Mode = "push"
 
 		// Start the process
@@ -1202,7 +1202,7 @@ func (r *ProtocolLXD) CopyContainerSnapshot(source InstanceServer, containerName
 	}
 
 	// Pull mode migration
-	req.Source.Type = "migration"
+	req.Source.Type = api.SourceTypeMigration
 	req.Source.Mode = "pull"
 	req.Source.Operation = opAPI.ID
 	req.Source.Websockets = sourceSecrets

--- a/client/lxd_images.go
+++ b/client/lxd_images.go
@@ -911,7 +911,7 @@ func (r *ProtocolLXD) CopyImage(source ImageServer, image api.Image, args *Image
 			},
 			Fingerprint: image.Fingerprint,
 			Mode:        "pull",
-			Type:        "image",
+			Type:        api.SourceTypeImage,
 			Project:     info.Project,
 		},
 		ImagePut: api.ImagePut{

--- a/client/lxd_instances.go
+++ b/client/lxd_instances.go
@@ -924,7 +924,7 @@ func (r *ProtocolLXD) CopyInstance(source InstanceServer, instance api.Instance,
 		}
 
 		// Local copy source fields
-		req.Source.Type = "copy"
+		req.Source.Type = api.SourceTypeCopy
 		req.Source.Source = instance.Name
 
 		// Copy the instance
@@ -965,7 +965,7 @@ func (r *ProtocolLXD) CopyInstance(source InstanceServer, instance api.Instance,
 		}
 
 		// Create the instance
-		req.Source.Type = "migration"
+		req.Source.Type = api.SourceTypeMigration
 		req.Source.Mode = "push"
 		req.Source.Refresh = args.Refresh
 
@@ -1022,7 +1022,7 @@ func (r *ProtocolLXD) CopyInstance(source InstanceServer, instance api.Instance,
 	// Relay mode migration
 	if args != nil && args.Mode == "relay" {
 		// Push copy source fields
-		req.Source.Type = "migration"
+		req.Source.Type = api.SourceTypeMigration
 		req.Source.Mode = "push"
 
 		// Start the process
@@ -1066,7 +1066,7 @@ func (r *ProtocolLXD) CopyInstance(source InstanceServer, instance api.Instance,
 	}
 
 	// Pull mode migration
-	req.Source.Type = "migration"
+	req.Source.Type = api.SourceTypeMigration
 	req.Source.Mode = "pull"
 	req.Source.Operation = opAPI.ID
 	req.Source.Websockets = sourceSecrets
@@ -2008,7 +2008,7 @@ func (r *ProtocolLXD) CopyInstanceSnapshot(source InstanceServer, instanceName s
 		}
 
 		// Local copy source fields
-		req.Source.Type = "copy"
+		req.Source.Type = api.SourceTypeCopy
 		req.Source.Source = fmt.Sprintf("%s/%s", cName, sName)
 
 		// Copy the instance
@@ -2060,7 +2060,7 @@ func (r *ProtocolLXD) CopyInstanceSnapshot(source InstanceServer, instanceName s
 		}
 
 		// Create the instance
-		req.Source.Type = "migration"
+		req.Source.Type = api.SourceTypeMigration
 		req.Source.Mode = "push"
 
 		op, err := r.CreateInstance(req)
@@ -2116,7 +2116,7 @@ func (r *ProtocolLXD) CopyInstanceSnapshot(source InstanceServer, instanceName s
 	// Relay mode migration
 	if args != nil && args.Mode == "relay" {
 		// Push copy source fields
-		req.Source.Type = "migration"
+		req.Source.Type = api.SourceTypeMigration
 		req.Source.Mode = "push"
 
 		// Start the process
@@ -2160,7 +2160,7 @@ func (r *ProtocolLXD) CopyInstanceSnapshot(source InstanceServer, instanceName s
 	}
 
 	// Pull mode migration
-	req.Source.Type = "migration"
+	req.Source.Type = api.SourceTypeMigration
 	req.Source.Mode = "pull"
 	req.Source.Operation = opAPI.ID
 	req.Source.Websockets = sourceSecrets

--- a/client/lxd_storage_volumes.go
+++ b/client/lxd_storage_volumes.go
@@ -708,7 +708,10 @@ func (r *ProtocolLXD) CopyStoragePoolVolume(pool string, source InstanceServer, 
 
 		targetSecrets := map[string]string{}
 		for k, v := range opAPI.Metadata {
-			targetSecrets[k] = v.(string)
+			value, ok := v.(string)
+			if ok {
+				targetSecrets[k] = value
+			}
 		}
 
 		// Prepare the source request
@@ -738,7 +741,10 @@ func (r *ProtocolLXD) CopyStoragePoolVolume(pool string, source InstanceServer, 
 	// Prepare source server secrets for remote
 	sourceSecrets := map[string]string{}
 	for k, v := range opAPI.Metadata {
-		sourceSecrets[k] = v.(string)
+		value, ok := v.(string)
+		if ok {
+			sourceSecrets[k] = value
+		}
 	}
 
 	// Relay mode migration
@@ -761,7 +767,10 @@ func (r *ProtocolLXD) CopyStoragePoolVolume(pool string, source InstanceServer, 
 		// Extract the websockets
 		targetSecrets := map[string]string{}
 		for k, v := range targetOpAPI.Metadata {
-			targetSecrets[k] = v.(string)
+			value, ok := v.(string)
+			if ok {
+				targetSecrets[k] = value
+			}
 		}
 
 		// Launch the relay

--- a/client/lxd_storage_volumes.go
+++ b/client/lxd_storage_volumes.go
@@ -609,7 +609,7 @@ func (r *ProtocolLXD) CopyStoragePoolVolume(pool string, source InstanceServer, 
 		Type: volume.Type,
 		Source: api.StorageVolumeSource{
 			Name:       volume.Name,
-			Type:       "copy",
+			Type:       api.SourceTypeCopy,
 			Pool:       sourcePool,
 			VolumeOnly: args.VolumeOnly,
 			Refresh:    args.Refresh,
@@ -692,7 +692,7 @@ func (r *ProtocolLXD) CopyStoragePoolVolume(pool string, source InstanceServer, 
 		}
 
 		// Create the container
-		req.Source.Type = "migration"
+		req.Source.Type = api.SourceTypeMigration
 		req.Source.Mode = "push"
 
 		// Send the request
@@ -744,7 +744,7 @@ func (r *ProtocolLXD) CopyStoragePoolVolume(pool string, source InstanceServer, 
 	// Relay mode migration
 	if args != nil && args.Mode == "relay" {
 		// Push copy source fields
-		req.Source.Type = "migration"
+		req.Source.Type = api.SourceTypeMigration
 		req.Source.Mode = "push"
 
 		// Send the request
@@ -786,7 +786,7 @@ func (r *ProtocolLXD) CopyStoragePoolVolume(pool string, source InstanceServer, 
 	}
 
 	// Pull mode migration
-	req.Source.Type = "migration"
+	req.Source.Type = api.SourceTypeMigration
 	req.Source.Mode = "pull"
 	req.Source.Operation = opAPI.ID
 	req.Source.Websockets = sourceSecrets

--- a/lxc-to-lxd/main.go
+++ b/lxc-to-lxd/main.go
@@ -44,6 +44,7 @@ __attribute__((constructor)) void init(void) {
 import "C"
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -83,6 +84,7 @@ func main() {
 	// Run the main command and handle errors
 	err := app.Execute()
 	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }

--- a/lxc-to-lxd/main_migrate.go
+++ b/lxc-to-lxd/main_migrate.go
@@ -381,7 +381,7 @@ func convertContainer(d lxd.ContainerServer, container *liblxc.Container, storag
 	req := api.ContainersPost{
 		Name: container.Name(),
 		Source: api.ContainerSource{
-			Type: "migration",
+			Type: api.SourceTypeMigration,
 			Mode: "push",
 		},
 	}

--- a/lxc-to-lxd/main_migrate.go
+++ b/lxc-to-lxd/main_migrate.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
-	"os"
 	"runtime"
 	"strconv"
 	"strings"
@@ -63,9 +63,9 @@ func (c *cmdMigrate) Command() *cobra.Command {
 // RunE executes the migrate command.
 func (c *cmdMigrate) RunE(cmd *cobra.Command, args []string) error {
 	if (len(c.flagContainers) == 0 && !c.flagAll) || (len(c.flagContainers) > 0 && c.flagAll) {
-		fmt.Fprintln(os.Stderr, "You must either pass container names or --all")
-		os.Exit(1)
+		return errors.New("You must either pass container names or --all")
 	}
+
 	// Connect to LXD
 	d, err := lxd.ConnectLXDUnix("", nil)
 	if err != nil {

--- a/lxc/init.go
+++ b/lxc/init.go
@@ -380,7 +380,7 @@ func (c *cmdInit) create(conf *config.Config, args []string, launch bool) (lxd.I
 
 		opInfo = *info
 	} else {
-		req.Source.Type = "none"
+		req.Source.Type = api.SourceTypeNone
 
 		op, err := d.CreateInstance(req)
 		if err != nil {

--- a/lxc/rebuild.go
+++ b/lxc/rebuild.go
@@ -161,7 +161,7 @@ func (c *cmdRebuild) rebuild(conf *config.Config, args []string) error {
 			return errors.New(i18n.G("Can't use an image with --empty"))
 		}
 
-		req.Source.Type = "none"
+		req.Source.Type = api.SourceTypeNone
 		op, err := d.RebuildInstance(name, req)
 		if err != nil {
 			return err

--- a/lxd-benchmark/benchmark/operation.go
+++ b/lxd-benchmark/benchmark/operation.go
@@ -16,7 +16,7 @@ func createContainer(c lxd.ContainerServer, fingerprint string, name string, pri
 	req := api.ContainersPost{
 		Name: name,
 		Source: api.ContainerSource{
-			Type:        "image",
+			Type:        api.SourceTypeImage,
 			Fingerprint: fingerprint,
 		},
 	}

--- a/lxd-migrate/main_migrate.go
+++ b/lxd-migrate/main_migrate.go
@@ -362,7 +362,7 @@ func (c *cmdMigrate) newMigrateData(server lxd.InstanceServer) (*cmdMigrateData,
 	config.InstanceArgs.Config = map[string]string{}
 	config.InstanceArgs.Devices = map[string]map[string]string{}
 	config.InstanceArgs.Source = api.InstanceSource{
-		Type:              "conversion",
+		Type:              api.SourceTypeConversion,
 		Mode:              "push",
 		ConversionOptions: c.flagConversionOpts,
 	}
@@ -372,7 +372,7 @@ func (c *cmdMigrate) newMigrateData(server lxd.InstanceServer) (*cmdMigrateData,
 	// LXD instance. This means that images of different formats,
 	// such as VMDK and QCow2, will not work.
 	if !server.HasExtension("instance_import_conversion") {
-		config.InstanceArgs.Source.Type = "migration"
+		config.InstanceArgs.Source.Type = api.SourceTypeMigration
 	}
 
 	// Parse instance type from a flag.
@@ -911,7 +911,7 @@ func (c *cmdMigrate) run(cmd *cobra.Command, args []string) error {
 		}
 
 		// In conversion mode, server expects the volume size hint in the request.
-		if config.InstanceArgs.Source.Type == "conversion" {
+		if config.InstanceArgs.Source.Type == api.SourceTypeConversion {
 			size, err := block.DiskSizeBytes(target)
 			if err != nil {
 				return err
@@ -943,7 +943,7 @@ func (c *cmdMigrate) run(cmd *cobra.Command, args []string) error {
 	})
 
 	progressPrefix := "Transferring instance: %s"
-	if config.InstanceArgs.Source.Type == "conversion" {
+	if config.InstanceArgs.Source.Type == api.SourceTypeConversion {
 		// In conversion mode, progress prefix is determined on the server side.
 		progressPrefix = "%s"
 	}
@@ -955,7 +955,7 @@ func (c *cmdMigrate) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if config.InstanceArgs.Source.Type == "conversion" {
+	if config.InstanceArgs.Source.Type == api.SourceTypeConversion {
 		err = transferRootDiskForConversion(ctx, op, fullPath, c.flagRsyncArgs, config.InstanceArgs.Type)
 	} else {
 		err = transferRootDiskForMigration(ctx, op, fullPath, c.flagRsyncArgs, config.InstanceArgs.Type)
@@ -1098,7 +1098,7 @@ func (c *cmdMigrate) checkSource(path string, instanceType api.InstanceType, mig
 		return errors.New("Path does not exist")
 	}
 
-	if instanceType == api.InstanceTypeVM && migrationMode == "migration" {
+	if instanceType == api.InstanceTypeVM && migrationMode == api.SourceTypeMigration {
 		isImageTypeRaw, err := isImageTypeRaw(path)
 		if err != nil {
 			return err

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -1229,7 +1229,7 @@ func imagesPost(d *Daemon, r *http.Request) response.Response {
 			/* Processing image upload */
 			info, err = getImgPostInfo(s, r, builddir, projectName, post, imageMetadata)
 		} else {
-			if req.Source.Type == "image" {
+			if req.Source.Type == api.SourceTypeImage {
 				/* Processing image copy from remote */
 				info, err = imgPostRemoteInfo(s, r, req, op, projectName, budget)
 			} else if req.Source.Type == "url" {

--- a/lxd/instance/instance_utils.go
+++ b/lxd/instance/instance_utils.go
@@ -547,7 +547,7 @@ func ResolveImage(ctx context.Context, tx *db.ClusterTx, projectName string, sou
 // A nil list indicates that we can't tell at this stage, typically for private images.
 func SuitableArchitectures(ctx context.Context, s *state.State, tx *db.ClusterTx, projectName string, sourceInst *cluster.Instance, sourceImageRef string, req api.InstancesPost) ([]int, error) {
 	// Handle cases where the architecture is already provided.
-	if shared.ValueInSlice(req.Source.Type, []string{"conversion", "migration", "none"}) && req.Architecture != "" {
+	if shared.ValueInSlice(req.Source.Type, []string{api.SourceTypeConversion, api.SourceTypeMigration, api.SourceTypeNone}) && req.Architecture != "" {
 		id, err := osarch.ArchitectureId(req.Architecture)
 		if err != nil {
 			return nil, err
@@ -557,22 +557,22 @@ func SuitableArchitectures(ctx context.Context, s *state.State, tx *db.ClusterTx
 	}
 
 	// For migration and conversion, an architecture must be specified in the req.
-	if shared.ValueInSlice(req.Source.Type, []string{"conversion", "migration"}) && req.Architecture == "" {
+	if shared.ValueInSlice(req.Source.Type, []string{api.SourceTypeConversion, api.SourceTypeMigration}) && req.Architecture == "" {
 		return nil, api.StatusErrorf(http.StatusBadRequest, "An architecture must be specified in migration or conversion requests")
 	}
 
 	// For none, allow any architecture.
-	if req.Source.Type == "none" {
+	if req.Source.Type == api.SourceTypeNone {
 		return []int{}, nil
 	}
 
 	// For copy, always use the source architecture.
-	if req.Source.Type == "copy" {
+	if req.Source.Type == api.SourceTypeCopy {
 		return []int{sourceInst.Architecture}, nil
 	}
 
 	// For image, things get a bit more complicated.
-	if req.Source.Type == "image" {
+	if req.Source.Type == api.SourceTypeImage {
 		// Handle local images.
 		if req.Source.Server == "" {
 			_, img, err := tx.GetImageByFingerprintPrefix(ctx, sourceImageRef, cluster.ImageFilter{Project: &projectName})

--- a/lxd/instance_post.go
+++ b/lxd/instance_post.go
@@ -768,7 +768,7 @@ func instancePostClusteringMigrate(s *state.State, r *http.Request, srcPool stor
 			InstancePut: srcInstInfo.Writable(),
 			Type:        api.InstanceType(srcInstInfo.Type),
 			Source: api.InstanceSource{
-				Type:        "migration",
+				Type:        api.SourceTypeMigration,
 				Mode:        "pull",
 				Operation:   fmt.Sprintf("https://%s%s", srcMember.Address, srcOp.URL()),
 				Websockets:  sourceSecrets,

--- a/lxd/instance_rebuild.go
+++ b/lxd/instance_rebuild.go
@@ -113,7 +113,7 @@ func instanceRebuildPost(d *Daemon, r *http.Request) response.Response {
 			return fmt.Errorf("Failed loading instance: %w", err)
 		}
 
-		if req.Source.Type != "none" {
+		if req.Source.Type != api.SourceTypeNone {
 			sourceImage, err = getSourceImageFromInstanceSource(ctx, s, tx, targetProject.Name, req.Source, &sourceImageRef, dbInst.Type.String())
 			if err != nil && !api.StatusErrorCheck(err, http.StatusNotFound) {
 				return err
@@ -136,7 +136,7 @@ func instanceRebuildPost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	run := func(op *operations.Operation) error {
-		if req.Source.Type == "none" {
+		if req.Source.Type == api.SourceTypeNone {
 			return instanceRebuildFromEmpty(inst, op)
 		}
 

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -1101,7 +1101,7 @@ func instancesPost(d *Daemon, r *http.Request) response.Response {
 		profileProject := project.ProfileProjectFromRecord(targetProject)
 
 		switch req.Source.Type {
-		case "copy":
+		case api.SourceTypeCopy:
 			if req.Source.Source == "" {
 				return api.StatusErrorf(http.StatusBadRequest, "Must specify a source instance")
 			}
@@ -1130,7 +1130,7 @@ func instancesPost(d *Daemon, r *http.Request) response.Response {
 				}
 			}
 
-		case "image":
+		case api.SourceTypeImage:
 			// Check if the image has an entry in the database but fail only if the error
 			// is different than the image not being found.
 			sourceImage, err = getSourceImageFromInstanceSource(ctx, s, tx, targetProject.Name, req.Source, &sourceImageRef, string(req.Type))
@@ -1339,15 +1339,15 @@ func instancesPost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	switch req.Source.Type {
-	case "image":
+	case api.SourceTypeImage:
 		return createFromImage(s, r, *targetProject, profiles, sourceImage, sourceImageRef, &req)
-	case "none":
+	case api.SourceTypeNone:
 		return createFromNone(s, r, targetProjectName, profiles, &req)
-	case "migration":
+	case api.SourceTypeMigration:
 		return createFromMigration(s, r, targetProjectName, profiles, &req)
-	case "conversion":
+	case api.SourceTypeConversion:
 		return createFromConversion(s, r, targetProjectName, profiles, &req)
-	case "copy":
+	case api.SourceTypeCopy:
 		return createFromCopy(s, r, targetProjectName, profiles, &req)
 	default:
 		return response.BadRequest(fmt.Errorf("Unknown source type %s", req.Source.Type))
@@ -1507,7 +1507,7 @@ func clusterCopyContainerInternal(s *state.State, r *http.Request, source instan
 	}
 
 	// Reset the source for a migration
-	req.Source.Type = "migration"
+	req.Source.Type = api.SourceTypeMigration
 	req.Source.Certificate = string(s.Endpoints.NetworkCert().PublicKey())
 	req.Source.Mode = "pull"
 	req.Source.Operation = fmt.Sprintf("https://%s/%s/operations/%s", nodeAddress, version.APIVersion, opAPI.ID)

--- a/lxd/project/limits/permissions.go
+++ b/lxd/project/limits/permissions.go
@@ -418,7 +418,7 @@ func getAggregateLimits(info *projectInfo, aggregateKeys []string) (map[string]a
 	}
 
 	for _, key := range aggregateKeys {
-		max := int64(-1)
+		maxValue := int64(-1)
 		limit := info.Project.Config[key]
 		if limit != "" {
 			keyName := key
@@ -429,7 +429,7 @@ func getAggregateLimits(info *projectInfo, aggregateKeys []string) (map[string]a
 			}
 
 			parser := aggregateLimitConfigValueParsers[keyName]
-			max, err = parser(info.Project.Config[key])
+			maxValue, err = parser(info.Project.Config[key])
 			if err != nil {
 				return nil, err
 			}
@@ -437,7 +437,7 @@ func getAggregateLimits(info *projectInfo, aggregateKeys []string) (map[string]a
 
 		resource := api.ProjectStateResource{
 			Usage: totals[key],
-			Limit: max,
+			Limit: maxValue,
 		}
 
 		result[key] = resource
@@ -465,12 +465,12 @@ func checkAggregateLimits(info *projectInfo, aggregateKeys []string) error {
 		}
 
 		parser := aggregateLimitConfigValueParsers[keyName]
-		max, err := parser(info.Project.Config[key])
+		maxValue, err := parser(info.Project.Config[key])
 		if err != nil {
 			return err
 		}
 
-		if totals[key] > max {
+		if totals[key] > maxValue {
 			return fmt.Errorf("Reached maximum aggregate value %q for %q in project %q", info.Project.Config[key], key, info.Project.Name)
 		}
 	}

--- a/lxd/project/limits/permissions.go
+++ b/lxd/project/limits/permissions.go
@@ -107,7 +107,7 @@ func AllowInstanceCreation(globalConfig *clusterConfig.Config, tx *db.ClusterTx,
 	// Special case restriction checks on volatile.* keys.
 	strip := false
 
-	if shared.ValueInSlice(req.Source.Type, []string{"copy", "migration"}) {
+	if shared.ValueInSlice(req.Source.Type, []string{api.SourceTypeCopy, api.SourceTypeMigration}) {
 		// Allow stripping volatile keys if dealing with a copy or migration.
 		strip = true
 	}

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -1095,13 +1095,13 @@ func storagePoolVolumesPost(d *Daemon, r *http.Request) response.Response {
 	switch req.Source.Type {
 	case "":
 		return doVolumeCreateOrCopy(s, r, requestProjectName, projectName, poolName, &req)
-	case "copy":
+	case api.SourceTypeCopy:
 		if dbVolume != nil {
 			return doCustomVolumeRefresh(s, r, requestProjectName, projectName, poolName, &req)
 		}
 
 		return doVolumeCreateOrCopy(s, r, requestProjectName, projectName, poolName, &req)
-	case "migration":
+	case api.SourceTypeMigration:
 		return doVolumeMigration(s, r, requestProjectName, projectName, poolName, &req)
 	default:
 		return response.BadRequest(fmt.Errorf("Unknown source type %q", req.Source.Type))
@@ -1146,7 +1146,7 @@ func clusterCopyCustomVolumeInternal(s *state.State, r *http.Request, sourceAddr
 	}
 
 	// Reset the source for a migration
-	req.Source.Type = "migration"
+	req.Source.Type = api.SourceTypeMigration
 	req.Source.Certificate = string(s.Endpoints.NetworkCert().PublicKey())
 	req.Source.Mode = "pull"
 	req.Source.Operation = fmt.Sprintf("https://%s/%s/operations/%s", sourceAddress, version.APIVersion, opAPI.ID)
@@ -1801,7 +1801,7 @@ func storageVolumePostClusteringMigrate(s *state.State, r *http.Request, srcPool
 			Name: newVolumeName,
 			Type: "custom",
 			Source: api.StorageVolumeSource{
-				Type:        "migration",
+				Type:        api.SourceTypeMigration,
 				Mode:        "pull",
 				Operation:   fmt.Sprintf("https://%s%s", srcMember.Address, srcOp.URL()),
 				Websockets:  sourceSecrets,

--- a/po/ar.po
+++ b/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-21 15:57-0700\n"
+"POT-Creation-Date: 2024-12-05 16:02+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -60,7 +60,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1239
+#: lxc/config.go:1240
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -1012,7 +1012,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1096
+#: lxc/config.go:702 lxc/config.go:1097
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1207,7 +1207,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1673,9 +1673,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:955
-#: lxc/config.go:995 lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172
-#: lxc/config.go:1226 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
+#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
+#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1690,8 +1690,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
+#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1952,7 +1952,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1225 lxc/config.go:1226
+#: lxc/config.go:1226 lxc/config.go:1227
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2499,7 +2499,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:995
+#: lxc/config.go:995 lxc/config.go:996
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2507,7 +2507,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1601 lxc/image.go:1602
 msgid "Get image properties"
 msgstr ""
 
@@ -2763,7 +2763,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:404
+#: lxc/main.go:406
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2785,7 +2785,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1517
 msgid "Image already up to date."
 msgstr ""
 
@@ -2801,11 +2801,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1472
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1698
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2815,7 +2815,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1515
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2901,7 +2901,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
+#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2995,7 +2995,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:506
+#: lxc/main.go:509
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3586,7 +3586,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:954 lxc/config.go:955
+#: lxc/config.go:955 lxc/config.go:956
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4435,7 +4435,7 @@ msgstr ""
 
 #: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -4555,7 +4555,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1649
 msgid "Property not found"
 msgstr ""
 
@@ -4685,7 +4685,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4722,7 +4722,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1444 lxc/image.go:1445
 msgid "Refresh images"
 msgstr ""
 
@@ -4731,7 +4731,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1481
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4939,7 +4939,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1031
+#: lxc/config.go:1032
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5116,7 +5116,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1049 lxc/config.go:1050
+#: lxc/config.go:1050 lxc/config.go:1051
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5150,7 +5150,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1665 lxc/image.go:1666
 msgid "Set image properties"
 msgstr ""
 
@@ -5455,11 +5455,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1535 lxc/image.go:1536
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1172
+#: lxc/config.go:1172 lxc/config.go:1173
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -6052,7 +6052,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:410
+#: lxc/main.go:412
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6231,7 +6231,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1140 lxc/config.go:1141
+#: lxc/config.go:1141 lxc/config.go:1142
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6247,7 +6247,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1728 lxc/image.go:1729
 msgid "Unset image properties"
 msgstr ""
 
@@ -6690,15 +6690,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1600 lxc/image.go:1727
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1664
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6718,11 +6718,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1443
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
+#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6744,11 +6744,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:993 lxc/config.go:1139
+#: lxc/config.go:994 lxc/config.go:1140
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1048
+#: lxc/config.go:1049
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7298,13 +7298,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1228
+#: lxc/config.go:1229
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1052
+#: lxc/config.go:1053
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-21 15:57-0700\n"
+"POT-Creation-Date: 2024-12-05 16:02+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1239
+#: lxc/config.go:1240
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1096
+#: lxc/config.go:702 lxc/config.go:1097
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1210,7 +1210,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1676,9 +1676,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:955
-#: lxc/config.go:995 lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172
-#: lxc/config.go:1226 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
+#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
+#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1693,8 +1693,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
+#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1955,7 +1955,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1225 lxc/config.go:1226
+#: lxc/config.go:1226 lxc/config.go:1227
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2502,7 +2502,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:995
+#: lxc/config.go:995 lxc/config.go:996
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2510,7 +2510,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1601 lxc/image.go:1602
 msgid "Get image properties"
 msgstr ""
 
@@ -2766,7 +2766,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:404
+#: lxc/main.go:406
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2788,7 +2788,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1517
 msgid "Image already up to date."
 msgstr ""
 
@@ -2804,11 +2804,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1472
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1698
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2818,7 +2818,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1515
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2904,7 +2904,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
+#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2998,7 +2998,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:506
+#: lxc/main.go:509
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3589,7 +3589,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:954 lxc/config.go:955
+#: lxc/config.go:955 lxc/config.go:956
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4438,7 +4438,7 @@ msgstr ""
 
 #: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -4558,7 +4558,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1649
 msgid "Property not found"
 msgstr ""
 
@@ -4688,7 +4688,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4725,7 +4725,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1444 lxc/image.go:1445
 msgid "Refresh images"
 msgstr ""
 
@@ -4734,7 +4734,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1481
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4942,7 +4942,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1031
+#: lxc/config.go:1032
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5119,7 +5119,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1049 lxc/config.go:1050
+#: lxc/config.go:1050 lxc/config.go:1051
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5153,7 +5153,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1665 lxc/image.go:1666
 msgid "Set image properties"
 msgstr ""
 
@@ -5458,11 +5458,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1535 lxc/image.go:1536
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1172
+#: lxc/config.go:1172 lxc/config.go:1173
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -6055,7 +6055,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:410
+#: lxc/main.go:412
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6234,7 +6234,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1140 lxc/config.go:1141
+#: lxc/config.go:1141 lxc/config.go:1142
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6250,7 +6250,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1728 lxc/image.go:1729
 msgid "Unset image properties"
 msgstr ""
 
@@ -6693,15 +6693,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1600 lxc/image.go:1727
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1664
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6721,11 +6721,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1443
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
+#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6747,11 +6747,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:993 lxc/config.go:1139
+#: lxc/config.go:994 lxc/config.go:1140
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1048
+#: lxc/config.go:1049
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7301,13 +7301,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1228
+#: lxc/config.go:1229
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1052
+#: lxc/config.go:1053
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-21 15:57-0700\n"
+"POT-Creation-Date: 2024-12-05 16:02+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1239
+#: lxc/config.go:1240
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1096
+#: lxc/config.go:702 lxc/config.go:1097
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1210,7 +1210,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1676,9 +1676,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:955
-#: lxc/config.go:995 lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172
-#: lxc/config.go:1226 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
+#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
+#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1693,8 +1693,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
+#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1955,7 +1955,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1225 lxc/config.go:1226
+#: lxc/config.go:1226 lxc/config.go:1227
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2502,7 +2502,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:995
+#: lxc/config.go:995 lxc/config.go:996
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2510,7 +2510,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1601 lxc/image.go:1602
 msgid "Get image properties"
 msgstr ""
 
@@ -2766,7 +2766,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:404
+#: lxc/main.go:406
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2788,7 +2788,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1517
 msgid "Image already up to date."
 msgstr ""
 
@@ -2804,11 +2804,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1472
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1698
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2818,7 +2818,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1515
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2904,7 +2904,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
+#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2998,7 +2998,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:506
+#: lxc/main.go:509
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3589,7 +3589,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:954 lxc/config.go:955
+#: lxc/config.go:955 lxc/config.go:956
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4438,7 +4438,7 @@ msgstr ""
 
 #: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -4558,7 +4558,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1649
 msgid "Property not found"
 msgstr ""
 
@@ -4688,7 +4688,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4725,7 +4725,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1444 lxc/image.go:1445
 msgid "Refresh images"
 msgstr ""
 
@@ -4734,7 +4734,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1481
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4942,7 +4942,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1031
+#: lxc/config.go:1032
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5119,7 +5119,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1049 lxc/config.go:1050
+#: lxc/config.go:1050 lxc/config.go:1051
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5153,7 +5153,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1665 lxc/image.go:1666
 msgid "Set image properties"
 msgstr ""
 
@@ -5458,11 +5458,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1535 lxc/image.go:1536
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1172
+#: lxc/config.go:1172 lxc/config.go:1173
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -6055,7 +6055,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:410
+#: lxc/main.go:412
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6234,7 +6234,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1140 lxc/config.go:1141
+#: lxc/config.go:1141 lxc/config.go:1142
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6250,7 +6250,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1728 lxc/image.go:1729
 msgid "Unset image properties"
 msgstr ""
 
@@ -6693,15 +6693,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1600 lxc/image.go:1727
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1664
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6721,11 +6721,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1443
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
+#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6747,11 +6747,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:993 lxc/config.go:1139
+#: lxc/config.go:994 lxc/config.go:1140
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1048
+#: lxc/config.go:1049
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7301,13 +7301,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1228
+#: lxc/config.go:1229
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1052
+#: lxc/config.go:1053
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-21 15:57-0700\n"
+"POT-Creation-Date: 2024-12-05 16:02+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1239
+#: lxc/config.go:1240
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1096
+#: lxc/config.go:702 lxc/config.go:1097
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1210,7 +1210,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1676,9 +1676,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:955
-#: lxc/config.go:995 lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172
-#: lxc/config.go:1226 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
+#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
+#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1693,8 +1693,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
+#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1955,7 +1955,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1225 lxc/config.go:1226
+#: lxc/config.go:1226 lxc/config.go:1227
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2502,7 +2502,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:995
+#: lxc/config.go:995 lxc/config.go:996
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2510,7 +2510,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1601 lxc/image.go:1602
 msgid "Get image properties"
 msgstr ""
 
@@ -2766,7 +2766,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:404
+#: lxc/main.go:406
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2788,7 +2788,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1517
 msgid "Image already up to date."
 msgstr ""
 
@@ -2804,11 +2804,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1472
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1698
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2818,7 +2818,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1515
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2904,7 +2904,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
+#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2998,7 +2998,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:506
+#: lxc/main.go:509
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3589,7 +3589,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:954 lxc/config.go:955
+#: lxc/config.go:955 lxc/config.go:956
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4438,7 +4438,7 @@ msgstr ""
 
 #: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -4558,7 +4558,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1649
 msgid "Property not found"
 msgstr ""
 
@@ -4688,7 +4688,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4725,7 +4725,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1444 lxc/image.go:1445
 msgid "Refresh images"
 msgstr ""
 
@@ -4734,7 +4734,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1481
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4942,7 +4942,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1031
+#: lxc/config.go:1032
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5119,7 +5119,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1049 lxc/config.go:1050
+#: lxc/config.go:1050 lxc/config.go:1051
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5153,7 +5153,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1665 lxc/image.go:1666
 msgid "Set image properties"
 msgstr ""
 
@@ -5458,11 +5458,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1535 lxc/image.go:1536
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1172
+#: lxc/config.go:1172 lxc/config.go:1173
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -6055,7 +6055,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:410
+#: lxc/main.go:412
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6234,7 +6234,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1140 lxc/config.go:1141
+#: lxc/config.go:1141 lxc/config.go:1142
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6250,7 +6250,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1728 lxc/image.go:1729
 msgid "Unset image properties"
 msgstr ""
 
@@ -6693,15 +6693,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1600 lxc/image.go:1727
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1664
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6721,11 +6721,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1443
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
+#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6747,11 +6747,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:993 lxc/config.go:1139
+#: lxc/config.go:994 lxc/config.go:1140
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1048
+#: lxc/config.go:1049
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7301,13 +7301,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1228
+#: lxc/config.go:1229
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1052
+#: lxc/config.go:1053
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-21 15:57-0700\n"
+"POT-Creation-Date: 2024-12-05 16:02+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1239
+#: lxc/config.go:1240
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1096
+#: lxc/config.go:702 lxc/config.go:1097
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1210,7 +1210,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1676,9 +1676,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:955
-#: lxc/config.go:995 lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172
-#: lxc/config.go:1226 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
+#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
+#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1693,8 +1693,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
+#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1955,7 +1955,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1225 lxc/config.go:1226
+#: lxc/config.go:1226 lxc/config.go:1227
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2502,7 +2502,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:995
+#: lxc/config.go:995 lxc/config.go:996
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2510,7 +2510,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1601 lxc/image.go:1602
 msgid "Get image properties"
 msgstr ""
 
@@ -2766,7 +2766,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:404
+#: lxc/main.go:406
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2788,7 +2788,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1517
 msgid "Image already up to date."
 msgstr ""
 
@@ -2804,11 +2804,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1472
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1698
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2818,7 +2818,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1515
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2904,7 +2904,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
+#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2998,7 +2998,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:506
+#: lxc/main.go:509
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3589,7 +3589,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:954 lxc/config.go:955
+#: lxc/config.go:955 lxc/config.go:956
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4438,7 +4438,7 @@ msgstr ""
 
 #: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -4558,7 +4558,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1649
 msgid "Property not found"
 msgstr ""
 
@@ -4688,7 +4688,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4725,7 +4725,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1444 lxc/image.go:1445
 msgid "Refresh images"
 msgstr ""
 
@@ -4734,7 +4734,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1481
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4942,7 +4942,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1031
+#: lxc/config.go:1032
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5119,7 +5119,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1049 lxc/config.go:1050
+#: lxc/config.go:1050 lxc/config.go:1051
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5153,7 +5153,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1665 lxc/image.go:1666
 msgid "Set image properties"
 msgstr ""
 
@@ -5458,11 +5458,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1535 lxc/image.go:1536
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1172
+#: lxc/config.go:1172 lxc/config.go:1173
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -6055,7 +6055,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:410
+#: lxc/main.go:412
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6234,7 +6234,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1140 lxc/config.go:1141
+#: lxc/config.go:1141 lxc/config.go:1142
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6250,7 +6250,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1728 lxc/image.go:1729
 msgid "Unset image properties"
 msgstr ""
 
@@ -6693,15 +6693,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1600 lxc/image.go:1727
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1664
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6721,11 +6721,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1443
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
+#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6747,11 +6747,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:993 lxc/config.go:1139
+#: lxc/config.go:994 lxc/config.go:1140
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1048
+#: lxc/config.go:1049
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7301,13 +7301,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1228
+#: lxc/config.go:1229
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1052
+#: lxc/config.go:1053
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-21 15:57-0700\n"
+"POT-Creation-Date: 2024-12-05 16:02+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -100,7 +100,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/config.go:1239
+#: lxc/config.go:1240
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -1311,7 +1311,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1096
+#: lxc/config.go:702 lxc/config.go:1097
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1515,7 +1515,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -2020,9 +2020,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:955
-#: lxc/config.go:995 lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172
-#: lxc/config.go:1226 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
+#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
+#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -2037,8 +2037,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
+#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -2319,7 +2319,7 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1225 lxc/config.go:1226
+#: lxc/config.go:1226 lxc/config.go:1227
 #, fuzzy
 msgid "Edit instance UEFI variables"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -2897,7 +2897,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "Generiere Nutzerzertifikat. Dies kann wenige Minuten dauern...\n"
 
-#: lxc/config.go:994 lxc/config.go:995
+#: lxc/config.go:995 lxc/config.go:996
 #, fuzzy
 msgid "Get UEFI variables for instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -2906,7 +2906,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1601 lxc/image.go:1602
 msgid "Get image properties"
 msgstr ""
 
@@ -3184,7 +3184,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:404
+#: lxc/main.go:406
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3207,7 +3207,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/image.go:1522
+#: lxc/image.go:1517
 msgid "Image already up to date."
 msgstr ""
 
@@ -3223,11 +3223,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1472
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1698
 #, fuzzy, c-format
 msgid "Image identifier missing: %s"
 msgstr "Abbild mit Fingerabdruck %s importiert\n"
@@ -3237,7 +3237,7 @@ msgstr "Abbild mit Fingerabdruck %s importiert\n"
 msgid "Image imported with fingerprint: %s"
 msgstr "Abbild mit Fingerabdruck %s importiert\n"
 
-#: lxc/image.go:1520
+#: lxc/image.go:1515
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3327,7 +3327,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
+#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3423,7 +3423,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:506
+#: lxc/main.go:509
 #, fuzzy
 msgid "Invalid number of arguments"
 msgstr "ungültiges Argument %s"
@@ -4068,7 +4068,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:954 lxc/config.go:955
+#: lxc/config.go:955 lxc/config.go:956
 #, fuzzy
 msgid "Manage instance UEFI variables"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -4981,7 +4981,7 @@ msgstr ""
 
 #: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -5107,7 +5107,7 @@ msgstr ""
 msgid "Properties:"
 msgstr "Eigenschaften:\n"
 
-#: lxc/image.go:1654
+#: lxc/image.go:1649
 msgid "Property not found"
 msgstr ""
 
@@ -5240,7 +5240,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5280,7 +5280,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1444 lxc/image.go:1445
 msgid "Refresh images"
 msgstr ""
 
@@ -5289,7 +5289,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/image.go:1486
+#: lxc/image.go:1481
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5519,7 +5519,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1031
+#: lxc/config.go:1032
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5706,7 +5706,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1049 lxc/config.go:1050
+#: lxc/config.go:1050 lxc/config.go:1051
 #, fuzzy
 msgid "Set UEFI variables for instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -5743,7 +5743,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1665 lxc/image.go:1666
 msgid "Set image properties"
 msgstr ""
 
@@ -6074,11 +6074,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1535 lxc/image.go:1536
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1172
+#: lxc/config.go:1172 lxc/config.go:1173
 #, fuzzy
 msgid "Show instance UEFI variables"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -6710,7 +6710,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:410
+#: lxc/main.go:412
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6892,7 +6892,7 @@ msgstr "Unbekannter Befehl %s für Abbild"
 msgid "Unknown output type %q"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/config.go:1140 lxc/config.go:1141
+#: lxc/config.go:1141 lxc/config.go:1142
 #, fuzzy
 msgid "Unset UEFI variables for instance"
 msgstr "nicht alle Profile der Quelle sind am Ziel vorhanden."
@@ -6912,7 +6912,7 @@ msgstr "nicht alle Profile der Quelle sind am Ziel vorhanden."
 msgid "Unset device configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1728 lxc/image.go:1729
 msgid "Unset image properties"
 msgstr ""
 
@@ -7524,7 +7524,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr ""
@@ -7533,7 +7533,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1600 lxc/image.go:1727
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr ""
@@ -7542,7 +7542,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/image.go:1669
+#: lxc/image.go:1664
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
@@ -7582,7 +7582,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1443
 #, fuzzy
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
@@ -7590,7 +7590,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
+#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 #, fuzzy
@@ -7633,7 +7633,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config.go:993 lxc/config.go:1139
+#: lxc/config.go:994 lxc/config.go:1140
 #, fuzzy
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
@@ -7641,7 +7641,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config.go:1048
+#: lxc/config.go:1049
 #, fuzzy
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
@@ -8626,13 +8626,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1228
+#: lxc/config.go:1229
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1052
+#: lxc/config.go:1053
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-21 15:57-0700\n"
+"POT-Creation-Date: 2024-12-05 16:02+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1239
+#: lxc/config.go:1240
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1096
+#: lxc/config.go:702 lxc/config.go:1097
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1214,7 +1214,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1688,9 +1688,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:955
-#: lxc/config.go:995 lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172
-#: lxc/config.go:1226 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
+#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
+#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1705,8 +1705,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
+#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1972,7 +1972,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1225 lxc/config.go:1226
+#: lxc/config.go:1226 lxc/config.go:1227
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2524,7 +2524,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:995
+#: lxc/config.go:995 lxc/config.go:996
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2532,7 +2532,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1601 lxc/image.go:1602
 msgid "Get image properties"
 msgstr ""
 
@@ -2801,7 +2801,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:404
+#: lxc/main.go:406
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2823,7 +2823,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1517
 msgid "Image already up to date."
 msgstr ""
 
@@ -2839,11 +2839,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1472
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1698
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2853,7 +2853,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1515
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2939,7 +2939,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
+#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3033,7 +3033,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:506
+#: lxc/main.go:509
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3628,7 +3628,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:954 lxc/config.go:955
+#: lxc/config.go:955 lxc/config.go:956
 #, fuzzy
 msgid "Manage instance UEFI variables"
 msgstr "  Χρήση δικτύου:"
@@ -4503,7 +4503,7 @@ msgstr ""
 
 #: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -4623,7 +4623,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1649
 msgid "Property not found"
 msgstr ""
 
@@ -4753,7 +4753,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4790,7 +4790,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1444 lxc/image.go:1445
 msgid "Refresh images"
 msgstr ""
 
@@ -4799,7 +4799,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1481
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5012,7 +5012,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1031
+#: lxc/config.go:1032
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5190,7 +5190,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1049 lxc/config.go:1050
+#: lxc/config.go:1050 lxc/config.go:1051
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5225,7 +5225,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1665 lxc/image.go:1666
 msgid "Set image properties"
 msgstr ""
 
@@ -5544,11 +5544,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1535 lxc/image.go:1536
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1172
+#: lxc/config.go:1172 lxc/config.go:1173
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -6151,7 +6151,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:410
+#: lxc/main.go:412
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6330,7 +6330,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1140 lxc/config.go:1141
+#: lxc/config.go:1141 lxc/config.go:1142
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6347,7 +6347,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1728 lxc/image.go:1729
 msgid "Unset image properties"
 msgstr ""
 
@@ -6806,15 +6806,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1600 lxc/image.go:1727
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1664
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6834,11 +6834,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1443
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
+#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6860,11 +6860,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:993 lxc/config.go:1139
+#: lxc/config.go:994 lxc/config.go:1140
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1048
+#: lxc/config.go:1049
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7414,13 +7414,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1228
+#: lxc/config.go:1229
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1052
+#: lxc/config.go:1053
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-21 15:57-0700\n"
+"POT-Creation-Date: 2024-12-05 16:02+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1239
+#: lxc/config.go:1240
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1096
+#: lxc/config.go:702 lxc/config.go:1097
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1210,7 +1210,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1676,9 +1676,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:955
-#: lxc/config.go:995 lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172
-#: lxc/config.go:1226 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
+#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
+#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1693,8 +1693,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
+#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1955,7 +1955,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1225 lxc/config.go:1226
+#: lxc/config.go:1226 lxc/config.go:1227
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2502,7 +2502,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:995
+#: lxc/config.go:995 lxc/config.go:996
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2510,7 +2510,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1601 lxc/image.go:1602
 msgid "Get image properties"
 msgstr ""
 
@@ -2766,7 +2766,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:404
+#: lxc/main.go:406
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2788,7 +2788,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1517
 msgid "Image already up to date."
 msgstr ""
 
@@ -2804,11 +2804,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1472
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1698
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2818,7 +2818,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1515
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2904,7 +2904,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
+#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2998,7 +2998,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:506
+#: lxc/main.go:509
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3589,7 +3589,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:954 lxc/config.go:955
+#: lxc/config.go:955 lxc/config.go:956
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4438,7 +4438,7 @@ msgstr ""
 
 #: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -4558,7 +4558,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1649
 msgid "Property not found"
 msgstr ""
 
@@ -4688,7 +4688,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4725,7 +4725,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1444 lxc/image.go:1445
 msgid "Refresh images"
 msgstr ""
 
@@ -4734,7 +4734,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1481
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4942,7 +4942,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1031
+#: lxc/config.go:1032
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5119,7 +5119,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1049 lxc/config.go:1050
+#: lxc/config.go:1050 lxc/config.go:1051
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5153,7 +5153,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1665 lxc/image.go:1666
 msgid "Set image properties"
 msgstr ""
 
@@ -5458,11 +5458,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1535 lxc/image.go:1536
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1172
+#: lxc/config.go:1172 lxc/config.go:1173
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -6055,7 +6055,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:410
+#: lxc/main.go:412
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6234,7 +6234,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1140 lxc/config.go:1141
+#: lxc/config.go:1141 lxc/config.go:1142
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6250,7 +6250,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1728 lxc/image.go:1729
 msgid "Unset image properties"
 msgstr ""
 
@@ -6693,15 +6693,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1600 lxc/image.go:1727
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1664
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6721,11 +6721,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1443
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
+#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6747,11 +6747,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:993 lxc/config.go:1139
+#: lxc/config.go:994 lxc/config.go:1140
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1048
+#: lxc/config.go:1049
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7301,13 +7301,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1228
+#: lxc/config.go:1229
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1052
+#: lxc/config.go:1053
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-21 15:57-0700\n"
+"POT-Creation-Date: 2024-12-05 16:02+0000\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -108,7 +108,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/config.go:1239
+#: lxc/config.go:1240
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -1269,7 +1269,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1096
+#: lxc/config.go:702 lxc/config.go:1097
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1468,7 +1468,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1952,9 +1952,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:955
-#: lxc/config.go:995 lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172
-#: lxc/config.go:1226 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
+#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
+#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1969,8 +1969,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
+#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -2237,7 +2237,7 @@ msgstr "Perfil %s creado"
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1225 lxc/config.go:1226
+#: lxc/config.go:1226 lxc/config.go:1227
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2794,7 +2794,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:995
+#: lxc/config.go:995 lxc/config.go:996
 #, fuzzy
 msgid "Get UEFI variables for instance"
 msgstr "Aliases:"
@@ -2803,7 +2803,7 @@ msgstr "Aliases:"
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1601 lxc/image.go:1602
 msgid "Get image properties"
 msgstr ""
 
@@ -3075,7 +3075,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:404
+#: lxc/main.go:406
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3097,7 +3097,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1517
 msgid "Image already up to date."
 msgstr ""
 
@@ -3113,11 +3113,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1472
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1698
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -3127,7 +3127,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1515
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3216,7 +3216,7 @@ msgstr "Nombre del contenedor es obligatorio"
 msgid "Instance name is: %s"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
+#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
 #, fuzzy
 msgid "Instance name must be specified"
 msgstr "Nombre del contenedor es: %s"
@@ -3312,7 +3312,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:506
+#: lxc/main.go:509
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3921,7 +3921,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:954 lxc/config.go:955
+#: lxc/config.go:955 lxc/config.go:956
 #, fuzzy
 msgid "Manage instance UEFI variables"
 msgstr "Nombre del Miembro del Cluster"
@@ -4804,7 +4804,7 @@ msgstr ""
 
 #: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -4928,7 +4928,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1649
 msgid "Property not found"
 msgstr ""
 
@@ -5058,7 +5058,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5097,7 +5097,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1444 lxc/image.go:1445
 msgid "Refresh images"
 msgstr ""
 
@@ -5106,7 +5106,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:1486
+#: lxc/image.go:1481
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr "Refrescando la imagen: %s"
@@ -5322,7 +5322,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1031
+#: lxc/config.go:1032
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5505,7 +5505,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1049 lxc/config.go:1050
+#: lxc/config.go:1050 lxc/config.go:1051
 #, fuzzy
 msgid "Set UEFI variables for instance"
 msgstr "Aliases:"
@@ -5541,7 +5541,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1665 lxc/image.go:1666
 msgid "Set image properties"
 msgstr ""
 
@@ -5860,11 +5860,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1535 lxc/image.go:1536
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1172
+#: lxc/config.go:1172 lxc/config.go:1173
 #, fuzzy
 msgid "Show instance UEFI variables"
 msgstr "Dispositivo %s añadido a %s"
@@ -6472,7 +6472,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:410
+#: lxc/main.go:412
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6653,7 +6653,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1140 lxc/config.go:1141
+#: lxc/config.go:1141 lxc/config.go:1142
 #, fuzzy
 msgid "Unset UEFI variables for instance"
 msgstr "Aliases:"
@@ -6671,7 +6671,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1728 lxc/image.go:1729
 msgid "Unset image properties"
 msgstr ""
 
@@ -7162,17 +7162,17 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1600 lxc/image.go:1727
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:1669
+#: lxc/image.go:1664
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7197,12 +7197,12 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<image> [<target>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1443
 #, fuzzy
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
+#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 #, fuzzy
@@ -7229,12 +7229,12 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config.go:993 lxc/config.go:1139
+#: lxc/config.go:994 lxc/config.go:1140
 #, fuzzy
 msgid "[<remote>:]<instance> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config.go:1048
+#: lxc/config.go:1049
 #, fuzzy
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7884,13 +7884,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1228
+#: lxc/config.go:1229
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1052
+#: lxc/config.go:1053
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-21 15:57-0700\n"
+"POT-Creation-Date: 2024-12-05 16:02+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1239
+#: lxc/config.go:1240
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1096
+#: lxc/config.go:702 lxc/config.go:1097
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1210,7 +1210,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1676,9 +1676,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:955
-#: lxc/config.go:995 lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172
-#: lxc/config.go:1226 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
+#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
+#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1693,8 +1693,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
+#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1955,7 +1955,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1225 lxc/config.go:1226
+#: lxc/config.go:1226 lxc/config.go:1227
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2502,7 +2502,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:995
+#: lxc/config.go:995 lxc/config.go:996
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2510,7 +2510,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1601 lxc/image.go:1602
 msgid "Get image properties"
 msgstr ""
 
@@ -2766,7 +2766,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:404
+#: lxc/main.go:406
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2788,7 +2788,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1517
 msgid "Image already up to date."
 msgstr ""
 
@@ -2804,11 +2804,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1472
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1698
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2818,7 +2818,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1515
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2904,7 +2904,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
+#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2998,7 +2998,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:506
+#: lxc/main.go:509
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3589,7 +3589,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:954 lxc/config.go:955
+#: lxc/config.go:955 lxc/config.go:956
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4438,7 +4438,7 @@ msgstr ""
 
 #: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -4558,7 +4558,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1649
 msgid "Property not found"
 msgstr ""
 
@@ -4688,7 +4688,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4725,7 +4725,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1444 lxc/image.go:1445
 msgid "Refresh images"
 msgstr ""
 
@@ -4734,7 +4734,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1481
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4942,7 +4942,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1031
+#: lxc/config.go:1032
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5119,7 +5119,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1049 lxc/config.go:1050
+#: lxc/config.go:1050 lxc/config.go:1051
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5153,7 +5153,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1665 lxc/image.go:1666
 msgid "Set image properties"
 msgstr ""
 
@@ -5458,11 +5458,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1535 lxc/image.go:1536
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1172
+#: lxc/config.go:1172 lxc/config.go:1173
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -6055,7 +6055,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:410
+#: lxc/main.go:412
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6234,7 +6234,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1140 lxc/config.go:1141
+#: lxc/config.go:1141 lxc/config.go:1142
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6250,7 +6250,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1728 lxc/image.go:1729
 msgid "Unset image properties"
 msgstr ""
 
@@ -6693,15 +6693,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1600 lxc/image.go:1727
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1664
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6721,11 +6721,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1443
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
+#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6747,11 +6747,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:993 lxc/config.go:1139
+#: lxc/config.go:994 lxc/config.go:1140
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1048
+#: lxc/config.go:1049
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7301,13 +7301,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1228
+#: lxc/config.go:1229
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1052
+#: lxc/config.go:1053
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-21 15:57-0700\n"
+"POT-Creation-Date: 2024-12-05 16:02+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1239
+#: lxc/config.go:1240
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1096
+#: lxc/config.go:702 lxc/config.go:1097
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1210,7 +1210,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1676,9 +1676,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:955
-#: lxc/config.go:995 lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172
-#: lxc/config.go:1226 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
+#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
+#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1693,8 +1693,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
+#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1955,7 +1955,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1225 lxc/config.go:1226
+#: lxc/config.go:1226 lxc/config.go:1227
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2502,7 +2502,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:995
+#: lxc/config.go:995 lxc/config.go:996
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2510,7 +2510,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1601 lxc/image.go:1602
 msgid "Get image properties"
 msgstr ""
 
@@ -2766,7 +2766,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:404
+#: lxc/main.go:406
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2788,7 +2788,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1517
 msgid "Image already up to date."
 msgstr ""
 
@@ -2804,11 +2804,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1472
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1698
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2818,7 +2818,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1515
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2904,7 +2904,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
+#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2998,7 +2998,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:506
+#: lxc/main.go:509
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3589,7 +3589,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:954 lxc/config.go:955
+#: lxc/config.go:955 lxc/config.go:956
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4438,7 +4438,7 @@ msgstr ""
 
 #: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -4558,7 +4558,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1649
 msgid "Property not found"
 msgstr ""
 
@@ -4688,7 +4688,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4725,7 +4725,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1444 lxc/image.go:1445
 msgid "Refresh images"
 msgstr ""
 
@@ -4734,7 +4734,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1481
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4942,7 +4942,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1031
+#: lxc/config.go:1032
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5119,7 +5119,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1049 lxc/config.go:1050
+#: lxc/config.go:1050 lxc/config.go:1051
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5153,7 +5153,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1665 lxc/image.go:1666
 msgid "Set image properties"
 msgstr ""
 
@@ -5458,11 +5458,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1535 lxc/image.go:1536
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1172
+#: lxc/config.go:1172 lxc/config.go:1173
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -6055,7 +6055,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:410
+#: lxc/main.go:412
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6234,7 +6234,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1140 lxc/config.go:1141
+#: lxc/config.go:1141 lxc/config.go:1142
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6250,7 +6250,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1728 lxc/image.go:1729
 msgid "Unset image properties"
 msgstr ""
 
@@ -6693,15 +6693,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1600 lxc/image.go:1727
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1664
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6721,11 +6721,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1443
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
+#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6747,11 +6747,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:993 lxc/config.go:1139
+#: lxc/config.go:994 lxc/config.go:1140
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1048
+#: lxc/config.go:1049
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7301,13 +7301,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1228
+#: lxc/config.go:1229
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1052
+#: lxc/config.go:1053
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-21 15:57-0700\n"
+"POT-Creation-Date: 2024-12-05 16:02+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -100,7 +100,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/config.go:1239
+#: lxc/config.go:1240
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -1308,7 +1308,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "impossible de spécifier uid/gid/mode en mode récursif"
 
-#: lxc/config.go:702 lxc/config.go:1096
+#: lxc/config.go:702 lxc/config.go:1097
 #, fuzzy, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1517,7 +1517,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -2046,9 +2046,9 @@ msgstr "Récupération de l'image : %s"
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:955
-#: lxc/config.go:995 lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172
-#: lxc/config.go:1226 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
+#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
+#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -2063,8 +2063,8 @@ msgstr "Récupération de l'image : %s"
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
+#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -2340,7 +2340,7 @@ msgstr "Clé de configuration invalide"
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1225 lxc/config.go:1226
+#: lxc/config.go:1226 lxc/config.go:1227
 #, fuzzy
 msgid "Edit instance UEFI variables"
 msgstr "L'arrêt du conteneur a échoué !"
@@ -2931,7 +2931,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "Génération d'un certificat client. Ceci peut prendre une minute…"
 
-#: lxc/config.go:994 lxc/config.go:995
+#: lxc/config.go:995 lxc/config.go:996
 #, fuzzy
 msgid "Get UEFI variables for instance"
 msgstr "Création du conteneur"
@@ -2940,7 +2940,7 @@ msgstr "Création du conteneur"
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1601 lxc/image.go:1602
 msgid "Get image properties"
 msgstr ""
 
@@ -3222,7 +3222,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:404
+#: lxc/main.go:406
 #, fuzzy
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
@@ -3248,7 +3248,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/image.go:1522
+#: lxc/image.go:1517
 msgid "Image already up to date."
 msgstr ""
 
@@ -3265,11 +3265,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr "Image copiée avec succès !"
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1472
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1698
 #, fuzzy, c-format
 msgid "Image identifier missing: %s"
 msgstr "Image importée avec l'empreinte : %s"
@@ -3279,7 +3279,7 @@ msgstr "Image importée avec l'empreinte : %s"
 msgid "Image imported with fingerprint: %s"
 msgstr "Image importée avec l'empreinte : %s"
 
-#: lxc/image.go:1520
+#: lxc/image.go:1515
 #, fuzzy
 msgid "Image refreshed successfully!"
 msgstr "Image copiée avec succès !"
@@ -3373,7 +3373,7 @@ msgstr "Le nom du conteneur est obligatoire"
 msgid "Instance name is: %s"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
+#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
 #, fuzzy
 msgid "Instance name must be specified"
 msgstr "Le nom du conteneur est : %s"
@@ -3469,7 +3469,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:506
+#: lxc/main.go:509
 #, fuzzy
 msgid "Invalid number of arguments"
 msgstr "nombre d'arguments incorrect pour la sous-comande"
@@ -4152,7 +4152,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:954 lxc/config.go:955
+#: lxc/config.go:955 lxc/config.go:956
 #, fuzzy
 msgid "Manage instance UEFI variables"
 msgstr "L'arrêt du conteneur a échoué !"
@@ -5084,7 +5084,7 @@ msgstr ""
 
 #: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -5210,7 +5210,7 @@ msgstr ""
 msgid "Properties:"
 msgstr "Propriétés :"
 
-#: lxc/image.go:1654
+#: lxc/image.go:1649
 msgid "Property not found"
 msgstr ""
 
@@ -5343,7 +5343,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5385,7 +5385,7 @@ msgstr "Pousser ou récupérer des fichiers récursivement"
 msgid "Refresh and update the existing storage volume copies"
 msgstr "Copie de l'image : %s"
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1444 lxc/image.go:1445
 #, fuzzy
 msgid "Refresh images"
 msgstr "Récupération de l'image : %s"
@@ -5395,7 +5395,7 @@ msgstr "Récupération de l'image : %s"
 msgid "Refreshing instance: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/image.go:1486
+#: lxc/image.go:1481
 #, fuzzy, c-format
 msgid "Refreshing the image: %s"
 msgstr "Récupération de l'image : %s"
@@ -5626,7 +5626,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1031
+#: lxc/config.go:1032
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5833,7 +5833,7 @@ msgstr "Protocole du serveur (lxd ou simplestreams)"
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1049 lxc/config.go:1050
+#: lxc/config.go:1050 lxc/config.go:1051
 #, fuzzy
 msgid "Set UEFI variables for instance"
 msgstr "Création du conteneur"
@@ -5870,7 +5870,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1665 lxc/image.go:1666
 msgid "Set image properties"
 msgstr ""
 
@@ -6203,11 +6203,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1535 lxc/image.go:1536
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1172
+#: lxc/config.go:1172 lxc/config.go:1173
 #, fuzzy
 msgid "Show instance UEFI variables"
 msgstr "L'arrêt du conteneur a échoué !"
@@ -6851,7 +6851,7 @@ msgstr "Pour créer un réseau, utiliser : lxc network create"
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:410
+#: lxc/main.go:412
 #, fuzzy
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
@@ -7036,7 +7036,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1140 lxc/config.go:1141
+#: lxc/config.go:1141 lxc/config.go:1142
 #, fuzzy
 msgid "Unset UEFI variables for instance"
 msgstr "tous les profils de la source n'existent pas sur la cible"
@@ -7056,7 +7056,7 @@ msgstr "tous les profils de la source n'existent pas sur la cible"
 msgid "Unset device configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1728 lxc/image.go:1729
 msgid "Unset image properties"
 msgstr ""
 
@@ -7687,7 +7687,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr ""
@@ -7699,7 +7699,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1600 lxc/image.go:1727
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr ""
@@ -7711,7 +7711,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/image.go:1669
+#: lxc/image.go:1664
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
@@ -7751,7 +7751,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1443
 #, fuzzy
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
@@ -7759,7 +7759,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
+#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 #, fuzzy
@@ -7805,7 +7805,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:993 lxc/config.go:1139
+#: lxc/config.go:994 lxc/config.go:1140
 #, fuzzy
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
@@ -7813,7 +7813,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:1048
+#: lxc/config.go:1049
 #, fuzzy
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
@@ -8889,13 +8889,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1228
+#: lxc/config.go:1229
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1052
+#: lxc/config.go:1053
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-21 15:57-0700\n"
+"POT-Creation-Date: 2024-12-05 16:02+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -64,7 +64,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1239
+#: lxc/config.go:1240
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -1016,7 +1016,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1096
+#: lxc/config.go:702 lxc/config.go:1097
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1211,7 +1211,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1677,9 +1677,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:955
-#: lxc/config.go:995 lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172
-#: lxc/config.go:1226 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
+#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
+#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1694,8 +1694,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
+#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1956,7 +1956,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1225 lxc/config.go:1226
+#: lxc/config.go:1226 lxc/config.go:1227
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2503,7 +2503,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:995
+#: lxc/config.go:995 lxc/config.go:996
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2511,7 +2511,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1601 lxc/image.go:1602
 msgid "Get image properties"
 msgstr ""
 
@@ -2767,7 +2767,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:404
+#: lxc/main.go:406
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2789,7 +2789,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1517
 msgid "Image already up to date."
 msgstr ""
 
@@ -2805,11 +2805,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1472
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1698
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2819,7 +2819,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1515
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2905,7 +2905,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
+#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2999,7 +2999,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:506
+#: lxc/main.go:509
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3590,7 +3590,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:954 lxc/config.go:955
+#: lxc/config.go:955 lxc/config.go:956
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4439,7 +4439,7 @@ msgstr ""
 
 #: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -4559,7 +4559,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1649
 msgid "Property not found"
 msgstr ""
 
@@ -4689,7 +4689,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4726,7 +4726,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1444 lxc/image.go:1445
 msgid "Refresh images"
 msgstr ""
 
@@ -4735,7 +4735,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1481
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4943,7 +4943,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1031
+#: lxc/config.go:1032
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5120,7 +5120,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1049 lxc/config.go:1050
+#: lxc/config.go:1050 lxc/config.go:1051
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5154,7 +5154,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1665 lxc/image.go:1666
 msgid "Set image properties"
 msgstr ""
 
@@ -5459,11 +5459,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1535 lxc/image.go:1536
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1172
+#: lxc/config.go:1172 lxc/config.go:1173
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -6056,7 +6056,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:410
+#: lxc/main.go:412
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6235,7 +6235,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1140 lxc/config.go:1141
+#: lxc/config.go:1141 lxc/config.go:1142
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6251,7 +6251,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1728 lxc/image.go:1729
 msgid "Unset image properties"
 msgstr ""
 
@@ -6694,15 +6694,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1600 lxc/image.go:1727
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1664
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6722,11 +6722,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1443
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
+#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6748,11 +6748,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:993 lxc/config.go:1139
+#: lxc/config.go:994 lxc/config.go:1140
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1048
+#: lxc/config.go:1049
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7302,13 +7302,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1228
+#: lxc/config.go:1229
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1052
+#: lxc/config.go:1053
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-21 15:57-0700\n"
+"POT-Creation-Date: 2024-12-05 16:02+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1239
+#: lxc/config.go:1240
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1096
+#: lxc/config.go:702 lxc/config.go:1097
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1210,7 +1210,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1676,9 +1676,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:955
-#: lxc/config.go:995 lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172
-#: lxc/config.go:1226 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
+#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
+#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1693,8 +1693,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
+#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1955,7 +1955,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1225 lxc/config.go:1226
+#: lxc/config.go:1226 lxc/config.go:1227
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2502,7 +2502,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:995
+#: lxc/config.go:995 lxc/config.go:996
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2510,7 +2510,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1601 lxc/image.go:1602
 msgid "Get image properties"
 msgstr ""
 
@@ -2766,7 +2766,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:404
+#: lxc/main.go:406
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2788,7 +2788,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1517
 msgid "Image already up to date."
 msgstr ""
 
@@ -2804,11 +2804,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1472
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1698
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2818,7 +2818,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1515
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2904,7 +2904,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
+#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2998,7 +2998,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:506
+#: lxc/main.go:509
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3589,7 +3589,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:954 lxc/config.go:955
+#: lxc/config.go:955 lxc/config.go:956
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4438,7 +4438,7 @@ msgstr ""
 
 #: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -4558,7 +4558,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1649
 msgid "Property not found"
 msgstr ""
 
@@ -4688,7 +4688,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4725,7 +4725,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1444 lxc/image.go:1445
 msgid "Refresh images"
 msgstr ""
 
@@ -4734,7 +4734,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1481
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4942,7 +4942,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1031
+#: lxc/config.go:1032
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5119,7 +5119,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1049 lxc/config.go:1050
+#: lxc/config.go:1050 lxc/config.go:1051
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5153,7 +5153,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1665 lxc/image.go:1666
 msgid "Set image properties"
 msgstr ""
 
@@ -5458,11 +5458,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1535 lxc/image.go:1536
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1172
+#: lxc/config.go:1172 lxc/config.go:1173
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -6055,7 +6055,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:410
+#: lxc/main.go:412
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6234,7 +6234,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1140 lxc/config.go:1141
+#: lxc/config.go:1141 lxc/config.go:1142
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6250,7 +6250,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1728 lxc/image.go:1729
 msgid "Unset image properties"
 msgstr ""
 
@@ -6693,15 +6693,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1600 lxc/image.go:1727
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1664
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6721,11 +6721,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1443
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
+#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6747,11 +6747,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:993 lxc/config.go:1139
+#: lxc/config.go:994 lxc/config.go:1140
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1048
+#: lxc/config.go:1049
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7301,13 +7301,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1228
+#: lxc/config.go:1229
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1052
+#: lxc/config.go:1053
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-21 15:57-0700\n"
+"POT-Creation-Date: 2024-12-05 16:02+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1239
+#: lxc/config.go:1240
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1096
+#: lxc/config.go:702 lxc/config.go:1097
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1210,7 +1210,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1676,9 +1676,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:955
-#: lxc/config.go:995 lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172
-#: lxc/config.go:1226 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
+#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
+#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1693,8 +1693,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
+#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1955,7 +1955,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1225 lxc/config.go:1226
+#: lxc/config.go:1226 lxc/config.go:1227
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2502,7 +2502,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:995
+#: lxc/config.go:995 lxc/config.go:996
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2510,7 +2510,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1601 lxc/image.go:1602
 msgid "Get image properties"
 msgstr ""
 
@@ -2766,7 +2766,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:404
+#: lxc/main.go:406
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2788,7 +2788,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1517
 msgid "Image already up to date."
 msgstr ""
 
@@ -2804,11 +2804,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1472
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1698
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2818,7 +2818,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1515
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2904,7 +2904,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
+#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2998,7 +2998,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:506
+#: lxc/main.go:509
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3589,7 +3589,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:954 lxc/config.go:955
+#: lxc/config.go:955 lxc/config.go:956
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4438,7 +4438,7 @@ msgstr ""
 
 #: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -4558,7 +4558,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1649
 msgid "Property not found"
 msgstr ""
 
@@ -4688,7 +4688,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4725,7 +4725,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1444 lxc/image.go:1445
 msgid "Refresh images"
 msgstr ""
 
@@ -4734,7 +4734,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1481
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4942,7 +4942,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1031
+#: lxc/config.go:1032
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5119,7 +5119,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1049 lxc/config.go:1050
+#: lxc/config.go:1050 lxc/config.go:1051
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5153,7 +5153,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1665 lxc/image.go:1666
 msgid "Set image properties"
 msgstr ""
 
@@ -5458,11 +5458,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1535 lxc/image.go:1536
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1172
+#: lxc/config.go:1172 lxc/config.go:1173
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -6055,7 +6055,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:410
+#: lxc/main.go:412
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6234,7 +6234,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1140 lxc/config.go:1141
+#: lxc/config.go:1141 lxc/config.go:1142
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6250,7 +6250,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1728 lxc/image.go:1729
 msgid "Unset image properties"
 msgstr ""
 
@@ -6693,15 +6693,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1600 lxc/image.go:1727
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1664
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6721,11 +6721,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1443
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
+#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6747,11 +6747,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:993 lxc/config.go:1139
+#: lxc/config.go:994 lxc/config.go:1140
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1048
+#: lxc/config.go:1049
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7301,13 +7301,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1228
+#: lxc/config.go:1229
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1052
+#: lxc/config.go:1053
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-21 15:57-0700\n"
+"POT-Creation-Date: 2024-12-05 16:02+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -108,7 +108,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/config.go:1239
+#: lxc/config.go:1240
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -1267,7 +1267,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1096
+#: lxc/config.go:702 lxc/config.go:1097
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1464,7 +1464,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1947,9 +1947,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:955
-#: lxc/config.go:995 lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172
-#: lxc/config.go:1226 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
+#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
+#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1964,8 +1964,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
+#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -2234,7 +2234,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1225 lxc/config.go:1226
+#: lxc/config.go:1226 lxc/config.go:1227
 #, fuzzy
 msgid "Edit instance UEFI variables"
 msgstr "Creazione del container in corso"
@@ -2791,7 +2791,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:995
+#: lxc/config.go:995 lxc/config.go:996
 #, fuzzy
 msgid "Get UEFI variables for instance"
 msgstr "Creazione del container in corso"
@@ -2800,7 +2800,7 @@ msgstr "Creazione del container in corso"
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1601 lxc/image.go:1602
 msgid "Get image properties"
 msgstr ""
 
@@ -3067,7 +3067,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:404
+#: lxc/main.go:406
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3090,7 +3090,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:1522
+#: lxc/image.go:1517
 msgid "Image already up to date."
 msgstr ""
 
@@ -3106,11 +3106,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1472
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1698
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -3120,7 +3120,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1515
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3208,7 +3208,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr "Il nome del container è: %s"
 
-#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
+#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
 #, fuzzy
 msgid "Instance name must be specified"
 msgstr "Il nome del container è: %s"
@@ -3304,7 +3304,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:506
+#: lxc/main.go:509
 #, fuzzy
 msgid "Invalid number of arguments"
 msgstr "numero errato di argomenti del sottocomando"
@@ -3919,7 +3919,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:954 lxc/config.go:955
+#: lxc/config.go:955 lxc/config.go:956
 #, fuzzy
 msgid "Manage instance UEFI variables"
 msgstr "Creazione del container in corso"
@@ -4805,7 +4805,7 @@ msgstr ""
 
 #: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -4927,7 +4927,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1649
 msgid "Property not found"
 msgstr ""
 
@@ -5058,7 +5058,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5097,7 +5097,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1444 lxc/image.go:1445
 msgid "Refresh images"
 msgstr ""
 
@@ -5106,7 +5106,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:1486
+#: lxc/image.go:1481
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5323,7 +5323,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1031
+#: lxc/config.go:1032
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5506,7 +5506,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1049 lxc/config.go:1050
+#: lxc/config.go:1050 lxc/config.go:1051
 #, fuzzy
 msgid "Set UEFI variables for instance"
 msgstr "Creazione del container in corso"
@@ -5542,7 +5542,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1665 lxc/image.go:1666
 msgid "Set image properties"
 msgstr ""
 
@@ -5857,11 +5857,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1535 lxc/image.go:1536
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1172
+#: lxc/config.go:1172 lxc/config.go:1173
 #, fuzzy
 msgid "Show instance UEFI variables"
 msgstr "errore di processamento degli alias %s\n"
@@ -6471,7 +6471,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:410
+#: lxc/main.go:412
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6652,7 +6652,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1140 lxc/config.go:1141
+#: lxc/config.go:1141 lxc/config.go:1142
 #, fuzzy
 msgid "Unset UEFI variables for instance"
 msgstr "non tutti i profili dell'origine esistono nella destinazione"
@@ -6671,7 +6671,7 @@ msgstr "non tutti i profili dell'origine esistono nella destinazione"
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1728 lxc/image.go:1729
 msgid "Unset image properties"
 msgstr ""
 
@@ -7160,17 +7160,17 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1600 lxc/image.go:1727
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:1669
+#: lxc/image.go:1664
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr "Creazione del container in corso"
@@ -7195,12 +7195,12 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<image> [<target>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1443
 #, fuzzy
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
+#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 #, fuzzy
@@ -7227,12 +7227,12 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/config.go:993 lxc/config.go:1139
+#: lxc/config.go:994 lxc/config.go:1140
 #, fuzzy
 msgid "[<remote>:]<instance> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/config.go:1048
+#: lxc/config.go:1049
 #, fuzzy
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr "Creazione del container in corso"
@@ -7882,13 +7882,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1228
+#: lxc/config.go:1229
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1052
+#: lxc/config.go:1053
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-21 15:57-0700\n"
+"POT-Creation-Date: 2024-12-05 16:02+0000\n"
 "PO-Revision-Date: 2023-03-10 15:14+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -95,7 +95,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/config.go:1239
+#: lxc/config.go:1240
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -1280,7 +1280,7 @@ msgstr "クラスタでない場合はカラムとして L は指定できませ
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "再帰 (recursive) モードでは uid/gid/mode を指定できません"
 
-#: lxc/config.go:702 lxc/config.go:1096
+#: lxc/config.go:702 lxc/config.go:1097
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr "キー '%s' が設定されていないので削除できません"
@@ -1484,7 +1484,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr "移動先のインスタンスに適用するキー/値の設定"
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1977,9 +1977,9 @@ msgstr "警告を削除します"
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:955
-#: lxc/config.go:995 lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172
-#: lxc/config.go:1226 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
+#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
+#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1994,8 +1994,8 @@ msgstr "警告を削除します"
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
+#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -2268,7 +2268,7 @@ msgstr "プロファイル設定をYAMLで編集します"
 msgid "Edit image properties"
 msgstr "イメージのプロパティを編集します"
 
-#: lxc/config.go:1225 lxc/config.go:1226
+#: lxc/config.go:1226 lxc/config.go:1227
 #, fuzzy
 msgid "Edit instance UEFI variables"
 msgstr "インスタンスのメタデータファイルを編集します"
@@ -2858,7 +2858,7 @@ msgstr "すべてのコマンドに対する man ページを作成します"
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "クライアント証明書を生成します。1分ぐらいかかります..."
 
-#: lxc/config.go:994 lxc/config.go:995
+#: lxc/config.go:995 lxc/config.go:996
 #, fuzzy
 msgid "Get UEFI variables for instance"
 msgstr "インスタンスからファイルをマウントします"
@@ -2867,7 +2867,7 @@ msgstr "インスタンスからファイルをマウントします"
 msgid "Get a summary of resource allocations"
 msgstr "リソース割当の状況を表示します"
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1601 lxc/image.go:1602
 msgid "Get image properties"
 msgstr "イメージのプロパティを取得します"
 
@@ -3138,7 +3138,7 @@ msgstr ""
 "存在するスナップショット名の場合は既存のスナップショットを削除したあとに新し"
 "いスナップショットを作成します"
 
-#: lxc/main.go:404
+#: lxc/main.go:406
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3160,7 +3160,7 @@ msgstr "コピー中にファイルが更新された場合のエラーを無視
 msgid "Ignore the instance state"
 msgstr "インスタンスの状態を無視します"
 
-#: lxc/image.go:1522
+#: lxc/image.go:1517
 msgid "Image already up to date."
 msgstr "イメージは更新済みです。"
 
@@ -3176,11 +3176,11 @@ msgstr "イメージの失効日（フォーマット: rfc3339）"
 msgid "Image exported successfully!"
 msgstr "イメージのエクスポートが成功しました!"
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1472
 msgid "Image identifier missing"
 msgstr "イメージ名を指定してください"
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1698
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr "イメージ名を指定してください: %s"
@@ -3190,7 +3190,7 @@ msgstr "イメージ名を指定してください: %s"
 msgid "Image imported with fingerprint: %s"
 msgstr "イメージは以下のフィンガープリントでインポートされました: %s"
 
-#: lxc/image.go:1520
+#: lxc/image.go:1515
 msgid "Image refreshed successfully!"
 msgstr "イメージの更新が成功しました!"
 
@@ -3284,7 +3284,7 @@ msgstr "インスタンス名を指定する必要があります"
 msgid "Instance name is: %s"
 msgstr "インスタンス名: %s"
 
-#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
+#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
 #, fuzzy
 msgid "Instance name must be specified"
 msgstr "インスタンス名: %s"
@@ -3387,7 +3387,7 @@ msgstr ""
 "新しいスナップショット名が不正です。親のボリュームはソースと同じでなければな"
 "りません"
 
-#: lxc/main.go:506
+#: lxc/main.go:509
 msgid "Invalid number of arguments"
 msgstr "引数の数が不正です"
 
@@ -4141,7 +4141,7 @@ msgstr ""
 "イメージは全ハッシュ文字列、一意に定まるハッシュの短縮表現、(設定され\n"
 "ている場合は) エイリアスで参照できます。"
 
-#: lxc/config.go:954 lxc/config.go:955
+#: lxc/config.go:955 lxc/config.go:956
 #, fuzzy
 msgid "Manage instance UEFI variables"
 msgstr "インスタンスのメタデータファイルを管理します"
@@ -5026,7 +5026,7 @@ msgstr "終了するには ctrl+c を押してください"
 
 #: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -5148,7 +5148,7 @@ msgstr "リモートで使用するプロジェクト"
 msgid "Properties:"
 msgstr "プロパティ:"
 
-#: lxc/image.go:1654
+#: lxc/image.go:1649
 msgid "Property not found"
 msgstr "プロパティが見つかりません"
 
@@ -5281,7 +5281,7 @@ msgstr "ファイル %s をコンテナ %s 内にコピーします: %%s"
 msgid "Query path must start with /"
 msgstr "query のパスは / で始める必要があります"
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
 msgid "Query virtual machine images"
 msgstr "仮想マシンイメージを対象にします"
 
@@ -5320,7 +5320,7 @@ msgstr "再帰的にファイルを転送します"
 msgid "Refresh and update the existing storage volume copies"
 msgstr "既存のストレージボリュームのコピーの再読込と更新"
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1444 lxc/image.go:1445
 msgid "Refresh images"
 msgstr "イメージを更新します"
 
@@ -5329,7 +5329,7 @@ msgstr "イメージを更新します"
 msgid "Refreshing instance: %s"
 msgstr "インスタンスの更新中: %s"
 
-#: lxc/image.go:1486
+#: lxc/image.go:1481
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr "イメージの更新中: %s"
@@ -5544,7 +5544,7 @@ msgstr "レンダー: %s (%s)"
 msgid "Request a join token for adding a cluster member"
 msgstr "クラスターメンバーに join するためのトークンを要求します"
 
-#: lxc/config.go:1031
+#: lxc/config.go:1032
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5730,7 +5730,7 @@ msgstr "サーバのプロトコル (lxd or simplestreams)"
 msgid "Server version: %s\n"
 msgstr "サーバのバージョン: %s\n"
 
-#: lxc/config.go:1049 lxc/config.go:1050
+#: lxc/config.go:1050 lxc/config.go:1051
 #, fuzzy
 msgid "Set UEFI variables for instance"
 msgstr "インスタンスからファイルをマウントします"
@@ -5773,7 +5773,7 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1665 lxc/image.go:1666
 msgid "Set image properties"
 msgstr "イメージのプロパティを設定します"
 
@@ -6141,11 +6141,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1535 lxc/image.go:1536
 msgid "Show image properties"
 msgstr "イメージのプロパティを表示します"
 
-#: lxc/config.go:1171 lxc/config.go:1172
+#: lxc/config.go:1172 lxc/config.go:1173
 #, fuzzy
 msgid "Show instance UEFI variables"
 msgstr "インスタンスのメタデータファイルを表示します"
@@ -6762,7 +6762,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr "コンソールから切り離すには <ctrl>+a q を押します"
 
-#: lxc/main.go:410
+#: lxc/main.go:412
 #, fuzzy
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
@@ -6950,7 +6950,7 @@ msgstr "未知の設定: %s"
 msgid "Unknown output type %q"
 msgstr "未知の出力タイプ: %q"
 
-#: lxc/config.go:1140 lxc/config.go:1141
+#: lxc/config.go:1141 lxc/config.go:1142
 #, fuzzy
 msgid "Unset UEFI variables for instance"
 msgstr "移動先のインスタンスのすべてのプロファイルを削除します"
@@ -6967,7 +6967,7 @@ msgstr "移動先のインスタンスのすべてのプロファイルを削除
 msgid "Unset device configuration keys"
 msgstr "デバイスの設定を削除します"
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1728 lxc/image.go:1729
 msgid "Unset image properties"
 msgstr "イメージのプロパティを削除します"
 
@@ -7436,15 +7436,15 @@ msgstr "[<remote>:]<member> <group>"
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr "[<remote>:]<group> <new-name>"
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
 msgid "[<remote>:]<image>"
 msgstr "[<remote>:]<image>"
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1600 lxc/image.go:1727
 msgid "[<remote>:]<image> <key>"
 msgstr "[<remote>:]<image> <key>"
 
-#: lxc/image.go:1669
+#: lxc/image.go:1664
 msgid "[<remote>:]<image> <key> <value>"
 msgstr "[<remote>:]<image> <key> <value>"
 
@@ -7465,11 +7465,11 @@ msgstr "[<remote>:]<image> [<remote>:][<name>]"
 msgid "[<remote>:]<image> [<target>]"
 msgstr "[<remote>:]<image> [<target>]"
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1443
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "[<remote>:]<image> [[<remote>:]<image>...]"
 
-#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
+#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -7491,12 +7491,12 @@ msgstr "[<remote>:]<instance> <device> <type> [key=value...]"
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr "[<remote>:]<instance> <device> [key=value...]"
 
-#: lxc/config.go:993 lxc/config.go:1139
+#: lxc/config.go:994 lxc/config.go:1140
 #, fuzzy
 msgid "[<remote>:]<instance> <key>"
 msgstr "[<remote>:][<instance>] <key>"
 
-#: lxc/config.go:1048
+#: lxc/config.go:1049
 #, fuzzy
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr "[<remote>:][<instance>] <key>=<value>..."
@@ -8117,7 +8117,7 @@ msgstr ""
 "lxc config set core.trust_password=blah\n"
 "    サーバの認証パスワードを blah に設定します。"
 
-#: lxc/config.go:1228
+#: lxc/config.go:1229
 #, fuzzy
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
@@ -8126,7 +8126,7 @@ msgstr ""
 "lxc config edit <instance> < instance.yaml\n"
 "    インスタンスの設定を config.yaml を使って更新します。"
 
-#: lxc/config.go:1052
+#: lxc/config.go:1053
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/ka.po
+++ b/po/ka.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-21 15:57-0700\n"
+"POT-Creation-Date: 2024-12-05 16:02+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -60,7 +60,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1239
+#: lxc/config.go:1240
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -1012,7 +1012,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1096
+#: lxc/config.go:702 lxc/config.go:1097
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1207,7 +1207,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1673,9 +1673,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:955
-#: lxc/config.go:995 lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172
-#: lxc/config.go:1226 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
+#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
+#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1690,8 +1690,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
+#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1952,7 +1952,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1225 lxc/config.go:1226
+#: lxc/config.go:1226 lxc/config.go:1227
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2499,7 +2499,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:995
+#: lxc/config.go:995 lxc/config.go:996
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2507,7 +2507,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1601 lxc/image.go:1602
 msgid "Get image properties"
 msgstr ""
 
@@ -2763,7 +2763,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:404
+#: lxc/main.go:406
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2785,7 +2785,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1517
 msgid "Image already up to date."
 msgstr ""
 
@@ -2801,11 +2801,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1472
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1698
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2815,7 +2815,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1515
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2901,7 +2901,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
+#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2995,7 +2995,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:506
+#: lxc/main.go:509
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3586,7 +3586,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:954 lxc/config.go:955
+#: lxc/config.go:955 lxc/config.go:956
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4435,7 +4435,7 @@ msgstr ""
 
 #: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -4555,7 +4555,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1649
 msgid "Property not found"
 msgstr ""
 
@@ -4685,7 +4685,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4722,7 +4722,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1444 lxc/image.go:1445
 msgid "Refresh images"
 msgstr ""
 
@@ -4731,7 +4731,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1481
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4939,7 +4939,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1031
+#: lxc/config.go:1032
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5116,7 +5116,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1049 lxc/config.go:1050
+#: lxc/config.go:1050 lxc/config.go:1051
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5150,7 +5150,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1665 lxc/image.go:1666
 msgid "Set image properties"
 msgstr ""
 
@@ -5455,11 +5455,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1535 lxc/image.go:1536
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1172
+#: lxc/config.go:1172 lxc/config.go:1173
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -6052,7 +6052,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:410
+#: lxc/main.go:412
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6231,7 +6231,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1140 lxc/config.go:1141
+#: lxc/config.go:1141 lxc/config.go:1142
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6247,7 +6247,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1728 lxc/image.go:1729
 msgid "Unset image properties"
 msgstr ""
 
@@ -6690,15 +6690,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1600 lxc/image.go:1727
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1664
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6718,11 +6718,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1443
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
+#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6744,11 +6744,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:993 lxc/config.go:1139
+#: lxc/config.go:994 lxc/config.go:1140
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1048
+#: lxc/config.go:1049
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7298,13 +7298,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1228
+#: lxc/config.go:1229
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1052
+#: lxc/config.go:1053
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-21 15:57-0700\n"
+"POT-Creation-Date: 2024-12-05 16:02+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1239
+#: lxc/config.go:1240
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1096
+#: lxc/config.go:702 lxc/config.go:1097
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1210,7 +1210,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1676,9 +1676,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:955
-#: lxc/config.go:995 lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172
-#: lxc/config.go:1226 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
+#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
+#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1693,8 +1693,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
+#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1955,7 +1955,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1225 lxc/config.go:1226
+#: lxc/config.go:1226 lxc/config.go:1227
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2502,7 +2502,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:995
+#: lxc/config.go:995 lxc/config.go:996
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2510,7 +2510,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1601 lxc/image.go:1602
 msgid "Get image properties"
 msgstr ""
 
@@ -2766,7 +2766,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:404
+#: lxc/main.go:406
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2788,7 +2788,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1517
 msgid "Image already up to date."
 msgstr ""
 
@@ -2804,11 +2804,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1472
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1698
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2818,7 +2818,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1515
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2904,7 +2904,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
+#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2998,7 +2998,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:506
+#: lxc/main.go:509
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3589,7 +3589,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:954 lxc/config.go:955
+#: lxc/config.go:955 lxc/config.go:956
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4438,7 +4438,7 @@ msgstr ""
 
 #: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -4558,7 +4558,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1649
 msgid "Property not found"
 msgstr ""
 
@@ -4688,7 +4688,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4725,7 +4725,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1444 lxc/image.go:1445
 msgid "Refresh images"
 msgstr ""
 
@@ -4734,7 +4734,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1481
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4942,7 +4942,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1031
+#: lxc/config.go:1032
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5119,7 +5119,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1049 lxc/config.go:1050
+#: lxc/config.go:1050 lxc/config.go:1051
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5153,7 +5153,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1665 lxc/image.go:1666
 msgid "Set image properties"
 msgstr ""
 
@@ -5458,11 +5458,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1535 lxc/image.go:1536
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1172
+#: lxc/config.go:1172 lxc/config.go:1173
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -6055,7 +6055,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:410
+#: lxc/main.go:412
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6234,7 +6234,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1140 lxc/config.go:1141
+#: lxc/config.go:1141 lxc/config.go:1142
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6250,7 +6250,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1728 lxc/image.go:1729
 msgid "Unset image properties"
 msgstr ""
 
@@ -6693,15 +6693,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1600 lxc/image.go:1727
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1664
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6721,11 +6721,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1443
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
+#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6747,11 +6747,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:993 lxc/config.go:1139
+#: lxc/config.go:994 lxc/config.go:1140
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1048
+#: lxc/config.go:1049
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7301,13 +7301,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1228
+#: lxc/config.go:1229
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1052
+#: lxc/config.go:1053
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-        "POT-Creation-Date: 2024-11-21 15:57-0700\n"
+        "POT-Creation-Date: 2024-12-05 16:02+0000\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -57,7 +57,7 @@ msgid   "### This is a YAML representation of a storage volume.\n"
         "###   size: \"61203283968\""
 msgstr  ""
 
-#: lxc/config.go:1239
+#: lxc/config.go:1240
 msgid   "### This is a YAML representation of the UEFI variables configuration.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -971,7 +971,7 @@ msgstr  ""
 msgid   "Can't supply uid/gid/mode in recursive mode"
 msgstr  ""
 
-#: lxc/config.go:702 lxc/config.go:1096
+#: lxc/config.go:702 lxc/config.go:1097
 #, c-format
 msgid   "Can't unset key '%s', it's not currently set"
 msgstr  ""
@@ -1135,7 +1135,7 @@ msgstr  ""
 msgid   "Config key/value to apply to the target instance"
 msgstr  ""
 
-#: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281 lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156 lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759 lxc/network_acl.go:698 lxc/network_forward.go:767 lxc/network_load_balancer.go:738 lxc/network_peer.go:698 lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595 lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349 lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156 lxc/storage_volume.go:1188
+#: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281 lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156 lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759 lxc/network_acl.go:698 lxc/network_forward.go:767 lxc/network_load_balancer.go:738 lxc/network_peer.go:698 lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595 lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349 lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156 lxc/storage_volume.go:1188
 #, c-format
 msgid   "Config parsing error: %s"
 msgstr  ""
@@ -1559,7 +1559,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104 lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398 lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581 lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985 lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292 lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464 lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781 lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060 lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087 lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329 lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170 lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:955 lxc/config.go:995 lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409 lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634 lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28 lxc/config_metadata.go:56 lxc/config_metadata.go:189 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:119 lxc/config_template.go:173 lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689 lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607 lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106 lxc/network.go:1185 lxc/network.go:1245 lxc/network.go:1341 lxc/network.go:1413 lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53 lxc/network_forward.go:33 lxc/network_forward.go:90 lxc/network_forward.go:179 lxc/network_forward.go:256 lxc/network_forward.go:404 lxc/network_forward.go:489 lxc/network_forward.go:599 lxc/network_forward.go:646 lxc/network_forward.go:800 lxc/network_forward.go:874 lxc/network_forward.go:889 lxc/network_forward.go:970 lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121 lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:165 lxc/network_zone.go:228 lxc/network_zone.go:301 lxc/network_zone.go:396 lxc/network_zone.go:484 lxc/network_zone.go:527 lxc/network_zone.go:654 lxc/network_zone.go:710 lxc/network_zone.go:767 lxc/network_zone.go:845 lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083 lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349 lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483 lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749 lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018 lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250 lxc/storage_bucket.go:383 lxc/storage_bucket.go:459 lxc/storage_bucket.go:536 lxc/storage_bucket.go:630 lxc/storage_bucket.go:699 lxc/storage_bucket.go:733 lxc/storage_bucket.go:774 lxc/storage_bucket.go:853 lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158 lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283 lxc/storage_volume.go:390 lxc/storage_volume.go:611 lxc/storage_volume.go:720 lxc/storage_volume.go:807 lxc/storage_volume.go:905 lxc/storage_volume.go:1002 lxc/storage_volume.go:1223 lxc/storage_volume.go:1354 lxc/storage_volume.go:1513 lxc/storage_volume.go:1597 lxc/storage_volume.go:1850 lxc/storage_volume.go:1949 lxc/storage_volume.go:2076 lxc/storage_volume.go:2234 lxc/storage_volume.go:2355 lxc/storage_volume.go:2417 lxc/storage_volume.go:2553 lxc/storage_volume.go:2636 lxc/storage_volume.go:2802 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104 lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398 lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581 lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985 lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292 lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464 lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781 lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060 lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087 lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329 lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170 lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956 lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409 lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634 lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28 lxc/config_metadata.go:56 lxc/config_metadata.go:189 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:119 lxc/config_template.go:173 lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689 lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602 lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106 lxc/network.go:1185 lxc/network.go:1245 lxc/network.go:1341 lxc/network.go:1413 lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53 lxc/network_forward.go:33 lxc/network_forward.go:90 lxc/network_forward.go:179 lxc/network_forward.go:256 lxc/network_forward.go:404 lxc/network_forward.go:489 lxc/network_forward.go:599 lxc/network_forward.go:646 lxc/network_forward.go:800 lxc/network_forward.go:874 lxc/network_forward.go:889 lxc/network_forward.go:970 lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121 lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:165 lxc/network_zone.go:228 lxc/network_zone.go:301 lxc/network_zone.go:396 lxc/network_zone.go:484 lxc/network_zone.go:527 lxc/network_zone.go:654 lxc/network_zone.go:710 lxc/network_zone.go:767 lxc/network_zone.go:845 lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083 lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349 lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483 lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749 lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018 lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250 lxc/storage_bucket.go:383 lxc/storage_bucket.go:459 lxc/storage_bucket.go:536 lxc/storage_bucket.go:630 lxc/storage_bucket.go:699 lxc/storage_bucket.go:733 lxc/storage_bucket.go:774 lxc/storage_bucket.go:853 lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158 lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283 lxc/storage_volume.go:390 lxc/storage_volume.go:611 lxc/storage_volume.go:720 lxc/storage_volume.go:807 lxc/storage_volume.go:905 lxc/storage_volume.go:1002 lxc/storage_volume.go:1223 lxc/storage_volume.go:1354 lxc/storage_volume.go:1513 lxc/storage_volume.go:1597 lxc/storage_volume.go:1850 lxc/storage_volume.go:1949 lxc/storage_volume.go:2076 lxc/storage_volume.go:2234 lxc/storage_volume.go:2355 lxc/storage_volume.go:2417 lxc/storage_volume.go:2553 lxc/storage_volume.go:2636 lxc/storage_volume.go:2802 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid   "Description"
 msgstr  ""
 
@@ -1743,7 +1743,7 @@ msgstr  ""
 msgid   "Edit image properties"
 msgstr  ""
 
-#: lxc/config.go:1225 lxc/config.go:1226
+#: lxc/config.go:1226 lxc/config.go:1227
 msgid   "Edit instance UEFI variables"
 msgstr  ""
 
@@ -2254,7 +2254,7 @@ msgstr  ""
 msgid   "Generating a client certificate. This may take a minute..."
 msgstr  ""
 
-#: lxc/config.go:994 lxc/config.go:995
+#: lxc/config.go:995 lxc/config.go:996
 msgid   "Get UEFI variables for instance"
 msgstr  ""
 
@@ -2262,7 +2262,7 @@ msgstr  ""
 msgid   "Get a summary of resource allocations"
 msgstr  ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1601 lxc/image.go:1602
 msgid   "Get image properties"
 msgstr  ""
 
@@ -2518,7 +2518,7 @@ msgstr  ""
 msgid   "If the snapshot name already exists, delete and create a new one"
 msgstr  ""
 
-#: lxc/main.go:404
+#: lxc/main.go:406
 msgid   "If this is your first time running LXD on this machine, you should also run: lxd init"
 msgstr  ""
 
@@ -2538,7 +2538,7 @@ msgstr  ""
 msgid   "Ignore the instance state"
 msgstr  ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1517
 msgid   "Image already up to date."
 msgstr  ""
 
@@ -2554,11 +2554,11 @@ msgstr  ""
 msgid   "Image exported successfully!"
 msgstr  ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1472
 msgid   "Image identifier missing"
 msgstr  ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1698
 #, c-format
 msgid   "Image identifier missing: %s"
 msgstr  ""
@@ -2568,7 +2568,7 @@ msgstr  ""
 msgid   "Image imported with fingerprint: %s"
 msgstr  ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1515
 msgid   "Image refreshed successfully!"
 msgstr  ""
 
@@ -2652,7 +2652,7 @@ msgstr  ""
 msgid   "Instance name is: %s"
 msgstr  ""
 
-#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
+#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
 msgid   "Instance name must be specified"
 msgstr  ""
 
@@ -2745,7 +2745,7 @@ msgstr  ""
 msgid   "Invalid new snapshot name, parent volume must be the same as source"
 msgstr  ""
 
-#: lxc/main.go:506
+#: lxc/main.go:509
 msgid   "Invalid number of arguments"
 msgstr  ""
 
@@ -3316,7 +3316,7 @@ msgid   "Manage images\n"
         "hash or alias name (if one is set)."
 msgstr  ""
 
-#: lxc/config.go:954 lxc/config.go:955
+#: lxc/config.go:955 lxc/config.go:956
 msgid   "Manage instance UEFI variables"
 msgstr  ""
 
@@ -4079,7 +4079,7 @@ msgstr  ""
 msgid   "Press ctrl+c to finish"
 msgstr  ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860 lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357 lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239 lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760 lxc/network_acl.go:699 lxc/network_forward.go:768 lxc/network_load_balancer.go:739 lxc/network_peer.go:699 lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596 lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350 lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157 lxc/storage_volume.go:1189
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860 lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357 lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239 lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760 lxc/network_acl.go:699 lxc/network_forward.go:768 lxc/network_load_balancer.go:739 lxc/network_peer.go:699 lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596 lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350 lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157 lxc/storage_volume.go:1189
 msgid   "Press enter to open the editor again or ctrl+c to abort change"
 msgstr  ""
 
@@ -4192,7 +4192,7 @@ msgstr  ""
 msgid   "Properties:"
 msgstr  ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1649
 msgid   "Property not found"
 msgstr  ""
 
@@ -4306,7 +4306,7 @@ msgstr  ""
 msgid   "Query path must start with /"
 msgstr  ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
 msgid   "Query virtual machine images"
 msgstr  ""
 
@@ -4343,7 +4343,7 @@ msgstr  ""
 msgid   "Refresh and update the existing storage volume copies"
 msgstr  ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1444 lxc/image.go:1445
 msgid   "Refresh images"
 msgstr  ""
 
@@ -4352,7 +4352,7 @@ msgstr  ""
 msgid   "Refreshing instance: %s"
 msgstr  ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1481
 #, c-format
 msgid   "Refreshing the image: %s"
 msgstr  ""
@@ -4558,7 +4558,7 @@ msgstr  ""
 msgid   "Request a join token for adding a cluster member"
 msgstr  ""
 
-#: lxc/config.go:1031
+#: lxc/config.go:1032
 msgid   "Requested UEFI variable does not exist"
 msgstr  ""
 
@@ -4732,7 +4732,7 @@ msgstr  ""
 msgid   "Server version: %s\n"
 msgstr  ""
 
-#: lxc/config.go:1049 lxc/config.go:1050
+#: lxc/config.go:1050 lxc/config.go:1051
 msgid   "Set UEFI variables for instance"
 msgstr  ""
 
@@ -4762,7 +4762,7 @@ msgid   "Set device configuration keys\n"
         "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr  ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1665 lxc/image.go:1666
 msgid   "Set image properties"
 msgstr  ""
 
@@ -5039,11 +5039,11 @@ msgid   "Show identity configurations\n"
         "method. Use the identifier instead if this occurs.\n"
 msgstr  ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1535 lxc/image.go:1536
 msgid   "Show image properties"
 msgstr  ""
 
-#: lxc/config.go:1171 lxc/config.go:1172
+#: lxc/config.go:1172 lxc/config.go:1173
 msgid   "Show instance UEFI variables"
 msgstr  ""
 
@@ -5620,7 +5620,7 @@ msgstr  ""
 msgid   "To detach from the console, press: <ctrl>+a q"
 msgstr  ""
 
-#: lxc/main.go:410
+#: lxc/main.go:412
 msgid   "To start your first container, try: lxc launch ubuntu:24.04\n"
         "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
 msgstr  ""
@@ -5791,7 +5791,7 @@ msgstr  ""
 msgid   "Unknown output type %q"
 msgstr  ""
 
-#: lxc/config.go:1140 lxc/config.go:1141
+#: lxc/config.go:1141 lxc/config.go:1142
 msgid   "Unset UEFI variables for instance"
 msgstr  ""
 
@@ -5807,7 +5807,7 @@ msgstr  ""
 msgid   "Unset device configuration keys"
 msgstr  ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1728 lxc/image.go:1729
 msgid   "Unset image properties"
 msgstr  ""
 
@@ -6228,15 +6228,15 @@ msgstr  ""
 msgid   "[<remote>:]<identity_provider_group> <new_name>"
 msgstr  ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
 msgid   "[<remote>:]<image>"
 msgstr  ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1600 lxc/image.go:1727
 msgid   "[<remote>:]<image> <key>"
 msgstr  ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1664
 msgid   "[<remote>:]<image> <key> <value>"
 msgstr  ""
 
@@ -6256,11 +6256,11 @@ msgstr  ""
 msgid   "[<remote>:]<image> [<target>]"
 msgstr  ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1443
 msgid   "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr  ""
 
-#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329 lxc/config_device.go:761 lxc/config_metadata.go:54 lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329 lxc/config_device.go:761 lxc/config_metadata.go:54 lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid   "[<remote>:]<instance>"
 msgstr  ""
 
@@ -6280,11 +6280,11 @@ msgstr  ""
 msgid   "[<remote>:]<instance> <device> [key=value...]"
 msgstr  ""
 
-#: lxc/config.go:993 lxc/config.go:1139
+#: lxc/config.go:994 lxc/config.go:1140
 msgid   "[<remote>:]<instance> <key>"
 msgstr  ""
 
-#: lxc/config.go:1048
+#: lxc/config.go:1049
 msgid   "[<remote>:]<instance> <key>=<value>..."
 msgstr  ""
 
@@ -6792,12 +6792,12 @@ msgid   "lxc config set [<remote>:]<instance> limits.cpu=2\n"
         "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr  ""
 
-#: lxc/config.go:1228
+#: lxc/config.go:1229
 msgid   "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
         "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr  ""
 
-#: lxc/config.go:1052
+#: lxc/config.go:1053
 msgid   "lxc config uefi set [<remote>:]<instance> testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
         "    Set a UEFI variable with name \"testvar\", GUID 9073e4e0-60ec-4b6e-9903-4c223c260f3c and value \"aabb\" (HEX-encoded) for the instance."
 msgstr  ""

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-21 15:57-0700\n"
+"POT-Creation-Date: 2024-12-05 16:02+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1239
+#: lxc/config.go:1240
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1096
+#: lxc/config.go:702 lxc/config.go:1097
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1210,7 +1210,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1676,9 +1676,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:955
-#: lxc/config.go:995 lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172
-#: lxc/config.go:1226 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
+#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
+#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1693,8 +1693,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
+#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1955,7 +1955,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1225 lxc/config.go:1226
+#: lxc/config.go:1226 lxc/config.go:1227
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2502,7 +2502,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:995
+#: lxc/config.go:995 lxc/config.go:996
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2510,7 +2510,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1601 lxc/image.go:1602
 msgid "Get image properties"
 msgstr ""
 
@@ -2766,7 +2766,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:404
+#: lxc/main.go:406
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2788,7 +2788,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1517
 msgid "Image already up to date."
 msgstr ""
 
@@ -2804,11 +2804,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1472
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1698
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2818,7 +2818,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1515
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2904,7 +2904,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
+#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2998,7 +2998,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:506
+#: lxc/main.go:509
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3589,7 +3589,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:954 lxc/config.go:955
+#: lxc/config.go:955 lxc/config.go:956
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4438,7 +4438,7 @@ msgstr ""
 
 #: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -4558,7 +4558,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1649
 msgid "Property not found"
 msgstr ""
 
@@ -4688,7 +4688,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4725,7 +4725,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1444 lxc/image.go:1445
 msgid "Refresh images"
 msgstr ""
 
@@ -4734,7 +4734,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1481
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4942,7 +4942,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1031
+#: lxc/config.go:1032
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5119,7 +5119,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1049 lxc/config.go:1050
+#: lxc/config.go:1050 lxc/config.go:1051
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5153,7 +5153,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1665 lxc/image.go:1666
 msgid "Set image properties"
 msgstr ""
 
@@ -5458,11 +5458,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1535 lxc/image.go:1536
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1172
+#: lxc/config.go:1172 lxc/config.go:1173
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -6055,7 +6055,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:410
+#: lxc/main.go:412
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6234,7 +6234,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1140 lxc/config.go:1141
+#: lxc/config.go:1141 lxc/config.go:1142
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6250,7 +6250,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1728 lxc/image.go:1729
 msgid "Unset image properties"
 msgstr ""
 
@@ -6693,15 +6693,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1600 lxc/image.go:1727
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1664
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6721,11 +6721,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1443
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
+#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6747,11 +6747,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:993 lxc/config.go:1139
+#: lxc/config.go:994 lxc/config.go:1140
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1048
+#: lxc/config.go:1049
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7301,13 +7301,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1228
+#: lxc/config.go:1229
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1052
+#: lxc/config.go:1053
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-21 15:57-0700\n"
+"POT-Creation-Date: 2024-12-05 16:02+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1239
+#: lxc/config.go:1240
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1096
+#: lxc/config.go:702 lxc/config.go:1097
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1210,7 +1210,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1676,9 +1676,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:955
-#: lxc/config.go:995 lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172
-#: lxc/config.go:1226 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
+#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
+#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1693,8 +1693,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
+#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1955,7 +1955,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1225 lxc/config.go:1226
+#: lxc/config.go:1226 lxc/config.go:1227
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2502,7 +2502,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:995
+#: lxc/config.go:995 lxc/config.go:996
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2510,7 +2510,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1601 lxc/image.go:1602
 msgid "Get image properties"
 msgstr ""
 
@@ -2766,7 +2766,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:404
+#: lxc/main.go:406
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2788,7 +2788,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1517
 msgid "Image already up to date."
 msgstr ""
 
@@ -2804,11 +2804,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1472
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1698
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2818,7 +2818,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1515
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2904,7 +2904,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
+#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2998,7 +2998,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:506
+#: lxc/main.go:509
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3589,7 +3589,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:954 lxc/config.go:955
+#: lxc/config.go:955 lxc/config.go:956
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4438,7 +4438,7 @@ msgstr ""
 
 #: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -4558,7 +4558,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1649
 msgid "Property not found"
 msgstr ""
 
@@ -4688,7 +4688,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4725,7 +4725,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1444 lxc/image.go:1445
 msgid "Refresh images"
 msgstr ""
 
@@ -4734,7 +4734,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1481
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4942,7 +4942,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1031
+#: lxc/config.go:1032
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5119,7 +5119,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1049 lxc/config.go:1050
+#: lxc/config.go:1050 lxc/config.go:1051
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5153,7 +5153,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1665 lxc/image.go:1666
 msgid "Set image properties"
 msgstr ""
 
@@ -5458,11 +5458,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1535 lxc/image.go:1536
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1172
+#: lxc/config.go:1172 lxc/config.go:1173
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -6055,7 +6055,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:410
+#: lxc/main.go:412
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6234,7 +6234,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1140 lxc/config.go:1141
+#: lxc/config.go:1141 lxc/config.go:1142
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6250,7 +6250,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1728 lxc/image.go:1729
 msgid "Unset image properties"
 msgstr ""
 
@@ -6693,15 +6693,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1600 lxc/image.go:1727
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1664
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6721,11 +6721,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1443
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
+#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6747,11 +6747,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:993 lxc/config.go:1139
+#: lxc/config.go:994 lxc/config.go:1140
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1048
+#: lxc/config.go:1049
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7301,13 +7301,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1228
+#: lxc/config.go:1229
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1052
+#: lxc/config.go:1053
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-21 15:57-0700\n"
+"POT-Creation-Date: 2024-12-05 16:02+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -99,7 +99,7 @@ msgstr ""
 "### config:\n"
 "###  size: \"61203283968\""
 
-#: lxc/config.go:1239
+#: lxc/config.go:1240
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1096
+#: lxc/config.go:702 lxc/config.go:1097
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1434,7 +1434,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1900,9 +1900,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:955
-#: lxc/config.go:995 lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172
-#: lxc/config.go:1226 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
+#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
+#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1917,8 +1917,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
+#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -2179,7 +2179,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1225 lxc/config.go:1226
+#: lxc/config.go:1226 lxc/config.go:1227
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2726,7 +2726,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:995
+#: lxc/config.go:995 lxc/config.go:996
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2734,7 +2734,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1601 lxc/image.go:1602
 msgid "Get image properties"
 msgstr ""
 
@@ -2990,7 +2990,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:404
+#: lxc/main.go:406
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3012,7 +3012,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1517
 msgid "Image already up to date."
 msgstr ""
 
@@ -3028,11 +3028,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1472
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1698
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -3042,7 +3042,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1515
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3128,7 +3128,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
+#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3222,7 +3222,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:506
+#: lxc/main.go:509
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3813,7 +3813,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:954 lxc/config.go:955
+#: lxc/config.go:955 lxc/config.go:956
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4662,7 +4662,7 @@ msgstr ""
 
 #: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -4782,7 +4782,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1649
 msgid "Property not found"
 msgstr ""
 
@@ -4912,7 +4912,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4949,7 +4949,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1444 lxc/image.go:1445
 msgid "Refresh images"
 msgstr ""
 
@@ -4958,7 +4958,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1481
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5166,7 +5166,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1031
+#: lxc/config.go:1032
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5343,7 +5343,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1049 lxc/config.go:1050
+#: lxc/config.go:1050 lxc/config.go:1051
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5377,7 +5377,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1665 lxc/image.go:1666
 msgid "Set image properties"
 msgstr ""
 
@@ -5682,11 +5682,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1535 lxc/image.go:1536
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1172
+#: lxc/config.go:1172 lxc/config.go:1173
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -6279,7 +6279,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:410
+#: lxc/main.go:412
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6458,7 +6458,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1140 lxc/config.go:1141
+#: lxc/config.go:1141 lxc/config.go:1142
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6474,7 +6474,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1728 lxc/image.go:1729
 msgid "Unset image properties"
 msgstr ""
 
@@ -6917,15 +6917,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1600 lxc/image.go:1727
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1664
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6945,11 +6945,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1443
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
+#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6971,11 +6971,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:993 lxc/config.go:1139
+#: lxc/config.go:994 lxc/config.go:1140
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1048
+#: lxc/config.go:1049
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7525,13 +7525,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1228
+#: lxc/config.go:1229
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1052
+#: lxc/config.go:1053
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-21 15:57-0700\n"
+"POT-Creation-Date: 2024-12-05 16:02+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1239
+#: lxc/config.go:1240
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1096
+#: lxc/config.go:702 lxc/config.go:1097
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1210,7 +1210,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1676,9 +1676,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:955
-#: lxc/config.go:995 lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172
-#: lxc/config.go:1226 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
+#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
+#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1693,8 +1693,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
+#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1955,7 +1955,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1225 lxc/config.go:1226
+#: lxc/config.go:1226 lxc/config.go:1227
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2502,7 +2502,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:995
+#: lxc/config.go:995 lxc/config.go:996
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2510,7 +2510,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1601 lxc/image.go:1602
 msgid "Get image properties"
 msgstr ""
 
@@ -2766,7 +2766,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:404
+#: lxc/main.go:406
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2788,7 +2788,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1517
 msgid "Image already up to date."
 msgstr ""
 
@@ -2804,11 +2804,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1472
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1698
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2818,7 +2818,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1515
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2904,7 +2904,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
+#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2998,7 +2998,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:506
+#: lxc/main.go:509
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3589,7 +3589,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:954 lxc/config.go:955
+#: lxc/config.go:955 lxc/config.go:956
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4438,7 +4438,7 @@ msgstr ""
 
 #: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -4558,7 +4558,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1649
 msgid "Property not found"
 msgstr ""
 
@@ -4688,7 +4688,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4725,7 +4725,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1444 lxc/image.go:1445
 msgid "Refresh images"
 msgstr ""
 
@@ -4734,7 +4734,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1481
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4942,7 +4942,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1031
+#: lxc/config.go:1032
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5119,7 +5119,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1049 lxc/config.go:1050
+#: lxc/config.go:1050 lxc/config.go:1051
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5153,7 +5153,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1665 lxc/image.go:1666
 msgid "Set image properties"
 msgstr ""
 
@@ -5458,11 +5458,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1535 lxc/image.go:1536
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1172
+#: lxc/config.go:1172 lxc/config.go:1173
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -6055,7 +6055,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:410
+#: lxc/main.go:412
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6234,7 +6234,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1140 lxc/config.go:1141
+#: lxc/config.go:1141 lxc/config.go:1142
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6250,7 +6250,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1728 lxc/image.go:1729
 msgid "Unset image properties"
 msgstr ""
 
@@ -6693,15 +6693,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1600 lxc/image.go:1727
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1664
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6721,11 +6721,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1443
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
+#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6747,11 +6747,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:993 lxc/config.go:1139
+#: lxc/config.go:994 lxc/config.go:1140
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1048
+#: lxc/config.go:1049
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7301,13 +7301,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1228
+#: lxc/config.go:1229
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1052
+#: lxc/config.go:1053
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-21 15:57-0700\n"
+"POT-Creation-Date: 2024-12-05 16:02+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -97,7 +97,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/config.go:1239
+#: lxc/config.go:1240
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -1277,7 +1277,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1096
+#: lxc/config.go:702 lxc/config.go:1097
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1472,7 +1472,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1938,9 +1938,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:955
-#: lxc/config.go:995 lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172
-#: lxc/config.go:1226 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
+#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
+#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1955,8 +1955,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
+#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -2217,7 +2217,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1225 lxc/config.go:1226
+#: lxc/config.go:1226 lxc/config.go:1227
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2764,7 +2764,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:995
+#: lxc/config.go:995 lxc/config.go:996
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2772,7 +2772,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1601 lxc/image.go:1602
 msgid "Get image properties"
 msgstr ""
 
@@ -3028,7 +3028,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:404
+#: lxc/main.go:406
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3050,7 +3050,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1517
 msgid "Image already up to date."
 msgstr ""
 
@@ -3066,11 +3066,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1472
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1698
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -3080,7 +3080,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1515
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3166,7 +3166,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
+#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3260,7 +3260,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:506
+#: lxc/main.go:509
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3851,7 +3851,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:954 lxc/config.go:955
+#: lxc/config.go:955 lxc/config.go:956
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4700,7 +4700,7 @@ msgstr ""
 
 #: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -4820,7 +4820,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1649
 msgid "Property not found"
 msgstr ""
 
@@ -4950,7 +4950,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4987,7 +4987,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1444 lxc/image.go:1445
 msgid "Refresh images"
 msgstr ""
 
@@ -4996,7 +4996,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1481
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5204,7 +5204,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1031
+#: lxc/config.go:1032
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5381,7 +5381,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1049 lxc/config.go:1050
+#: lxc/config.go:1050 lxc/config.go:1051
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5415,7 +5415,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1665 lxc/image.go:1666
 msgid "Set image properties"
 msgstr ""
 
@@ -5720,11 +5720,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1535 lxc/image.go:1536
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1172
+#: lxc/config.go:1172 lxc/config.go:1173
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -6317,7 +6317,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:410
+#: lxc/main.go:412
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6496,7 +6496,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1140 lxc/config.go:1141
+#: lxc/config.go:1141 lxc/config.go:1142
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6512,7 +6512,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1728 lxc/image.go:1729
 msgid "Unset image properties"
 msgstr ""
 
@@ -6955,15 +6955,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1600 lxc/image.go:1727
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1664
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6983,11 +6983,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1443
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
+#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -7009,11 +7009,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:993 lxc/config.go:1139
+#: lxc/config.go:994 lxc/config.go:1140
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1048
+#: lxc/config.go:1049
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7563,13 +7563,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1228
+#: lxc/config.go:1229
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1052
+#: lxc/config.go:1053
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-21 15:57-0700\n"
+"POT-Creation-Date: 2024-12-05 16:02+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -60,7 +60,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1239
+#: lxc/config.go:1240
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -1012,7 +1012,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1096
+#: lxc/config.go:702 lxc/config.go:1097
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1207,7 +1207,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1673,9 +1673,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:955
-#: lxc/config.go:995 lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172
-#: lxc/config.go:1226 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
+#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
+#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1690,8 +1690,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
+#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1952,7 +1952,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1225 lxc/config.go:1226
+#: lxc/config.go:1226 lxc/config.go:1227
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2499,7 +2499,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:995
+#: lxc/config.go:995 lxc/config.go:996
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2507,7 +2507,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1601 lxc/image.go:1602
 msgid "Get image properties"
 msgstr ""
 
@@ -2763,7 +2763,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:404
+#: lxc/main.go:406
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2785,7 +2785,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1517
 msgid "Image already up to date."
 msgstr ""
 
@@ -2801,11 +2801,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1472
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1698
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2815,7 +2815,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1515
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2901,7 +2901,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
+#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2995,7 +2995,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:506
+#: lxc/main.go:509
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3586,7 +3586,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:954 lxc/config.go:955
+#: lxc/config.go:955 lxc/config.go:956
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4435,7 +4435,7 @@ msgstr ""
 
 #: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -4555,7 +4555,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1649
 msgid "Property not found"
 msgstr ""
 
@@ -4685,7 +4685,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4722,7 +4722,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1444 lxc/image.go:1445
 msgid "Refresh images"
 msgstr ""
 
@@ -4731,7 +4731,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1481
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4939,7 +4939,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1031
+#: lxc/config.go:1032
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5116,7 +5116,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1049 lxc/config.go:1050
+#: lxc/config.go:1050 lxc/config.go:1051
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5150,7 +5150,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1665 lxc/image.go:1666
 msgid "Set image properties"
 msgstr ""
 
@@ -5455,11 +5455,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1535 lxc/image.go:1536
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1172
+#: lxc/config.go:1172 lxc/config.go:1173
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -6052,7 +6052,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:410
+#: lxc/main.go:412
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6231,7 +6231,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1140 lxc/config.go:1141
+#: lxc/config.go:1141 lxc/config.go:1142
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6247,7 +6247,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1728 lxc/image.go:1729
 msgid "Unset image properties"
 msgstr ""
 
@@ -6690,15 +6690,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1600 lxc/image.go:1727
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1664
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6718,11 +6718,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1443
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
+#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6744,11 +6744,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:993 lxc/config.go:1139
+#: lxc/config.go:994 lxc/config.go:1140
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1048
+#: lxc/config.go:1049
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7298,13 +7298,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1228
+#: lxc/config.go:1229
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1052
+#: lxc/config.go:1053
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-21 15:57-0700\n"
+"POT-Creation-Date: 2024-12-05 16:02+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -102,7 +102,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/config.go:1239
+#: lxc/config.go:1240
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -1293,7 +1293,7 @@ msgstr "Não pode especificar a coluna L, quando não em cluster"
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "Não é possível fornecer o uid/gid/modo no modo recursivo"
 
-#: lxc/config.go:702 lxc/config.go:1096
+#: lxc/config.go:702 lxc/config.go:1097
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr "Não é possível remover chave '%s', não está atualmente definido"
@@ -1499,7 +1499,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -2001,9 +2001,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:955
-#: lxc/config.go:995 lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172
-#: lxc/config.go:1226 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
+#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
+#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -2018,8 +2018,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
+#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -2293,7 +2293,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Edit image properties"
 msgstr "Editar propriedades da imagem"
 
-#: lxc/config.go:1225 lxc/config.go:1226
+#: lxc/config.go:1226 lxc/config.go:1227
 #, fuzzy
 msgid "Edit instance UEFI variables"
 msgstr "Editar arquivos de metadados do container"
@@ -2855,7 +2855,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:995
+#: lxc/config.go:995 lxc/config.go:996
 #, fuzzy
 msgid "Get UEFI variables for instance"
 msgstr "Adicionar perfis aos containers"
@@ -2864,7 +2864,7 @@ msgstr "Adicionar perfis aos containers"
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1601 lxc/image.go:1602
 #, fuzzy
 msgid "Get image properties"
 msgstr "Editar propriedades da imagem"
@@ -3139,7 +3139,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:404
+#: lxc/main.go:406
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3162,7 +3162,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr "Ignorar o estado do container"
 
-#: lxc/image.go:1522
+#: lxc/image.go:1517
 msgid "Image already up to date."
 msgstr ""
 
@@ -3178,11 +3178,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr "Imagem exportada com sucesso!"
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1472
 msgid "Image identifier missing"
 msgstr "Falta o identificador da imagem"
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1698
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr "Falta o identificador da imagem: %s"
@@ -3192,7 +3192,7 @@ msgstr "Falta o identificador da imagem: %s"
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1515
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3279,7 +3279,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
+#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3374,7 +3374,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:506
+#: lxc/main.go:509
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3982,7 +3982,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:954 lxc/config.go:955
+#: lxc/config.go:955 lxc/config.go:956
 #, fuzzy
 msgid "Manage instance UEFI variables"
 msgstr "Editar arquivos de metadados do container"
@@ -4870,7 +4870,7 @@ msgstr ""
 
 #: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -4995,7 +4995,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1649
 msgid "Property not found"
 msgstr ""
 
@@ -5126,7 +5126,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5165,7 +5165,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1444 lxc/image.go:1445
 msgid "Refresh images"
 msgstr ""
 
@@ -5174,7 +5174,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/image.go:1486
+#: lxc/image.go:1481
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5399,7 +5399,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1031
+#: lxc/config.go:1032
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5586,7 +5586,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1049 lxc/config.go:1050
+#: lxc/config.go:1050 lxc/config.go:1051
 #, fuzzy
 msgid "Set UEFI variables for instance"
 msgstr "Adicionar perfis aos containers"
@@ -5623,7 +5623,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1665 lxc/image.go:1666
 #, fuzzy
 msgid "Set image properties"
 msgstr "Editar propriedades da imagem"
@@ -5949,11 +5949,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1535 lxc/image.go:1536
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1172
+#: lxc/config.go:1172 lxc/config.go:1173
 #, fuzzy
 msgid "Show instance UEFI variables"
 msgstr "Editar arquivos de metadados do container"
@@ -6570,7 +6570,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:410
+#: lxc/main.go:412
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6752,7 +6752,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1140 lxc/config.go:1141
+#: lxc/config.go:1141 lxc/config.go:1142
 #, fuzzy
 msgid "Unset UEFI variables for instance"
 msgstr "Não pode fornecer um nome para a imagem de destino"
@@ -6772,7 +6772,7 @@ msgstr "Não pode fornecer um nome para a imagem de destino"
 msgid "Unset device configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1728 lxc/image.go:1729
 #, fuzzy
 msgid "Unset image properties"
 msgstr "Editar propriedades da imagem"
@@ -7259,16 +7259,16 @@ msgstr "Editar templates de arquivo do container"
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr "Criar perfis"
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1600 lxc/image.go:1727
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/image.go:1669
+#: lxc/image.go:1664
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr "Editar templates de arquivo do container"
@@ -7290,11 +7290,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1443
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
+#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -7316,12 +7316,12 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:993 lxc/config.go:1139
+#: lxc/config.go:994 lxc/config.go:1140
 #, fuzzy
 msgid "[<remote>:]<instance> <key>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/config.go:1048
+#: lxc/config.go:1049
 #, fuzzy
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr "Editar templates de arquivo do container"
@@ -7921,13 +7921,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1228
+#: lxc/config.go:1229
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1052
+#: lxc/config.go:1053
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-21 15:57-0700\n"
+"POT-Creation-Date: 2024-12-05 16:02+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -106,7 +106,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/config.go:1239
+#: lxc/config.go:1240
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -1290,7 +1290,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1096
+#: lxc/config.go:702 lxc/config.go:1097
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1490,7 +1490,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1988,9 +1988,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:955
-#: lxc/config.go:995 lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172
-#: lxc/config.go:1226 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
+#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
+#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -2005,8 +2005,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
+#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -2275,7 +2275,7 @@ msgstr "Копирование образа: %s"
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1225 lxc/config.go:1226
+#: lxc/config.go:1226 lxc/config.go:1227
 #, fuzzy
 msgid "Edit instance UEFI variables"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -2840,7 +2840,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:995
+#: lxc/config.go:995 lxc/config.go:996
 #, fuzzy
 msgid "Get UEFI variables for instance"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -2849,7 +2849,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1601 lxc/image.go:1602
 msgid "Get image properties"
 msgstr ""
 
@@ -3121,7 +3121,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:404
+#: lxc/main.go:406
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -3144,7 +3144,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/image.go:1522
+#: lxc/image.go:1517
 msgid "Image already up to date."
 msgstr ""
 
@@ -3160,11 +3160,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1472
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1698
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -3174,7 +3174,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1515
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3265,7 +3265,7 @@ msgstr "Имя контейнера является обязательным"
 msgid "Instance name is: %s"
 msgstr "Имя контейнера: %s"
 
-#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
+#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
 #, fuzzy
 msgid "Instance name must be specified"
 msgstr "Имя контейнера: %s"
@@ -3361,7 +3361,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:506
+#: lxc/main.go:509
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3978,7 +3978,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:954 lxc/config.go:955
+#: lxc/config.go:955 lxc/config.go:956
 #, fuzzy
 msgid "Manage instance UEFI variables"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -4876,7 +4876,7 @@ msgstr ""
 
 #: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -4996,7 +4996,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1649
 msgid "Property not found"
 msgstr ""
 
@@ -5126,7 +5126,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5166,7 +5166,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr "Копирование образа: %s"
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1444 lxc/image.go:1445
 #, fuzzy
 msgid "Refresh images"
 msgstr "Копирование образа: %s"
@@ -5176,7 +5176,7 @@ msgstr "Копирование образа: %s"
 msgid "Refreshing instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/image.go:1486
+#: lxc/image.go:1481
 #, fuzzy, c-format
 msgid "Refreshing the image: %s"
 msgstr "Копирование образа: %s"
@@ -5397,7 +5397,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1031
+#: lxc/config.go:1032
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5581,7 +5581,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1049 lxc/config.go:1050
+#: lxc/config.go:1050 lxc/config.go:1051
 #, fuzzy
 msgid "Set UEFI variables for instance"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -5617,7 +5617,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1665 lxc/image.go:1666
 msgid "Set image properties"
 msgstr ""
 
@@ -5939,11 +5939,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1535 lxc/image.go:1536
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1172
+#: lxc/config.go:1172 lxc/config.go:1173
 #, fuzzy
 msgid "Show instance UEFI variables"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -6556,7 +6556,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:410
+#: lxc/main.go:412
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6736,7 +6736,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1140 lxc/config.go:1141
+#: lxc/config.go:1141 lxc/config.go:1142
 #, fuzzy
 msgid "Unset UEFI variables for instance"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -6754,7 +6754,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1728 lxc/image.go:1729
 msgid "Unset image properties"
 msgstr ""
 
@@ -7341,7 +7341,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr ""
@@ -7349,7 +7349,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1600 lxc/image.go:1727
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr ""
@@ -7357,7 +7357,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:1669
+#: lxc/image.go:1664
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
@@ -7397,7 +7397,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1443
 #, fuzzy
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
@@ -7405,7 +7405,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
+#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 #, fuzzy
@@ -7447,7 +7447,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:993 lxc/config.go:1139
+#: lxc/config.go:994 lxc/config.go:1140
 #, fuzzy
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
@@ -7455,7 +7455,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:1048
+#: lxc/config.go:1049
 #, fuzzy
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
@@ -8409,13 +8409,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1228
+#: lxc/config.go:1229
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1052
+#: lxc/config.go:1053
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-21 15:57-0700\n"
+"POT-Creation-Date: 2024-12-05 16:02+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1239
+#: lxc/config.go:1240
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1096
+#: lxc/config.go:702 lxc/config.go:1097
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1210,7 +1210,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1676,9 +1676,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:955
-#: lxc/config.go:995 lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172
-#: lxc/config.go:1226 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
+#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
+#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1693,8 +1693,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
+#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1955,7 +1955,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1225 lxc/config.go:1226
+#: lxc/config.go:1226 lxc/config.go:1227
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2502,7 +2502,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:995
+#: lxc/config.go:995 lxc/config.go:996
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2510,7 +2510,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1601 lxc/image.go:1602
 msgid "Get image properties"
 msgstr ""
 
@@ -2766,7 +2766,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:404
+#: lxc/main.go:406
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2788,7 +2788,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1517
 msgid "Image already up to date."
 msgstr ""
 
@@ -2804,11 +2804,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1472
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1698
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2818,7 +2818,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1515
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2904,7 +2904,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
+#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2998,7 +2998,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:506
+#: lxc/main.go:509
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3589,7 +3589,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:954 lxc/config.go:955
+#: lxc/config.go:955 lxc/config.go:956
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4438,7 +4438,7 @@ msgstr ""
 
 #: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -4558,7 +4558,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1649
 msgid "Property not found"
 msgstr ""
 
@@ -4688,7 +4688,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4725,7 +4725,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1444 lxc/image.go:1445
 msgid "Refresh images"
 msgstr ""
 
@@ -4734,7 +4734,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1481
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4942,7 +4942,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1031
+#: lxc/config.go:1032
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5119,7 +5119,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1049 lxc/config.go:1050
+#: lxc/config.go:1050 lxc/config.go:1051
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5153,7 +5153,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1665 lxc/image.go:1666
 msgid "Set image properties"
 msgstr ""
 
@@ -5458,11 +5458,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1535 lxc/image.go:1536
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1172
+#: lxc/config.go:1172 lxc/config.go:1173
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -6055,7 +6055,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:410
+#: lxc/main.go:412
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6234,7 +6234,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1140 lxc/config.go:1141
+#: lxc/config.go:1141 lxc/config.go:1142
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6250,7 +6250,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1728 lxc/image.go:1729
 msgid "Unset image properties"
 msgstr ""
 
@@ -6693,15 +6693,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1600 lxc/image.go:1727
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1664
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6721,11 +6721,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1443
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
+#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6747,11 +6747,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:993 lxc/config.go:1139
+#: lxc/config.go:994 lxc/config.go:1140
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1048
+#: lxc/config.go:1049
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7301,13 +7301,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1228
+#: lxc/config.go:1229
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1052
+#: lxc/config.go:1053
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-21 15:57-0700\n"
+"POT-Creation-Date: 2024-12-05 16:02+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -64,7 +64,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1239
+#: lxc/config.go:1240
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -1016,7 +1016,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1096
+#: lxc/config.go:702 lxc/config.go:1097
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1211,7 +1211,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1677,9 +1677,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:955
-#: lxc/config.go:995 lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172
-#: lxc/config.go:1226 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
+#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
+#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1694,8 +1694,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
+#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1956,7 +1956,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1225 lxc/config.go:1226
+#: lxc/config.go:1226 lxc/config.go:1227
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2503,7 +2503,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:995
+#: lxc/config.go:995 lxc/config.go:996
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2511,7 +2511,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1601 lxc/image.go:1602
 msgid "Get image properties"
 msgstr ""
 
@@ -2767,7 +2767,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:404
+#: lxc/main.go:406
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2789,7 +2789,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1517
 msgid "Image already up to date."
 msgstr ""
 
@@ -2805,11 +2805,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1472
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1698
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2819,7 +2819,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1515
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2905,7 +2905,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
+#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2999,7 +2999,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:506
+#: lxc/main.go:509
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3590,7 +3590,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:954 lxc/config.go:955
+#: lxc/config.go:955 lxc/config.go:956
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4439,7 +4439,7 @@ msgstr ""
 
 #: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -4559,7 +4559,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1649
 msgid "Property not found"
 msgstr ""
 
@@ -4689,7 +4689,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4726,7 +4726,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1444 lxc/image.go:1445
 msgid "Refresh images"
 msgstr ""
 
@@ -4735,7 +4735,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1481
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4943,7 +4943,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1031
+#: lxc/config.go:1032
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5120,7 +5120,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1049 lxc/config.go:1050
+#: lxc/config.go:1050 lxc/config.go:1051
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5154,7 +5154,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1665 lxc/image.go:1666
 msgid "Set image properties"
 msgstr ""
 
@@ -5459,11 +5459,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1535 lxc/image.go:1536
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1172
+#: lxc/config.go:1172 lxc/config.go:1173
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -6056,7 +6056,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:410
+#: lxc/main.go:412
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6235,7 +6235,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1140 lxc/config.go:1141
+#: lxc/config.go:1141 lxc/config.go:1142
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6251,7 +6251,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1728 lxc/image.go:1729
 msgid "Unset image properties"
 msgstr ""
 
@@ -6694,15 +6694,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1600 lxc/image.go:1727
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1664
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6722,11 +6722,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1443
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
+#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6748,11 +6748,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:993 lxc/config.go:1139
+#: lxc/config.go:994 lxc/config.go:1140
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1048
+#: lxc/config.go:1049
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7302,13 +7302,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1228
+#: lxc/config.go:1229
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1052
+#: lxc/config.go:1053
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-21 15:57-0700\n"
+"POT-Creation-Date: 2024-12-05 16:02+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -64,7 +64,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1239
+#: lxc/config.go:1240
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -1016,7 +1016,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1096
+#: lxc/config.go:702 lxc/config.go:1097
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1211,7 +1211,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1677,9 +1677,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:955
-#: lxc/config.go:995 lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172
-#: lxc/config.go:1226 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
+#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
+#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1694,8 +1694,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
+#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1956,7 +1956,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1225 lxc/config.go:1226
+#: lxc/config.go:1226 lxc/config.go:1227
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2503,7 +2503,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:995
+#: lxc/config.go:995 lxc/config.go:996
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2511,7 +2511,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1601 lxc/image.go:1602
 msgid "Get image properties"
 msgstr ""
 
@@ -2767,7 +2767,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:404
+#: lxc/main.go:406
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2789,7 +2789,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1517
 msgid "Image already up to date."
 msgstr ""
 
@@ -2805,11 +2805,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1472
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1698
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2819,7 +2819,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1515
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2905,7 +2905,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
+#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2999,7 +2999,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:506
+#: lxc/main.go:509
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3590,7 +3590,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:954 lxc/config.go:955
+#: lxc/config.go:955 lxc/config.go:956
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4439,7 +4439,7 @@ msgstr ""
 
 #: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -4559,7 +4559,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1649
 msgid "Property not found"
 msgstr ""
 
@@ -4689,7 +4689,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4726,7 +4726,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1444 lxc/image.go:1445
 msgid "Refresh images"
 msgstr ""
 
@@ -4735,7 +4735,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1481
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4943,7 +4943,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1031
+#: lxc/config.go:1032
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5120,7 +5120,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1049 lxc/config.go:1050
+#: lxc/config.go:1050 lxc/config.go:1051
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5154,7 +5154,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1665 lxc/image.go:1666
 msgid "Set image properties"
 msgstr ""
 
@@ -5459,11 +5459,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1535 lxc/image.go:1536
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1172
+#: lxc/config.go:1172 lxc/config.go:1173
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -6056,7 +6056,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:410
+#: lxc/main.go:412
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6235,7 +6235,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1140 lxc/config.go:1141
+#: lxc/config.go:1141 lxc/config.go:1142
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6251,7 +6251,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1728 lxc/image.go:1729
 msgid "Unset image properties"
 msgstr ""
 
@@ -6694,15 +6694,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1600 lxc/image.go:1727
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1664
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6722,11 +6722,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1443
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
+#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6748,11 +6748,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:993 lxc/config.go:1139
+#: lxc/config.go:994 lxc/config.go:1140
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1048
+#: lxc/config.go:1049
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7302,13 +7302,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1228
+#: lxc/config.go:1229
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1052
+#: lxc/config.go:1053
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-21 15:57-0700\n"
+"POT-Creation-Date: 2024-12-05 16:02+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1239
+#: lxc/config.go:1240
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1096
+#: lxc/config.go:702 lxc/config.go:1097
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1210,7 +1210,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1676,9 +1676,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:955
-#: lxc/config.go:995 lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172
-#: lxc/config.go:1226 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
+#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
+#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1693,8 +1693,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
+#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1955,7 +1955,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1225 lxc/config.go:1226
+#: lxc/config.go:1226 lxc/config.go:1227
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2502,7 +2502,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:995
+#: lxc/config.go:995 lxc/config.go:996
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2510,7 +2510,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1601 lxc/image.go:1602
 msgid "Get image properties"
 msgstr ""
 
@@ -2766,7 +2766,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:404
+#: lxc/main.go:406
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2788,7 +2788,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1517
 msgid "Image already up to date."
 msgstr ""
 
@@ -2804,11 +2804,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1472
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1698
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2818,7 +2818,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1515
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2904,7 +2904,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
+#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2998,7 +2998,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:506
+#: lxc/main.go:509
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3589,7 +3589,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:954 lxc/config.go:955
+#: lxc/config.go:955 lxc/config.go:956
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4438,7 +4438,7 @@ msgstr ""
 
 #: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -4558,7 +4558,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1649
 msgid "Property not found"
 msgstr ""
 
@@ -4688,7 +4688,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4725,7 +4725,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1444 lxc/image.go:1445
 msgid "Refresh images"
 msgstr ""
 
@@ -4734,7 +4734,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1481
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4942,7 +4942,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1031
+#: lxc/config.go:1032
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5119,7 +5119,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1049 lxc/config.go:1050
+#: lxc/config.go:1050 lxc/config.go:1051
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5153,7 +5153,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1665 lxc/image.go:1666
 msgid "Set image properties"
 msgstr ""
 
@@ -5458,11 +5458,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1535 lxc/image.go:1536
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1172
+#: lxc/config.go:1172 lxc/config.go:1173
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -6055,7 +6055,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:410
+#: lxc/main.go:412
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6234,7 +6234,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1140 lxc/config.go:1141
+#: lxc/config.go:1141 lxc/config.go:1142
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6250,7 +6250,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1728 lxc/image.go:1729
 msgid "Unset image properties"
 msgstr ""
 
@@ -6693,15 +6693,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1600 lxc/image.go:1727
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1664
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6721,11 +6721,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1443
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
+#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6747,11 +6747,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:993 lxc/config.go:1139
+#: lxc/config.go:994 lxc/config.go:1140
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1048
+#: lxc/config.go:1049
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7301,13 +7301,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1228
+#: lxc/config.go:1229
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1052
+#: lxc/config.go:1053
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-21 15:57-0700\n"
+"POT-Creation-Date: 2024-12-05 16:02+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1239
+#: lxc/config.go:1240
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1096
+#: lxc/config.go:702 lxc/config.go:1097
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1210,7 +1210,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1676,9 +1676,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:955
-#: lxc/config.go:995 lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172
-#: lxc/config.go:1226 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
+#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
+#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1693,8 +1693,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
+#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1955,7 +1955,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1225 lxc/config.go:1226
+#: lxc/config.go:1226 lxc/config.go:1227
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2502,7 +2502,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:995
+#: lxc/config.go:995 lxc/config.go:996
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2510,7 +2510,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1601 lxc/image.go:1602
 msgid "Get image properties"
 msgstr ""
 
@@ -2766,7 +2766,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:404
+#: lxc/main.go:406
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2788,7 +2788,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1517
 msgid "Image already up to date."
 msgstr ""
 
@@ -2804,11 +2804,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1472
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1698
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2818,7 +2818,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1515
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2904,7 +2904,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
+#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2998,7 +2998,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:506
+#: lxc/main.go:509
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3589,7 +3589,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:954 lxc/config.go:955
+#: lxc/config.go:955 lxc/config.go:956
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4438,7 +4438,7 @@ msgstr ""
 
 #: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -4558,7 +4558,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1649
 msgid "Property not found"
 msgstr ""
 
@@ -4688,7 +4688,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4725,7 +4725,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1444 lxc/image.go:1445
 msgid "Refresh images"
 msgstr ""
 
@@ -4734,7 +4734,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1481
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4942,7 +4942,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1031
+#: lxc/config.go:1032
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5119,7 +5119,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1049 lxc/config.go:1050
+#: lxc/config.go:1050 lxc/config.go:1051
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5153,7 +5153,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1665 lxc/image.go:1666
 msgid "Set image properties"
 msgstr ""
 
@@ -5458,11 +5458,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1535 lxc/image.go:1536
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1172
+#: lxc/config.go:1172 lxc/config.go:1173
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -6055,7 +6055,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:410
+#: lxc/main.go:412
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6234,7 +6234,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1140 lxc/config.go:1141
+#: lxc/config.go:1141 lxc/config.go:1142
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6250,7 +6250,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1728 lxc/image.go:1729
 msgid "Unset image properties"
 msgstr ""
 
@@ -6693,15 +6693,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1600 lxc/image.go:1727
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1664
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6721,11 +6721,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1443
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
+#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6747,11 +6747,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:993 lxc/config.go:1139
+#: lxc/config.go:994 lxc/config.go:1140
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1048
+#: lxc/config.go:1049
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7301,13 +7301,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1228
+#: lxc/config.go:1229
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1052
+#: lxc/config.go:1053
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/th.po
+++ b/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-21 15:57-0700\n"
+"POT-Creation-Date: 2024-12-05 16:02+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -60,7 +60,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1239
+#: lxc/config.go:1240
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -1012,7 +1012,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1096
+#: lxc/config.go:702 lxc/config.go:1097
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1207,7 +1207,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1673,9 +1673,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:955
-#: lxc/config.go:995 lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172
-#: lxc/config.go:1226 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
+#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
+#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1690,8 +1690,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
+#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1952,7 +1952,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1225 lxc/config.go:1226
+#: lxc/config.go:1226 lxc/config.go:1227
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2499,7 +2499,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:995
+#: lxc/config.go:995 lxc/config.go:996
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2507,7 +2507,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1601 lxc/image.go:1602
 msgid "Get image properties"
 msgstr ""
 
@@ -2763,7 +2763,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:404
+#: lxc/main.go:406
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2785,7 +2785,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1517
 msgid "Image already up to date."
 msgstr ""
 
@@ -2801,11 +2801,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1472
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1698
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2815,7 +2815,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1515
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2901,7 +2901,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
+#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2995,7 +2995,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:506
+#: lxc/main.go:509
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3586,7 +3586,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:954 lxc/config.go:955
+#: lxc/config.go:955 lxc/config.go:956
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4435,7 +4435,7 @@ msgstr ""
 
 #: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -4555,7 +4555,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1649
 msgid "Property not found"
 msgstr ""
 
@@ -4685,7 +4685,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4722,7 +4722,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1444 lxc/image.go:1445
 msgid "Refresh images"
 msgstr ""
 
@@ -4731,7 +4731,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1481
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4939,7 +4939,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1031
+#: lxc/config.go:1032
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5116,7 +5116,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1049 lxc/config.go:1050
+#: lxc/config.go:1050 lxc/config.go:1051
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5150,7 +5150,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1665 lxc/image.go:1666
 msgid "Set image properties"
 msgstr ""
 
@@ -5455,11 +5455,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1535 lxc/image.go:1536
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1172
+#: lxc/config.go:1172 lxc/config.go:1173
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -6052,7 +6052,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:410
+#: lxc/main.go:412
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6231,7 +6231,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1140 lxc/config.go:1141
+#: lxc/config.go:1141 lxc/config.go:1142
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6247,7 +6247,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1728 lxc/image.go:1729
 msgid "Unset image properties"
 msgstr ""
 
@@ -6690,15 +6690,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1600 lxc/image.go:1727
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1664
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6718,11 +6718,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1443
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
+#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6744,11 +6744,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:993 lxc/config.go:1139
+#: lxc/config.go:994 lxc/config.go:1140
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1048
+#: lxc/config.go:1049
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7298,13 +7298,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1228
+#: lxc/config.go:1229
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1052
+#: lxc/config.go:1053
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-21 15:57-0700\n"
+"POT-Creation-Date: 2024-12-05 16:02+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1239
+#: lxc/config.go:1240
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1096
+#: lxc/config.go:702 lxc/config.go:1097
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1210,7 +1210,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1676,9 +1676,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:955
-#: lxc/config.go:995 lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172
-#: lxc/config.go:1226 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
+#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
+#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1693,8 +1693,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
+#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1955,7 +1955,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1225 lxc/config.go:1226
+#: lxc/config.go:1226 lxc/config.go:1227
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2502,7 +2502,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:995
+#: lxc/config.go:995 lxc/config.go:996
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2510,7 +2510,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1601 lxc/image.go:1602
 msgid "Get image properties"
 msgstr ""
 
@@ -2766,7 +2766,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:404
+#: lxc/main.go:406
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2788,7 +2788,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1517
 msgid "Image already up to date."
 msgstr ""
 
@@ -2804,11 +2804,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1472
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1698
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2818,7 +2818,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1515
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2904,7 +2904,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
+#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2998,7 +2998,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:506
+#: lxc/main.go:509
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3589,7 +3589,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:954 lxc/config.go:955
+#: lxc/config.go:955 lxc/config.go:956
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4438,7 +4438,7 @@ msgstr ""
 
 #: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -4558,7 +4558,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1649
 msgid "Property not found"
 msgstr ""
 
@@ -4688,7 +4688,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4725,7 +4725,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1444 lxc/image.go:1445
 msgid "Refresh images"
 msgstr ""
 
@@ -4734,7 +4734,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1481
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4942,7 +4942,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1031
+#: lxc/config.go:1032
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5119,7 +5119,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1049 lxc/config.go:1050
+#: lxc/config.go:1050 lxc/config.go:1051
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5153,7 +5153,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1665 lxc/image.go:1666
 msgid "Set image properties"
 msgstr ""
 
@@ -5458,11 +5458,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1535 lxc/image.go:1536
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1172
+#: lxc/config.go:1172 lxc/config.go:1173
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -6055,7 +6055,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:410
+#: lxc/main.go:412
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6234,7 +6234,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1140 lxc/config.go:1141
+#: lxc/config.go:1141 lxc/config.go:1142
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6250,7 +6250,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1728 lxc/image.go:1729
 msgid "Unset image properties"
 msgstr ""
 
@@ -6693,15 +6693,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1600 lxc/image.go:1727
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1664
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6721,11 +6721,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1443
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
+#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6747,11 +6747,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:993 lxc/config.go:1139
+#: lxc/config.go:994 lxc/config.go:1140
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1048
+#: lxc/config.go:1049
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7301,13 +7301,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1228
+#: lxc/config.go:1229
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1052
+#: lxc/config.go:1053
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-21 15:57-0700\n"
+"POT-Creation-Date: 2024-12-05 16:02+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1239
+#: lxc/config.go:1240
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1096
+#: lxc/config.go:702 lxc/config.go:1097
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1210,7 +1210,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1676,9 +1676,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:955
-#: lxc/config.go:995 lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172
-#: lxc/config.go:1226 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
+#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
+#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1693,8 +1693,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
+#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1955,7 +1955,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1225 lxc/config.go:1226
+#: lxc/config.go:1226 lxc/config.go:1227
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2502,7 +2502,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:995
+#: lxc/config.go:995 lxc/config.go:996
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2510,7 +2510,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1601 lxc/image.go:1602
 msgid "Get image properties"
 msgstr ""
 
@@ -2766,7 +2766,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:404
+#: lxc/main.go:406
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2788,7 +2788,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1517
 msgid "Image already up to date."
 msgstr ""
 
@@ -2804,11 +2804,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1472
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1698
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2818,7 +2818,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1515
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2904,7 +2904,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
+#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2998,7 +2998,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:506
+#: lxc/main.go:509
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3589,7 +3589,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:954 lxc/config.go:955
+#: lxc/config.go:955 lxc/config.go:956
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4438,7 +4438,7 @@ msgstr ""
 
 #: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -4558,7 +4558,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1649
 msgid "Property not found"
 msgstr ""
 
@@ -4688,7 +4688,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4725,7 +4725,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1444 lxc/image.go:1445
 msgid "Refresh images"
 msgstr ""
 
@@ -4734,7 +4734,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1481
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4942,7 +4942,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1031
+#: lxc/config.go:1032
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5119,7 +5119,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1049 lxc/config.go:1050
+#: lxc/config.go:1050 lxc/config.go:1051
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5153,7 +5153,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1665 lxc/image.go:1666
 msgid "Set image properties"
 msgstr ""
 
@@ -5458,11 +5458,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1535 lxc/image.go:1536
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1172
+#: lxc/config.go:1172 lxc/config.go:1173
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -6055,7 +6055,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:410
+#: lxc/main.go:412
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6234,7 +6234,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1140 lxc/config.go:1141
+#: lxc/config.go:1141 lxc/config.go:1142
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6250,7 +6250,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1728 lxc/image.go:1729
 msgid "Unset image properties"
 msgstr ""
 
@@ -6693,15 +6693,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1600 lxc/image.go:1727
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1664
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6721,11 +6721,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1443
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
+#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6747,11 +6747,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:993 lxc/config.go:1139
+#: lxc/config.go:994 lxc/config.go:1140
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1048
+#: lxc/config.go:1049
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7301,13 +7301,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1228
+#: lxc/config.go:1229
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1052
+#: lxc/config.go:1053
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-21 15:57-0700\n"
+"POT-Creation-Date: 2024-12-05 16:02+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1239
+#: lxc/config.go:1240
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1096
+#: lxc/config.go:702 lxc/config.go:1097
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1210,7 +1210,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1676,9 +1676,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:955
-#: lxc/config.go:995 lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172
-#: lxc/config.go:1226 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
+#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
+#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1693,8 +1693,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
+#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1955,7 +1955,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1225 lxc/config.go:1226
+#: lxc/config.go:1226 lxc/config.go:1227
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2502,7 +2502,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:995
+#: lxc/config.go:995 lxc/config.go:996
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2510,7 +2510,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1601 lxc/image.go:1602
 msgid "Get image properties"
 msgstr ""
 
@@ -2766,7 +2766,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:404
+#: lxc/main.go:406
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2788,7 +2788,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1517
 msgid "Image already up to date."
 msgstr ""
 
@@ -2804,11 +2804,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1472
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1698
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2818,7 +2818,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1515
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2904,7 +2904,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
+#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2998,7 +2998,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:506
+#: lxc/main.go:509
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3589,7 +3589,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:954 lxc/config.go:955
+#: lxc/config.go:955 lxc/config.go:956
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4438,7 +4438,7 @@ msgstr ""
 
 #: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -4558,7 +4558,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1649
 msgid "Property not found"
 msgstr ""
 
@@ -4688,7 +4688,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4725,7 +4725,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1444 lxc/image.go:1445
 msgid "Refresh images"
 msgstr ""
 
@@ -4734,7 +4734,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1481
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4942,7 +4942,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1031
+#: lxc/config.go:1032
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5119,7 +5119,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1049 lxc/config.go:1050
+#: lxc/config.go:1050 lxc/config.go:1051
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5153,7 +5153,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1665 lxc/image.go:1666
 msgid "Set image properties"
 msgstr ""
 
@@ -5458,11 +5458,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1535 lxc/image.go:1536
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1172
+#: lxc/config.go:1172 lxc/config.go:1173
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -6055,7 +6055,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:410
+#: lxc/main.go:412
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6234,7 +6234,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1140 lxc/config.go:1141
+#: lxc/config.go:1141 lxc/config.go:1142
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6250,7 +6250,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1728 lxc/image.go:1729
 msgid "Unset image properties"
 msgstr ""
 
@@ -6693,15 +6693,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1600 lxc/image.go:1727
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1664
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6721,11 +6721,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1443
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
+#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6747,11 +6747,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:993 lxc/config.go:1139
+#: lxc/config.go:994 lxc/config.go:1140
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1048
+#: lxc/config.go:1049
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7301,13 +7301,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1228
+#: lxc/config.go:1229
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1052
+#: lxc/config.go:1053
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-21 15:57-0700\n"
+"POT-Creation-Date: 2024-12-05 16:02+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -64,7 +64,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1239
+#: lxc/config.go:1240
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -1016,7 +1016,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1096
+#: lxc/config.go:702 lxc/config.go:1097
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1211,7 +1211,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1677,9 +1677,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:955
-#: lxc/config.go:995 lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172
-#: lxc/config.go:1226 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
+#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
+#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1694,8 +1694,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
+#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1956,7 +1956,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1225 lxc/config.go:1226
+#: lxc/config.go:1226 lxc/config.go:1227
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2503,7 +2503,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:995
+#: lxc/config.go:995 lxc/config.go:996
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2511,7 +2511,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1601 lxc/image.go:1602
 msgid "Get image properties"
 msgstr ""
 
@@ -2767,7 +2767,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:404
+#: lxc/main.go:406
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2789,7 +2789,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1517
 msgid "Image already up to date."
 msgstr ""
 
@@ -2805,11 +2805,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1472
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1698
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2819,7 +2819,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1515
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2905,7 +2905,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
+#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2999,7 +2999,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:506
+#: lxc/main.go:509
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3590,7 +3590,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:954 lxc/config.go:955
+#: lxc/config.go:955 lxc/config.go:956
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4439,7 +4439,7 @@ msgstr ""
 
 #: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -4559,7 +4559,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1649
 msgid "Property not found"
 msgstr ""
 
@@ -4689,7 +4689,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4726,7 +4726,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1444 lxc/image.go:1445
 msgid "Refresh images"
 msgstr ""
 
@@ -4735,7 +4735,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1481
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4943,7 +4943,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1031
+#: lxc/config.go:1032
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5120,7 +5120,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1049 lxc/config.go:1050
+#: lxc/config.go:1050 lxc/config.go:1051
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5154,7 +5154,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1665 lxc/image.go:1666
 msgid "Set image properties"
 msgstr ""
 
@@ -5459,11 +5459,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1535 lxc/image.go:1536
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1172
+#: lxc/config.go:1172 lxc/config.go:1173
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -6056,7 +6056,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:410
+#: lxc/main.go:412
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6235,7 +6235,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1140 lxc/config.go:1141
+#: lxc/config.go:1141 lxc/config.go:1142
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6251,7 +6251,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1728 lxc/image.go:1729
 msgid "Unset image properties"
 msgstr ""
 
@@ -6694,15 +6694,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1600 lxc/image.go:1727
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1664
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6722,11 +6722,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1443
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
+#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6748,11 +6748,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:993 lxc/config.go:1139
+#: lxc/config.go:994 lxc/config.go:1140
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1048
+#: lxc/config.go:1049
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7302,13 +7302,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1228
+#: lxc/config.go:1229
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1052
+#: lxc/config.go:1053
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-21 15:57-0700\n"
+"POT-Creation-Date: 2024-12-05 16:02+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -97,7 +97,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/config.go:1239
+#: lxc/config.go:1240
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -1176,7 +1176,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1096
+#: lxc/config.go:702 lxc/config.go:1097
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1371,7 +1371,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1837,9 +1837,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:955
-#: lxc/config.go:995 lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172
-#: lxc/config.go:1226 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
+#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
+#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1854,8 +1854,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
+#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -2116,7 +2116,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1225 lxc/config.go:1226
+#: lxc/config.go:1226 lxc/config.go:1227
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2663,7 +2663,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:995
+#: lxc/config.go:995 lxc/config.go:996
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2671,7 +2671,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1601 lxc/image.go:1602
 msgid "Get image properties"
 msgstr ""
 
@@ -2927,7 +2927,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:404
+#: lxc/main.go:406
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2949,7 +2949,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1517
 msgid "Image already up to date."
 msgstr ""
 
@@ -2965,11 +2965,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1472
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1698
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2979,7 +2979,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1515
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3065,7 +3065,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
+#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3159,7 +3159,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:506
+#: lxc/main.go:509
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3750,7 +3750,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:954 lxc/config.go:955
+#: lxc/config.go:955 lxc/config.go:956
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4599,7 +4599,7 @@ msgstr ""
 
 #: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -4719,7 +4719,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1649
 msgid "Property not found"
 msgstr ""
 
@@ -4849,7 +4849,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4886,7 +4886,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1444 lxc/image.go:1445
 msgid "Refresh images"
 msgstr ""
 
@@ -4895,7 +4895,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1481
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5103,7 +5103,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1031
+#: lxc/config.go:1032
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5280,7 +5280,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1049 lxc/config.go:1050
+#: lxc/config.go:1050 lxc/config.go:1051
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5314,7 +5314,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1665 lxc/image.go:1666
 msgid "Set image properties"
 msgstr ""
 
@@ -5619,11 +5619,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1535 lxc/image.go:1536
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1172
+#: lxc/config.go:1172 lxc/config.go:1173
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -6216,7 +6216,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:410
+#: lxc/main.go:412
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6395,7 +6395,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1140 lxc/config.go:1141
+#: lxc/config.go:1141 lxc/config.go:1142
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6411,7 +6411,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1728 lxc/image.go:1729
 msgid "Unset image properties"
 msgstr ""
 
@@ -6854,15 +6854,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1600 lxc/image.go:1727
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1664
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6882,11 +6882,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1443
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
+#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6908,11 +6908,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:993 lxc/config.go:1139
+#: lxc/config.go:994 lxc/config.go:1140
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1048
+#: lxc/config.go:1049
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7462,13 +7462,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1228
+#: lxc/config.go:1229
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1052
+#: lxc/config.go:1053
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-11-21 15:57-0700\n"
+"POT-Creation-Date: 2024-12-05 16:02+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1239
+#: lxc/config.go:1240
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1096
+#: lxc/config.go:702 lxc/config.go:1097
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1210,7 +1210,7 @@ msgid "Config key/value to apply to the target instance"
 msgstr ""
 
 #: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1339 lxc/config_metadata.go:156
+#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
@@ -1676,9 +1676,9 @@ msgstr ""
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:955
-#: lxc/config.go:995 lxc/config.go:1050 lxc/config.go:1141 lxc/config.go:1172
-#: lxc/config.go:1226 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
+#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
+#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1693,8 +1693,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602
+#: lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1955,7 +1955,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1225 lxc/config.go:1226
+#: lxc/config.go:1226 lxc/config.go:1227
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2502,7 +2502,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:995
+#: lxc/config.go:995 lxc/config.go:996
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2510,7 +2510,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1601 lxc/image.go:1602
 msgid "Get image properties"
 msgstr ""
 
@@ -2766,7 +2766,7 @@ msgstr ""
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/main.go:404
+#: lxc/main.go:406
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -2788,7 +2788,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1517
 msgid "Image already up to date."
 msgstr ""
 
@@ -2804,11 +2804,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1472
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1698
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2818,7 +2818,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1515
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -2904,7 +2904,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1020 lxc/config.go:1078 lxc/config.go:1197 lxc/config.go:1289
+#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2998,7 +2998,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
-#: lxc/main.go:506
+#: lxc/main.go:509
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -3589,7 +3589,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:954 lxc/config.go:955
+#: lxc/config.go:955 lxc/config.go:956
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -4438,7 +4438,7 @@ msgstr ""
 
 #: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1340 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
@@ -4558,7 +4558,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1649
 msgid "Property not found"
 msgstr ""
 
@@ -4688,7 +4688,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1539
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4725,7 +4725,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1444 lxc/image.go:1445
 msgid "Refresh images"
 msgstr ""
 
@@ -4734,7 +4734,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1481
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -4942,7 +4942,7 @@ msgstr ""
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1031
+#: lxc/config.go:1032
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5119,7 +5119,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1049 lxc/config.go:1050
+#: lxc/config.go:1050 lxc/config.go:1051
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5153,7 +5153,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1665 lxc/image.go:1666
 msgid "Set image properties"
 msgstr ""
 
@@ -5458,11 +5458,11 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1535 lxc/image.go:1536
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1172
+#: lxc/config.go:1172 lxc/config.go:1173
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -6055,7 +6055,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:410
+#: lxc/main.go:412
 msgid ""
 "To start your first container, try: lxc launch ubuntu:24.04\n"
 "Or for a virtual machine: lxc launch ubuntu:24.04 --vm"
@@ -6234,7 +6234,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1140 lxc/config.go:1141
+#: lxc/config.go:1141 lxc/config.go:1142
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6250,7 +6250,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1728 lxc/image.go:1729
 msgid "Unset image properties"
 msgstr ""
 
@@ -6693,15 +6693,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1534
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1600 lxc/image.go:1727
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1664
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6721,11 +6721,11 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1443
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1170 lxc/config.go:1224 lxc/config_device.go:329
+#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6747,11 +6747,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:993 lxc/config.go:1139
+#: lxc/config.go:994 lxc/config.go:1140
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1048
+#: lxc/config.go:1049
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7301,13 +7301,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1228
+#: lxc/config.go:1229
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1052
+#: lxc/config.go:1053
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"

--- a/shared/api/instance.go
+++ b/shared/api/instance.go
@@ -27,6 +27,23 @@ const InstanceTypeContainer = InstanceType("container")
 // InstanceTypeVM defines the instance type value for a virtual-machine.
 const InstanceTypeVM = InstanceType("virtual-machine")
 
+const (
+	// SourceTypeMigration represents instance creation from migration.
+	SourceTypeMigration = "migration"
+
+	// SourceTypeConversion represents instance creation from conversion.
+	SourceTypeConversion = "conversion"
+
+	// SourceTypeImage represents instance creation from an image.
+	SourceTypeImage = "image"
+
+	// SourceTypeCopy represents instance creation from a copy operation.
+	SourceTypeCopy = "copy"
+
+	// SourceTypeNone represents an unknown source type for instance creation.
+	SourceTypeNone = "none"
+)
+
 // InstancesPost represents the fields available for a new LXD instance.
 //
 // swagger:model


### PR DESCRIPTION
Replace hardcoded strings for container/instance source type.

Also fixed some issue reported by static analysis.