### PR TITLE
doc: clarify that storage size is equal to quota

### DIFF
--- a/doc/cloud-init.md
+++ b/doc/cloud-init.md
@@ -19,7 +19,7 @@ Possible actions include, for example:
 * Adding users
 * Enabling services
 * Running commands or scripts
-* Automatically growing the file system of a VM to the size of the disk
+* Automatically growing the file system of a VM to the size (quota) of the disk
 
 See the {ref}`cloud-init:index` for detailed information.
 

--- a/doc/explanation/clustering.md
+++ b/doc/explanation/clustering.md
@@ -103,7 +103,7 @@ Most often, this is done through the interactive `lxd init` command, which asks 
 
 Those settings typically include:
 
-- The source device and size for a storage pool
+- The source device and size (quota) for a storage pool
 - The name for a ZFS zpool, LVM thin pool or LVM volume group
 - External interfaces and BGP next-hop for a bridged network
 - The name of the parent network device for managed `physical` or `macvlan` networks

--- a/doc/explanation/storage.md
+++ b/doc/explanation/storage.md
@@ -66,7 +66,7 @@ The loop files reside in `/var/snap/lxd/common/lxd/disks/` if you are using the 
 
 Loop files usually cannot be shrunk.
 They will grow up to the configured limit, but deleting instances or images will not cause the file to shrink.
-You can increase their size though; see {ref}`storage-resize-pool`.
+You can increase their size (quota) though; see {ref}`storage-resize-pool`.
 
 #### Remote storage
 

--- a/doc/howto/initialize.md
+++ b/doc/howto/initialize.md
@@ -43,7 +43,7 @@ Storage pools (see {ref}`exp-storage` and  {ref}`storage-drivers`)
 : Instances (and other data) are stored in storage pools.
 
   For testing purposes, you can create a loop-backed storage pool.
