### PR TITLE
Draft: shared/api: clusterNodesPost change metadata serverName to server_name

### DIFF
--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -1446,6 +1446,7 @@ func clusterNodesPost(d *Daemon, r *http.Request) response.Response {
 
 	meta := map[string]any{
 		"serverName":  req.ServerName, // Add server name to allow validation of name during join process.
+		"server_name":  req.ServerName, // Add server_name so the metadata returned can be base64 encode and then used
 		"secret":      joinSecret,
 		"fingerprint": fingerprint,
 		"addresses":   onlineNodeAddresses,


### PR DESCRIPTION
This should result in the metadata being returned to be base64 encode and used as a cluster add token