### PR TITLE
Documentation: Update link prefix for `doc/reference/storage_cephfs`

### DIFF
--- a/doc/reference/storage_cephfs.md
+++ b/doc/reference/storage_cephfs.md
@@ -1,5 +1,5 @@
 ---
-discourse: 15457
+discourse: lxc:15457
 ---
 
 (storage-cephfs)=


### PR DESCRIPTION
This PR adds the `lxc` prefix to the link in `doc/reference/storage_cephfs`. It was missed with https://github.com/canonical/lxd/pull/14600/commits/b15618883058d334807ab0c35502928cd03d8947#diff-15639efc2f09d9560a2350f733e0aa1b1ace86af9678844499d5c16c72582ecc.