### PR TITLE
Storage: Define per-pool default block size

### DIFF
--- a/lxd/scriptlet/instance_placement.go
+++ b/lxd/scriptlet/instance_placement.go
@@ -15,7 +15,7 @@ import (
 	"github.com/canonical/lxd/lxd/resources"
 	scriptletLoad "github.com/canonical/lxd/lxd/scriptlet/load"
 	"github.com/canonical/lxd/lxd/state"
-	storageDrivers "github.com/canonical/lxd/lxd/storage/drivers"
+	"github.com/canonical/lxd/lxd/storage"
 	"github.com/canonical/lxd/shared/api"
 	apiScriptlet "github.com/canonical/lxd/shared/api/scriptlet"
 	"github.com/canonical/lxd/shared/logger"
@@ -221,7 +221,10 @@ func InstancePlacementRun(ctx context.Context, l logger.Logger, s *state.State, 
 
 			// Apply VM root disk size defaults if not specified.
 			if req.Type == api.InstanceTypeVM && rootDiskSizeStr == "" {
-				rootDiskSizeStr = storageDrivers.DefaultBlockSize
+				rootDiskSizeStr, err = storage.GetPoolDefaultBlockSize(s, rootDiskConfig["pool"])
+				if err != nil {
+					return nil, fmt.Errorf("Failed loading pool default size: %w", err)
+				}
 			}
 
 			if rootDiskSizeStr != "" {

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -4158,7 +4158,7 @@ func (b *lxdBackend) EnsureImage(fingerprint string, op *operations.Operation) e
 
 // shouldUseOptimizedImage determines if an optimized image should be used based on the provided volume config.
 // It returns true if the volume config aligns with the pool's default configuration, and an optimized image does
-// not exist or also matches the pool's default confgiuration.
+// not exist or also matches the pool's default configuration.
 func (b *lxdBackend) shouldUseOptimizedImage(fingerprint string, contentType drivers.ContentType, volConfig map[string]string) (bool, error) {
 	canOptimizeImage := b.driver.Info().OptimizedImages
 

--- a/lxd/storage/drivers/driver_btrfs.go
+++ b/lxd/storage/drivers/driver_btrfs.go
@@ -92,6 +92,7 @@ func (d *btrfs) Info() Info {
 	return Info{
 		Name:                         "btrfs",
 		Version:                      btrfsVersion,
+		DefaultBlockSize:             d.defaultBlockVolumeSize(),
 		DefaultVMBlockFilesystemSize: d.defaultVMBlockFilesystemSize(),
 		OptimizedImages:              true,
 		OptimizedBackups:             true,

--- a/lxd/storage/drivers/driver_ceph.go
+++ b/lxd/storage/drivers/driver_ceph.go
@@ -80,6 +80,7 @@ func (d *ceph) Info() Info {
 	return Info{
 		Name:                         "ceph",
 		Version:                      cephVersion,
+		DefaultBlockSize:             d.defaultBlockVolumeSize(),
 		DefaultVMBlockFilesystemSize: d.defaultVMBlockFilesystemSize(),
 		OptimizedImages:              true,
 		PreservesInodes:              false,

--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -80,7 +80,7 @@ func (d *ceph) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Ope
 				return err
 			}
 
-			poolVolSize := DefaultBlockSize
+			poolVolSize := d.Info().DefaultBlockSize
 			if vol.poolConfig["volume.size"] != "" {
 				poolVolSize = vol.poolConfig["volume.size"]
 			}

--- a/lxd/storage/drivers/driver_cephfs.go
+++ b/lxd/storage/drivers/driver_cephfs.go
@@ -78,6 +78,7 @@ func (d *cephfs) Info() Info {
 	return Info{
 		Name:                         "cephfs",
 		Version:                      cephfsVersion,
+		DefaultBlockSize:             d.defaultBlockVolumeSize(),
 		DefaultVMBlockFilesystemSize: d.defaultVMBlockFilesystemSize(),
 		OptimizedImages:              false,
 		PreservesInodes:              false,

--- a/lxd/storage/drivers/driver_common.go
+++ b/lxd/storage/drivers/driver_common.go
@@ -51,6 +51,11 @@ func (d *common) defaultVMBlockFilesystemSize() string {
 	return defaultVMBlockFilesystemSize
 }
 
+// defaultBlockVolumeSize returns the default size for block volumes in this pool.
+func (d *common) defaultBlockVolumeSize() string {
+	return defaultBlockSize
+}
+
 // validatePool validates a pool config against common rules and optional driver specific rules.
 func (d *common) validatePool(config map[string]string, driverRules map[string]func(value string) error, volumeRules map[string]func(value string) error) error {
 	checkedFields := map[string]struct{}{}

--- a/lxd/storage/drivers/driver_dir.go
+++ b/lxd/storage/drivers/driver_dir.go
@@ -37,6 +37,7 @@ func (d *dir) Info() Info {
 	return Info{
 		Name:                         "dir",
 		Version:                      "1",
+		DefaultBlockSize:             d.defaultBlockVolumeSize(),
 		DefaultVMBlockFilesystemSize: d.defaultVMBlockFilesystemSize(),
 		OptimizedImages:              false,
 		PreservesInodes:              false,

--- a/lxd/storage/drivers/driver_lvm.go
+++ b/lxd/storage/drivers/driver_lvm.go
@@ -86,6 +86,7 @@ func (d *lvm) Info() Info {
 	return Info{
 		Name:                         "lvm",
 		Version:                      lvmVersion,
+		DefaultBlockSize:             d.defaultBlockVolumeSize(),
 		DefaultVMBlockFilesystemSize: d.defaultVMBlockFilesystemSize(),
 		OptimizedImages:              d.usesThinpool(), // Only thinpool pools support optimized images.
 		PreservesInodes:              false,

--- a/lxd/storage/drivers/driver_mock.go
+++ b/lxd/storage/drivers/driver_mock.go
@@ -25,6 +25,7 @@ func (d *mock) Info() Info {
 	return Info{
 		Name:                         "mock",
 		Version:                      "1",
+		DefaultBlockSize:             d.defaultBlockVolumeSize(),
 		DefaultVMBlockFilesystemSize: d.defaultVMBlockFilesystemSize(),
 		OptimizedImages:              false,
 		PreservesInodes:              false,

--- a/lxd/storage/drivers/driver_powerflex.go
+++ b/lxd/storage/drivers/driver_powerflex.go
@@ -78,6 +78,7 @@ func (d *powerflex) Info() Info {
 	return Info{
 		Name:                         "powerflex",
 		Version:                      powerFlexVersion,
+		DefaultBlockSize:             d.defaultBlockVolumeSize(),
 		DefaultVMBlockFilesystemSize: d.defaultVMBlockFilesystemSize(),
 		OptimizedImages:              false,
 		PreservesInodes:              false,

--- a/lxd/storage/drivers/driver_powerflex_volumes.go
+++ b/lxd/storage/drivers/driver_powerflex_volumes.go
@@ -532,7 +532,7 @@ func (d *powerflex) GetVolumeUsage(vol Volume) (int64, error) {
 
 	// Getting the usage of an unmounted volume is not supported.
 	// PowerFlex reports the usage on pool level only.
-	return 0, ErrNotSupported
+	return -1, ErrNotSupported
 }
 
 // SetVolumeQuota applies a size limit on volume.

--- a/lxd/storage/drivers/driver_powerflex_volumes.go
+++ b/lxd/storage/drivers/driver_powerflex_volumes.go
@@ -656,6 +656,11 @@ func (d *powerflex) defaultVMBlockFilesystemSize() string {
 	return powerFlexDefaultSize
 }
 
+// defaultBlockVolumeSize returns the default size for block volumes in this pool.
+func (d *powerflex) defaultBlockVolumeSize() string {
+	return powerFlexDefaultSize
+}
+
 // MountVolume mounts a volume and increments ref counter. Please call UnmountVolume() when done with the volume.
 func (d *powerflex) MountVolume(vol Volume, op *operations.Operation) error {
 	unlock, err := vol.MountLock()

--- a/lxd/storage/drivers/driver_types.go
+++ b/lxd/storage/drivers/driver_types.go
@@ -5,6 +5,7 @@ type Info struct {
 	Name                         string
 	Version                      string
 	VolumeTypes                  []VolumeType // Supported volume types.
+	DefaultBlockSize             string       // Default block volume size.
 	DefaultVMBlockFilesystemSize string       // Default volume size for VM block filesystems.
 	Buckets                      bool         // Buckets supported.
 	Remote                       bool         // Whether the driver uses a remote backing store.

--- a/lxd/storage/drivers/driver_zfs.go
+++ b/lxd/storage/drivers/driver_zfs.go
@@ -118,6 +118,7 @@ func (d *zfs) Info() Info {
 	info := Info{
 		Name:                         "zfs",
 		Version:                      zfsVersion,
+		DefaultBlockSize:             d.defaultBlockVolumeSize(),
 		DefaultVMBlockFilesystemSize: d.defaultVMBlockFilesystemSize(),
 		OptimizedImages:              true,
 		OptimizedBackups:             true,

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -73,7 +73,7 @@ func (d *zfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 					return err
 				}
 
-				poolVolSize := DefaultBlockSize
+				poolVolSize := d.Info().DefaultBlockSize
 				if vol.poolConfig["volume.size"] != "" {
 					poolVolSize = vol.poolConfig["volume.size"]
 				}

--- a/lxd/storage/drivers/volume.go
+++ b/lxd/storage/drivers/volume.go
@@ -22,7 +22,7 @@ const tmpVolSuffix = ".lxdtmp"
 const isoVolSuffix = ".iso"
 
 // DefaultBlockSize is the default size of block volumes.
-const DefaultBlockSize = "10GiB"
+const defaultBlockSize = "10GiB"
 
 // DefaultFilesystem filesytem to use for block devices by default.
 const DefaultFilesystem = "ext4"

--- a/lxd/storage/drivers/volume.go
+++ b/lxd/storage/drivers/volume.go
@@ -475,7 +475,7 @@ func (v Volume) ConfigSize() string {
 	// If volume size isn't defined in either volume or pool config, then for block volumes or block-backed
 	// volumes return the defaultBlockSize.
 	if (size == "" || size == "0") && (v.contentType == ContentTypeBlock || v.IsBlockBacked()) {
-		return DefaultBlockSize
+		return v.driver.Info().DefaultBlockSize
 	}
 
 	// Return defined size or empty string if not defined.

--- a/lxd/storage/drivers/volume_test.go
+++ b/lxd/storage/drivers/volume_test.go
@@ -46,7 +46,7 @@ func Test_Volume_ConfigSizeFromSource(t *testing.T) {
 			vol:    Volume{driver: &nonBlockBackedDriver, volType: VolumeTypeVM, contentType: ContentTypeBlock},
 			srcVol: Volume{volType: VolumeTypeImage},
 			err:    nil,
-			size:   DefaultBlockSize,
+			size:   defaultBlockSize,
 		},
 		{
 			// Check that the volume's smaller size than source image's rootfs size causes error.
@@ -93,7 +93,7 @@ func Test_Volume_ConfigSizeFromSource(t *testing.T) {
 			vol:    Volume{driver: &blockBackedDriver, volType: VolumeTypeVM, config: map[string]string{}},
 			srcVol: Volume{volType: VolumeTypeImage, config: map[string]string{"volatile.rootfs.size": "5GiB"}},
 			err:    nil,
-			size:   DefaultBlockSize,
+			size:   defaultBlockSize,
 		},
 		{
 			// Check volume's size is used when VM filesystem volume is supplied with image source.

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -1377,3 +1377,13 @@ func ValidVolumeName(volumeName string) error {
 
 	return nil
 }
+
+// GetPoolDefaultBlockSize returns the default block size for the specified storage pool according to its driver.
+func GetPoolDefaultBlockSize(s *state.State, poolName string) (string, error) {
+	pool, err := LoadByName(s, poolName)
+	if err != nil {
+		return "", fmt.Errorf("Failed loading storage pool: %w", err)
+	}
+
+	return pool.Driver().Info().DefaultBlockSize, nil
+}


### PR DESCRIPTION
This includes some improvements that were originally a part of the fix implemented in https://github.com/canonical/lxd/pull/14511, but ended up not being needed for that fix. They are still nice to have and thus were included here.