-  For production use, however, you should use an empty partition (or full disk) instead of loop-backed storage (because loop-backed pools are slower and their size can't be reduced).
+  For production use, however, you should use an empty partition (or full disk) instead of loop-backed storage (because loop-backed pools are slower and their size/quota can't be reduced).
 
   The recommended backends are `zfs` and `btrfs`.
 

--- a/doc/howto/instances_backup.md
+++ b/doc/howto/instances_backup.md
@@ -292,7 +292,7 @@ You can add any of the following fields to the request data:
   In this case, the backup can only be used with pools that use the same storage driver.
 
   Exporting a volume in optimized mode is usually quicker than exporting the individual files.
-  Snapshots are exported as differences from the main volume, which decreases their size and makes them easily accessible.
+  Snapshots are exported as differences from the main volume, which decreases their size (quota) and makes them easily accessible.
 
 `"instance-only": true`
 : By default, the backup contains all snapshots of the instance.

--- a/doc/howto/storage_backup_volume.md
+++ b/doc/howto/storage_backup_volume.md
@@ -138,7 +138,7 @@ You can add any of the following flags to the command:
   In this case, the export file can only be used with pools that use the same storage driver.
 
   Exporting a volume in optimized mode is usually quicker than exporting the individual files.
-  Snapshots are exported as differences from the main volume, which decreases their size and makes them easily accessible.
+  Snapshots are exported as differences from the main volume, which decreases their size (quota) and makes them easily accessible.
 <!-- Include end export info -->
 
 `--volume-only`

--- a/doc/howto/storage_buckets.md
+++ b/doc/howto/storage_buckets.md
@@ -81,7 +81,7 @@ Use the following command to set configuration options for a storage bucket:
 
     lxc storage bucket set <pool_name> <bucket_name> <key> <value>
 
-For example, to set the quota size of a bucket, use the following command:
+For example, to set the size (quota) of a bucket, use the following command:
 
     lxc storage bucket set my-pool my-bucket size 1MiB
 

--- a/doc/howto/storage_pools.md
+++ b/doc/howto/storage_pools.md
@@ -17,7 +17,7 @@ To create a storage pool, use the following command:
 
     lxc storage create <pool_name> <driver> [configuration_options...]
 
-Unless specified otherwise, LXD sets up loop-based storage with a sensible default size (20% of the free disk space, but at least 5 GiB and at most 30 GiB).
+Unless specified otherwise, LXD sets up loop-based storage with a sensible default size/quota (20% of the free disk space, but at least 5 GiB and at most 30 GiB).
 
 See the {ref}`storage-drivers` documentation for a list of available configuration options for each driver.
 
@@ -280,7 +280,7 @@ To see usage information for a specific pool, run the following command:
 (storage-resize-pool)=
 ## Resize a storage pool
 
-If you need more storage, you can increase the size of your storage pool by changing the `size` configuration key:
+If you need more storage, you can increase the size (quota) of your storage pool by changing the `size` configuration key:
 
     lxc storage set <pool_name> size=<new_size>
 

--- a/doc/metadata.txt
+++ b/doc/metadata.txt
@@ -173,7 +173,7 @@ Specify a value in bytes (various suffixes supported, see {ref}`instances-limit-
 ```{config:option} size.state device-disk-device-conf
 :condition: "virtual machine"
 :required: "no"
-:shortdesc: "Size/quota of the file-system volume used for saving runtime state"
+:shortdesc: "Size of the file-system volume used for saving runtime state"
 :type: "string"
 This option is similar to {config:option}`device-disk-device-conf:size`, but applies to the file-system volume used for saving the runtime state in VMs.
 ```
@@ -4853,7 +4853,7 @@ for automatic access control.
 ```{config:option} size storage-btrfs-pool-conf
 :defaultdesc: "auto (20% of free disk space, >= 5 GiB and <= 30 GiB)"
 :scope: "local"
-:shortdesc: "Size/quota of the storage pool (for loop-based pools)"
+:shortdesc: "Size of the storage pool (for loop-based pools)"
 :type: "string"
 When creating loop-based pools, specify the size in bytes ({ref}`suffixes <instances-limit-units>` are supported).
 You can increase the size to grow the storage pool.
@@ -5308,7 +5308,7 @@ Specify either a cron expression (`<minute> <hour> <dom> <month> <dow>`), a comm
 <!-- config group storage-cephobject-bucket-conf start -->
 ```{config:option} size storage-cephobject-bucket-conf
 :scope: "local"
-:shortdesc: "Size/quota of the storage bucket"
+:shortdesc: "Quota of the storage bucket"
 :type: "string"
 
 ```
@@ -5486,7 +5486,7 @@ Specify either a cron expression (`<minute> <hour> <dom> <month> <dow>`), a comm
 ```{config:option} lvm.thinpool_metadata_size storage-lvm-pool-conf
 :defaultdesc: "`0` (auto)"
 :scope: "global"
-:shortdesc: "Size/quota of the thin pool metadata volume"
+:shortdesc: "The size of the thin pool metadata volume"
 :type: "string"
 By default, LVM calculates an appropriate size.
 ```
@@ -5543,7 +5543,7 @@ to be placed on the socket I/O.
 ```{config:option} size storage-lvm-pool-conf
 :defaultdesc: "auto (20% of free disk space, >= 5 GiB and <= 30 GiB)"
 :scope: "local"
-:shortdesc: "Size/quota of the storage pool (for loop-based pools)"
+:shortdesc: "Size of the storage pool (for loop-based pools)"
 :type: "string"
 When creating loop-based pools, specify the size in bytes ({ref}`suffixes <instances-limit-units>` are supported).
 You can increase the size to grow the storage pool.
@@ -5914,7 +5914,7 @@ Specify either a cron expression (`<minute> <hour> <dom> <month> <dow>`), a comm
 ```{config:option} size storage-zfs-pool-conf
 :defaultdesc: "auto (20% of free disk space, >= 5 GiB and <= 30 GiB)"
 :scope: "local"
-:shortdesc: "Size/quota of the storage pool (for loop-based pools)"
+:shortdesc: "Size of the storage pool (for loop-based pools)"
 :type: "string"
 When creating loop-based pools, specify the size in bytes ({ref}`suffixes <instances-limit-units>` are supported).
 You can increase the size to grow the storage pool.

--- a/doc/metadata.txt
+++ b/doc/metadata.txt
@@ -173,7 +173,7 @@ Specify a value in bytes (various suffixes supported, see {ref}`instances-limit-
 ```{config:option} size.state device-disk-device-conf
 :condition: "virtual machine"
 :required: "no"
-:shortdesc: "Size of the file-system volume used for saving runtime state"
+:shortdesc: "Size/quota of the file-system volume used for saving runtime state"
 :type: "string"
 This option is similar to {config:option}`device-disk-device-conf:size`, but applies to the file-system volume used for saving the runtime state in VMs.
 ```
@@ -4853,7 +4853,7 @@ for automatic access control.
 ```{config:option} size storage-btrfs-pool-conf
 :defaultdesc: "auto (20% of free disk space, >= 5 GiB and <= 30 GiB)"
 :scope: "local"
-:shortdesc: "Size of the storage pool (for loop-based pools)"
+:shortdesc: "Size/quota of the storage pool (for loop-based pools)"
 :type: "string"
 When creating loop-based pools, specify the size in bytes ({ref}`suffixes <instances-limit-units>` are supported).
 You can increase the size to grow the storage pool.
@@ -5308,7 +5308,7 @@ Specify either a cron expression (`<minute> <hour> <dom> <month> <dow>`), a comm
 <!-- config group storage-cephobject-bucket-conf start -->
 ```{config:option} size storage-cephobject-bucket-conf
 :scope: "local"
-:shortdesc: "Quota of the storage bucket"
+:shortdesc: "Size/quota of the storage bucket"
 :type: "string"
 
 ```
@@ -5486,7 +5486,7 @@ Specify either a cron expression (`<minute> <hour> <dom> <month> <dow>`), a comm
 ```{config:option} lvm.thinpool_metadata_size storage-lvm-pool-conf
 :defaultdesc: "`0` (auto)"
 :scope: "global"
-:shortdesc: "The size of the thin pool metadata volume"
+:shortdesc: "Size/quota of the thin pool metadata volume"
 :type: "string"
 By default, LVM calculates an appropriate size.
 ```
@@ -5543,7 +5543,7 @@ to be placed on the socket I/O.
 ```{config:option} size storage-lvm-pool-conf
 :defaultdesc: "auto (20% of free disk space, >= 5 GiB and <= 30 GiB)"
 :scope: "local"
-:shortdesc: "Size of the storage pool (for loop-based pools)"
+:shortdesc: "Size/quota of the storage pool (for loop-based pools)"
 :type: "string"
 When creating loop-based pools, specify the size in bytes ({ref}`suffixes <instances-limit-units>` are supported).
 You can increase the size to grow the storage pool.
@@ -5914,7 +5914,7 @@ Specify either a cron expression (`<minute> <hour> <dom> <month> <dow>`), a comm
 ```{config:option} size storage-zfs-pool-conf
 :defaultdesc: "auto (20% of free disk space, >= 5 GiB and <= 30 GiB)"
 :scope: "local"
-:shortdesc: "Size of the storage pool (for loop-based pools)"
+:shortdesc: "Size/quota of the storage pool (for loop-based pools)"
 :type: "string"
 When creating loop-based pools, specify the size in bytes ({ref}`suffixes <instances-limit-units>` are supported).
 You can increase the size to grow the storage pool.

--- a/doc/reference/devices_disk.md
+++ b/doc/reference/devices_disk.md
@@ -84,7 +84,7 @@ You can also set an initial configuration directly when creating an instance. Fo
 
     lxc init <image> <instance_name> --device <device_name>,initial.zfs.block_mode=true
 
-Note that you cannot use initial volume configurations with custom volume options or to set the volume's size.
+Note that you cannot use initial volume configurations with custom volume options or to set the volume's size (quota).
 
 (devices-disk-options)=
 ## Device options

--- a/doc/reference/storage_lvm.md
+++ b/doc/reference/storage_lvm.md
@@ -16,7 +16,7 @@ To use LVM, make sure you have `lvm2` installed on your machine.
 LVM can combine several physical storage devices into a *volume group*.
 You can then allocate *logical volumes* of different types from this volume group.
 
-One supported volume type is a *thin pool*, which allows over-committing the resources by creating  thinly provisioned volumes whose total allowed maximum size is larger than the available physical storage.
+One supported volume type is a *thin pool*, which allows over-committing the resources by creating thinly provisioned volumes whose total allowed maximum size (quota) is larger than the available physical storage.
 Another type is a *volume snapshot*, which captures a specific state of a logical volume.
 
 ## `lvm` driver in LXD
@@ -32,7 +32,7 @@ This behavior can be changed by setting {config:option}`storage-lvm-pool-conf:lv
 In this case, LXD uses "normal" logical volumes for all storage entities that are not snapshots.
 Note that this entails serious performance and space reductions for the `lvm` driver (close to the `dir` driver both in speed and storage usage).
 The reason for this is that most storage operations must fall back to using `rsync`, because logical volumes that are not thin pools do not support snapshots of snapshots.
-In addition, non-thin snapshots take up much more storage space than thin snapshots, because they must reserve space for their maximum size at creation time.
+In addition, non-thin snapshots take up much more storage space than thin snapshots, because they must reserve space for their maximum size (quota) at creation time.
 Therefore, this option should only be chosen if the use case requires it.
 
 For environments with a high instance turnover (for example, continuous integration) you should tweak the backup `retain_min` and `retain_days` settings in `/etc/lvm/lvm.conf` to avoid slowdowns when interacting with LXD.

--- a/doc/reference/storage_powerflex.md
+++ b/doc/reference/storage_powerflex.md
@@ -87,7 +87,7 @@ Copying volumes
   This implicates an increased use of bandwidth due to the volume's contents being transferred over the network twice.
 
 Volume size constraints
-: In PowerFlex, the size of a volume must be in multiples of 8 GiB.
+: In PowerFlex, the size (quota) of a volume must be in multiples of 8 GiB.
   This results in the smallest possible volume size of 8 GiB.
   However, if not specified otherwise, volumes are getting thin-provisioned by LXD.
   PowerFlex volumes can only be increased in size.

--- a/doc/reference/storage_zfs.md
+++ b/doc/reference/storage_zfs.md
@@ -86,7 +86,7 @@ ZFS provides two different quota properties: `quota` and `refquota`.
 `quota` restricts the total size of a {spellexception}`dataset`, including its snapshots and clones.
 `refquota` restricts only the size of the data in the {spellexception}`dataset`, not its snapshots and clones.
 
-By default, LXD uses the `quota` property when you set up a quota for your storage volume.
+By default, LXD uses the `quota` property when you set up a size/quota for your storage volume.
 If you want to use the `refquota` property instead, set the {config:option}`storage-zfs-volume-conf:zfs.use_refquota` configuration for the volume (or the corresponding `volume.zfs.use_refquota` configuration on the storage pool for all volumes in the pool).
 
 You can also set the {config:option}`storage-zfs-volume-conf:zfs.reserve_space` (or `volume.zfs.reserve_space`) configuration to use ZFS `reservation` or `refreservation` along with `quota` or `refquota`.

--- a/doc/tutorial/first_steps.md
+++ b/doc/tutorial/first_steps.md
@@ -213,7 +213,7 @@ Let's create another container with some resource limits:
       Note that the number has changed.
 
 1. Depending on the instance type and the storage drivers that you use, there are more configuration options that you can specify.
-   For example, you can configure the size of the root disk device for a VM:
+   For example, you can configure the size (quota) of the root disk device for a VM:
 
    1. Check the current size of the root disk device of the Ubuntu VM:
 

--- a/doc/tutorial/ui.md
+++ b/doc/tutorial/ui.md
@@ -242,7 +242,7 @@ Let's create another container with some resource limits:
       Note that the number has changed.
 
 Depending on the instance type and the storage drivers that you use, there are more configuration options that you can specify.
-For example, you can configure the size of the root disk device for a VM:
+For example, you can configure the size (quota) of the root disk device for a VM:
 
 1. Go to the terminal for the `ubuntu-desktop` VM and check the current size of the root disk device (`/dev/sda2`):
 


### PR DESCRIPTION
To address #14349 where users seek information about disk quotas, these commits clarify that when storage `size` is discussed in LXD docs, it means the same as `quota`. This already exists in some of the docs, but sparsely and inconsistently.