### PR TITLE
test: Improve usage of `lxd sql` in tests

### DIFF
--- a/test/suites/auth.sh
+++ b/test/suites/auth.sh
@@ -76,7 +76,7 @@ test_authorization() {
   # Test permission is removed automatically when instance is removed.
   lxc auth group permission add test-group instance c1 can_exec project=default # Valid
   lxc rm c1 --force
-  ! lxd sql global "SELECT * FROM auth_groups_permissions WHERE entitlement = 'can_exec'" | grep c1 || false # Permission should be removed when instance is removed.
+  [ "$(lxd sql global --format csv "SELECT count(*) FROM auth_groups_permissions WHERE entitlement = 'can_exec'")" = 0 ] # Permission should be removed when instance is removed.
 
   # Network permissions
   ! lxc auth group permission add test-group network n1 can_view project=default || false # Not found

--- a/test/suites/backup.sh
+++ b/test/suites/backup.sh
@@ -221,7 +221,7 @@ EOF
     lxc exec c1 --project test -- hostname
 
     # Test recover after pool DB config deletion too.
-    poolConfigBefore=$(lxd sql global "SELECT key,value FROM storage_pools_config JOIN storage_pools ON storage_pools.id = storage_pools_config.storage_pool_id WHERE storage_pools.name = '${poolName}' ORDER BY key")
+    poolConfigBefore=$(lxd sql global --format csv "SELECT key,value FROM storage_pools_config JOIN storage_pools ON storage_pools.id = storage_pools_config.storage_pool_id WHERE storage_pools.name = '${poolName}' ORDER BY key")
     poolSource=$(lxc storage get "${poolName}" source)
     poolExtraConfig=""
 
@@ -259,7 +259,7 @@ EOF
 
     # Check recovered pool config (from instance backup file) matches what originally was there.
     lxc storage show "${poolName}"
-    poolConfigAfter=$(lxd sql global "SELECT key,value FROM storage_pools_config JOIN storage_pools ON storage_pools.id = storage_pools_config.storage_pool_id WHERE storage_pools.name = '${poolName}' ORDER BY key")
+    poolConfigAfter=$(lxd sql global --format csv "SELECT key,value FROM storage_pools_config JOIN storage_pools ON storage_pools.id = storage_pools_config.storage_pool_id WHERE storage_pools.name = '${poolName}' ORDER BY key")
     echo "Before:"
     echo "${poolConfigBefore}"
 

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -272,10 +272,10 @@ test_clustering_membership() {
 
   # Gracefully remove a node and check trust certificate is removed.
   LXD_DIR="${LXD_ONE_DIR}" lxc cluster list | grep node4
-  LXD_DIR="${LXD_ONE_DIR}" lxd sql global 'SELECT name FROM identities WHERE type = 3' | grep node4
+  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxd sql global --format csv 'SELECT count(*) FROM identities WHERE type = 3 and name = "node4"')" = 1 ]
   LXD_DIR="${LXD_TWO_DIR}" lxc cluster remove node4
   ! LXD_DIR="${LXD_ONE_DIR}" lxc cluster list | grep node4 || false
-  ! LXD_DIR="${LXD_ONE_DIR}" lxd sql global 'SELECT name FROM identities WHERE type = 3' | grep node4 || false
+  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxd sql global --format csv 'SELECT count(*) FROM identities WHERE type = 3 and name = "node4"')" = 0 ]
 
   # The node isn't clustered anymore.
   ! LXD_DIR="${LXD_FOUR_DIR}" lxc cluster list || false

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -1082,8 +1082,8 @@ test_clustering_network() {
   LXD_DIR="${LXD_ONE_DIR}" lxc network list| grep "${bridge}" | grep -q CREATED
 
   # Check both nodes show network created.
-  LXD_DIR="${LXD_ONE_DIR}" lxd sql global "SELECT nodes.name,networks_nodes.state FROM nodes JOIN networks_nodes ON networks_nodes.node_id = nodes.id JOIN networks ON networks.id = networks_nodes.network_id WHERE networks.name = '${bridge}' AND nodes.name = 'node1'" | grep "| node1 | 1     |"
-  LXD_DIR="${LXD_ONE_DIR}" lxd sql global "SELECT nodes.name,networks_nodes.state FROM nodes JOIN networks_nodes ON networks_nodes.node_id = nodes.id JOIN networks ON networks.id = networks_nodes.network_id WHERE networks.name = '${bridge}' AND nodes.name = 'node2'" | grep "| node2 | 1     |"
+  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxd sql global --format csv "SELECT nodes.name,networks_nodes.state FROM nodes JOIN networks_nodes ON networks_nodes.node_id = nodes.id JOIN networks ON networks.id = networks_nodes.network_id WHERE networks.name = '${bridge}' AND nodes.name = 'node1'")" = "node1,1" ]
+  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxd sql global --format csv "SELECT nodes.name,networks_nodes.state FROM nodes JOIN networks_nodes ON networks_nodes.node_id = nodes.id JOIN networks ON networks.id = networks_nodes.network_id WHERE networks.name = '${bridge}' AND nodes.name = 'node2'")" = "node2,1" ]
 
   # Trying to pass config values other than
   # 'bridge.external_interfaces' results in an error
