### PR TITLE
CLI: Exclude default remote from `lxc remote switch|remove` shell completions

### DIFF
--- a/lxc/completion.go
+++ b/lxc/completion.go
@@ -1347,10 +1347,13 @@ func (g *cmdGlobal) cmpRemotes(includeAll bool) ([]string, cobra.ShellCompDirect
 
 // cmpRemoteNames provides shell completion for remote names.
 // It returns a list of remote names provided by `g.conf.Remotes` along with a shell completion directive.
-func (g *cmdGlobal) cmpRemoteNames() ([]string, cobra.ShellCompDirective) {
-	var results []string
-
+func (g *cmdGlobal) cmpRemoteNames(includeDefaultRemote bool) ([]string, cobra.ShellCompDirective) {
+	results := make([]string, 0, len(g.conf.Remotes))
 	for remoteName := range g.conf.Remotes {
+		if !includeDefaultRemote && remoteName == g.conf.DefaultRemote {
+			continue
+		}
+
 		results = append(results, remoteName)
 	}
 

--- a/lxc/remote.go
+++ b/lxc/remote.go
@@ -877,7 +877,7 @@ func (c *cmdRemoteRename) command() *cobra.Command {
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
-			return c.global.cmpRemoteNames()
+			return c.global.cmpRemoteNames(true)
 		}
 
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -958,7 +958,7 @@ func (c *cmdRemoteRemove) command() *cobra.Command {
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
-			return c.global.cmpRemoteNames()
+			return c.global.cmpRemoteNames(false)
 		}
 
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -1022,7 +1022,7 @@ func (c *cmdRemoteSwitch) command() *cobra.Command {
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
-			return c.global.cmpRemoteNames()
+			return c.global.cmpRemoteNames(false)
 		}
 
 		return nil, cobra.ShellCompDirectiveNoFileComp
@@ -1070,7 +1070,7 @@ func (c *cmdRemoteSetURL) command() *cobra.Command {
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
-			return c.global.cmpRemoteNames()
+			return c.global.cmpRemoteNames(true)
 		}
 
 		return nil, cobra.ShellCompDirectiveNoFileComp


### PR DESCRIPTION
Resolves 1/2 issues raised in https://github.com/canonical/lxd/issues/14635.

This PR adds logic to exclude the default (current) remote from shell completions when running `lxc remote switch|remove`. As described in [this comment](https://github.com/canonical/lxd/issues/14635#issuecomment-2547022037), it appears that `snapd` is intercepting the response and excluding non-default remotes (`cdimage` in this case). I'll see if I can land a fix for the second issue in https://github.com/canonical/lxd-pkg-snap.