### PR TITLE
Per-project uplink IP quotas

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2552,3 +2552,8 @@ This adds support for listing network zones across all projects using the `all-p
 Adds support for instance root volumes to be attached to other instances as disk
 devices. Introduces the `<type>/<volume>` syntax for the `source` property of
 disk devices.
+
+## `projects_limits_uplink_ips`
+
+Introduces per-project uplink IP limits for each available uplink network, adding `limits.networks.uplink_ips.ipv4.NETWORK_NAME` and `limits.networks.uplink_ips.ipv6.NETWORK_NAME` configuration keys for projects with `features.networks` enabled.
+These keys define the maximum value of IPs made available on a network named NETWORK_NAME to be assigned as uplink IPs for entities inside a certain project. These entities can be other networks, network forwards or load balancers.

--- a/doc/metadata.txt
+++ b/doc/metadata.txt
@@ -4053,6 +4053,22 @@ The value is the maximum value for the sum of the individual {config:option}`ins
 
 ```
 
+```{config:option} limits.networks.uplink_ips.ipv4.NETWORK_NAME project-limits
+:shortdesc: "Quota of IPv4 addresses from a specified uplink network that can be used by entities in this project"
+:type: "string"
+Maximum number of IPv4 addresses that this project can consume from the specified uplink network.
+This number of IPs can be consumed by networks, forwards and load balancers in this project.
+
+```
+
+```{config:option} limits.networks.uplink_ips.ipv6.NETWORK_NAME project-limits
+:shortdesc: "Quota of IPv4 addresses from a specified uplink network that can be used by entities in this project"
+:type: "string"
+Maximum number of IPv6 addresses that this project can consume from the specified uplink network.
+This number of IPs can be consumed by networks, forwards and load balancers in this project.
+
+```
+
 ```{config:option} limits.processes project-limits
 :shortdesc: "Maximum number of processes within the project"
 :type: "integer"

--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -294,7 +294,7 @@ func projectsPost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Validate the configuration.
-	err = projectValidateConfig(s, project.Config)
+	err = projectValidateConfig(s, project.Config, project.Name)
 	if err != nil {
 		return response.BadRequest(err)
 	}
@@ -682,7 +682,7 @@ func projectChange(s *state.State, project *api.Project, req api.ProjectPut) res
 	}
 
 	// Validate the configuration.
-	err := projectValidateConfig(s, req.Config)
+	err := projectValidateConfig(s, req.Config, project.Name)
 	if err != nil {
 		return response.BadRequest(err)
 	}
@@ -1024,7 +1024,7 @@ func isEitherAllowOrBlockOrManaged(value string) error {
 	return validate.Optional(validate.IsOneOf("block", "allow", "managed"))(value)
 }
 