@@ -1132,15 +1132,15 @@ test_clustering_network() {
   LXD_DIR="${LXD_ONE_DIR}" lxc network show "${net}" | grep status: | grep -q Errored # Check has errored status.
 
   # Check each node status (expect both node1 and node2 to be pending as local member running created failed first).
-  LXD_DIR="${LXD_ONE_DIR}" lxd sql global "SELECT nodes.name,networks_nodes.state FROM nodes JOIN networks_nodes ON networks_nodes.node_id = nodes.id JOIN networks ON networks.id = networks_nodes.network_id WHERE networks.name = '${net}' AND nodes.name = 'node1'" | grep "| node1 | 0     |"
-  LXD_DIR="${LXD_ONE_DIR}" lxd sql global "SELECT nodes.name,networks_nodes.state FROM nodes JOIN networks_nodes ON networks_nodes.node_id = nodes.id JOIN networks ON networks.id = networks_nodes.network_id WHERE networks.name = '${net}' AND nodes.name = 'node2'" | grep "| node2 | 0     |"
+[ "$(LXD_DIR="${LXD_ONE_DIR}" lxd sql global --format csv "SELECT nodes.name,networks_nodes.state FROM nodes JOIN networks_nodes ON networks_nodes.node_id = nodes.id JOIN networks ON networks.id = networks_nodes.network_id WHERE networks.name = '${net}' AND nodes.name = 'node1'")" = "node1,0" ]
+[ "$(LXD_DIR="${LXD_ONE_DIR}" lxd sql global --format csv "SELECT nodes.name,networks_nodes.state FROM nodes JOIN networks_nodes ON networks_nodes.node_id = nodes.id JOIN networks ON networks.id = networks_nodes.network_id WHERE networks.name = '${net}' AND nodes.name = 'node2'")" = "node2,0" ]
 
   # Run network create on other node2 (still excpect to fail on node1, but expect node2 create to succeed).
   ! LXD_DIR="${LXD_TWO_DIR}" lxc network create "${net}" || false
 
   # Check each node status (expect node1 to be pending and node2 to be created).
-  LXD_DIR="${LXD_ONE_DIR}" lxd sql global "SELECT nodes.name,networks_nodes.state FROM nodes JOIN networks_nodes ON networks_nodes.node_id = nodes.id JOIN networks ON networks.id = networks_nodes.network_id WHERE networks.name = '${net}' AND nodes.name = 'node1'" | grep "| node1 | 0     |"
-  LXD_DIR="${LXD_ONE_DIR}" lxd sql global "SELECT nodes.name,networks_nodes.state FROM nodes JOIN networks_nodes ON networks_nodes.node_id = nodes.id JOIN networks ON networks.id = networks_nodes.network_id WHERE networks.name = '${net}' AND nodes.name = 'node2'" | grep "| node2 | 1     |"
+[ "$(LXD_DIR="${LXD_ONE_DIR}" lxd sql global --format csv "SELECT nodes.name,networks_nodes.state FROM nodes JOIN networks_nodes ON networks_nodes.node_id = nodes.id JOIN networks ON networks.id = networks_nodes.network_id WHERE networks.name = '${net}' AND nodes.name = 'node1'")" = "node1,0" ]
+[ "$(LXD_DIR="${LXD_ONE_DIR}" lxd sql global --format csv "SELECT nodes.name,networks_nodes.state FROM nodes JOIN networks_nodes ON networks_nodes.node_id = nodes.id JOIN networks ON networks.id = networks_nodes.network_id WHERE networks.name = '${net}' AND nodes.name = 'node2'")" = "node2,1" ]
 
   # Check interfaces are expected types (dummy on node1 and bridge on node2).
   nsenter -n -t "${LXD_PID1}" -- ip -details link show "${net}" | grep dummy
@@ -1181,8 +1181,8 @@ test_clustering_network() {
   ! LXD_DIR="${LXD_ONE_DIR}" lxc network create "${net}" || false # Check re-create is blocked after success.
 
   # Check both nodes marked created.
-  LXD_DIR="${LXD_ONE_DIR}" lxd sql global "SELECT nodes.name,networks_nodes.state FROM nodes JOIN networks_nodes ON networks_nodes.node_id = nodes.id JOIN networks ON networks.id = networks_nodes.network_id WHERE networks.name = '${net}' AND nodes.name = 'node1'" | grep "| node1 | 1     |"
-  LXD_DIR="${LXD_ONE_DIR}" lxd sql global "SELECT nodes.name,networks_nodes.state FROM nodes JOIN networks_nodes ON networks_nodes.node_id = nodes.id JOIN networks ON networks.id = networks_nodes.network_id WHERE networks.name = '${net}' AND nodes.name = 'node2'" | grep "| node2 | 1     |"
+[ "$(LXD_DIR="${LXD_ONE_DIR}" lxd sql global --format csv "SELECT nodes.name,networks_nodes.state FROM nodes JOIN networks_nodes ON networks_nodes.node_id = nodes.id JOIN networks ON networks.id = networks_nodes.network_id WHERE networks.name = '${net}' AND nodes.name = 'node1'")" = "node1,1" ]
+[ "$(LXD_DIR="${LXD_ONE_DIR}" lxd sql global --format csv "SELECT nodes.name,networks_nodes.state FROM nodes JOIN networks_nodes ON networks_nodes.node_id = nodes.id JOIN networks ON networks.id = networks_nodes.network_id WHERE networks.name = '${net}' AND nodes.name = 'node2'")" = "node2,1" ]
 
   # Check instance can be connected to created network and assign static DHCP allocations.
   LXD_DIR="${LXD_ONE_DIR}" lxc network show "${net}"

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -2755,7 +2755,8 @@ test_clustering_remove_raft_node() {
   LXD_DIR="${LXD_ONE_DIR}" lxc cluster show node4 | grep -q "\- database$"
 
   # The second node is still in the raft_nodes table.
-  LXD_DIR="${LXD_ONE_DIR}" lxd sql local "SELECT * FROM raft_nodes" | grep -qF "10.1.1.102"
+  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxd sql local --format csv "SELECT count(*) FROM raft_nodes WHERE address = '10.1.1.102:8443'")" = 1 ]
+  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxd sql local --format csv "SELECT count(*) FROM raft_nodes")" = 4 ]
 
   # Force removing the raft node.
   LXD_DIR="${LXD_ONE_DIR}" lxd cluster remove-raft-node -q "10.1.1.102"
@@ -2770,7 +2771,8 @@ test_clustering_remove_raft_node() {
   LXD_DIR="${LXD_ONE_DIR}" lxc cluster show node4 | grep -q "\- database$"
 
   # The second node is gone from the raft_nodes_table.
-  ! LXD_DIR="${LXD_ONE_DIR}" lxd sql local "SELECT * FROM raft_nodes" | grep -qF "10.1.1.102" || false
+  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxd sql local --format csv "SELECT count(*) FROM raft_nodes WHERE address = '10.1.1.102:8443'")" = 0 ]
+  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxd sql local --format csv "SELECT count(*) FROM raft_nodes")" = 3 ]
 
   LXD_DIR="${LXD_ONE_DIR}" lxd shutdown
   LXD_DIR="${LXD_THREE_DIR}" lxd shutdown

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -2990,11 +2990,10 @@ test_clustering_image_refresh() {
 
   if [ "${poolDriver}" != "dir" ]; then
     # Check image storage volume records exist.
-    lxd sql global 'select name from storage_volumes'
     if [ "${poolDriver}" = "ceph" ]; then
-      [ "$(lxd sql global 'select name from storage_volumes' | grep -Fc "${old_fingerprint}")" = "1" ]
+      [ "$(lxd sql global --format csv "SELECT count(*) FROM storage_volumes WHERE name LIKE '${old_fingerprint}%'")" = 1 ]
     else
-      [ "$(lxd sql global 'select name from storage_volumes' | grep -Fc "${old_fingerprint}")" = "3" ]
+      [ "$(lxd sql global --format csv "SELECT count(*) FROM storage_volumes WHERE name LIKE '${old_fingerprint}%'")" = 3 ]
     fi
   fi
 
@@ -3011,14 +3010,13 @@ test_clustering_image_refresh() {
   done
 
   if [ "${poolDriver}" != "dir" ]; then
-    lxd sql global 'select name from storage_volumes'
     # Check image storage volume records actually removed from relevant members and replaced with new fingerprint.
     if [ "${poolDriver}" = "ceph" ]; then
-      [ "$(lxd sql global 'select name from storage_volumes' | grep -Fc "${old_fingerprint}")" = "0" ]
-      [ "$(lxd sql global 'select name from storage_volumes' | grep -Fc "${new_fingerprint}")" = "1" ]
+      [ "$(lxd sql global --format csv "SELECT count(*) FROM storage_volumes WHERE name LIKE '${old_fingerprint}%'")" = 0 ]
+      [ "$(lxd sql global --format csv "SELECT count(*) FROM storage_volumes WHERE name LIKE '${new_fingerprint}%'")" = 1 ]
     else
-      [ "$(lxd sql global 'select name from storage_volumes' | grep -Fc "${old_fingerprint}")" = "1" ]
-      [ "$(lxd sql global 'select name from storage_volumes' | grep -Fc "${new_fingerprint}")" = "2" ]
+      [ "$(lxd sql global --format csv "SELECT count(*) FROM storage_volumes WHERE name LIKE '${old_fingerprint}%'")" = 1 ]
+      [ "$(lxd sql global --format csv "SELECT count(*) FROM storage_volumes WHERE name LIKE '${new_fingerprint}%'")" = 2 ]
     fi
   fi
 
@@ -3026,12 +3024,12 @@ test_clustering_image_refresh() {
   # while project foo should still have the old image.
   # Also, it should only show 1 entry for the old image and 2 entries
   # for the new one.
-  LXD_DIR="${LXD_ONE_DIR}" lxd sql global 'select images.fingerprint from images join projects on images.project_id=projects.id where projects.name="foo"' | grep -F "${old_fingerprint}"
-  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxd sql global 'select images.fingerprint from images' | grep -cF "${old_fingerprint}")" -eq 1 ]
+  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxd sql global --format csv 'SELECT images.fingerprint FROM images JOIN projects ON images.project_id=projects.id WHERE projects.name="foo"' | cut -c1-12)" = "${old_fingerprint}" ]
+  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxd sql global --format csv "SELECT count(*) FROM images WHERE fingerprint LIKE '${old_fingerprint}%'")" = 1 ]
 
