### PR TITLE
Device: Rework `ueventParseVendorProduct` logic

### DIFF
--- a/lxd/devices.go
+++ b/lxd/devices.go
@@ -697,25 +697,24 @@ func ueventParseVendorProduct(props map[string]string, subsystem string, devname
 		return vendor, product, true
 	}
 
-	if subsystem != "hidraw" {
-		return "", "", false
-	}
+	// Retrieve missing device info.
+	if subsystem == "hidraw" {
+		if !filepath.IsAbs(devname) {
+			return "", "", false
+		}
 
-	if !filepath.IsAbs(devname) {
-		return "", "", false
-	}
+		file, err := os.OpenFile(devname, os.O_RDWR, 0000)
+		if err != nil {
+			return "", "", false
+		}
 
-	file, err := os.OpenFile(devname, os.O_RDWR, 0000)
-	if err != nil {
-		return "", "", false
-	}
+		defer func() { _ = file.Close() }()
 
-	defer func() { _ = file.Close() }()
-
-	vendor, product, err = getHidrawDevInfo(int(file.Fd()))
-	if err != nil {
-		logger.Debugf("Failed to retrieve device info from hidraw device \"%s\"", devname)
-		return "", "", false
+		vendor, product, err = getHidrawDevInfo(int(file.Fd()))
+		if err != nil {
+			logger.Debugf("Failed to retrieve device info from hidraw device \"%s\"", devname)
+			return "", "", false
+		}
 	}
 
 	return vendor, product, true

--- a/lxd/devices.go
+++ b/lxd/devices.go
@@ -712,7 +712,7 @@ func ueventParseVendorProduct(props map[string]string, subsystem string, devname
 
 		vendor, product, err = getHidrawDevInfo(int(file.Fd()))
 		if err != nil {
-			logger.Debugf("Failed to retrieve device info from hidraw device \"%s\"", devname)
+			logger.Debugf("Failed to retrieve device info from hidraw device %q", devname)
 			return "", "", false
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/canonical/lxd/issues/14591.

This PR reworks the logic in `ueventParseVendorProduct` to allow adding `unix-hotplug` devices with only `subsystem` specified. Rather than an early return for devices with subsystems that don't match `hidraw`, we gather the missing device info (`vendorid`/`productid`) when device system is `hidraw`. Otherwise, the `vendorid` and `productid` found in the config are returned.