### PR TITLE
golangci: Add `prealloc` linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,7 @@ linters:
     - godot
     - gofmt
     - misspell
+    - prealloc
     - whitespace
     - revive
 issues:


### PR DESCRIPTION
This PR adds the [`prealloc`](https://golangci-lint.run/usage/linters/#prealloc) linter to our `golangci-lint` config. `prealloc` finds slice declarations that could potentially be pre-allocated.