-  LXD_DIR="${LXD_ONE_DIR}" lxd sql global 'select images.fingerprint from images join projects on images.project_id=projects.id where projects.name="default"' | grep -F "${new_fingerprint}"
-  LXD_DIR="${LXD_ONE_DIR}" lxd sql global 'select images.fingerprint from images join projects on images.project_id=projects.id where projects.name="bar"' | grep -F "${new_fingerprint}"
-  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxd sql global 'select images.fingerprint from images' | grep -cF "${new_fingerprint}")" -eq 2 ]
+  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxd sql global --format csv 'SELECT images.fingerprint FROM images JOIN projects ON images.project_id=projects.id WHERE projects.name="default"' | cut -c1-12)" = "${new_fingerprint}" ]
+  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxd sql global --format csv 'SELECT images.fingerprint FROM images JOIN projects ON images.project_id=projects.id WHERE projects.name="bar"' | cut -c1-12)" = "${new_fingerprint}" ]
+  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxd sql global --format csv "SELECT count(*) FROM images WHERE fingerprint LIKE '${new_fingerprint}%'")" = 2 ]
 
   pids=""
 
@@ -3048,12 +3046,12 @@ test_clustering_image_refresh() {
     wait "${pid}" || true
   done
 
-  LXD_DIR="${LXD_ONE_DIR}" lxd sql global 'select images.fingerprint from images join projects on images.project_id=projects.id where projects.name="foo"' | grep -F "${old_fingerprint}"
-  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxd sql global 'select images.fingerprint from images' | grep -cF "${old_fingerprint}")" -eq 1 ]
+  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxd sql global --format csv 'SELECT images.fingerprint FROM images JOIN projects ON images.project_id=projects.id WHERE projects.name="foo"' | cut -c1-12)" = "${old_fingerprint}" ]
+  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxd sql global --format csv "SELECT count(*) FROM images WHERE fingerprint LIKE '${old_fingerprint}%'")" = 1 ]
 
