### PR TITLE
lxd: Deny creation of empty ISO volume

### DIFF
--- a/doc/explanation/storage.md
+++ b/doc/explanation/storage.md
@@ -161,7 +161,7 @@ Each storage volume uses one of the following content types:
 
 `iso`
 : This content type is used for custom ISO volumes.
-  A custom storage volume of type `iso` can only be created by importing an ISO file using [`lxc storage volume import`](lxc_storage_volume_import.md).
+  A custom storage volume of type `iso` can only be created by importing an ISO file using [`lxc storage volume import`](lxc_storage_volume_import.md) or by copying another volume.
 
   Custom storage volumes of content type `iso` can only be attached to virtual machines.
   They can be attached to multiple machines simultaneously as they are always read-only.

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -1094,6 +1094,11 @@ func storagePoolVolumesPost(d *Daemon, r *http.Request) response.Response {
 
 	switch req.Source.Type {
 	case "":
+		// Makes no sense to create an empty ISO volume.
+		if req.ContentType == "iso" {
+			return response.BadRequest(errors.New("Creation of empty iso volumes is not allowed, either copy or import"))
+		}
+
 		return doVolumeCreateOrCopy(s, r, requestProjectName, projectName, poolName, &req)
 	case "copy":
 		if dbVolume != nil {

--- a/test/suites/storage_local_volume_handling.sh
+++ b/test/suites/storage_local_volume_handling.sh
@@ -132,6 +132,9 @@ test_storage_local_volume_handling() {
     lxc storage volume move "${pool}1/vol1" "${pool}1/vol1" --project "${project}" --target-project default
     lxc storage volume show "${pool}1" vol1 --project default
 
+    # Create empty ISO volumes is not allowed
+    ! lxc storage volume create "${pool}" isoVol --type=iso || false
+
     # Create new pools
     lxc storage create pool_1 dir
     lxc storage create pool_2 dir


### PR DESCRIPTION
I noticed `lxc storage volume create "${pool}" isoVol --type=iso` worked inconsistently across drivers. Which led me to see that, according to the docs: `A custom storage volume of type `iso` can only be created by importing an ISO file using`, which makes sense because an empty ISO volume is useless AFAIK. So this implements this prohibition of creating empty ISO volumes.