### PR TITLE
CLI: Add dynamic `lxc config unset` shell completions for server config keys

### DIFF
--- a/lxc/completion.go
+++ b/lxc/completion.go
@@ -389,9 +389,9 @@ func (g *cmdGlobal) cmpInstanceSetKeys(instanceName string) ([]string, cobra.She
 }
 
 // cmpServerAllKeys provides shell completion for all server configuration keys.
-// It takes an instance name and returns a list of all server configuration keys along with a shell completion directive.
-func (g *cmdGlobal) cmpServerAllKeys(instanceName string) ([]string, cobra.ShellCompDirective) {
-	resources, err := g.ParseServers(instanceName)
+// It takes a partial input string and returns a list of all server configuration keys along with a shell completion directive.
+func (g *cmdGlobal) cmpServerAllKeys(toComplete string) ([]string, cobra.ShellCompDirective) {
+	resources, err := g.ParseServers(toComplete)
 	if err != nil || len(resources) == 0 {
 		return nil, cobra.ShellCompDirectiveError
 	}

--- a/lxc/config.go
+++ b/lxc/config.go
@@ -24,7 +24,7 @@ type cmdConfig struct {
 	flagTarget string
 }
 
-// Command creates a Cobra command for managing instance and server configurations,
+// command creates a Cobra command for managing instance and server configurations,
 // including options for device, edit, get, metadata, profile, set, show, template, trust, and unset.
 func (c *cmdConfig) command() *cobra.Command {
 	cmd := &cobra.Command{}
@@ -92,7 +92,7 @@ type cmdConfigEdit struct {
 	config *cmdConfig
 }
 
-// Command creates a Cobra command to edit instance or server configurations using YAML, with optional flags for targeting cluster members.
+// command creates a Cobra command to edit instance or server configurations using YAML, with optional flags for targeting cluster members.
 func (c *cmdConfigEdit) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("edit", i18n.G("[<remote>:][<instance>[/<snapshot>]]"))
@@ -139,7 +139,7 @@ func (c *cmdConfigEdit) helpTemplate() string {
 ### Note that the name is shown but cannot be changed`)
 }
 
-// Run executes the config edit command, allowing users to edit instance or server configurations via an interactive YAML editor.
+// run executes the config edit command, allowing users to edit instance or server configurations via an interactive YAML editor.
 func (c *cmdConfigEdit) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 0, 1)
@@ -384,7 +384,7 @@ type cmdConfigGet struct {
 	flagIsProperty bool
 }
 
-// Command creates a Cobra command to fetch values for given instance or server configuration keys,
+// command creates a Cobra command to fetch values for given instance or server configuration keys,
 // with optional flags for expanded configuration and cluster targeting.
 func (c *cmdConfigGet) command() *cobra.Command {
 	cmd := &cobra.Command{}
@@ -417,7 +417,7 @@ func (c *cmdConfigGet) command() *cobra.Command {
 	return cmd
 }
 
-// Run fetches and prints the specified configuration key's value for an instance or server, also handling target and expansion flags.
+// run fetches and prints the specified configuration key's value for an instance or server, also handling target and expansion flags.
 func (c *cmdConfigGet) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 2)
@@ -534,7 +534,7 @@ type cmdConfigSet struct {
 	flagIsProperty bool
 }
 
-// Command creates a new Cobra command to set instance or server configuration keys and returns it.
+// command creates a new Cobra command to set instance or server configuration keys and returns it.
 func (c *cmdConfigSet) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("set", i18n.G("[<remote>:][<instance>] <key>=<value>..."))
@@ -574,7 +574,7 @@ lxc config set core.https_address=[::]:8443
 	return cmd
 }
 
-// Run executes the "set" command, updating instance or server configuration keys based on provided arguments.
+// run executes the "set" command, updating instance or server configuration keys based on provided arguments.
 func (c *cmdConfigSet) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, -1)
@@ -764,7 +764,7 @@ type cmdConfigShow struct {
 	flagExpanded bool
 }
 
-// Command sets up the "show" command, which displays instance or server configurations based on the provided arguments.
+// command sets up the "show" command, which displays instance or server configurations based on the provided arguments.
 func (c *cmdConfigShow) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("show", i18n.G("[<remote>:][<instance>[/<snapshot>]]"))
@@ -787,7 +787,7 @@ func (c *cmdConfigShow) command() *cobra.Command {
 	return cmd
 }
 
-// Run executes the "show" command, displaying the YAML-formatted configuration of a specified server or instance.
+// run executes the "show" command, displaying the YAML-formatted configuration of a specified server or instance.
 func (c *cmdConfigShow) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 0, 1)
@@ -896,7 +896,7 @@ type cmdConfigUnset struct {
 	flagIsProperty bool
 }
 
-// Command generates a new "unset" command to remove specific configuration keys for an instance or server.
+// command generates a new "unset" command to remove specific configuration keys for an instance or server.
 func (c *cmdConfigUnset) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("unset", i18n.G("[<remote>:][<instance>] <key>"))
@@ -929,7 +929,7 @@ func (c *cmdConfigUnset) command() *cobra.Command {
 	return cmd
 }
 
-// Run executes the "unset" command, delegating to the "set" command to remove specific configuration keys.
+// run executes the "unset" command, delegating to the "set" command to remove specific configuration keys.
 func (c *cmdConfigUnset) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 2)