-  LXD_DIR="${LXD_ONE_DIR}" lxd sql global 'select images.fingerprint from images join projects on images.project_id=projects.id where projects.name="default"' | grep -F "${new_fingerprint}"
-  LXD_DIR="${LXD_ONE_DIR}" lxd sql global 'select images.fingerprint from images join projects on images.project_id=projects.id where projects.name="bar"' | grep -F "${new_fingerprint}"
-  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxd sql global 'select images.fingerprint from images' | grep -cF "${new_fingerprint}")" -eq 2 ]
+  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxd sql global --format csv 'SELECT images.fingerprint FROM images JOIN projects ON images.project_id=projects.id WHERE projects.name="default"' | cut -c1-12)" = "${new_fingerprint}" ]
+  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxd sql global --format csv 'SELECT images.fingerprint FROM images JOIN projects ON images.project_id=projects.id WHERE projects.name="bar"' | cut -c1-12)" = "${new_fingerprint}" ]
+  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxd sql global --format csv "SELECT count(*) FROM images WHERE fingerprint LIKE '${new_fingerprint}%'")" = 2 ]
 
   # Modify public testimage
   dd if=/dev/urandom count=32 | LXD_DIR="${LXD_REMOTE_DIR}" lxc file push - c1/foo
@@ -3076,12 +3074,12 @@ test_clustering_image_refresh() {
 
   pids=""
 
-  LXD_DIR="${LXD_ONE_DIR}" lxd sql global 'select images.fingerprint from images join projects on images.project_id=projects.id where projects.name="foo"' | grep -F "${old_fingerprint}"
-  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxd sql global 'select images.fingerprint from images' | grep -cF "${old_fingerprint}")" -eq 1 ]
+  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxd sql global --format csv 'SELECT images.fingerprint FROM images JOIN projects ON images.project_id=projects.id WHERE projects.name="foo"' | cut -c1-12)" = "${old_fingerprint}" ]
+  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxd sql global --format csv "SELECT count(*) FROM images WHERE fingerprint LIKE '${old_fingerprint}%'")" = 1 ]
 
