### PR TITLE
Check default osd pool size before setting on create.

### DIFF
--- a/lxd/storage/drivers/driver_ceph.go
+++ b/lxd/storage/drivers/driver_ceph.go
@@ -115,26 +115,12 @@ func (d *ceph) FillConfig() error {
 	}
 
 	if d.config["ceph.osd.pool_size"] == "" {
-		size, err := shared.TryRunCommand("ceph",
-			"--name", "client."+d.config["ceph.user.name"],
-			"--cluster", d.config["ceph.cluster_name"],
-			"config",
-			"get",
-			"mon",
-			"osd_pool_default_size",
-			"--format",
-			"json")
+		defaultSize, err := d.getOSDPoolDefaultSize()
 		if err != nil {
 			return err
 		}
 
-		var sizeInt int
-		err = json.Unmarshal([]byte(size), &sizeInt)
-		if err != nil {
-			return err
-		}
-
-		d.config["ceph.osd.pool_size"] = strconv.Itoa(sizeInt)
+		d.config["ceph.osd.pool_size"] = strconv.Itoa(defaultSize)
 	}
 
 	return nil

--- a/lxd/storage/drivers/driver_cephfs.go
+++ b/lxd/storage/drivers/driver_cephfs.go
@@ -1,7 +1,6 @@
 package drivers
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -213,18 +212,25 @@ func (d *cephfs) Create() error {
 					)
 				})
 
-				_, err = shared.TryRunCommand("ceph",
-					"--name", "client."+d.config["cephfs.user.name"],
-					"--cluster", d.config["cephfs.cluster_name"],
-					"osd",
-					"pool",
-					"set",
-					pool,
-					"size",
-					d.config["cephfs.osd_pool_size"],
-					"--yes-i-really-mean-it")
+				defaultSize, err := d.getOSDPoolDefaultSize()
 				if err != nil {
 					return err
+				}
+
+				if strconv.Itoa(defaultSize) != d.config["cephfs.osd_pool_size"] {
+					_, err = shared.TryRunCommand("ceph",
+						"--name", "client."+d.config["cephfs.user.name"],
+						"--cluster", d.config["cephfs.cluster_name"],
+						"osd",
+						"pool",
+						"set",
+						pool,
+						"size",
+						d.config["cephfs.osd_pool_size"],
+						"--yes-i-really-mean-it")
+					if err != nil {
+						return err
+					}
 				}
 			}
 		}

--- a/lxd/storage/drivers/driver_cephfs.go
+++ b/lxd/storage/drivers/driver_cephfs.go
@@ -105,26 +105,12 @@ func (d *cephfs) FillConfig() error {
 	}
 
 	if d.config["cephfs.osd_pool_size"] == "" {
-		size, err := shared.TryRunCommand("ceph",
-			"--name", "client."+d.config["cephfs.user.name"],
-			"--cluster", d.config["cephfs.cluster_name"],
-			"config",
-			"get",
-			"mon",
-			"osd_pool_default_size",
-			"--format",
-			"json")
+		defaultSize, err := d.getOSDPoolDefaultSize()
 		if err != nil {
 			return err
 		}
 
-		var sizeInt int
-		err = json.Unmarshal([]byte(size), &sizeInt)
-		if err != nil {
-			return err
-		}
-
-		d.config["cephfs.osd_pool_size"] = strconv.Itoa(sizeInt)
+		d.config["cephfs.osd_pool_size"] = strconv.Itoa(defaultSize)
 	}
 
 	return nil


### PR DESCRIPTION
Fixes `lxd-ci` pipeline errors from `mon_allow_pool_size_one` not being set