### PR TITLE
lxc: Accept volume full name on `detach`

### DIFF
--- a/lxc/completion.go
+++ b/lxc/completion.go
@@ -1368,10 +1368,8 @@ func (g *cmdGlobal) cmpStoragePoolWithVolume(toComplete string) ([]string, cobra
 
 	var results []string
 	for _, volume := range volumes {
-		volName, volType := parseVolume("custom", volume)
-		if volType == "custom" {
-			results = append(results, pool+"/"+volName)
-		}
+		volName, _ := parseVolume("custom", volume)
+		results = append(results, pool+"/"+volName)
 	}
 
 	return results, cobra.ShellCompDirectiveNoFileComp

--- a/lxc/storage_volume.go
+++ b/lxc/storage_volume.go
@@ -236,6 +236,7 @@ func (c *cmdStorageVolumeAttach) run(cmd *cobra.Command, args []string) error {
 		case "block", "iso":
 			devName = args[3]
 		case "filesystem":
+			// If using a filesystem volume, the path must also be provided as the fourth argument.
 			if !strings.HasPrefix(args[3], "/") {
 				devPath = path.Join("/", args[3])
 			} else {

--- a/lxc/storage_volume.go
+++ b/lxc/storage_volume.go
@@ -177,7 +177,7 @@ func (c *cmdStorageVolumeAttach) command() *cobra.Command {
 		}
 
 		if len(args) == 1 {
-			return c.global.cmpStoragePoolVolumes(args[0])
+			return c.global.cmpStoragePoolVolumes(args[0], "custom")
 		}
 
 		if len(args) == 2 {
@@ -292,7 +292,7 @@ func (c *cmdStorageVolumeAttachProfile) command() *cobra.Command {
 		}
 
 		if len(args) == 1 {
-			return c.global.cmpStoragePoolVolumes(args[0])
+			return c.global.cmpStoragePoolVolumes(args[0], "custom")
 		}
 
 		if len(args) == 2 {
@@ -816,7 +816,7 @@ func (c *cmdStorageVolumeDetach) command() *cobra.Command {
 		}
 
 		if len(args) == 1 {
-			return c.global.cmpStoragePoolVolumes(args[0])
+			return c.global.cmpStoragePoolVolumes(args[0], "custom")
 		}
 
 		if len(args) == 2 {
@@ -919,7 +919,7 @@ func (c *cmdStorageVolumeDetachProfile) command() *cobra.Command {
 		}
 
 		if len(args) == 1 {
-			return c.global.cmpStoragePoolVolumes(args[0])
+			return c.global.cmpStoragePoolVolumes(args[0], "custom")
 		}
 
 		if len(args) == 2 {

--- a/lxc/storage_volume.go
+++ b/lxc/storage_volume.go
@@ -859,10 +859,15 @@ func (c *cmdStorageVolumeDetach) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	volName, volType := parseVolume("custom", args[1])
+	if volType != "custom" {
+		return errors.New(i18n.G(`Only "custom" volumes can be attached to instances`))
+	}
+
 	// Find the device
 	if devName == "" {
 		for n, d := range inst.Devices {
-			if d["type"] == "disk" && d["pool"] == resource.name && d["source"] == args[1] {
+			if d["type"] == "disk" && d["pool"] == resource.name && d["source"] == volName {
 				if devName != "" {
 					return errors.New(i18n.G("More than one device matches, specify the device name"))
 				}
@@ -956,10 +961,15 @@ func (c *cmdStorageVolumeDetachProfile) run(cmd *cobra.Command, args []string) e
 		return err
 	}
 
+	volName, volType := parseVolume("custom", args[1])
+	if volType != "custom" {
+		return errors.New(i18n.G(`Only "custom" volumes can be attached to instances`))
+	}
+
 	// Find the device
 	if devName == "" {
 		for n, d := range profile.Devices {
-			if d["type"] == "disk" && d["pool"] == resource.name && d["source"] == args[1] {
+			if d["type"] == "disk" && d["pool"] == resource.name && d["source"] == volName {
 				if devName != "" {
 					return errors.New(i18n.G("More than one device matches, specify the device name"))
 				}

--- a/test/suites/storage.sh
+++ b/test/suites/storage.sh
@@ -337,10 +337,12 @@ EOF
       lxc storage volume set "lxdtest-$(basename "${LXD_DIR}")-pool1" c1pool1 zfs.use_refquota true
       lxc storage volume attach "lxdtest-$(basename "${LXD_DIR}")-pool1" c1pool1 c1pool1 testDevice /opt
       ! lxc storage volume attach "lxdtest-$(basename "${LXD_DIR}")-pool1" c1pool1 c1pool1 testDevice2 /opt || false
+      lxc config show c1pool1 | grep -Pz "  testDevice:\n    path: /opt\n    pool: lxdtest-$(basename "${LXD_DIR}")-pool1\n    source: c1pool1\n    type: disk\n"
       lxc storage volume detach "lxdtest-$(basename "${LXD_DIR}")-pool1" c1pool1 c1pool1
+      ! lxc config show c1pool1 | grep "testDevice" || false
       lxc storage volume attach "lxdtest-$(basename "${LXD_DIR}")-pool1" custom/c1pool1 c1pool1 testDevice /opt
       ! lxc storage volume attach "lxdtest-$(basename "${LXD_DIR}")-pool1" custom/c1pool1 c1pool1 testDevice2 /opt || false
-      lxc storage volume detach "lxdtest-$(basename "${LXD_DIR}")-pool1" c1pool1 c1pool1
+      lxc storage volume detach "lxdtest-$(basename "${LXD_DIR}")-pool1" custom/c1pool1 c1pool1
 
       lxc storage volume create "lxdtest-$(basename "${LXD_DIR}")-pool1" c2pool2
       lxc storage volume attach "lxdtest-$(basename "${LXD_DIR}")-pool1" c2pool2 c2pool2 testDevice /opt


### PR DESCRIPTION
The completions suggest the volume name but the client doesn't parse it correctly and this has been annoying me, so I took some of my time off to fix it and also improved the completions for detach/attach commands. Along with other small improvements.