### PR TITLE
VM: Move check for container-specific prefixed keys applied to VMs up

### DIFF
--- a/lxd/instance/instance_utils.go
+++ b/lxd/instance/instance_utils.go
@@ -128,14 +128,14 @@ func ValidConfig(sysOS *sys.OS, config map[string]string, expanded bool, instanc
 }
 
 func validConfigKey(os *sys.OS, key string, value string, instanceType instancetype.Type) error {
+	// Disallow keys with container-specific prefixes such as "linux.sysctl." and "limits.kernel." for VMs.
+	if instanceType == instancetype.VM && shared.StringHasPrefix(key, instancetype.ConfigKeyPrefixesContainer...) {
+		return fmt.Errorf("%q isn't supported for %q", key, instanceType)
+	}
+
 	// Check if the key is a valid prefix and whether or not it requires a subkey.
 	knownPrefixes := append(instancetype.ConfigKeyPrefixesAny, instancetype.ConfigKeyPrefixesContainer...)
 	if strings.HasSuffix(key, ".") {
-		// Disallow keys with container-specific prefixes such as "linux.sysctl." and "limits.kernel." for VMs.
-		if instanceType == instancetype.VM && shared.StringHasPrefix(key, instancetype.ConfigKeyPrefixesContainer...) {
-			return fmt.Errorf("%q isn't supported for %q", key, instanceType)
-		}
-
 		if !(key == instancetype.ConfigVolatilePrefix || shared.ValueInSlice(key, knownPrefixes)) {
 			// Not a known prefix.
 			return fmt.Errorf("Unknown configuration key: %q", key)


### PR DESCRIPTION
This PR fixes the following regression:
https://github.com/canonical/lxd-ci/actions/runs/12367790805/job/34516721509#step:11:93.

We always need to check config keys applied to VM's to ensure container-specific prefixed keys are disallowed.