### PR TITLE
Storage: Show correct disk size

### DIFF
--- a/lxc/info.go
+++ b/lxc/info.go
@@ -519,8 +519,8 @@ func (c *cmdInfo) instanceInfo(d lxd.InstanceServer, name string, showLog bool) 
 
 			for entry, disk := range inst.State.Disk {
 				// Only show total for disks that are bounded within the pool.
-				if disk.Total != -1 {
-					diskTotal += fmt.Sprintf("    %s: %s\n", entry, units.GetByteSizeStringIEC(disk.Usage, 2))
+				if disk.Total > 0 {
+					diskTotal += fmt.Sprintf("    %s: %s\n", entry, units.GetByteSizeStringIEC(disk.Total, 2))
 				}
 			}
 		}

--- a/lxc/info.go
+++ b/lxc/info.go
@@ -501,37 +501,39 @@ func (c *cmdInfo) instanceInfo(d lxd.InstanceServer, name string, showLog bool) 
 		fmt.Printf(i18n.G("Last Used: %s")+"\n", inst.LastUsedAt.Local().Format(layout))
 	}
 
+	// Show instance resources
+	fmt.Println("\n" + i18n.G("Resources:"))
+
+	// Disk usage
+	diskUsage := ""
+	diskTotal := ""
+	if inst.State.Disk != nil {
+		for entry, disk := range inst.State.Disk {
+			// Only show usage when supported.
+			if disk.Usage != -1 {
+				diskUsage += fmt.Sprintf("    %s: %s\n", entry, units.GetByteSizeStringIEC(disk.Usage, 2))
+			}
+		}
+
+		for entry, disk := range inst.State.Disk {
+			// Only show total for disks that are bounded within the pool.
+			if disk.Total > 0 {
+				diskTotal += fmt.Sprintf("    %s: %s\n", entry, units.GetByteSizeStringIEC(disk.Total, 2))
+			}
+		}
+	}
+
+	if diskUsage != "" {
+		fmt.Printf("  %s\n%s", i18n.G("Disk usage:"), diskUsage)
+	}
+
+	if diskTotal != "" {
+		fmt.Printf("  %s\n%s", i18n.G("Disk total:"), diskTotal)
+	}
+
 	if inst.State.Pid != 0 {
-		fmt.Println("\n" + i18n.G("Resources:"))
 		// Processes
 		fmt.Printf("  "+i18n.G("Processes: %d")+"\n", inst.State.Processes)
-
-		// Disk usage
-		diskUsage := ""
-		diskTotal := ""
-		if inst.State.Disk != nil {
-			for entry, disk := range inst.State.Disk {
-				// Only show usage when supported.
-				if disk.Usage != -1 {
-					diskUsage += fmt.Sprintf("    %s: %s\n", entry, units.GetByteSizeStringIEC(disk.Usage, 2))
-				}
-			}
-
-			for entry, disk := range inst.State.Disk {
-				// Only show total for disks that are bounded within the pool.
-				if disk.Total > 0 {
-					diskTotal += fmt.Sprintf("    %s: %s\n", entry, units.GetByteSizeStringIEC(disk.Total, 2))
-				}
-			}
-		}
-
-		if diskUsage != "" {
-			fmt.Printf("  %s\n%s", i18n.G("Disk usage:"), diskUsage)
-		}
-
-		if diskTotal != "" {
-			fmt.Printf("  %s\n%s", i18n.G("Disk total:"), diskTotal)
-		}
 
 		// CPU usage
 		cpuInfo := ""

--- a/lxd/db/storage_volumes.go
+++ b/lxd/db/storage_volumes.go
@@ -372,6 +372,23 @@ func storageVolumeSnapshotConfig(ctx context.Context, tx *ClusterTx, volumeSnaps
 	}, volumeSnapshotID)
 }
 