@@ -948,7 +948,7 @@ type cmdConfigUefi struct {
 	config *cmdConfig
 }
 
-// Command creates a Cobra command for managing virtual machine instance UEFI variables,
+// command creates a Cobra command for managing virtual machine instance UEFI variables,
 // including options for get, set, unset, show, edit.
 func (c *cmdConfigUefi) command() *cobra.Command {
 	cmd := &cobra.Command{}
@@ -989,7 +989,7 @@ type cmdConfigUefiGet struct {
 	configUefi *cmdConfigUefi
 }
 
-// Command creates a Cobra command to fetch virtual machine instance UEFI variables.
+// command creates a Cobra command to fetch virtual machine instance UEFI variables.
 func (c *cmdConfigUefiGet) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("get", i18n.G("[<remote>:]<instance> <key>"))
@@ -1002,7 +1002,7 @@ func (c *cmdConfigUefiGet) command() *cobra.Command {
 	return cmd
 }
 
-// Run fetches and prints the specified UEFI variable's value.
+// run fetches and prints the specified UEFI variable's value.
 func (c *cmdConfigUefiGet) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
@@ -1044,7 +1044,7 @@ type cmdConfigUefiSet struct {
 	configUefi *cmdConfigUefi
 }
 
-// Command creates a new Cobra command to set virtual machine instance UEFI variables.
+// command creates a new Cobra command to set virtual machine instance UEFI variables.
 func (c *cmdConfigUefiSet) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("set", i18n.G("[<remote>:]<instance> <key>=<value>..."))
@@ -1060,7 +1060,7 @@ func (c *cmdConfigUefiSet) command() *cobra.Command {
 	return cmd
 }
 
-// Run executes the "set" command, updating virtual machine instance UEFI variables based on provided arguments.
+// run executes the "set" command, updating virtual machine instance UEFI variables based on provided arguments.
 func (c *cmdConfigUefiSet) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, -1)
@@ -1135,7 +1135,7 @@ type cmdConfigUefiUnset struct {
 	configSet  *cmdConfigUefiSet
 }
 
-// Command generates a new "unset" command to remove specific virtual machine instance UEFI variable.
+// command generates a new "unset" command to remove specific virtual machine instance UEFI variable.
 func (c *cmdConfigUefiUnset) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("unset", i18n.G("[<remote>:]<instance> <key>"))
@@ -1148,7 +1148,7 @@ func (c *cmdConfigUefiUnset) command() *cobra.Command {
 	return cmd
 }
 
-// Run executes the "unset" command, delegating to the "set" command to remove specific UEFI variable.
+// run executes the "unset" command, delegating to the "set" command to remove specific UEFI variable.
 func (c *cmdConfigUefiUnset) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
@@ -1166,7 +1166,7 @@ type cmdConfigUefiShow struct {
 	configUefi *cmdConfigUefi
 }
 
-// Command sets up the "show" command, which displays virtual machine instance UEFI variables based on the provided arguments.
+// command sets up the "show" command, which displays virtual machine instance UEFI variables based on the provided arguments.
 func (c *cmdConfigUefiShow) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("show", i18n.G("[<remote>:]<instance>"))
@@ -1179,7 +1179,7 @@ func (c *cmdConfigUefiShow) command() *cobra.Command {
 	return cmd
 }
 
-// Run executes the "show" command, displaying the YAML-formatted configuration of a virtual machine instance UEFI variables.
+// run executes the "show" command, displaying the YAML-formatted configuration of a virtual machine instance UEFI variables.
 func (c *cmdConfigUefiShow) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 1)
@@ -1220,7 +1220,7 @@ type cmdConfigUefiEdit struct {
 	configUefi *cmdConfigUefi
 }
 
-// Command creates a Cobra command to edit virtual machine instance UEFI variables.
+// command creates a Cobra command to edit virtual machine instance UEFI variables.
 func (c *cmdConfigUefiEdit) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = usage("edit", i18n.G("[<remote>:]<instance>"))
@@ -1271,7 +1271,7 @@ func (c *cmdConfigUefiEdit) helpTemplate() string {
 ###`)
 }
 
-// Run executes the config edit command, allowing users to edit virtual machine instance UEFI variables via an interactive YAML editor.
+// run executes the config edit command, allowing users to edit virtual machine instance UEFI variables via an interactive YAML editor.
 func (c *cmdConfigUefiEdit) run(cmd *cobra.Command, args []string) error {
 	// Quick checks.
 	exit, err := c.global.CheckArgs(cmd, args, 1, 1)

--- a/lxc/config.go
+++ b/lxc/config.go
@@ -911,7 +911,8 @@ func (c *cmdConfigUnset) command() *cobra.Command {
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
 			if strings.Contains(toComplete, ".") {
-				return c.global.cmpServerAllKeys(toComplete)
+				// Only complete config keys which are currently set.
+				return c.global.cmpServerSetKeys(toComplete)
 			}
 
 			return c.global.cmpInstances(toComplete)


### PR DESCRIPTION
Resolves https://github.com/canonical/lxd/issues/14647.

Adds the `cmpServerSetKeys` function for improved `lxc config unset` completions - only server config keys that are currently set will be completed when running `lxc config unset`.