### PR TITLE
Documentation: Update doc links

### DIFF
--- a/doc/authentication.md
+++ b/doc/authentication.md
@@ -1,5 +1,5 @@
 ---
-discourse: 13114,15142
+discourse: lxc:13114,lxc:15142
 relatedlinks: https://www.youtube.com/watch?v=6O0q3rSWr8A
 ---
 

--- a/doc/cloud-init.md
+++ b/doc/cloud-init.md
@@ -1,5 +1,5 @@
 ---
-discourse: 12559
+discourse: lxc:12559
 relatedlinks: https://cloudinit.readthedocs.org/
 ---
 

--- a/doc/clustering.md
+++ b/doc/clustering.md
@@ -1,5 +1,5 @@
 ---
-discourse: 9076,15871
+discourse: lxc:9076,lxc:15871
 ---
 
 (clustering)=

--- a/doc/custom_conf.py
+++ b/doc/custom_conf.py
@@ -90,8 +90,8 @@ html_context = {
 
     # ru-fu: we're using different Discourses
     'discourse_prefix': {
-        'lxc': 'https://discuss.linuxcontainers.org/t/',
-        'ubuntu': 'https://discourse.ubuntu.com/t/'
+        'ubuntu': 'https://discourse.ubuntu.com/t/',
+        'lxc': 'https://discuss.linuxcontainers.org/t/'
     },
 
     # Change to the Mattermost channel you want to link to

--- a/doc/explanation/clustering.md
+++ b/doc/explanation/clustering.md
@@ -1,5 +1,5 @@
 ---
-discourse: 15728
+discourse: lxc:15728
 ---
 
 (exp-clustering)=

--- a/doc/explanation/instances.md
+++ b/doc/explanation/instances.md
@@ -1,5 +1,5 @@
 ---
-discourse: 8767,7519,9281
+discourse: lxc:8767,lxc:7519,lxc:9281
 relatedlinks: '[LXD&#32;virtual&#32;machines:&#32;an&#32;overview](https://ubuntu.com/blog/lxd-virtual-machines-an-overview)'
 ---
 

--- a/doc/explanation/lxd_lxc.md
+++ b/doc/explanation/lxd_lxc.md
@@ -1,5 +1,5 @@
 ---
-discourse: 24
+discourse: lxc:24
 ---
 
 (lxd-lxc)=

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -1,5 +1,5 @@
 ---
-discourse: 14705
+discourse: lxc:14705
 ---
 
 # Frequently asked questions

--- a/doc/howto/cluster_form.md
+++ b/doc/howto/cluster_form.md
@@ -1,5 +1,5 @@
 ---
-discourse: 15871
+discourse: lxc:15871
 ---
 
 (cluster-form)=

--- a/doc/howto/cluster_groups.md
+++ b/doc/howto/cluster_groups.md
@@ -1,5 +1,5 @@
 ---
-discourse: 12716
+discourse: lxc:12716
 ---
 
 (howto-cluster-groups)=

--- a/doc/howto/cluster_manage.md
+++ b/doc/howto/cluster_manage.md
@@ -1,5 +1,5 @@
 ---
-discourse: 11330
+discourse: lxc:11330
 ---
 
 (cluster-manage)=

--- a/doc/howto/disaster_recovery.md
+++ b/doc/howto/disaster_recovery.md
@@ -1,5 +1,5 @@
 ---
-discourse: 11296
+discourse: lxc:11296
 ---
 
 (disaster-recovery)=

--- a/doc/howto/import_machines_to_instances.md
+++ b/doc/howto/import_machines_to_instances.md
@@ -1,5 +1,5 @@
 ---
-discourse: 14345
+discourse: lxc:14345
 ---
 
 (import-machines-to-instances)=

--- a/doc/howto/instances_console.md
+++ b/doc/howto/instances_console.md
@@ -1,5 +1,5 @@
 ---
-discourse: 9223
+discourse: lxc:9223
 ---
 
 (instances-console)=

--- a/doc/howto/instances_troubleshoot.md
+++ b/doc/howto/instances_troubleshoot.md
@@ -1,5 +1,5 @@
 ---
-discourse: 7362
+discourse: lxc:7362
 ---
 
 (instances-troubleshoot)=

--- a/doc/howto/move_instances.md
+++ b/doc/howto/move_instances.md
@@ -1,5 +1,5 @@
 ---
-discourse: 16635
+discourse: lxc:16635
 ---
 
 (move-instances)=

--- a/doc/howto/network_acls.md
+++ b/doc/howto/network_acls.md
@@ -1,5 +1,5 @@
 ---
-discourse: 13223
+discourse: lxc:13223
 ---
 
 (network-acls)=

--- a/doc/howto/network_bgp.md
+++ b/doc/howto/network_bgp.md
@@ -1,5 +1,5 @@
 ---
-discourse: 11567
+discourse: lxc:11567
 ---
 
 (network-bgp)=

--- a/doc/howto/network_bridge_firewalld.md
+++ b/doc/howto/network_bridge_firewalld.md
@@ -1,5 +1,5 @@
 ---
-discourse: 10034,9953
+discourse: lxc:10034,lxc:9953
 ---
 
 (network-bridge-firewall)=

--- a/doc/howto/network_forwards.md
+++ b/doc/howto/network_forwards.md
@@ -1,5 +1,5 @@
 ---
-discourse: 11801
+discourse: lxc:11801
 ---
 
 (network-forwards)=

--- a/doc/howto/network_load_balancers.md
+++ b/doc/howto/network_load_balancers.md
@@ -1,5 +1,5 @@
 ---
-discourse: 14317
+discourse: lxc:14317
 ---
 
 (network-load-balancers)=

--- a/doc/howto/network_ovn_peers.md
+++ b/doc/howto/network_ovn_peers.md
@@ -1,5 +1,5 @@
 ---
-discourse: 12165
+discourse: lxc:12165
 ---
 
 (network-ovn-peers)=

--- a/doc/howto/network_zones.md
+++ b/doc/howto/network_zones.md
@@ -1,5 +1,5 @@
 ---
-discourse: 12033,13128
+discourse: lxc:12033,lxc:13128
 ---
 
 (network-zones)=

--- a/doc/howto/storage_move_volume.md
+++ b/doc/howto/storage_move_volume.md
@@ -1,5 +1,5 @@
 ---
-discourse: 10877
+discourse: lxc:10877
 ---
 
 (howto-storage-move-volume)=

--- a/doc/howto/storage_pools.md
+++ b/doc/howto/storage_pools.md
@@ -1,5 +1,5 @@
 ---
-discourse: 1333
+discourse: lxc:1333
 ---
 
 (howto-storage-pools)=

--- a/doc/metrics.md
+++ b/doc/metrics.md
@@ -1,5 +1,5 @@
 ---
-discourse: 12281,11735
+discourse: lxc:12281,lxc:11735
 ---
 
 (metrics)=

--- a/doc/myconf.py
+++ b/doc/myconf.py
@@ -189,8 +189,8 @@ html_context = {
     "github_folder": "/doc/",
     "github_filetype": "md",
     "discourse_prefix": {
-        "lxc": "https://discuss.linuxcontainers.org/t/",
-        "ubuntu": "https://discourse.ubuntu.com/t/"}
+        "ubuntu": "https://discourse.ubuntu.com/t/",
+        "lxc": "https://discuss.linuxcontainers.org/t/"}
 }
 
 source_suffix = ".md"