+// UpdateStoragePoolVolumeConfig updates a storage volume's config on the database.
+func (c *ClusterTx) UpdateStoragePoolVolumeConfig(volumeName string, volumeID int64, volumeConfig map[string]string) error {
+	isSnapshot := strings.Contains(volumeName, shared.SnapshotDelimiter)
+
+	err := storageVolumeConfigClear(c.tx, volumeID, isSnapshot)
+	if err != nil {
+		return err
+	}
+
+	err = storageVolumeConfigAdd(c.tx, volumeID, volumeConfig, isSnapshot)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // UpdateStoragePoolVolume updates the storage volume attached to a given storage pool.
 func (c *ClusterTx) UpdateStoragePoolVolume(ctx context.Context, projectName string, volumeName string, volumeType int, poolID int64, volumeDescription string, volumeConfig map[string]string) error {
 	isSnapshot := strings.Contains(volumeName, shared.SnapshotDelimiter)

--- a/lxd/db/storage_volumes.go
+++ b/lxd/db/storage_volumes.go
@@ -398,12 +398,7 @@ func (c *ClusterTx) UpdateStoragePoolVolume(ctx context.Context, projectName str
 		return err
 	}
 
-	err = storageVolumeConfigClear(c.tx, volume.ID, isSnapshot)
-	if err != nil {
-		return err
-	}
-
-	err = storageVolumeConfigAdd(c.tx, volume.ID, volumeConfig, isSnapshot)
+	err = c.UpdateStoragePoolVolumeConfig(volume.Name, volume.ID, volumeConfig)
 	if err != nil {
 		return err
 	}

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -250,10 +250,14 @@ func (b *lxdBackend) Create(clientType request.ClientType, op *operations.Operat
 }
 
 // GetNewVolume returns a drivers.Volume that doesn't yet exist in the database.
-// It contains copies of the supplied volume config, including a new UUID, and the pools config.
+// It contains copies of the supplied volume config, including a new UUID and
+// default configuration for the poo driver, as well as the pool's config.
 // Use the returned drivers.Volume as the base for actions performed on the new volume.
 func (b *lxdBackend) GetNewVolume(volType drivers.VolumeType, contentType drivers.ContentType, volName string, volConfig map[string]string) drivers.Volume {
 	newVol := b.GetVolume(volType, contentType, volName, volConfig)
+
+	// Fill default config.
+	b.Driver().FillVolumeConfig(newVol)
 
 	// Set a new UUID.
 	newVol.Config()["volatile.uuid"] = uuid.New().String()

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -915,9 +915,12 @@ func (b *lxdBackend) CreateInstanceFromBackup(srcBackup backup.Info, srcData io.
 
 			newSnapshotName := drivers.GetSnapshotVolumeName(inst.Name(), backupFileSnap)
 
+			// Ensure driver specific config is filled in new volume.
+			snapVol := b.GetNewVolume(volType, contentType, newSnapshotName, volumeSnapConfig)
+
 			// Validate config and create database entry for new storage volume.
 			// Strip unsupported config keys (in case the export was made from a different type of storage pool).
-			err = VolumeDBCreate(b, inst.Project().Name, newSnapshotName, volumeSnapDescription, volType, true, volumeSnapConfig, volumeSnapCreationDate, volumeSnapExpiryDate, contentType, true, true)
+			err = VolumeDBCreate(b, inst.Project().Name, newSnapshotName, volumeSnapDescription, volType, true, snapVol.Config(), volumeSnapCreationDate, volumeSnapExpiryDate, contentType, true, true)
 			if err != nil {
 				return err
 			}

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -2241,6 +2241,12 @@ func (b *lxdBackend) CreateInstanceFromMigration(inst instance.Instance, conn io
 	revert := revert.New()
 	defer revert.Fail()
 
+	// Generate the effective root device volume for instance.
+	err = b.applyInstanceRootDiskOverrides(inst, &vol)
+	if err != nil {
+		return err
+	}
+
 	if !args.Refresh {
 		if volExists {
 			if !isRemoteClusterMove {
@@ -2301,12 +2307,6 @@ func (b *lxdBackend) CreateInstanceFromMigration(inst instance.Instance, conn io
 
 			revert.Add(func() { _ = VolumeDBDelete(b, inst.Project().Name, newSnapshotName, volType) })
 		}
-	}
-
-	// Generate the effective root device volume for instance.
-	err = b.applyInstanceRootDiskOverrides(inst, &vol)
-	if err != nil {
-		return err
 	}
 
 	// Override args.Name and args.Config to ensure volume is created based on instance.

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -2206,10 +2206,7 @@ func (b *lxdBackend) CreateInstanceFromMigration(inst instance.Instance, conn io
 	if args.MigrationType.FSType == migration.MigrationFSType_RSYNC || args.MigrationType.FSType == migration.MigrationFSType_BLOCK_AND_RSYNC {
 		vol.SetHasSource(false)
 
-		err = b.driver.FillVolumeConfig(vol)
-		if err != nil {
-			return fmt.Errorf("Failed filling volume config: %w", err)
-		}
+		b.driver.FillVolumeConfig(vol)
 	}
 
 	// Check if the volume exists on storage.
@@ -2465,10 +2462,7 @@ func (b *lxdBackend) CreateInstanceFromConversion(inst instance.Instance, conn i
 
 	// Ensure storage volume settings are honored when doing conversion.
 	vol.SetHasSource(false)
-	err = b.driver.FillVolumeConfig(vol)
-	if err != nil {
-		return fmt.Errorf("Failed filling volume config: %w", err)
-	}
+	b.driver.FillVolumeConfig(vol)
 
 	// Check if the volume exists in database
 	dbVol, err := VolumeDBGet(b, inst.Project().Name, inst.Name(), volType)
@@ -4102,10 +4096,7 @@ func (b *lxdBackend) EnsureImage(fingerprint string, op *operations.Operation) e
 		// Generate a temporary volume instance that represents how a new volume using pool defaults would
 		// be configured.
 		tmpImgVol := imgVol.Clone()
-		err := b.Driver().FillVolumeConfig(tmpImgVol)
-		if err != nil {
-			return err
-		}
+		b.Driver().FillVolumeConfig(tmpImgVol)
 
 		// Add existing image volume's config to imgVol.
 		imgVol = b.GetVolume(drivers.VolumeTypeImage, contentType, image.Fingerprint, imgDBVol.Config)
@@ -4251,17 +4242,11 @@ func (b *lxdBackend) shouldUseOptimizedImage(fingerprint string, contentType dri
 
 	// Create the image volume with the provided volume config.
 	newImgVol := b.GetVolume(drivers.VolumeTypeImage, contentType, fingerprint, volConfig)
-	err := b.Driver().FillVolumeConfig(newImgVol)
-	if err != nil {
-		return false, err
-	}
+	b.Driver().FillVolumeConfig(newImgVol)
 
 	// Create the image volume with pool's default settings.
 	poolDefaultImgVol := b.GetVolume(drivers.VolumeTypeImage, contentType, fingerprint, nil)
-	err = b.Driver().FillVolumeConfig(poolDefaultImgVol)
-	if err != nil {
-		return false, err
-	}
+	b.Driver().FillVolumeConfig(poolDefaultImgVol)
 
 	// If the new volume's config doesn't match the pool's default configuration, don't use an optimized image.
 	if !volumeConfigsMatch(newImgVol, poolDefaultImgVol) {
@@ -7338,10 +7323,7 @@ func (b *lxdBackend) detectUnknownCustomVolume(vol *drivers.Volume, projectVols 
 
 	// This may not always be the correct thing to do, but seeing as we don't know what the volume's config
 	// was lets take a best guess that it was the default config.
-	err = b.driver.FillVolumeConfig(*vol)
-	if err != nil {
-		return fmt.Errorf("Failed filling custom volume default config: %w", err)
-	}
+	b.driver.FillVolumeConfig(*vol)
 
 	// Check the filesystem detected is valid for the storage driver.
 	err = b.driver.ValidateVolume(*vol, false)
@@ -7398,10 +7380,7 @@ func (b *lxdBackend) detectUnknownBuckets(vol *drivers.Volume, projectVols map[s
 
 	// This may not always be the correct thing to do, but seeing as we don't know what the volume's config
 	// was lets take a best guess that it was the default config.
-	err = b.driver.FillVolumeConfig(*vol)
-	if err != nil {
-		return fmt.Errorf("Failed filling bucket default config: %w", err)
-	}
+	b.driver.FillVolumeConfig(*vol)
 
 	// Check the detected filesystem is valid for the storage driver.
 	err = b.driver.ValidateVolume(*vol, false)

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -685,6 +685,11 @@ func (b *lxdBackend) CreateInstance(inst instance.Instance, op *operations.Opera
 		return err
 	}
 
+	err = b.applyInstanceRootDiskOverrides(inst, &vol)
+	if err != nil {
+		return err
+	}
+
 	// Validate config and create database entry for new storage volume.
 	err = VolumeDBCreate(b, inst.Project().Name, inst.Name(), "", volType, false, vol.Config(), inst.CreationDate(), time.Time{}, contentType, true, false)
 	if err != nil {
@@ -692,11 +697,6 @@ func (b *lxdBackend) CreateInstance(inst instance.Instance, op *operations.Opera
 	}
 
 	revert.Add(func() { _ = VolumeDBDelete(b, inst.Project().Name, inst.Name(), volType) })
-
-	err = b.applyInstanceRootDiskOverrides(inst, &vol)
-	if err != nil {
-		return err
-	}
 
 	err = b.driver.CreateVolume(vol, nil, op)
 	if err != nil {

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -2484,7 +2484,6 @@ func (b *lxdBackend) CreateInstanceFromConversion(inst instance.Instance, conn i
 
 	// Ensure storage volume settings are honored when doing conversion.
 	vol.SetHasSource(false)
-	b.driver.FillVolumeConfig(vol)
 
 	// Check if the volume exists in database
 	dbVol, err := VolumeDBGet(b, inst.Project().Name, inst.Name(), volType)

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -7078,7 +7078,7 @@ func (b *lxdBackend) ListUnknownVolumes(op *operations.Operation) (map[string][]
 			return nil, fmt.Errorf("Storage driver returned unexpected VM volume with filesystem content type (%q)", poolVol.Name())
 		}
 
-		if volType == drivers.VolumeTypeVM || volType == drivers.VolumeTypeContainer {
+		if volType.IsInstance() {
 			err = b.detectUnknownInstanceVolume(&poolVol, projectVols, op)
 			if err != nil {
 				return nil, err

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -6447,8 +6447,7 @@ func (b *lxdBackend) ImportCustomVolume(projectName string, poolVol *backupConfi
 	for _, poolVolSnap := range poolVol.VolumeSnapshots {
 		fullSnapName := drivers.GetSnapshotVolumeName(poolVol.Volume.Name, poolVolSnap.Name)
 
-		// Copy volume config from backup file if present
-		// (so VolumeDBCreate can safely modify the copy if needed).
+		// Create new volume object to get a proper configuration for the driver in use.
 		snapVol := b.GetNewVolume(drivers.VolumeTypeCustom, drivers.ContentType(poolVolSnap.ContentType), fullSnapName, poolVolSnap.Config)
 
 		// Validate config and create database entry for restored storage volume.
@@ -6556,7 +6555,6 @@ func (b *lxdBackend) CreateCustomVolumeSnapshot(projectName, volName string, new
 	}
 
 	// Validate config and create database entry for new storage volume.
-	// Copy volume config from parent.
 	err = VolumeDBCreate(b, projectName, fullSnapshotName, description, drivers.VolumeTypeCustom, true, vol.Config(), time.Now().UTC(), newExpiryDate, drivers.ContentType(parentVol.ContentType), false, true)
 	if err != nil {
 		return err
@@ -7455,7 +7453,6 @@ func (b *lxdBackend) ImportInstance(inst instance.Instance, poolVol *backupConfi
 	// Generate the effective root device volume for instance.
 	volStorageName := project.Instance(inst.Project().Name, inst.Name())
 
-	// Copy the volume's config so VolumeDBCreate can safely modify the copy if needed.
 	vol := b.GetNewVolume(volType, contentType, volStorageName, volumeConfig)
 
 	// Create storage volume database records if in recover mode.
@@ -7481,8 +7478,7 @@ func (b *lxdBackend) ImportInstance(inst instance.Instance, poolVol *backupConfi
 			for _, poolVolSnap := range poolVol.VolumeSnapshots {
 				fullSnapName := drivers.GetSnapshotVolumeName(inst.Name(), poolVolSnap.Name)
 
-				// Copy volume config from backup file if present,
-				// so VolumeDBCreate can safely modify the copy if needed.
+				// Create new volume object to get a proper configuration for the driver in use.
 				snapVol := b.GetNewVolume(volType, contentType, fullSnapName, poolVolSnap.Config)
 
 				// Validate config and create database entry for recovered storage volume.
@@ -7503,8 +7499,7 @@ func (b *lxdBackend) ImportInstance(inst instance.Instance, poolVol *backupConfi
 			for _, i := range snapshots {
 				fullSnapName := i // Local var for revert.
 
-				// Copy the parent volume's config,
-				// so VolumeDBCreate can safely modify the copy if needed.
+				// Create new volume object to get a proper configuration for the driver in use.
 				snapVol := b.GetNewVolume(volType, contentType, fullSnapName, volumeConfig)
 
 				// Validate config and create database entry for new storage volume.

--- a/lxd/storage/drivers/driver_btrfs_volumes.go
+++ b/lxd/storage/drivers/driver_btrfs_volumes.go
@@ -404,7 +404,7 @@ func (d *btrfs) CreateVolumeFromBackup(vol VolumeCopy, srcBackup backup.Info, sr
 
 // createVolumeFromCopy creates a volume from copy by snapshotting the parent volume.
 // It also copies the source volume's snapshots and supports refreshing an already existing volume.
-func (d *btrfs) createVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInconsistent bool, refresh bool, op *operations.Operation) error {
+func (d *btrfs) createVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, refresh bool, op *operations.Operation) error {
 	revert := revert.New()
 	defer revert.Fail()
 
@@ -533,7 +533,7 @@ func (d *btrfs) createVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInc
 
 // CreateVolumeFromCopy provides same-pool volume copying functionality.
 func (d *btrfs) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInconsistent bool, op *operations.Operation) error {
-	return d.createVolumeFromCopy(vol, srcVol, allowInconsistent, false, op)
+	return d.createVolumeFromCopy(vol, srcVol, false, op)
 }
 
 // CreateVolumeFromMigration creates a volume being sent via a migration.
@@ -582,7 +582,7 @@ func (d *btrfs) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteClose
 	}
 
 	if volTargetArgs.Refresh && shared.ValueInSlice(migration.BTRFSFeatureSubvolumeUUIDs, volTargetArgs.MigrationType.Features) {
-		snapshots, err := d.volumeSnapshotsSorted(vol.Volume, op)
+		snapshots, err := d.volumeSnapshotsSorted(vol.Volume)
 		if err != nil {
 			return err
 		}
@@ -641,10 +641,10 @@ func (d *btrfs) CreateVolumeFromMigration(vol VolumeCopy, conn io.ReadWriteClose
 		syncSubvolumes = migrationHeader.Subvolumes
 	}
 
-	return d.createVolumeFromMigrationOptimized(vol.Volume, conn, volTargetArgs, preFiller, syncSubvolumes, op)
+	return d.createVolumeFromMigrationOptimized(vol.Volume, conn, volTargetArgs, syncSubvolumes, op)
 }
 
-func (d *btrfs) createVolumeFromMigrationOptimized(vol Volume, conn io.ReadWriteCloser, volTargetArgs migration.VolumeTargetArgs, preFiller *VolumeFiller, subvolumes []BTRFSSubVolume, op *operations.Operation) error {
+func (d *btrfs) createVolumeFromMigrationOptimized(vol Volume, conn io.ReadWriteCloser, volTargetArgs migration.VolumeTargetArgs, subvolumes []BTRFSSubVolume, op *operations.Operation) error {
 	revert := revert.New()
 	defer revert.Fail()
 
@@ -819,7 +819,7 @@ func (d *btrfs) createVolumeFromMigrationOptimized(vol Volume, conn io.ReadWrite
 
 // RefreshVolume provides same-pool volume and specific snapshots syncing functionality.
 func (d *btrfs) RefreshVolume(vol VolumeCopy, srcVol VolumeCopy, refreshSnapshots []string, allowInconsistent bool, op *operations.Operation) error {
-	return d.createVolumeFromCopy(vol, srcVol, allowInconsistent, true, op)
+	return d.createVolumeFromCopy(vol, srcVol, true, op)
 }
 
 // DeleteVolume deletes a volume of the storage device. If any snapshots of the volume remain then
@@ -1183,7 +1183,7 @@ func (d *btrfs) MigrateVolume(vol VolumeCopy, conn io.ReadWriteCloser, volSrcArg
 
 	if !volSrcArgs.VolumeOnly {
 		// Generate restoration header, containing info on the subvolumes and how they should be restored.
-		snapshots, err = d.volumeSnapshotsSorted(vol.Volume, op)
+		snapshots, err = d.volumeSnapshotsSorted(vol.Volume)
 		if err != nil {
 			return err
 		}
@@ -1778,7 +1778,7 @@ func (d *btrfs) VolumeSnapshots(vol Volume, op *operations.Operation) ([]string,
 
 // volumeSnapshotsSorted returns a list of snapshots for the volume (ordered by subvolume ID).
 // Since the subvolume ID is incremental, this also represents the order of creation.
-func (d *btrfs) volumeSnapshotsSorted(vol Volume, op *operations.Operation) ([]string, error) {
+func (d *btrfs) volumeSnapshotsSorted(vol Volume) ([]string, error) {
 	stdout := bytes.Buffer{}
 
 	err := shared.RunCommandWithFds(d.state.ShutdownCtx, nil, &stdout, "btrfs", "subvolume", "list", GetPoolMountPath(vol.pool))

--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -1116,14 +1116,11 @@ func (d *ceph) HasVolume(vol Volume) (bool, error) {
 }
 
 // FillVolumeConfig populate volume with default config.
-func (d *ceph) FillVolumeConfig(vol Volume) error {
+func (d *ceph) FillVolumeConfig(vol Volume) {
 	// Copy volume.* configuration options from pool.
 	// Exclude 'block.filesystem' and 'block.mount_options'
 	// as this ones are handled below in this function and depends from volume type
-	err := d.fillVolumeConfig(&vol, "block.filesystem", "block.mount_options")
-	if err != nil {
-		return err
-	}
+	d.fillVolumeConfig(&vol, "block.filesystem", "block.mount_options")
 
 	// Only validate filesystem config keys for filesystem volumes or VM block volumes (which have an
 	// associated filesystem volume).
@@ -1155,8 +1152,6 @@ func (d *ceph) FillVolumeConfig(vol Volume) error {
 			vol.config["block.mount_options"] = "discard"
 		}
 	}
-
-	return nil
 }
 
 // commonVolumeRules returns validation rules which are common for pool and volume.

--- a/lxd/storage/drivers/driver_common.go
+++ b/lxd/storage/drivers/driver_common.go
@@ -105,7 +105,7 @@ func (d *common) validatePool(config map[string]string, driverRules map[string]f
 // excludeKeys allow exclude some keys from copying to volume config.
 // Sometimes that can be useful when copying is dependant from specific conditions
 // and shouldn't be done in generic way.
-func (d *common) fillVolumeConfig(vol *Volume, excludedKeys ...string) error {
+func (d *common) fillVolumeConfig(vol *Volume, excludedKeys ...string) {
 	for k := range d.config {
 		if !strings.HasPrefix(k, "volume.") {
 			continue
@@ -144,13 +144,11 @@ func (d *common) fillVolumeConfig(vol *Volume, excludedKeys ...string) error {
 			vol.config[volKey] = d.config[k]
 		}
 	}
-
-	return nil
 }
 
 // FillVolumeConfig populate volume with default config.
-func (d *common) FillVolumeConfig(vol Volume) error {
-	return d.fillVolumeConfig(&vol)
+func (d *common) FillVolumeConfig(vol Volume) {
+	d.fillVolumeConfig(&vol)
 }
 
 // validateVolume validates a volume config against common rules and optional driver specific rules.

--- a/lxd/storage/drivers/driver_dir_volumes.go
+++ b/lxd/storage/drivers/driver_dir_volumes.go
@@ -226,21 +226,16 @@ func (d *dir) HasVolume(vol Volume) (bool, error) {
 }
 
 // FillVolumeConfig populate volume with default config.
-func (d *dir) FillVolumeConfig(vol Volume) error {
+func (d *dir) FillVolumeConfig(vol Volume) {
 	initialSize := vol.config["size"]
 
-	err := d.fillVolumeConfig(&vol)
-	if err != nil {
-		return err
-	}
+	d.fillVolumeConfig(&vol)
 
 	// Buckets do not support default volume size.
 	// If size is specified manually, do not remove, so it triggers validation failure and an error to user.
 	if vol.volType == VolumeTypeBucket && initialSize == "" {
 		delete(vol.config, "size")
 	}
-
-	return nil
 }
 
 // ValidateVolume validates the supplied volume config. Optionally removes invalid keys from the volume's config.

--- a/lxd/storage/drivers/driver_lvm_volumes.go
+++ b/lxd/storage/drivers/driver_lvm_volumes.go
@@ -265,14 +265,11 @@ func (d *lvm) HasVolume(vol Volume) (bool, error) {
 }
 
 // FillVolumeConfig populate volume with default config.
-func (d *lvm) FillVolumeConfig(vol Volume) error {
+func (d *lvm) FillVolumeConfig(vol Volume) {
 	// Copy volume.* configuration options from pool.
 	// Exclude "block.filesystem" and "block.mount_options" as they depend on volume type (handled below).
 	// Exclude "lvm.stripes", "lvm.stripes.size" as they only work on non-thin storage pools (handled below).
-	err := d.fillVolumeConfig(&vol, "block.filesystem", "block.mount_options", "lvm.stripes", "lvm.stripes.size")
-	if err != nil {
-		return err
-	}
+	d.fillVolumeConfig(&vol, "block.filesystem", "block.mount_options", "lvm.stripes", "lvm.stripes.size")
 
 	// Only validate filesystem config keys for filesystem volumes or VM block volumes (which have an
 	// associated filesystem volume).
@@ -315,8 +312,6 @@ func (d *lvm) FillVolumeConfig(vol Volume) error {
 			vol.config["lvm.stripes.size"] = d.config["lvm.stripes.size"]
 		}
 	}
-
-	return nil
 }
 
 // commonVolumeRules returns validation rules which are common for pool and volume.

--- a/lxd/storage/drivers/driver_powerflex_volumes.go
+++ b/lxd/storage/drivers/driver_powerflex_volumes.go
@@ -376,14 +376,11 @@ func (d *powerflex) HasVolume(vol Volume) (bool, error) {
 }
 
 // FillVolumeConfig populate volume with default config.
-func (d *powerflex) FillVolumeConfig(vol Volume) error {
+func (d *powerflex) FillVolumeConfig(vol Volume) {
 	// Copy volume.* configuration options from pool.
 	// Exclude 'block.filesystem' and 'block.mount_options'
 	// as these ones are handled below in this function and depend on the volume's type.
-	err := d.fillVolumeConfig(&vol, "block.filesystem", "block.mount_options")
-	if err != nil {
-		return err
-	}
+	d.fillVolumeConfig(&vol, "block.filesystem", "block.mount_options")
 
 	// Only validate filesystem config keys for filesystem volumes or VM block volumes (which have an
 	// associated filesystem volume).
@@ -415,8 +412,6 @@ func (d *powerflex) FillVolumeConfig(vol Volume) error {
 			vol.config["block.mount_options"] = "discard"
 		}
 	}
-
-	return nil
 }
 
 // commonVolumeRules returns validation rules which are common for pool and volume.

--- a/lxd/storage/drivers/driver_pure_volumes.go
+++ b/lxd/storage/drivers/driver_pure_volumes.go
@@ -671,14 +671,11 @@ func (d *pure) HasVolume(vol Volume) (bool, error) {
 }
 
 // FillVolumeConfig populate volume with default config.
-func (d *pure) FillVolumeConfig(vol Volume) error {
+func (d *pure) FillVolumeConfig(vol Volume) {
 	// Copy volume.* configuration options from pool.
 	// Exclude 'block.filesystem' and 'block.mount_options'
 	// as these ones are handled below in this function and depend on the volume's type.
-	err := d.fillVolumeConfig(&vol, "block.filesystem", "block.mount_options")
-	if err != nil {
-		return err
-	}
+	d.fillVolumeConfig(&vol, "block.filesystem", "block.mount_options")
 
 	// Only validate filesystem config keys for filesystem volumes or VM block volumes (which have an
 	// associated filesystem volume).
@@ -710,8 +707,6 @@ func (d *pure) FillVolumeConfig(vol Volume) error {
 			vol.config["block.mount_options"] = "discard"
 		}
 	}
-
-	return nil
 }
 
 // ValidateVolume validates the supplied volume config.

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -3501,7 +3501,7 @@ func (d *zfs) RenameVolumeSnapshot(vol Volume, newSnapshotName string, op *opera
 }
 
 // FillVolumeConfig populate volume with default config.
-func (d *zfs) FillVolumeConfig(vol Volume) error {
+func (d *zfs) FillVolumeConfig(vol Volume) {
 	var excludedKeys []string
 
 	// Copy volume.* configuration options from pool.
@@ -3512,10 +3512,7 @@ func (d *zfs) FillVolumeConfig(vol Volume) error {
 		excludedKeys = []string{"block.filesystem", "block.mount_options"}
 	}
 
-	err := d.fillVolumeConfig(&vol, excludedKeys...)
-	if err != nil {
-		return err
-	}
+	d.fillVolumeConfig(&vol, excludedKeys...)
 
 	// Only validate filesystem config keys for filesystem volumes.
 	if d.isBlockBacked(vol) && vol.ContentType() == ContentTypeFS {
@@ -3546,8 +3543,6 @@ func (d *zfs) FillVolumeConfig(vol Volume) error {
 			vol.config["block.mount_options"] = "discard"
 		}
 	}
-
-	return nil
 }
 
 func (d *zfs) isBlockBacked(vol Volume) bool {

--- a/lxd/storage/drivers/interface.go
+++ b/lxd/storage/drivers/interface.go
@@ -63,7 +63,7 @@ type Driver interface {
 	DeleteBucketKey(bucket Volume, keyName string, op *operations.Operation) error
 
 	// Volumes.
-	FillVolumeConfig(vol Volume) error
+	FillVolumeConfig(vol Volume)
 	ValidateVolume(vol Volume, removeUnknownKeys bool) error
 	CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Operation) error
 	CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allowInconsistent bool, op *operations.Operation) error

--- a/lxd/storage/drivers/volume.go
+++ b/lxd/storage/drivers/volume.go
@@ -38,11 +38,7 @@ type VolumeType string
 
 // IsInstance indicates if the VolumeType represents an instance type.
 func (t VolumeType) IsInstance() bool {
-	if t == VolumeTypeContainer || t == VolumeTypeVM {
-		return true
-	}
-
-	return false
+	return t == VolumeTypeContainer || t == VolumeTypeVM
 }
 
 // VolumeTypeBucket represents a bucket storage volume.

--- a/lxd/storage/pool_load.go
+++ b/lxd/storage/pool_load.go
@@ -38,7 +38,7 @@ func volIDFuncMake(state *state.State, poolID int64) func(volType drivers.Volume
 		// Currently only Containers, VMs and custom volumes support project level volumes.
 		// This means that other volume types may have underscores in their names that don't
 		// indicate the project name.
-		if volType == drivers.VolumeTypeContainer || volType == drivers.VolumeTypeVM {
+		if volType.IsInstance() {
 			projectName, volName = project.InstanceParts(volName)
 		} else if volType == drivers.VolumeTypeCustom {
 			projectName, volName = project.StorageVolumeParts(volName)

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -395,13 +395,10 @@ func BucketDBCreate(ctx context.Context, pool Pool, projectName string, memberSp
 	bucketVol := drivers.NewVolume(pool.Driver(), pool.Name(), drivers.VolumeTypeBucket, drivers.ContentTypeFS, bucketVolName, bucket.Config, pool.Driver().Config())
 
 	// Fill default config.
-	err := pool.Driver().FillVolumeConfig(bucketVol)
-	if err != nil {
-		return -1, err
-	}
+	pool.Driver().FillVolumeConfig(bucketVol)
 
 	// Validate bucket name.
-	err = pool.Driver().ValidateBucket(bucketVol)
+	err := pool.Driver().ValidateBucket(bucketVol)
 	if err != nil {
 		return -1, err
 	}

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -219,7 +219,6 @@ func VolumeDBGet(pool Pool, projectName string, volumeName string, volumeType dr
 }
 
 // VolumeDBCreate creates a volume in the database.
-// If volumeConfig is supplied, it is modified with any driver level default config options (if not set).
 // If removeUnknownKeys is true, any unknown config keys are removed from volumeConfig rather than failing.
 func VolumeDBCreate(pool Pool, projectName string, volumeName string, volumeDescription string, volumeType drivers.VolumeType, snapshot bool, volumeConfig map[string]string, creationDate time.Time, expiryDate time.Time, contentType drivers.ContentType, removeUnknownKeys bool, hasSource bool) error {
 	p, ok := pool.(*lxdBackend)
@@ -268,12 +267,6 @@ func VolumeDBCreate(pool Pool, projectName string, volumeName string, volumeDesc
 
 	// Set source indicator.
 	vol.SetHasSource(hasSource)
-
-	// Fill default config.
-	err = pool.Driver().FillVolumeConfig(vol)
-	if err != nil {
-		return err
-	}
 
 	// Validate config.
 	err = pool.Driver().ValidateVolume(vol, removeUnknownKeys)

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -668,8 +668,8 @@ func validateVolumeCommonRules(vol drivers.Volume) map[string]func(string) error
 		rules["block.filesystem"] = validate.IsAny
 	}
 
-	// volatile.rootfs.size is only used for image volumes.
-	if vol.Type() == drivers.VolumeTypeImage {
+	// volatile.rootfs.size is only used for image and instance volumes.
+	if vol.Type().IsInstance() || vol.Type() == drivers.VolumeTypeImage {
 		rules["volatile.rootfs.size"] = validate.Optional(validate.IsInt64)
 	}
 

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -670,7 +670,7 @@ func validateVolumeCommonRules(vol drivers.Volume) map[string]func(string) error
 
 	// volatile.rootfs.size is only used for image and instance volumes.
 	if vol.Type().IsInstance() || vol.Type() == drivers.VolumeTypeImage {
-		rules["volatile.rootfs.size"] = validate.Optional(validate.IsInt64)
+		rules["volatile.rootfs.size"] = validate.Optional(validate.IsSize)
 	}
 
 	return rules


### PR DESCRIPTION
This is a follow up PR for https://github.com/canonical/lxd/pull/14511 and this aims to address the problems outlined in https://github.com/canonical/lxd/pull/14511#issuecomment-2502356227.

For this, we using the `volatile.rootfs.size` config key, previously only available for images, for instance volumes. This config key is used to represent the current total size of an instance volume at any point in time. This way we can determine whether a volume had its quota set based on `volume.size` or not, and also determine if has been resized after changing the disk's `size` property, as some instances are not live-resizable.

This key was chosen instead of the `size` key because the intended behavior of this config key fits better the pattern we see with `volatile.*` keys, that can be changed by LXD itself, without the user specifying them.