### PR TITLE
Remove defunct lint exceptions

### DIFF
--- a/lxd-agent/main.go
+++ b/lxd-agent/main.go
@@ -46,6 +46,6 @@ func main() {
 	err := app.Execute()
 	if err != nil {
 		// Ensure we exit with a non-zero exit code.
-		os.Exit(1) //nolint:revive
+		os.Exit(1)
 	}
 }

--- a/lxd/api_internal_recover.go
+++ b/lxd/api_internal_recover.go
@@ -214,7 +214,7 @@ func internalRecoverScan(s *state.State, userPools []api.StoragePoolsPost, valid
 		// This way if we are dealing with an existing pool or have successfully created the DB record then
 		// we won't unmount it. As we should leave successfully imported pools mounted.
 		if ourMount {
-			defer func() { //nolint:revive
+			defer func() {
 				cleanupPool := pools[pool.Name()]
 				if cleanupPool != nil && cleanupPool.ID() == storagePools.PoolIDTemporary {
 					_, _ = cleanupPool.Unmount()

--- a/lxd/db/cluster/entities.go
+++ b/lxd/db/cluster/entities.go
@@ -246,7 +246,7 @@ func GetEntityURL(ctx context.Context, tx *sql.Tx, entityType entity.Type, entit
 // This method combines the above queries into a single query using the UNION operator. If no entity types are given, this function will
 // return URLs for all entity types. If no project name is given, this function will return URLs for all projects. This may result in
 // stupendously large queries, so use with caution!
-func GetEntityURLs(ctx context.Context, tx *sql.Tx, projectName string, filteringEntityTypes ...entity.Type) (map[entity.Type]map[int]*api.URL, error) { //nolint:unused // This will be used in a forthcoming feature.
+func GetEntityURLs(ctx context.Context, tx *sql.Tx, projectName string, filteringEntityTypes ...entity.Type) (map[entity.Type]map[int]*api.URL, error) {
 	var stmts []string
 	var args []any
 	result := make(map[entity.Type]map[int]*api.URL)

--- a/lxd/instance_test.go
+++ b/lxd/instance_test.go
@@ -73,7 +73,6 @@ func (suite *containerTestSuite) TestContainer_ProfilesMulti() {
 	suite.Req.Nil(err, "Failed to create the unprivileged profile.")
 	defer func() {
 		_ = suite.d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-			//nolint:revive // revive seems to think this return is outside of the transaction.
 			return cluster.DeleteProfile(ctx, tx.Tx(), "default", "unprivileged")
 		})
 	}()

--- a/lxd/operations.go
+++ b/lxd/operations.go
@@ -69,7 +69,7 @@ func waitForOperations(ctx context.Context, cluster *db.Cluster, consoleShutdown
 				logger.Error("Failed cleaning up operations")
 			}
 
-			return nil //nolint:revive // False positive: raises "return in a defer function has no effect".
+			return nil
 		})
 	}()
 

--- a/test/mini-oidc/storage/storage_dynamic.go
+++ b/test/mini-oidc/storage/storage_dynamic.go
@@ -15,7 +15,7 @@ type multiStorage struct {
 
 // NewMultiStorage implements the op.Storage interface by wrapping multiple storage structs
 // and selecting them by the calling issuer.
-func NewMultiStorage(issuers []string) *multiStorage { //nolint:revive
+func NewMultiStorage(issuers []string) *multiStorage {
 	s := make(map[string]*Storage)
 	for _, issuer := range issuers {
 		s[issuer] = NewStorage(NewUserStore(issuer))


### PR DESCRIPTION
Some `//nolint` comments have become defunct after changes to the linter configuration. This PR removes them!

Follow up to #14649