--- a/doc/networks.md
+++ b/doc/networks.md
@@ -1,5 +1,5 @@
 ---
-discourse: 13021
+discourse: lxc:13021
 ---
 
 (networking)=

--- a/doc/reference/devices_proxy.md
+++ b/doc/reference/devices_proxy.md
@@ -1,5 +1,5 @@
 ---
-discourse: 8355
+discourse: lxc:8355
 ---
 
 (devices-proxy)=

--- a/doc/reference/network_bridge.md
+++ b/doc/reference/network_bridge.md
@@ -1,5 +1,5 @@
 ---
-discourse: 7322
+discourse: lxc:7322
 ---
 
 (network-bridge)=

--- a/doc/reference/network_ovn.md
+++ b/doc/reference/network_ovn.md
@@ -1,5 +1,5 @@
 ---
-discourse: 11033
+discourse: lxc:11033
 ---
 
 (network-ovn)=

--- a/doc/reference/storage_ceph.md
+++ b/doc/reference/storage_ceph.md
@@ -1,5 +1,5 @@
 ---
-discourse: 15457
+discourse: lxc:15457
 ---
 
 (storage-ceph)=

--- a/doc/reference/storage_cephobject.md
+++ b/doc/reference/storage_cephobject.md
@@ -1,5 +1,5 @@
 ---
-discourse: 14579,15457
+discourse: lxc:14579,lxc:15457
 relatedlinks: https://youtube.com/watch?v=kVLGbvRU98A
 ---
 

--- a/doc/reference/storage_zfs.md
+++ b/doc/reference/storage_zfs.md
@@ -1,5 +1,5 @@
 ---
-discourse: 15872
+discourse: lxc:15872
 ---
 
 (storage-zfs)=

--- a/doc/storage.md
+++ b/doc/storage.md
@@ -1,5 +1,5 @@
 ---
-discourse: 7735
+discourse: lxc:7735
 ---
 
 (storage)=


### PR DESCRIPTION
This PR switches the order of discourse link prefixes, changing priority from linux containers forums to ubuntu forums. The `lxc:` prefix is added before linux container discourse post reference numbers, so we're aware of which specs to incrementally move over to ubuntu forums.