-  LXD_DIR="${LXD_ONE_DIR}" lxd sql global 'select images.fingerprint from images join projects on images.project_id=projects.id where projects.name="default"' | grep -F "${new_fingerprint}"
-  LXD_DIR="${LXD_ONE_DIR}" lxd sql global 'select images.fingerprint from images join projects on images.project_id=projects.id where projects.name="bar"' | grep -F "${new_fingerprint}"
-  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxd sql global 'select images.fingerprint from images' | grep -cF "${new_fingerprint}")" -eq 2 ]
+  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxd sql global --format csv 'SELECT images.fingerprint FROM images JOIN projects ON images.project_id=projects.id WHERE projects.name="default"' | cut -c1-12)" = "${new_fingerprint}" ]
+  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxd sql global --format csv 'SELECT images.fingerprint FROM images JOIN projects ON images.project_id=projects.id WHERE projects.name="bar"' | cut -c1-12)" = "${new_fingerprint}" ]
+  [ "$(LXD_DIR="${LXD_ONE_DIR}" lxd sql global --format csv "SELECT count(*) FROM images WHERE fingerprint LIKE '${new_fingerprint}%'")" = 2 ]
 
   # Clean up everything
   for project in default foo bar; do

--- a/test/suites/oidc.sh
+++ b/test/suites/oidc.sh
@@ -33,6 +33,7 @@ test_oidc() {
   [ "$(lxd sql global --format csv "SELECT count(*) FROM identities WHERE type = 5 AND identifier = 'test-user@example.com' AND auth_method = 2")" = 1 ]
 
   # Cleanup OIDC
+  lxc auth identity delete oidc/test-user@example.com
   lxc remote remove oidc
   kill_oidc
   lxc config unset oidc.issuer

--- a/test/suites/oidc.sh
+++ b/test/suites/oidc.sh
@@ -29,7 +29,7 @@ test_oidc() {
   [ "$(lxc info oidc: | grep ^auth_user_name | sed "s/.*: //g")" = "test-user@example.com" ]
 
   # OIDC user should be added to identities table.
-  [ "$(lxd sql global "SELECT identifier, name, auth_method, type FROM identities WHERE type = 5 AND identifier = 'test-user@example.com' AND auth_method = 2" | wc -l)" = 5 ]
+  [ "$(lxd sql global --format csv "SELECT count(*) FROM identities WHERE type = 5 AND identifier = 'test-user@example.com' AND auth_method = 2")" = 1 ]
 
   # Cleanup OIDC
   lxc remote remove oidc

--- a/test/suites/oidc.sh
+++ b/test/suites/oidc.sh
@@ -25,8 +25,9 @@ test_oidc() {
   # This should succeed.
   BROWSER=curl lxc remote add --accept-certificate oidc "${LXD_ADDR}" --auth-type oidc
 
-  # lxc info should show the email address as the username.
-  [ "$(lxc info oidc: | grep ^auth_user_name | sed "s/.*: //g")" = "test-user@example.com" ]
+  # The user should now be logged in and their email should show in the "auth_user_name" field.
+  [ "$(lxc query oidc:/1.0 | jq -r '.auth')" = "trusted" ]
+  [ "$(lxc query oidc:/1.0 | jq -r '.auth_user_name')" = "test-user@example.com" ]
 
   # OIDC user should be added to identities table.
   [ "$(lxd sql global --format csv "SELECT count(*) FROM identities WHERE type = 5 AND identifier = 'test-user@example.com' AND auth_method = 2")" = 1 ]

--- a/test/suites/sql.sh
+++ b/test/suites/sql.sh
@@ -1,22 +1,27 @@
 # Test the lxd sql command.
 test_sql() {
   # Invalid arguments
-  ! lxd sql foo "SELECT * FROM CONFIG" || false
+  ! lxd sql foo "SELECT * FROM config" || false
   ! lxd sql global "" || false
 
   # Local database query
-  lxd sql local "SELECT * FROM config" | grep -qF "core.https_address"
+  [ "$(lxd sql local --format csv "SELECT count(*) FROM config WHERE key = 'core.https_address'")" = 1 ]
 
   # Global database query
   lxc config set user.foo=bar
-  lxd sql global "SELECT * FROM config" | grep -qF "user.foo"
+  [ "$(lxd sql global --format csv "SELECT value FROM config WHERE key = 'user.foo'")" = "bar" ]
+
+  # Test formats
+  lxd sql global --format sql 'SELECT key FROM config' | grep -F 'key'
+  lxd sql global --format table 'SELECT key FROM config' | grep -F 'KEY'
+  lxd sql global --format compact 'SELECT key FROM config' | grep -F 'KEY'
 
   # Global database insert
   lxd sql global "INSERT INTO config(key,value) VALUES('core.https_allowed_credentials','true')" | grep -qxF "Rows affected: 1"
   lxd sql global "DELETE FROM config WHERE key='core.https_allowed_credentials'" | grep -qxF "Rows affected: 1"
 
   # Standard input
-  echo "SELECT * FROM config" | lxd sql global - | grep -qF "user.foo"
+  [ "$(echo "SELECT value FROM config WHERE key = 'user.foo'" | lxd sql global --format csv -)" = "bar" ]
 
   # Multiple queries
   lxd sql global "SELECT * FROM config; SELECT * FROM instances" | grep -qxF "=> Query 0:"


### PR DESCRIPTION
Support for the `--format` flag was added in #14670. This PR uses the format flag where possible in our test suite to avoid e.g. grepping for table formatted output.

In some cases I've changed queries to use a `SELECT count(*) FROM ...` instead of a `SELECT * FROM ...` where the output was piped into a word count or grepped with the -c flag.