### PR TITLE
Preserve `custom/c1` syntax during storage volume rename

### DIFF
--- a/lxd/storage_volumes_utils.go
+++ b/lxd/storage_volumes_utils.go
@@ -30,7 +30,12 @@ func storagePoolVolumeUpdateUsers(s *state.State, projectName string, oldPoolNam
 			_, exists := localDevices[devName]
 			if exists {
 				localDevices[devName]["pool"] = newPoolName
-				localDevices[devName]["source"] = newVol.Name
+
+				if strings.Contains(localDevices[devName]["source"], "/") {
+					localDevices[devName]["source"] = newVol.Type + "/" + newVol.Name
+				} else {
+					localDevices[devName]["source"] = newVol.Name
+				}
 			}
 		}
 
@@ -62,7 +67,12 @@ func storagePoolVolumeUpdateUsers(s *state.State, projectName string, oldPoolNam
 		for name, dev := range profile.Devices {
 			if shared.ValueInSlice(name, usedByDevices) {
 				dev["pool"] = newPoolName
-				dev["source"] = newVol.Name
+
+				if strings.Contains(dev["source"], "/") {
+					dev["source"] = newVol.Type + "/" + newVol.Name
+				} else {
+					dev["source"] = newVol.Name
+				}
 			}
 		}
 

--- a/test/suites/storage_volume_attach.sh
+++ b/test/suites/storage_volume_attach.sh
@@ -116,8 +116,15 @@ EOF
 
   lxc storage volume show "${pool}" testvolume | grep -q '/1.0/instances/c1'
 
+  # rename should preserve source=custom/testvolume syntax
+  lxc stop c1
+
+  lxc storage volume rename "${pool}" testvolume testvolume2
+
+  [ "$(lxc config device get c1 testvolume source)" = "custom/testvolume2" ]
+
   # delete containers
   lxc delete -f c1
   lxc delete -f c2
-  lxc storage volume delete "${pool}" testvolume
+  lxc storage volume delete "${pool}" testvolume2
 }


### PR DESCRIPTION
Follow-up to #14491; if a volume is specified as `source: custom/c1`, then a rename of `c1`->`c2` should leave the device with `source: custom/c2`.