### PR TITLE
Fix typo: Reusuable -> Reusable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -241,13 +241,13 @@ po/%.mo: po/%.po
 	msgfmt --statistics -o $@ $<
 
 po/%.po: po/$(DOMAIN).pot
-	msgmerge -U po/$*.po po/$(DOMAIN).pot
+	msgmerge --silent -U po/$*.po po/$(DOMAIN).pot
 
 .PHONY: update-po
 update-po:
 	set -eu; \
 	for lang in $(LINGUAS); do \
-		msgmerge --backup=none -U $$lang.po po/$(DOMAIN).pot; \
+		msgmerge --silent --backup=none -U $$lang.po po/$(DOMAIN).pot; \
 	done; \
 	if [ -t 0 ] && ! git diff --quiet -- po/*.po; then \
 		read -rp "Would you like to commit i18n changes (Y/n)? " answer; \

--- a/Makefile
+++ b/Makefile
@@ -295,13 +295,13 @@ endif
 	shellcheck test/*.sh test/includes/*.sh test/suites/*.sh test/backends/*.sh test/lint/*.sh test/extras/*.sh
 	NOT_EXEC="$(shell find test/lint -type f -not -executable)"; \
 	if [ -n "$$NOT_EXEC" ]; then \
-        echo "lint scripts not executable: $$NOT_EXEC"; \
-        exit 1; \
+		echo "lint scripts not executable: $$NOT_EXEC"; \
+		exit 1; \
 	fi
 	BAD_NAME="$(shell find test/lint -type f -not -name '*.sh')"; \
 	if [ -n "$$BAD_NAME" ]; then \
-        echo "lint scripts missing .sh extension: $$BAD_NAME"; \
-        exit 1; \
+		echo "lint scripts missing .sh extension: $$BAD_NAME"; \
+		exit 1; \
 	fi
 	run-parts --verbose --exit-on-error --regex '.sh' test/lint
 

--- a/Makefile
+++ b/Makefile
@@ -246,8 +246,8 @@ po/%.po: po/$(DOMAIN).pot
 .PHONY: update-po
 update-po:
 	set -eu; \
-	for lang in $(LINGUAS); do\
-	    msgmerge --backup=none -U $$lang.po po/$(DOMAIN).pot; \
+	for lang in $(LINGUAS); do \
+		msgmerge --backup=none -U $$lang.po po/$(DOMAIN).pot; \
 	done; \
 	if [ -t 0 ] && ! git diff --quiet -- po/*.po; then \
 		read -rp "Would you like to commit i18n changes (Y/n)? " answer; \

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -2376,7 +2376,7 @@ func (d *lxc) Start(stateful bool) error {
 	// Setup a new operation.
 	op, err := operationlock.CreateWaitGet(d.Project().Name, d.Name(), operationlock.ActionStart, []operationlock.Action{operationlock.ActionRestart, operationlock.ActionRestore}, false, false)
 	if err != nil {
-		if errors.Is(err, operationlock.ErrNonReusuableSucceeded) {
+		if errors.Is(err, operationlock.ErrNonReusableSucceeded) {
 			// An existing matching operation has now succeeded, return.
 			return nil
 		}
@@ -2630,7 +2630,7 @@ func (d *lxc) Stop(stateful bool) error {
 	// Setup a new operation
 	op, err := operationlock.CreateWaitGet(d.Project().Name, d.Name(), operationlock.ActionStop, []operationlock.Action{operationlock.ActionRestart, operationlock.ActionRestore}, false, true)
 	if err != nil {
-		if errors.Is(err, operationlock.ErrNonReusuableSucceeded) {
+		if errors.Is(err, operationlock.ErrNonReusableSucceeded) {
 			// An existing matching operation has now succeeded, return.
 			return nil
 		}
@@ -2813,7 +2813,7 @@ func (d *lxc) Shutdown(timeout time.Duration) error {
 	// Setup a new operation
 	op, err := operationlock.CreateWaitGet(d.Project().Name, d.Name(), operationlock.ActionStop, []operationlock.Action{operationlock.ActionRestart}, true, true)
 	if err != nil {
-		if errors.Is(err, operationlock.ErrNonReusuableSucceeded) {
+		if errors.Is(err, operationlock.ErrNonReusableSucceeded) {
 			// An existing matching operation has now succeeded, return.
 			return nil
 		}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -684,7 +684,7 @@ func (d *qemu) Shutdown(timeout time.Duration) error {
 	// of its operations. This allow for multiple Shutdown() attempts.
 	op, err := operationlock.CreateWaitGet(d.Project().Name, d.Name(), operationlock.ActionStop, []operationlock.Action{operationlock.ActionRestart}, true, true)
 	if err != nil {
-		if errors.Is(err, operationlock.ErrNonReusuableSucceeded) {
+		if errors.Is(err, operationlock.ErrNonReusableSucceeded) {
 			// An existing matching operation has now succeeded, return.
 			return nil
 		}
@@ -1104,7 +1104,7 @@ func (d *qemu) start(stateful bool, op *operationlock.InstanceOperation) error {
 	if op == nil {
 		op, err = operationlock.CreateWaitGet(d.Project().Name, d.Name(), operationlock.ActionStart, []operationlock.Action{operationlock.ActionRestart, operationlock.ActionRestore}, false, false)
 		if err != nil {
-			if errors.Is(err, operationlock.ErrNonReusuableSucceeded) {
+			if errors.Is(err, operationlock.ErrNonReusableSucceeded) {
 				// An existing matching operation has now succeeded, return.
 				return nil
 			}
@@ -4839,7 +4839,7 @@ func (d *qemu) Stop(stateful bool) error {
 	// of its operations. This allow for Stop() to inherit from Shutdown() where instance is stuck.
 	op, err := operationlock.CreateWaitGet(d.Project().Name, d.Name(), operationlock.ActionStop, []operationlock.Action{operationlock.ActionRestart, operationlock.ActionRestore}, false, true)
 	if err != nil {
-		if errors.Is(err, operationlock.ErrNonReusuableSucceeded) {
+		if errors.Is(err, operationlock.ErrNonReusableSucceeded) {
 			// An existing matching operation has now succeeded, return.
 			return nil
 		}

--- a/test/lint/i18n-up-to-date.sh
+++ b/test/lint/i18n-up-to-date.sh
@@ -10,7 +10,7 @@ echo "Checking that the .pot files are up to date..."
 # make sure the .pot is updated
 hash1=$(safe_pot_hash)
 mv "po/lxd.pot" "po/lxd.pot.bak"
-make i18n -s
+make i18n --silent < /dev/null
 hash2=$(safe_pot_hash)
 mv "po/lxd.pot.bak" "po/lxd.pot"
 git checkout -- po/*.po

--- a/test/lint/licenses.sh
+++ b/test/lint/licenses.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 set -eu
 
+cleanup() {
+    # Restore COPYING into place
+    git restore -- COPYING
+}
+trap cleanup EXIT HUP INT TERM
+
 # Check LXD doesn't include non-permissive licenses (except for itself).
-mv COPYING COPYING.tmp
 cp client/COPYING COPYING
 go-licenses check ./...
-mv COPYING.tmp COPYING
-
-

--- a/test/lint/metadata-up-to-date.sh
+++ b/test/lint/metadata-up-to-date.sh
@@ -21,7 +21,7 @@ echo "Checking that the metadata is up to date..."
 metadata_hash "$hash_before"
 cp "${json_metadata}" "${json_metadata}.bak"
 cp "${doc_config_options}" "${doc_config_options}.bak"
-make update-metadata -s
+make update-metadata --silent 2>&1 | grep -vF ' Found lxddoc at '
 metadata_hash "$hash_after"
 mv "${json_metadata}.bak" "${json_metadata}"
 mv "${doc_config_options}.bak" "${doc_config_options}"

--- a/test/lint/metadata-up-to-date.sh
+++ b/test/lint/metadata-up-to-date.sh
@@ -19,12 +19,9 @@ echo "Checking that the metadata is up to date..."
 
 # make sure the YAML metadata file and the documentation config option file are up to date
 metadata_hash "$hash_before"
-cp "${json_metadata}" "${json_metadata}.bak"
-cp "${doc_config_options}" "${doc_config_options}.bak"
 make update-metadata --silent 2>&1 | grep -vF ' Found lxddoc at '
 metadata_hash "$hash_after"
-mv "${json_metadata}.bak" "${json_metadata}"
-mv "${doc_config_options}.bak" "${doc_config_options}"
+git restore -- "${json_metadata}" "${doc_config_options}"
 
 d="$(diff -Nau "$hash_before" "$hash_after" || true)"
 rm "$hash_before" "$hash_after"

--- a/test/lint/test-tests.sh
+++ b/test/lint/test-tests.sh
@@ -5,6 +5,8 @@ set -o pipefail
 # This is a meta-test as it tests the tests themselves. It makes sure that all
 # the exising test functions are being called by the test suite.
 
+# It also check there are no invalid test constructs like: `! cmd_should_fail || true`
+
 # Ensure predictable sorting
 export LC_ALL=C.UTF-8
 
@@ -49,3 +51,10 @@ diff -Nau "${CALLED_TESTS}" "${EXISTING_TESTS}"
 
 # Cleanup
 rm -f "${CALLED_TESTS}" "${EXISTING_TESTS}" "${SKIPPED_TESTS}" "${REQUIRED_TESTS}"
+
+
+# Check for invalid test constructs
+if grep -rlE '\!.* \|\| true$' test/; then
+    echo "Some tests commands are ignoring expected failures (! cmd_should_fail || true)" >&2
+    exit 1
+fi


### PR DESCRIPTION
I added some "quality of life" improvement to our `make static-analysis` target after looking at the `revive` error flagged during CI.