### PR TITLE
github: Use cohort="+" for trivy snap scan

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -95,7 +95,7 @@ jobs:
 
       - name: Download snap for scan
         run: |
-          snap download lxd --channel=${{ matrix.version }}/stable
+          snap download lxd --channel=${{ matrix.version }}/stable --cohort="+"
           unsquashfs ./lxd*.snap
 
       - name: Run Trivy vulnerability scanner


### PR DESCRIPTION
So that we get the latest version when rolling out new releases.