-func projectValidateConfig(s *state.State, config map[string]string) error {
+func projectValidateConfig(s *state.State, config map[string]string, projectName string) error {
 	// Validate the project configuration.
 	projectConfigKeys := map[string]func(value string) error{
 		// lxdmeta:generate(entities=project; group=specific; key=backups.compression_algorithm)

--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -1463,6 +1463,36 @@ func projectValidateConfig(s *state.State, config map[string]string, projectName
 		return fmt.Errorf("Failed loading storage pool names: %w", err)
 	}
 
+	// Per-network project limits for uplink IPs only make sense for projects with their own networks.
+	if shared.IsTrue(config["features.networks"]) {
+		// Get networks that are allowed to be used as uplinks by this project.
+		allowedUplinkNetworks, err := network.AllowedUplinkNetworks(s, config)
+		if err != nil {
+			return err
+		}
+
+		// Add network-specific config keys.
+		for _, networkName := range allowedUplinkNetworks {
+			// lxdmeta:generate(entities=project; group=limits; key=limits.networks.uplink_ips.ipv4.NETWORK_NAME)
+			// Maximum number of IPv4 addresses that this project can consume from the specified uplink network.
+			// This number of IPs can be consumed by networks, forwards and load balancers in this project.
+			//
+			// ---
+			//  type: string
+			//  shortdesc: Quota of IPv4 addresses from a specified uplink network that can be used by entities in this project
+			projectConfigKeys["limits.networks.uplink_ips.ipv4."+networkName] = validate.Optional(uplinkIPLimitValidator(s, projectName, networkName, "ipv4"))
+
+			// lxdmeta:generate(entities=project; group=limits; key=limits.networks.uplink_ips.ipv6.NETWORK_NAME)
+			// Maximum number of IPv6 addresses that this project can consume from the specified uplink network.
+			// This number of IPs can be consumed by networks, forwards and load balancers in this project.
+			//
+			// ---
+			//  type: string
+			//  shortdesc: Quota of IPv4 addresses from a specified uplink network that can be used by entities in this project
+			projectConfigKeys["limits.networks.uplink_ips.ipv6."+networkName] = validate.Optional(uplinkIPLimitValidator(s, projectName, networkName, "ipv6"))
+		}
+	}
+
 	for k, v := range config {
 		key := k
 

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -4604,6 +4604,20 @@
 						}
 					},
 					{
+						"limits.networks.uplink_ips.ipv4.NETWORK_NAME": {
+							"longdesc": "Maximum number of IPv4 addresses that this project can consume from the specified uplink network.\nThis number of IPs can be consumed by networks, forwards and load balancers in this project.\n",
+							"shortdesc": "Quota of IPv4 addresses from a specified uplink network that can be used by entities in this project",
+							"type": "string"
+						}
+					},
+					{
+						"limits.networks.uplink_ips.ipv6.NETWORK_NAME": {
+							"longdesc": "Maximum number of IPv6 addresses that this project can consume from the specified uplink network.\nThis number of IPs can be consumed by networks, forwards and load balancers in this project.\n",
+							"shortdesc": "Quota of IPv4 addresses from a specified uplink network that can be used by entities in this project",
+							"type": "string"
+						}
+					},
+					{
 						"limits.processes": {
 							"longdesc": "This value is the maximum value for the sum of the individual {config:option}`instance-resource-limits:limits.processes` configurations set on the instances of the project.",
 							"shortdesc": "Maximum number of processes within the project",

--- a/lxd/network/driver_common.go
+++ b/lxd/network/driver_common.go
@@ -15,6 +15,7 @@ import (
 	"github.com/canonical/lxd/lxd/db"
 	dbCluster "github.com/canonical/lxd/lxd/db/cluster"
 	"github.com/canonical/lxd/lxd/network/acl"
+	"github.com/canonical/lxd/lxd/project/limits"
 	"github.com/canonical/lxd/lxd/resources"
 	"github.com/canonical/lxd/lxd/state"
 	"github.com/canonical/lxd/shared"
@@ -827,6 +828,28 @@ func (n *common) bgpGetPeers(config map[string]string) []string {
 	}
 
 	return peers
+}
+
+// projectUplinkIPQuotaAvailable checks if a project has quota available to assign new uplink IPs in a certain network.
+func (n *common) projectUplinkIPQuotaAvailable(ctx context.Context, tx *db.ClusterTx, p *api.Project, uplinkName string) (ipv4QuotaAvailable bool, ipv6QuotaAvailable bool, err error) {
+	rawIPV4Quota, hasIPV4Quota := p.Config["limits.networks.uplink_ips.ipv4."+uplinkName]
+	rawIPV6Quota, hasIPV6Quota := p.Config["limits.networks.uplink_ips.ipv6."+uplinkName]
+
+	// Will be 0 if the limit is not set.
+	ipv4AddressLimit, _ := strconv.Atoi(rawIPV4Quota)
+	ipv6AddressLimit, _ := strconv.Atoi(rawIPV6Quota)
+
+	var ipv4QuotaMet bool
+	var ipv6QuotaMet bool
+
+	// If limit-1 is exceeded, than that means we have no quota available.
+	ipv4QuotaMet, ipv6QuotaMet, err = limits.UplinkAddressQuotasExceeded(ctx, tx, p.Name, uplinkName, ipv4AddressLimit-1, ipv6AddressLimit-1)
+	if err != nil {
+		return false, false, err
+	}
+
+	// Undefined quotas are always available.
+	return !hasIPV4Quota || !ipv4QuotaMet, !hasIPV6Quota || !ipv6QuotaMet, nil
 }
 
 // forwardValidate validates the forward request.

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -4731,6 +4731,8 @@ func (n *ovn) allocateUplinkAddress(listenIPAddress net.IP) (net.IP, error) {
 	// Load the project to get uplink network restrictions.
 	var p *api.Project
 	var uplink *api.Network
+	var ipv4QuotaAvailable bool
+	var ipv6QuotaAvailable bool
 
 	err := n.state.DB.Cluster.Transaction(n.state.ShutdownCtx, func(ctx context.Context, tx *db.ClusterTx) error {
 		project, err := dbCluster.GetProject(ctx, tx.Tx(), n.project)
@@ -4749,7 +4751,9 @@ func (n *ovn) allocateUplinkAddress(listenIPAddress net.IP) (net.IP, error) {
 			return fmt.Errorf("Failed to load uplink network %q: %w", n.config["network"], err)
 		}
 
-		return nil
+		// Check project quotas for uplink IPs in this uplink.
+		ipv4QuotaAvailable, ipv6QuotaAvailable, err = n.projectUplinkIPQuotaAvailable(ctx, tx, p, uplink.Name)
+		return err
 	})
 	if err != nil {
 		return nil, err
@@ -4764,6 +4768,13 @@ func (n *ovn) allocateUplinkAddress(listenIPAddress net.IP) (net.IP, error) {
 	projectRestrictedSubnets, err := n.projectRestrictedSubnets(p, n.config["network"])
 	if err != nil {
 		return nil, err
+	}
+
+	usingIPV6 := listenIPAddress.To4() == nil
+
+	// If there is no quota available for the required protocol, return an error.
+	if usingIPV6 && !ipv6QuotaAvailable || !usingIPV6 && !ipv4QuotaAvailable {
+		return nil, fmt.Errorf("Project quota for uplink IPs on network %q is exhausted", uplink.Name)
 	}
 
 	// We're auto-allocating the external IP address if the given listen address is unspecified.

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -431,6 +431,7 @@ var APIExtensions = []string{
 	"network_get_target",
 	"network_zones_all_projects",
 	"instance_root_volume_attachment",
+	"projects_limits_uplink_ips",
 }
 
 // APIExtensionsCount returns the number of available API extensions.

--- a/test/suites/network_ovn.sh
+++ b/test/suites/network_ovn.sh
@@ -235,6 +235,149 @@ test_network_ovn() {
   # Clean up.
   lxc delete c1 --force
   lxc network delete "${ovn_network}"
+
+  # Create project for following tests.
+  lxc project create testovn \
+    -c features.images=false \
+    -c features.profiles=false \
+    -c features.storage.volumes=false
+
+  lxc project switch testovn
+
+  # Project uplink IP limits are exclusive to projects with features.networks enabled.
+  ! lxc project set testovn limits.networks.uplink_ips.ipv4."${uplink_network}" 0 || false
+  ! lxc project set testovn limits.networks.uplink_ips.ipv6."${uplink_network}" 0 || false
+  lxc project set testovn features.networks true
+  lxc project set testovn limits.networks.uplink_ips.ipv4."${uplink_network}" 3
+  lxc project set testovn limits.networks.uplink_ips.ipv6."${uplink_network}" 3
+
+  # We cannot restrict a project with uplink IP limits set.
+  lxc project set testovn features.profiles true # Needed to restrict project
+  ! lxc project set testovn restricted true || false
+  lxc project unset testovn limits.networks.uplink_ips.ipv4."${uplink_network}"
+  lxc project unset testovn limits.networks.uplink_ips.ipv6."${uplink_network}"
+  lxc project set testovn restricted true
+
+  # We cannot set uplink IP limits on a restricted project unless the target network is in its allowed uplinks.
+  ! lxc project set testovn limits.networks.uplink_ips.ipv4."${uplink_network}" 1 || false
+  ! lxc project set testovn limits.networks.uplink_ips.ipv6."${uplink_network}" 1 || false
+  lxc project set testovn restricted.networks.uplinks="${uplink_network}"
+  lxc project set testovn limits.networks.uplink_ips.ipv4."${uplink_network}" 1
+  lxc project set testovn limits.networks.uplink_ips.ipv6."${uplink_network}" 1
+
+  # Project uplink IP limits have to be non negative numbers.
+  ! lxc project set testovn limits.networks.uplink_ips.ipv4."${uplink_network}" true || false
+  ! lxc project set testovn limits.networks.uplink_ips.ipv4."${uplink_network}" something || false
+  ! lxc project set testovn limits.networks.uplink_ips.ipv4."${uplink_network}" -1 || false
+  ! lxc project set testovn limits.networks.uplink_ips.ipv6."${uplink_network}" true || false
+  ! lxc project set testovn limits.networks.uplink_ips.ipv6."${uplink_network}" something || false
+  ! lxc project set testovn limits.networks.uplink_ips.ipv6."${uplink_network}" -1 || false
+
+  # Check project uplink IP limits are enforced on OVN network creation.
+  lxc network create first-ovn-network network="${uplink_network}"
+  ! lxc network create second-ovn-network network="${uplink_network}" --type=ovn || false
+  lxc network delete first-ovn-network
+  lxc network create second-ovn-network network="${uplink_network}" --type=ovn
+
+  # Only when both limits are relaxed, we are able to create another network.
+  ! lxc network create failed-ovn-network --project testovn --type=ovn || false
+  lxc project unset testovn limits.networks.uplink_ips.ipv6."${uplink_network}"
+  ! lxc network create failed-ovn-network --project testovn --type=ovn || false
+  lxc project set testovn limits.networks.uplink_ips.ipv4."${uplink_network}" 2
+  lxc network create third-ovn-network --project testovn --type=ovn
+
+  # Cannot set uplink IP limits lower than the currently used uplink IPs.
+  lxc project set testovn limits.networks.uplink_ips.ipv4."${uplink_network}" 3
+  lxc project set testovn limits.networks.uplink_ips.ipv6."${uplink_network}" 3
+  ! lxc project set testovn limits.networks.uplink_ips.ipv4."${uplink_network}" 1 || false
+  ! lxc project set testovn limits.networks.uplink_ips.ipv6."${uplink_network}" 1 || false
+  lxc network delete third-ovn-network --project testovn
+  lxc project set testovn limits.networks.uplink_ips.ipv4."${uplink_network}" 1
+
+  # Cannot set uplink IP limits for a network that is not suitable to be an uplink.
+  ! lxc project set testovn limits.networks.uplink_ips.ipv4.non-existent 2 || false
+  ! lxc project set testovn limits.networks.uplink_ips.ipv6.non-existent 2 || false
+  ! lxc project set testovn limits.networks.uplink_ips.ipv4.third-ovn-network 2 || false
+  ! lxc project set testovn limits.networks.uplink_ips.ipv6.third-ovn-network 2 || false
+
+  # A bit of cleanup.
+  lxc network delete second-ovn-network --project testovn
+  ! lxc project unset testovn restricted.networks.uplinks || false # Cannot unset while having limits set for the uplink network.
+  lxc project set testovn restricted false
+  lxc project unset testovn restricted.networks.uplinks
+  lxc project unset testovn limits.networks.uplink_ips.ipv4."${uplink_network}"
+  lxc project unset testovn limits.networks.uplink_ips.ipv6."${uplink_network}"
+  lxc project set testovn features.profiles false
+
+  # Create an OVN network.
+  project_ovn_network="project-ovn$$"
+  lxc network create "${project_ovn_network}" --type ovn network="${uplink_network}" \
+    ipv4.address=10.24.140.1/24 ipv4.nat=true \
+    ipv6.address=fd42:bd85:5f89:5293::1/64 ipv6.nat=true
+
+  # No forward can be created with a listen address that is not in the uplink's routes
+  ! lxc network forward create "${project_ovn_network}" 192.0.3.1 || false
+  ! lxc network forward create "${project_ovn_network}" 2001:db8:1:3::1 || false
+
+  # Create a couple of forwards without a target address.
+  lxc network forward create "${project_ovn_network}" 192.0.2.1
+  lxc network forward create "${project_ovn_network}" 2001:db8:1:2::1
+  [ "$(ovn-nbctl list load_balancer | grep -cF name)" = 0 ]
+
+  # Cannot set uplink IP limits lower than the currently used uplink IPs.
+  # There is one ovn network created and one forward of each protocol, so 2 IPs in use for each protocol.
+  ! lxc project set testovn limits.networks.uplink_ips.ipv4."${uplink_network}" 1 || false
+  ! lxc project set testovn limits.networks.uplink_ips.ipv6."${uplink_network}" 1 || false
+  lxc project set testovn limits.networks.uplink_ips.ipv4."${uplink_network}" 2
+  lxc project set testovn limits.networks.uplink_ips.ipv6."${uplink_network}" 2
+
+  # Check project uplink IP limits are enforced on network forward creation.
+  ! lxc network forward create "${project_ovn_network}" 192.0.2.2 || false
+  ! lxc network forward create "${project_ovn_network}" 2001:db8:1:2::2 || false
+  lxc project set testovn limits.networks.uplink_ips.ipv4."${uplink_network}" 3
+  lxc project set testovn limits.networks.uplink_ips.ipv6."${uplink_network}" 3
+  lxc network forward create "${project_ovn_network}" 192.0.2.2
+  lxc network forward create "${project_ovn_network}" 2001:db8:1:2::2
+
+  # Clean up
+  lxc network forward delete "${project_ovn_network}" 192.0.2.2
+  lxc network forward delete "${project_ovn_network}" 2001:db8:1:2::2
+  lxc project unset testovn limits.networks.uplink_ips.ipv4."${uplink_network}"
+  lxc project unset testovn limits.networks.uplink_ips.ipv6."${uplink_network}"
+  lxc network forward delete "${project_ovn_network}" 192.0.2.1
+  lxc network forward delete "${project_ovn_network}" 2001:db8:1:2::1
+
+  # No forward can be created with a listen address that is not in the uplink's routes
+  ! lxc network load-balancer create "${project_ovn_network}" 192.0.3.1 || false
+  ! lxc network load-balancer create "${project_ovn_network}" 2001:db8:1:3::1 || false
+
+  # Create a couple of load balancers.
+  lxc network load-balancer create "${project_ovn_network}" 192.0.2.1
+  lxc network load-balancer create "${project_ovn_network}" 2001:db8:1:2::1
+  [ "$(ovn-nbctl list load_balancer | grep -cF name)" = 0 ]
+
+  # Cannot set uplink IP limits lower than the currently used uplink IPs.
+  # There is one ovn network created and one load balancer for each protocol, so 2 IPs in use for each protocol.
+  ! lxc project set testovn limits.networks.uplink_ips.ipv4."${uplink_network}" 1 || false
+  ! lxc project set testovn limits.networks.uplink_ips.ipv6."${uplink_network}" 1 || false
+  lxc project set testovn limits.networks.uplink_ips.ipv4."${uplink_network}" 2
+  lxc project set testovn limits.networks.uplink_ips.ipv6."${uplink_network}" 2
+
+  # Check project uplink IP limits are enforced on load balancer creation.
+  ! lxc network load-balancer create "${project_ovn_network}" 192.0.2.2 || false
+  ! lxc network load-balancer create "${project_ovn_network}" 2001:db8:1:2::2 || false
+  lxc project set testovn limits.networks.uplink_ips.ipv4."${uplink_network}" 3
+  lxc project set testovn limits.networks.uplink_ips.ipv6."${uplink_network}" 3
+  lxc network load-balancer create "${project_ovn_network}" 192.0.2.2
+  lxc network load-balancer create "${project_ovn_network}" 2001:db8:1:2::2
+
+  # Clean up
+  lxc network load-balancer delete "${project_ovn_network}" 192.0.2.2
+  lxc network load-balancer delete "${project_ovn_network}" 2001:db8:1:2::2
+  lxc network delete "${project_ovn_network}"
+  lxc project switch default
+  lxc project delete testovn
+
   lxc network delete "${uplink_network}"
 
   # Validate northbound database is now empty.


### PR DESCRIPTION
Introduces per-network project uplink IP limits, adding a `limits.networks.uplink_ips.NETWORK_NAME` configuration key to projects.
This config key defines the maximum value of IPs made available on a network named NETWORK_NAME to be assigned as uplink IPs for entities inside a cetain project.