### PR TITLE
doc: fix lxc network load-balancer backend add command syntax

### DIFF
--- a/doc/howto/network_load_balancers.md
+++ b/doc/howto/network_load_balancers.md
@@ -59,7 +59,7 @@ The backend target address must be within the same subnet as the network that th
 Use the following command to add a backend specification:
 
 ```bash
-lxc network load-balancer backend add <network_name> <listen_address> <backend_name> <listen_ports> <target_address> [<target_ports>]
+lxc network load-balancer backend add <network_name> <listen_address> <backend_name> <target_address> [<target_ports>]
 ```
 
 The target ports are optional.


### PR DESCRIPTION
This PR removes an unnecessary <listen_ports> option in the syntax for `lxc network load-balancer backend add`. This is correct in [the man page](https://documentation.ubuntu.com/lxd/en/latest/reference/manpages/lxc/network/load-balancer/backend/add/) but incorrect in [the how-to guide this PR fixes](https://documentation.ubuntu.com/lxd/en/latest/howto/network_load_balancers/#configure-backends). There is no `listen_ports` backend property. `listen_ports` is a port property that is used in `lxc network load-balancer port add`. 