### PR TITLE
Add `--format` flag to `lxd sql`

### DIFF
--- a/lxd/main.go
+++ b/lxd/main.go
@@ -209,7 +209,7 @@ func main() {
 
 	// sql sub-command
 	sqlCmd := cmdSql{global: &globalCmd}
-	app.AddCommand(sqlCmd.Command())
+	app.AddCommand(sqlCmd.command())
 
 	// version sub-command
 	versionCmd := cmdVersion{global: &globalCmd}

--- a/lxd/main.go
+++ b/lxd/main.go
@@ -208,7 +208,7 @@ func main() {
 	app.AddCommand(shutdownCmd.Command())
 
 	// sql sub-command
-	sqlCmd := cmdSql{global: &globalCmd}
+	sqlCmd := cmdSQL{global: &globalCmd}
 	app.AddCommand(sqlCmd.command())
 
 	// version sub-command

--- a/lxd/main_sql.go
+++ b/lxd/main_sql.go
@@ -161,7 +161,7 @@ func sqlPrintSelectResult(format string, result internalSQLResult) error {
 	for _, row := range result.Rows {
 		r := make([]string, 0, len(row))
 		for _, col := range row {
-			r = append(r, fmt.Sprintf("%v", col))
+			r = append(r, fmt.Sprint(col))
 		}
 
 		data = append(data, r)

--- a/lxd/main_sql.go
+++ b/lxd/main_sql.go
@@ -6,15 +6,16 @@ import (
 	"io"
 	"os"
 
-	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 
 	"github.com/canonical/lxd/client"
 	"github.com/canonical/lxd/shared"
+	cli "github.com/canonical/lxd/shared/cmd"
 )
 
 type cmdSql struct {
-	global *cmdGlobal
+	global     *cmdGlobal
+	flagFormat string
 }
 
 func (c *cmdSql) Command() *cobra.Command {
@@ -52,6 +53,7 @@ func (c *cmdSql) Command() *cobra.Command {
 `
 	cmd.RunE = c.Run
 	cmd.Hidden = true
+	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", cli.TableFormatSQLResult, `Format (sql|csv|json|table|yaml|compact) (default "sql")`)
 
 	return cmd
 }
@@ -139,7 +141,10 @@ func (c *cmdSql) Run(cmd *cobra.Command, args []string) error {
 		}
 
 		if result.Type == "select" {
-			sqlPrintSelectResult(result)
+			err = sqlPrintSelectResult(c.flagFormat, result)
+			if err != nil {
+				return err
+			}
 		} else {
 			fmt.Printf("Rows affected: %d\n", result.RowsAffected)
 		}
@@ -151,20 +156,16 @@ func (c *cmdSql) Run(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func sqlPrintSelectResult(result internalSQLResult) {
-	table := tablewriter.NewWriter(os.Stdout)
-	table.SetAlignment(tablewriter.ALIGN_LEFT)
-	table.SetAutoWrapText(false)
-	table.SetAutoFormatHeaders(false)
-	table.SetHeader(result.Columns)
+func sqlPrintSelectResult(format string, result internalSQLResult) error {
+	data := make([][]string, 0, len(result.Rows))
 	for _, row := range result.Rows {
-		data := []string{}
+		r := make([]string, 0, len(row))
 		for _, col := range row {
-			data = append(data, fmt.Sprintf("%v", col))
+			r = append(r, fmt.Sprintf("%v", col))
 		}
 
-		table.Append(data)
+		data = append(data, r)
 	}
 
-	table.Render()
+	return cli.RenderTable(format, result.Columns, data, result)
 }

--- a/lxd/main_sql.go
+++ b/lxd/main_sql.go
@@ -13,12 +13,12 @@ import (
 	cli "github.com/canonical/lxd/shared/cmd"
 )
 
-type cmdSql struct {
+type cmdSQL struct {
 	global     *cmdGlobal
 	flagFormat string
 }
 
-func (c *cmdSql) command() *cobra.Command {
+func (c *cmdSQL) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = "sql <local|global> <query>"
 	cmd.Short = "Execute a SQL query against the LXD local or global database"
@@ -58,7 +58,7 @@ func (c *cmdSql) command() *cobra.Command {
 	return cmd
 }
 
-func (c *cmdSql) run(cmd *cobra.Command, args []string) error {
+func (c *cmdSQL) run(cmd *cobra.Command, args []string) error {
 	if len(args) != 2 {
 		_ = cmd.Help()
 

--- a/lxd/main_sql.go
+++ b/lxd/main_sql.go
@@ -18,7 +18,7 @@ type cmdSql struct {
 	flagFormat string
 }
 
-func (c *cmdSql) Command() *cobra.Command {
+func (c *cmdSql) command() *cobra.Command {
 	cmd := &cobra.Command{}
 	cmd.Use = "sql <local|global> <query>"
 	cmd.Short = "Execute a SQL query against the LXD local or global database"
@@ -51,14 +51,14 @@ func (c *cmdSql) Command() *cobra.Command {
   This command targets the global LXD database and works in both local
   and cluster mode.
 `
-	cmd.RunE = c.Run
+	cmd.RunE = c.run
 	cmd.Hidden = true
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", cli.TableFormatSQLResult, `Format (sql|csv|json|table|yaml|compact) (default "sql")`)
 
 	return cmd
 }
 
-func (c *cmdSql) Run(cmd *cobra.Command, args []string) error {
+func (c *cmdSql) run(cmd *cobra.Command, args []string) error {
 	if len(args) != 2 {
 		_ = cmd.Help()
 

--- a/shared/cmd/table.go
+++ b/shared/cmd/table.go
@@ -15,11 +15,12 @@ import (
 
 // Table list format.
 const (
-	TableFormatCSV     = "csv"
-	TableFormatJSON    = "json"
-	TableFormatTable   = "table"
-	TableFormatYAML    = "yaml"
-	TableFormatCompact = "compact"
+	TableFormatCSV       = "csv"
+	TableFormatJSON      = "json"
+	TableFormatTable     = "table"
+	TableFormatYAML      = "yaml"
+	TableFormatCompact   = "compact"
+	TableFormatSQLResult = "sql"
 )
 
 // RenderTable renders tabular data in various formats.
@@ -34,6 +35,10 @@ func RenderTable(format string, header []string, data [][]string, raw any) error
 		table.SetColumnSeparator("")
 		table.SetHeaderLine(false)
 		table.SetBorder(false)
+		table.Render()
+	case TableFormatSQLResult:
+		table := getBaseTable(header, data)
+		table.SetAutoFormatHeaders(false)
 		table.Render()
 	case TableFormatCSV:
 		w := csv.NewWriter(os.Stdout)

--- a/shared/cmd/table.go
+++ b/shared/cmd/table.go
@@ -10,6 +10,7 @@ import (
 	"github.com/olekukonko/tablewriter"
 	"gopkg.in/yaml.v2"
 
+	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/i18n"
 )
 
@@ -22,6 +23,11 @@ const (
 	TableFormatCompact   = "compact"
 	TableFormatSQLResult = "sql"
 )
+
+// isTableFormat returns true if the given format can be rendered as an actual table or csv with columns and rows.
+func isTableFormat(format string) bool {
+	return shared.ValueInSlice(format, []string{TableFormatTable, TableFormatCSV, TableFormatCompact, TableFormatSQLResult})
+}
 
 // RenderTable renders tabular data in various formats.
 func RenderTable(format string, header []string, data [][]string, raw any) error {
@@ -97,46 +103,41 @@ type Column struct {
 // is not a slice, if the format is unrecognized, if any characters in the columns argument is not present in the
 // columnMap argument.
 func RenderSlice(data any, format string, displayColumns string, sortColumns string, columnMap map[rune]Column) error {
-	rows, err := anyToSlice(data)
-	if err != nil {
-		return fmt.Errorf("Cannot render table: %w", err)
-	}
-
-	switch format {
-	case TableFormatTable, TableFormatCSV, TableFormatCompact:
-		break
-	case TableFormatJSON, TableFormatYAML:
-		return RenderTable(format, nil, nil, data)
-	default:
-		return fmt.Errorf(i18n.G("Invalid format %q"), format)
-	}
-
-	headers := make([]string, len(displayColumns))
-	for i, r := range displayColumns {
-		column, ok := columnMap[r]
-		if !ok {
-			return fmt.Errorf("Invalid column %q", string(r))
+	var headers []string
+	var tableData [][]string
+	if isTableFormat(format) {
+		rows, err := anyToSlice(data)
+		if err != nil {
+			return fmt.Errorf("Cannot render table: %w", err)
 		}
 
-		headers[i] = column.Header
-	}
-
-	tableData := make([][]string, len(rows))
-	for i, row := range rows {
-		rowData := make([]string, len(displayColumns))
-		for j, r := range displayColumns {
-			rowData[j], err = columnMap[r].DataFunc(row)
-			if err != nil {
-				return err
+		headers = make([]string, 0, len(displayColumns))
+		for _, r := range displayColumns {
+			column, ok := columnMap[r]
+			if !ok {
+				return fmt.Errorf("Invalid column %q", string(r))
 			}
+
+			headers = append(headers, column.Header)
 		}
 
-		tableData[i] = rowData
-	}
+		tableData = make([][]string, len(rows))
+		for i, row := range rows {
+			rowData := make([]string, len(displayColumns))
+			for j, r := range displayColumns {
+				rowData[j], err = columnMap[r].DataFunc(row)
+				if err != nil {
+					return err
+				}
+			}
 
-	err = SortByPrecedence(tableData, displayColumns, sortColumns)
-	if err != nil {
-		return nil
+			tableData[i] = rowData
+		}
+
+		err = SortByPrecedence(tableData, displayColumns, sortColumns)
+		if err != nil {
+			return nil
+		}
 	}
 
 	return RenderTable(format, headers, tableData, data)

--- a/shared/cmd/table.go
+++ b/shared/cmd/table.go
@@ -155,7 +155,7 @@ func anyToSlice(slice any) ([]any, error) {
 		return nil, nil
 	}
 
-	ret := make([]interface{}, s.Len())
+	ret := make([]any, s.Len())
 
 	for i := 0; i < s.Len(); i++ {
 		ret[i] = s.Index(i).Interface()


### PR DESCRIPTION
This allows specifying the output of `lxd sql` as `sql`, `csv`, `table`, `compact`, `json`, or `yaml`. The new `sql` format is added so that the column names are not auto-formatted (upper cased, replacing underscores with spaces).

This is added to ease scripting in tests and is required for #14651.