### PR TITLE
lxd: Remove lint exception for defer rule.

### DIFF
--- a/lxd/api_internal.go
+++ b/lxd/api_internal.go
@@ -902,7 +902,7 @@ func internalImportFromBackup(s *state.State, projectName string, instName strin
 		}
 
 		revert.Add(cleanup)
-		defer snapInstOp.Done(err) //nolint:revive
+		defer snapInstOp.Done(err)
 
 		// Recreate missing mountpoints and symlinks.
 		volStorageName := project.Instance(projectName, snapInstName)


### PR DESCRIPTION
The defer rule was removed from our golangci-lint configuration in 0b3a0941185bad6b52808c30c313aff08d41742d. With this change, the defer in this function (which is called in a for loop) no longer needs to be ignored by the linter.

The defer rule was originally removed because refactoring existing code to stop calling defer within loops was resulting in subtle bugs that were hard to reason about.

We have extensive tests for LXD, so we should:
- Avoid calling defer inside a for loop, and watch for these in pull requests.
- Focus on improving code quality from a TICS perspective first.

Closes #12854 