### PR TITLE
lxc: man pages fixes and updates

### DIFF
--- a/lxc/cluster.go
+++ b/lxc/cluster.go
@@ -680,9 +680,10 @@ func (c *cmdClusterEnable) command() *cobra.Command {
   This command turns a non-clustered LXD server into the first member of a new
   LXD cluster, which will have the given name.
 
-  It's required that the LXD is already available on the network. You can check
-  that by running 'lxc config get core.https_address', and possibly set a value
-  for the address if not yet set.`))
+  It's required that LXD is already available on the network. You can check
+  this by running 'lxc config get core.https_address'. If either an IP address
+  and port is displayed, or both, LXD is already available on the network. If
+  no value is set, use 'lxc config set core.https_address' to set it.`))
 
 	cmd.RunE = c.run
 

--- a/lxc/info.go
+++ b/lxc/info.go
@@ -40,7 +40,7 @@ lxc info [<remote>:] [--resources]
     For LXD server information.`))
 
 	cmd.RunE = c.run
-	cmd.Flags().BoolVar(&c.flagShowLog, "show-log", false, i18n.G("Show the instance's last 100 log lines?"))
+	cmd.Flags().BoolVar(&c.flagShowLog, "show-log", false, i18n.G("Show the instance's last 100 log lines"))
 	cmd.Flags().BoolVar(&c.flagResources, "resources", false, i18n.G("Show the resources available to the server"))
 	cmd.Flags().StringVar(&c.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 

--- a/lxc/list.go
+++ b/lxc/list.go
@@ -52,7 +52,7 @@ func (c *cmdList) command() *cobra.Command {
 Default column layout: ns46tS
 Fast column layout: nsacPt
 
-A single keyword like "web" which will list any instance with a name starting by "web".
+A single keyword like "web" which will list any instance with a name starting with "web".
 A regular expression on the instance name. (e.g. .*web.*01$).
 A key/value pair referring to a configuration item. For those, the
 namespace can be abbreviated to the smallest unambiguous identifier.

--- a/lxc/list.go
+++ b/lxc/list.go
@@ -105,7 +105,7 @@ Pre-defined column shorthand chars:
   P - Profiles
   s - State
   S - Number of snapshots
-  t - Type (persistent or ephemeral)
+  t - Type (container or virtual-machine, ephemeral indicated if applicable)
   u - CPU usage (in seconds)
   L - Location of the instance (e.g. its cluster member)
   f - Base Image Fingerprint (short)

--- a/lxc/move.go
+++ b/lxc/move.go
@@ -62,7 +62,7 @@ lxc move <instance>/<old snapshot name> <instance>/<new snapshot name>
 	cmd.Flags().BoolVar(&c.flagNoProfiles, "no-profiles", false, i18n.G("Unset all profiles on the target instance"))
 	cmd.Flags().BoolVar(&c.flagInstanceOnly, "instance-only", false, i18n.G("Move the instance without its snapshots"))
 	cmd.Flags().StringVar(&c.flagMode, "mode", moveDefaultMode, i18n.G("Transfer mode. One of pull, push or relay.")+"``")
-	cmd.Flags().BoolVar(&c.flagStateless, "stateless", false, i18n.G("Copy a stateful instance stateless"))
+	cmd.Flags().BoolVar(&c.flagStateless, "stateless", false, i18n.G("Copy a stateful instance as stateless"))
 	cmd.Flags().StringVarP(&c.flagStorage, "storage", "s", "", i18n.G("Storage pool name")+"``")
 	cmd.Flags().StringVar(&c.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 	cmd.Flags().StringVar(&c.flagTargetProject, "target-project", "", i18n.G("Copy to a project different from the source")+"``")

--- a/lxc/query.go
+++ b/lxc/query.go
@@ -40,7 +40,7 @@ func (c *cmdQuery) command() *cobra.Command {
 	cmd.RunE = c.run
 	cmd.Flags().BoolVar(&c.flagRespWait, "wait", false, i18n.G("Wait for the operation to complete"))
 	cmd.Flags().BoolVar(&c.flagRespRaw, "raw", false, i18n.G("Print the raw response"))
-	cmd.Flags().StringVarP(&c.flagAction, "request", "X", "GET", i18n.G("Action (defaults to GET)")+"``")
+	cmd.Flags().StringVarP(&c.flagAction, "request", "X", "GET", i18n.G("Action")+"``")
 	cmd.Flags().StringVarP(&c.flagData, "data", "d", "", i18n.G("Input data")+"``")
 
 	return cmd

--- a/lxc/storage_volume.go
+++ b/lxc/storage_volume.go
@@ -2370,7 +2370,7 @@ func (c *cmdStorageVolumeUnset) command() *cobra.Command {
 Supported types are custom, image, container and virtual-machine.
 
 lxc storage volume unset default data size
-    Remotes the size/quota of a custom volume "data" in pool "default".
+    Removes the size/quota of a custom volume "data" in pool "default".
 
 lxc storage volume unset default virtual-machine/data snapshots.expiry
     Removes the snapshot expiration period for a virtual machine "data" in pool "default".`))

--- a/po/ar.po
+++ b/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-09 03:18-0300\n"
+"POT-Creation-Date: 2024-12-18 08:40-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -46,7 +46,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1030
+#: lxc/storage_volume.go:1041
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -60,7 +60,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1240
+#: lxc/config.go:1241
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -409,7 +409,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:790
+#: lxc/cluster.go:791
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -582,13 +582,13 @@ msgstr ""
 msgid "Acknowledge warning"
 msgstr ""
 
+#: lxc/query.go:43
+msgid "Action"
+msgstr ""
+
 #: lxc/query.go:76
 #, c-format
 msgid "Action %q isn't supported by this tool"
-msgstr ""
-
-#: lxc/query.go:43
-msgid "Action (defaults to GET)"
 msgstr ""
 
 #: lxc/cluster_group.go:725
@@ -735,7 +735,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1596
+#: lxc/storage_volume.go:1607
 msgid "All projects"
 msgstr ""
 
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1371
+#: lxc/cluster.go:1372
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -794,7 +794,7 @@ msgstr ""
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:282 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -846,16 +846,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2708
+#: lxc/storage_volume.go:2719
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2785
+#: lxc/export.go:192 lxc/storage_volume.go:2796
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1538
 msgid "Backups:"
 msgstr ""
 
@@ -876,7 +876,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -919,7 +919,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1739
+#: lxc/storage_volume.go:1750
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1004,7 +1004,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1012,7 +1012,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1097
+#: lxc/config.go:702 lxc/config.go:1098
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1021,12 +1021,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:492
+#: lxc/storage_volume.go:493
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:446
+#: lxc/storage_volume.go:447
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1102,7 +1102,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1154
+#: lxc/cluster.go:1155
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1130,8 +1130,8 @@ msgstr ""
 #: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
 #: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
-#: lxc/network_forward.go:182 lxc/network_forward.go:264
+#: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
+#: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
 #: lxc/network_forward.go:497 lxc/network_forward.go:649
 #: lxc/network_forward.go:803 lxc/network_forward.go:892
 #: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
@@ -1146,30 +1146,30 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
-#: lxc/storage_volume.go:1952 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2251 lxc/storage_volume.go:2367
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2555
-#: lxc/storage_volume.go:2643 lxc/storage_volume.go:2807
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
+#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
+#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:894
+#: lxc/cluster.go:895
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:926
+#: lxc/cluster.go:927
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:756
+#: lxc/cluster.go:757
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1206,24 +1206,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
+#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
-#: lxc/storage_volume.go:1188
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
+#: lxc/storage_volume.go:1199
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:619
+#: lxc/storage_volume.go:620
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1233,7 +1233,11 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/move.go:65
+#: lxc/move.go:65
+msgid "Copy a stateful instance as stateless"
+msgstr ""
+
+#: lxc/copy.go:60
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1281,7 +1285,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:389 lxc/storage_volume.go:390
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1289,12 +1293,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:396
+#: lxc/storage_volume.go:397
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:398
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1307,7 +1311,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:515
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1330,12 +1334,12 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1235
+#: lxc/cluster.go:1236
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1239
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1350,17 +1354,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1266
+#: lxc/cluster.go:1267
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1442,7 +1446,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1494,7 +1498,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1523,13 +1527,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1738
+#: lxc/storage_volume.go:1749
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1549,7 +1553,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2642
+#: lxc/storage_volume.go:2653
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1645,7 +1649,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1666,16 +1670,16 @@ msgstr ""
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
-#: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
+#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
+#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
-#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
-#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
+#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
+#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1698,8 +1702,8 @@ msgstr ""
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
 #: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1005 lxc/network.go:1106 lxc/network.go:1185
-#: lxc/network.go:1245 lxc/network.go:1341 lxc/network.go:1413
+#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
+#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
 #: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
 #: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
 #: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
@@ -1750,27 +1754,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
-#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
-#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
-#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1949
-#: lxc/storage_volume.go:2076 lxc/storage_volume.go:2234
-#: lxc/storage_volume.go:2355 lxc/storage_volume.go:2417
-#: lxc/storage_volume.go:2553 lxc/storage_volume.go:2636
-#: lxc/storage_volume.go:2802 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1454
+#: lxc/storage_volume.go:1465
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1782,11 +1786,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
+#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1914,7 +1918,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:516
+#: lxc/cluster.go:1072 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1936,7 +1940,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:769 lxc/cluster.go:770
+#: lxc/cluster.go:770 lxc/cluster.go:771
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1956,7 +1960,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1226 lxc/config.go:1227
+#: lxc/config.go:1227 lxc/config.go:1228
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2020,7 +2024,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2028,7 +2032,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2046,11 +2050,12 @@ msgid ""
 "new\n"
 "  LXD cluster, which will have the given name.\n"
 "\n"
-"  It's required that the LXD is already available on the network. You can "
-"check\n"
-"  that by running 'lxc config get core.https_address', and possibly set a "
-"value\n"
-"  for the address if not yet set."
+"  It's required that LXD is already available on the network. You can check\n"
+"  this by running 'lxc config get core.https_address'. If either an IP "
+"address\n"
+"  and port is displayed, or both, LXD is already available on the network. "
+"If\n"
+"  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
 #: lxc/network_zone.go:1427
@@ -2080,12 +2085,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
+#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2095,12 +2100,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
+#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
-#: lxc/storage_volume.go:2199
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
+#: lxc/storage_volume.go:2210
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2110,11 +2115,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1298 lxc/cluster.go:1299
+#: lxc/cluster.go:1299 lxc/cluster.go:1300
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1396
+#: lxc/cluster.go:1397
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2142,8 +2147,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
-#: lxc/storage_volume.go:1564
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Expires at"
 msgstr ""
 
@@ -2167,7 +2172,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2635 lxc/storage_volume.go:2636
+#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2179,11 +2184,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2639
+#: lxc/storage_volume.go:2650
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2768
+#: lxc/export.go:152 lxc/storage_volume.go:2779
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2363,7 +2368,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
+#: lxc/network.go:1046 lxc/network_acl.go:133 lxc/network_zone.go:124
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2373,7 +2378,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1303
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2381,7 +2386,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1301
+#: lxc/cluster.go:1302
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2393,7 +2398,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1331
+#: lxc/cluster.go:1332
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2434,16 +2439,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
-#: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1614 lxc/warning.go:94
+#: lxc/storage_volume.go:1625 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2503,7 +2508,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:996
+#: lxc/config.go:996 lxc/config.go:997
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2567,7 +2572,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1249
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2631,11 +2636,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
+#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:475
+#: lxc/storage_volume.go:476
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2663,7 +2668,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1161
+#: lxc/network.go:1170
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2717,7 +2722,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1163
+#: lxc/network.go:1172
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2729,11 +2734,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1084
+#: lxc/list.go:560 lxc/network.go:1093
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1085
+#: lxc/list.go:561 lxc/network.go:1094
 msgid "IPV6"
 msgstr ""
 
@@ -2763,7 +2768,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2427
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2777,7 +2782,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2437
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2827,7 +2832,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2802
+#: lxc/storage_volume.go:2813
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2835,7 +2840,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2801
+#: lxc/storage_volume.go:2812
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2857,11 +2862,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2809
+#: lxc/storage_volume.go:2820
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2883
+#: lxc/storage_volume.go:2894
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2905,7 +2910,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
+#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2987,7 +2992,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2012
+#: lxc/move.go:148 lxc/storage_volume.go:2023
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2995,7 +3000,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2019
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3013,9 +3018,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
-#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2144 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
+#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3059,9 +3064,9 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
+#: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3073,8 +3078,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1020 lxc/cluster.go:1123
-#: lxc/cluster.go:1231 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
+#: lxc/cluster.go:1232 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3111,7 +3116,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1105 lxc/network.go:1106
+#: lxc/network.go:1114 lxc/network.go:1115
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3123,7 +3128,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:976 lxc/cluster.go:977
+#: lxc/cluster.go:977 lxc/cluster.go:978
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -3171,7 +3176,7 @@ msgstr ""
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1004 lxc/network.go:1005
+#: lxc/network.go:1005 lxc/network.go:1006
 msgid "List available networks"
 msgstr ""
 
@@ -3259,7 +3264,7 @@ msgid ""
 "Fast column layout: nsacPt\n"
 "\n"
 "A single keyword like \"web\" which will list any instance with a name "
-"starting by \"web\".\n"
+"starting with \"web\".\n"
 "A regular expression on the instance name. (e.g. .*web.*01$).\n"
 "A key/value pair referring to a configuration item. For those, the\n"
 "namespace can be abbreviated to the smallest unambiguous identifier.\n"
@@ -3316,7 +3321,8 @@ msgid ""
 "  P - Profiles\n"
 "  s - State\n"
 "  S - Number of snapshots\n"
-"  t - Type (persistent or ephemeral)\n"
+"  t - Type (container or virtual-machine, ephemeral indicated if "
+"applicable)\n"
 "  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
@@ -3365,11 +3371,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1603
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1608
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3428,7 +3434,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1470
+#: lxc/info.go:489 lxc/storage_volume.go:1481
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3449,7 +3455,7 @@ msgstr ""
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1162
+#: lxc/network.go:1171
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3467,7 +3473,7 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1083
+#: lxc/network.go:1092
 msgid "MANAGED"
 msgstr ""
 
@@ -3590,7 +3596,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:955 lxc/config.go:956
+#: lxc/config.go:956 lxc/config.go:957
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3729,7 +3735,7 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:957
+#: lxc/cluster.go:958
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
@@ -3793,7 +3799,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:811 lxc/cluster.go:1367 lxc/cluster_group.go:129
+#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -3856,8 +3862,8 @@ msgstr ""
 
 #: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1139 lxc/network.go:1217 lxc/network.go:1283
-#: lxc/network.go:1375 lxc/network_forward.go:127 lxc/network_forward.go:215
+#: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
+#: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
 #: lxc/network_forward.go:284 lxc/network_forward.go:445
 #: lxc/network_forward.go:530 lxc/network_forward.go:705
 #: lxc/network_forward.go:836 lxc/network_forward.go:929
@@ -3898,12 +3904,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
-#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
-#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1986
-#: lxc/storage_volume.go:2127 lxc/storage_volume.go:2285
-#: lxc/storage_volume.go:2476 lxc/storage_volume.go:2593
+#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
+#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
 msgid "Missing pool name"
 msgstr ""
 
@@ -3922,11 +3928,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:438 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1411
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3963,8 +3969,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
-#: lxc/storage_volume.go:964
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
+#: lxc/storage_volume.go:975
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4001,7 +4007,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4009,11 +4015,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1856
+#: lxc/storage_volume.go:1867
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:518
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4035,12 +4041,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
+#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
 msgid "NAME"
 msgstr ""
 
@@ -4068,7 +4074,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
 #: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4092,8 +4098,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
-#: lxc/storage_volume.go:1562
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1573
 msgid "Name"
 msgstr ""
 
@@ -4101,7 +4107,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4126,7 +4132,7 @@ msgstr ""
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1227
+#: lxc/network.go:1236
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4236,7 +4242,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1161
+#: lxc/cluster.go:1162
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4245,7 +4251,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
+#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4265,11 +4271,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:502 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4283,7 +4289,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2035
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4291,15 +4297,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:343
+#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
+#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2690
+#: lxc/storage_volume.go:2701
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2489
+#: lxc/storage_volume.go:2500
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4311,11 +4318,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1418
+#: lxc/storage_volume.go:1429
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1298
+#: lxc/network.go:735 lxc/network.go:1307
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4324,7 +4331,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1577
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4354,7 +4361,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1767
 msgid "POOL"
 msgstr ""
 
@@ -4370,7 +4377,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1773
 #: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4416,7 +4423,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -4437,16 +4444,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
-#: lxc/storage_volume.go:1189
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
+#: lxc/storage_volume.go:1200
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4563,7 +4570,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1356
+#: lxc/storage_volume.go:1367
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4577,7 +4584,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1225
+#: lxc/storage_volume.go:1236
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4593,7 +4600,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2247
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4614,7 +4621,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1004
+#: lxc/storage_volume.go:1015
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4623,7 +4630,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2081
+#: lxc/storage_volume.go:2092
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4636,13 +4643,13 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2357
+#: lxc/storage_volume.go:2368
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
 "\n"
 "lxc storage volume unset default data size\n"
-"    Remotes the size/quota of a custom volume \"data\" in pool \"default\".\n"
+"    Removes the size/quota of a custom volume \"data\" in pool \"default\".\n"
 "\n"
 "lxc storage volume unset default virtual-machine/data snapshots.expiry\n"
 "    Removes the snapshot expiration period for a virtual machine \"data\" in "
@@ -4722,7 +4729,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4905,7 +4912,7 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1184 lxc/network.go:1185
+#: lxc/network.go:1193 lxc/network.go:1194
 msgid "Rename networks"
 msgstr ""
 
@@ -4921,15 +4928,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1949
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:1959
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2037 lxc/storage_volume.go:2057
+#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4939,11 +4946,11 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:892 lxc/cluster.go:893
+#: lxc/cluster.go:893 lxc/cluster.go:894
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1032
+#: lxc/config.go:1033
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -4966,7 +4973,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1328 lxc/cluster.go:1329
+#: lxc/cluster.go:1329 lxc/cluster.go:1330
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4981,11 +4988,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2552 lxc/storage_volume.go:2553
+#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1394
+#: lxc/cluster.go:1395
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5007,7 +5014,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1087
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5057,7 +5064,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1088
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1097
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5120,7 +5127,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1050 lxc/config.go:1051
+#: lxc/config.go:1051 lxc/config.go:1052
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5184,11 +5191,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1244
+#: lxc/network.go:1253
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1245
+#: lxc/network.go:1254
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5305,11 +5312,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2075
+#: lxc/storage_volume.go:2086
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2076
+#: lxc/storage_volume.go:2087
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5366,7 +5373,7 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1252
+#: lxc/network.go:1261
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5394,7 +5401,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2103
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5463,7 +5470,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1173
+#: lxc/config.go:1173 lxc/config.go:1174
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5495,7 +5502,7 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1340 lxc/network.go:1341
+#: lxc/network.go:1349 lxc/network.go:1350
 msgid "Show network configurations"
 msgstr ""
 
@@ -5543,11 +5550,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2233 lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5570,7 +5577,7 @@ msgid "Show the expanded configuration"
 msgstr ""
 
 #: lxc/info.go:43
-msgid "Show the instance's last 100 log lines?"
+msgid "Show the instance's last 100 log lines"
 msgstr ""
 
 #: lxc/info.go:44
@@ -5615,15 +5622,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2417
+#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2179
+#: lxc/storage_volume.go:2190
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1502
 msgid "Snapshots:"
 msgstr ""
 
@@ -5728,21 +5735,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:702
+#: lxc/storage_volume.go:703
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:790
+#: lxc/storage_volume.go:791
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:516
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:520
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5750,7 +5757,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5799,18 +5806,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1070 lxc/config_trust.go:515
+#: lxc/cluster.go:1071 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1736 lxc/warning.go:216
+#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1747 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
 msgid "Taken at"
 msgstr ""
 
@@ -5967,12 +5974,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1340
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1306
+#: lxc/storage_volume.go:1317
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -5991,8 +5998,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
-#: lxc/storage_volume.go:978
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:989
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6012,11 +6019,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:739
+#: lxc/cluster.go:740
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:729
+#: lxc/cluster.go:730
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6067,7 +6074,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6082,7 +6089,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1853
+#: lxc/storage_volume.go:1864
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6090,7 +6097,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:394
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6149,7 +6156,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1472
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6171,13 +6178,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:995 lxc/storage_volume.go:1752
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
+#: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1740
+#: lxc/storage.go:724 lxc/storage_volume.go:1751
 msgid "USED BY"
 msgstr ""
 
@@ -6209,7 +6216,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6235,7 +6242,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1141 lxc/config.go:1142
+#: lxc/config.go:1142 lxc/config.go:1143
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6263,7 +6270,7 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1412 lxc/network.go:1413
+#: lxc/network.go:1421 lxc/network.go:1422
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -6315,7 +6322,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2354 lxc/storage_volume.go:2355
+#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6339,7 +6346,7 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1417
+#: lxc/network.go:1426
 msgid "Unset the key as a network property"
 msgstr ""
 
@@ -6367,7 +6374,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2379
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6375,7 +6382,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:247
+#: lxc/storage_volume.go:248
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6388,11 +6395,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1174
+#: lxc/cluster.go:1175
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1176
+#: lxc/cluster.go:1177
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6411,12 +6418,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2641
+#: lxc/export.go:42 lxc/storage_volume.go:2652
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6483,7 +6490,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1576
 msgid "Volume Only"
 msgstr ""
 
@@ -6516,7 +6523,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
 #: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6542,18 +6549,18 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:903
+#: lxc/storage_volume.go:909
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:281
+#: lxc/storage_volume.go:282
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
-#: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
+#: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
@@ -6563,7 +6570,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1172
+#: lxc/cluster.go:1173
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -6726,7 +6733,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6748,11 +6755,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:1140
+#: lxc/config.go:995 lxc/config.go:1141
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1049
+#: lxc/config.go:1050
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -6831,8 +6838,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:768
-#: lxc/cluster.go:1085 lxc/cluster.go:1297 lxc/cluster.go:1327
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
+#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -6856,8 +6863,8 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1104
-#: lxc/network.go:1339 lxc/network_forward.go:87
+#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1113
+#: lxc/network.go:1348 lxc/network_forward.go:87
 #: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -6870,11 +6877,11 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1411
+#: lxc/network.go:791 lxc/network.go:1420
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1243
+#: lxc/network.go:1252
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
@@ -6919,7 +6926,7 @@ msgstr ""
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1182
+#: lxc/network.go:1191
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -6970,7 +6977,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2800
+#: lxc/storage_volume.go:2811
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7005,13 +7012,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:1958
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:806
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7019,51 +7026,51 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2551
+#: lxc/storage_volume.go:2562
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2634
+#: lxc/storage_volume.go:2645
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2415
+#: lxc/storage_volume.go:2426
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:609
+#: lxc/storage_volume.go:610
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:718
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2353
+#: lxc/storage_volume.go:2364
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2085
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2232
+#: lxc/storage_volume.go:2243
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1221
+#: lxc/storage_volume.go:1232
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1858
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:387
+#: lxc/storage_volume.go:388
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7169,7 +7176,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1601
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7181,7 +7188,7 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:891
+#: lxc/cluster.go:892
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -7253,7 +7260,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:772
+#: lxc/cluster.go:773
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7302,13 +7309,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1229
+#: lxc/config.go:1230
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1053
+#: lxc/config.go:1054
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7645,7 +7652,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:614
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7653,13 +7660,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2804
+#: lxc/storage_volume.go:2815
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2419
+#: lxc/storage_volume.go:2430
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-09 03:18-0300\n"
+"POT-Creation-Date: 2024-12-18 08:40-0700\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1030
+#: lxc/storage_volume.go:1041
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1240
+#: lxc/config.go:1241
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -412,7 +412,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:790
+#: lxc/cluster.go:791
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -585,13 +585,13 @@ msgstr ""
 msgid "Acknowledge warning"
 msgstr ""
 
+#: lxc/query.go:43
+msgid "Action"
+msgstr ""
+
 #: lxc/query.go:76
 #, c-format
 msgid "Action %q isn't supported by this tool"
-msgstr ""
-
-#: lxc/query.go:43
-msgid "Action (defaults to GET)"
 msgstr ""
 
 #: lxc/cluster_group.go:725
@@ -738,7 +738,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1596
+#: lxc/storage_volume.go:1607
 msgid "All projects"
 msgstr ""
 
@@ -760,7 +760,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1371
+#: lxc/cluster.go:1372
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -797,7 +797,7 @@ msgstr ""
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:282 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -849,16 +849,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2708
+#: lxc/storage_volume.go:2719
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2785
+#: lxc/export.go:192 lxc/storage_volume.go:2796
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1538
 msgid "Backups:"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -922,7 +922,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1739
+#: lxc/storage_volume.go:1750
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1007,7 +1007,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1097
+#: lxc/config.go:702 lxc/config.go:1098
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1024,12 +1024,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:492
+#: lxc/storage_volume.go:493
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:446
+#: lxc/storage_volume.go:447
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1105,7 +1105,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1154
+#: lxc/cluster.go:1155
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1133,8 +1133,8 @@ msgstr ""
 #: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
 #: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
-#: lxc/network_forward.go:182 lxc/network_forward.go:264
+#: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
+#: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
 #: lxc/network_forward.go:497 lxc/network_forward.go:649
 #: lxc/network_forward.go:803 lxc/network_forward.go:892
 #: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
@@ -1149,30 +1149,30 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
-#: lxc/storage_volume.go:1952 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2251 lxc/storage_volume.go:2367
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2555
-#: lxc/storage_volume.go:2643 lxc/storage_volume.go:2807
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
+#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
+#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:894
+#: lxc/cluster.go:895
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:926
+#: lxc/cluster.go:927
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:756
+#: lxc/cluster.go:757
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1209,24 +1209,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
+#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
-#: lxc/storage_volume.go:1188
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
+#: lxc/storage_volume.go:1199
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:619
+#: lxc/storage_volume.go:620
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1236,7 +1236,11 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/move.go:65
+#: lxc/move.go:65
+msgid "Copy a stateful instance as stateless"
+msgstr ""
+
+#: lxc/copy.go:60
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1284,7 +1288,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:389 lxc/storage_volume.go:390
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1292,12 +1296,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:396
+#: lxc/storage_volume.go:397
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:398
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1310,7 +1314,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:515
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1333,12 +1337,12 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1235
+#: lxc/cluster.go:1236
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1239
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1353,17 +1357,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1266
+#: lxc/cluster.go:1267
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1445,7 +1449,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1497,7 +1501,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1526,13 +1530,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1738
+#: lxc/storage_volume.go:1749
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1552,7 +1556,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2642
+#: lxc/storage_volume.go:2653
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1648,7 +1652,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1669,16 +1673,16 @@ msgstr ""
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
-#: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
+#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
+#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
-#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
-#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
+#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
+#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1701,8 +1705,8 @@ msgstr ""
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
 #: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1005 lxc/network.go:1106 lxc/network.go:1185
-#: lxc/network.go:1245 lxc/network.go:1341 lxc/network.go:1413
+#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
+#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
 #: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
 #: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
 #: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
@@ -1753,27 +1757,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
-#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
-#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
-#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1949
-#: lxc/storage_volume.go:2076 lxc/storage_volume.go:2234
-#: lxc/storage_volume.go:2355 lxc/storage_volume.go:2417
-#: lxc/storage_volume.go:2553 lxc/storage_volume.go:2636
-#: lxc/storage_volume.go:2802 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1454
+#: lxc/storage_volume.go:1465
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1785,11 +1789,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
+#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1917,7 +1921,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:516
+#: lxc/cluster.go:1072 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1939,7 +1943,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:769 lxc/cluster.go:770
+#: lxc/cluster.go:770 lxc/cluster.go:771
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1959,7 +1963,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1226 lxc/config.go:1227
+#: lxc/config.go:1227 lxc/config.go:1228
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2023,7 +2027,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2031,7 +2035,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2049,11 +2053,12 @@ msgid ""
 "new\n"
 "  LXD cluster, which will have the given name.\n"
 "\n"
-"  It's required that the LXD is already available on the network. You can "
-"check\n"
-"  that by running 'lxc config get core.https_address', and possibly set a "
-"value\n"
-"  for the address if not yet set."
+"  It's required that LXD is already available on the network. You can check\n"
+"  this by running 'lxc config get core.https_address'. If either an IP "
+"address\n"
+"  and port is displayed, or both, LXD is already available on the network. "
+"If\n"
+"  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
 #: lxc/network_zone.go:1427
@@ -2083,12 +2088,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
+#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2098,12 +2103,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
+#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
-#: lxc/storage_volume.go:2199
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
+#: lxc/storage_volume.go:2210
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2113,11 +2118,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1298 lxc/cluster.go:1299
+#: lxc/cluster.go:1299 lxc/cluster.go:1300
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1396
+#: lxc/cluster.go:1397
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2145,8 +2150,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
-#: lxc/storage_volume.go:1564
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Expires at"
 msgstr ""
 
@@ -2170,7 +2175,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2635 lxc/storage_volume.go:2636
+#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2182,11 +2187,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2639
+#: lxc/storage_volume.go:2650
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2768
+#: lxc/export.go:152 lxc/storage_volume.go:2779
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2366,7 +2371,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
+#: lxc/network.go:1046 lxc/network_acl.go:133 lxc/network_zone.go:124
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2376,7 +2381,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1303
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2384,7 +2389,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1301
+#: lxc/cluster.go:1302
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2396,7 +2401,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1331
+#: lxc/cluster.go:1332
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2437,16 +2442,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
-#: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1614 lxc/warning.go:94
+#: lxc/storage_volume.go:1625 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2506,7 +2511,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:996
+#: lxc/config.go:996 lxc/config.go:997
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2570,7 +2575,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1249
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2634,11 +2639,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
+#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:475
+#: lxc/storage_volume.go:476
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2666,7 +2671,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1161
+#: lxc/network.go:1170
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2720,7 +2725,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1163
+#: lxc/network.go:1172
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2732,11 +2737,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1084
+#: lxc/list.go:560 lxc/network.go:1093
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1085
+#: lxc/list.go:561 lxc/network.go:1094
 msgid "IPV6"
 msgstr ""
 
@@ -2766,7 +2771,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2427
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2780,7 +2785,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2437
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2830,7 +2835,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2802
+#: lxc/storage_volume.go:2813
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2838,7 +2843,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2801
+#: lxc/storage_volume.go:2812
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2860,11 +2865,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2809
+#: lxc/storage_volume.go:2820
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2883
+#: lxc/storage_volume.go:2894
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2908,7 +2913,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
+#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2990,7 +2995,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2012
+#: lxc/move.go:148 lxc/storage_volume.go:2023
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2998,7 +3003,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2019
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3016,9 +3021,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
-#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2144 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
+#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3062,9 +3067,9 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
+#: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3076,8 +3081,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1020 lxc/cluster.go:1123
-#: lxc/cluster.go:1231 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
+#: lxc/cluster.go:1232 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3114,7 +3119,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1105 lxc/network.go:1106
+#: lxc/network.go:1114 lxc/network.go:1115
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3126,7 +3131,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:976 lxc/cluster.go:977
+#: lxc/cluster.go:977 lxc/cluster.go:978
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -3174,7 +3179,7 @@ msgstr ""
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1004 lxc/network.go:1005
+#: lxc/network.go:1005 lxc/network.go:1006
 msgid "List available networks"
 msgstr ""
 
@@ -3262,7 +3267,7 @@ msgid ""
 "Fast column layout: nsacPt\n"
 "\n"
 "A single keyword like \"web\" which will list any instance with a name "
-"starting by \"web\".\n"
+"starting with \"web\".\n"
 "A regular expression on the instance name. (e.g. .*web.*01$).\n"
 "A key/value pair referring to a configuration item. For those, the\n"
 "namespace can be abbreviated to the smallest unambiguous identifier.\n"
@@ -3319,7 +3324,8 @@ msgid ""
 "  P - Profiles\n"
 "  s - State\n"
 "  S - Number of snapshots\n"
-"  t - Type (persistent or ephemeral)\n"
+"  t - Type (container or virtual-machine, ephemeral indicated if "
+"applicable)\n"
 "  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
@@ -3368,11 +3374,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1603
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1608
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3431,7 +3437,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1470
+#: lxc/info.go:489 lxc/storage_volume.go:1481
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3452,7 +3458,7 @@ msgstr ""
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1162
+#: lxc/network.go:1171
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3470,7 +3476,7 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1083
+#: lxc/network.go:1092
 msgid "MANAGED"
 msgstr ""
 
@@ -3593,7 +3599,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:955 lxc/config.go:956
+#: lxc/config.go:956 lxc/config.go:957
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3732,7 +3738,7 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:957
+#: lxc/cluster.go:958
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
@@ -3796,7 +3802,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:811 lxc/cluster.go:1367 lxc/cluster_group.go:129
+#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -3859,8 +3865,8 @@ msgstr ""
 
 #: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1139 lxc/network.go:1217 lxc/network.go:1283
-#: lxc/network.go:1375 lxc/network_forward.go:127 lxc/network_forward.go:215
+#: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
+#: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
 #: lxc/network_forward.go:284 lxc/network_forward.go:445
 #: lxc/network_forward.go:530 lxc/network_forward.go:705
 #: lxc/network_forward.go:836 lxc/network_forward.go:929
@@ -3901,12 +3907,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
-#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
-#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1986
-#: lxc/storage_volume.go:2127 lxc/storage_volume.go:2285
-#: lxc/storage_volume.go:2476 lxc/storage_volume.go:2593
+#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
+#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
 msgid "Missing pool name"
 msgstr ""
 
@@ -3925,11 +3931,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:438 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1411
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3966,8 +3972,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
-#: lxc/storage_volume.go:964
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
+#: lxc/storage_volume.go:975
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4004,7 +4010,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4012,11 +4018,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1856
+#: lxc/storage_volume.go:1867
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:518
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4038,12 +4044,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
+#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
 msgid "NAME"
 msgstr ""
 
@@ -4071,7 +4077,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
 #: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4095,8 +4101,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
-#: lxc/storage_volume.go:1562
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1573
 msgid "Name"
 msgstr ""
 
@@ -4104,7 +4110,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4129,7 +4135,7 @@ msgstr ""
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1227
+#: lxc/network.go:1236
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4239,7 +4245,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1161
+#: lxc/cluster.go:1162
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4248,7 +4254,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
+#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4268,11 +4274,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:502 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4286,7 +4292,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2035
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4294,15 +4300,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:343
+#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
+#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2690
+#: lxc/storage_volume.go:2701
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2489
+#: lxc/storage_volume.go:2500
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4314,11 +4321,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1418
+#: lxc/storage_volume.go:1429
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1298
+#: lxc/network.go:735 lxc/network.go:1307
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4327,7 +4334,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1577
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4357,7 +4364,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1767
 msgid "POOL"
 msgstr ""
 
@@ -4373,7 +4380,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1773
 #: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4419,7 +4426,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -4440,16 +4447,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
-#: lxc/storage_volume.go:1189
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
+#: lxc/storage_volume.go:1200
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4566,7 +4573,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1356
+#: lxc/storage_volume.go:1367
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4580,7 +4587,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1225
+#: lxc/storage_volume.go:1236
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4596,7 +4603,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2247
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4617,7 +4624,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1004
+#: lxc/storage_volume.go:1015
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4626,7 +4633,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2081
+#: lxc/storage_volume.go:2092
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4639,13 +4646,13 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2357
+#: lxc/storage_volume.go:2368
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
 "\n"
 "lxc storage volume unset default data size\n"
-"    Remotes the size/quota of a custom volume \"data\" in pool \"default\".\n"
+"    Removes the size/quota of a custom volume \"data\" in pool \"default\".\n"
 "\n"
 "lxc storage volume unset default virtual-machine/data snapshots.expiry\n"
 "    Removes the snapshot expiration period for a virtual machine \"data\" in "
@@ -4725,7 +4732,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4908,7 +4915,7 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1184 lxc/network.go:1185
+#: lxc/network.go:1193 lxc/network.go:1194
 msgid "Rename networks"
 msgstr ""
 
@@ -4924,15 +4931,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1949
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:1959
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2037 lxc/storage_volume.go:2057
+#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4942,11 +4949,11 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:892 lxc/cluster.go:893
+#: lxc/cluster.go:893 lxc/cluster.go:894
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1032
+#: lxc/config.go:1033
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -4969,7 +4976,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1328 lxc/cluster.go:1329
+#: lxc/cluster.go:1329 lxc/cluster.go:1330
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4984,11 +4991,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2552 lxc/storage_volume.go:2553
+#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1394
+#: lxc/cluster.go:1395
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5010,7 +5017,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1087
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5060,7 +5067,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1088
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1097
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5123,7 +5130,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1050 lxc/config.go:1051
+#: lxc/config.go:1051 lxc/config.go:1052
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5187,11 +5194,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1244
+#: lxc/network.go:1253
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1245
+#: lxc/network.go:1254
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5308,11 +5315,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2075
+#: lxc/storage_volume.go:2086
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2076
+#: lxc/storage_volume.go:2087
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5369,7 +5376,7 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1252
+#: lxc/network.go:1261
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5397,7 +5404,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2103
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5466,7 +5473,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1173
+#: lxc/config.go:1173 lxc/config.go:1174
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5498,7 +5505,7 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1340 lxc/network.go:1341
+#: lxc/network.go:1349 lxc/network.go:1350
 msgid "Show network configurations"
 msgstr ""
 
@@ -5546,11 +5553,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2233 lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5573,7 +5580,7 @@ msgid "Show the expanded configuration"
 msgstr ""
 
 #: lxc/info.go:43
-msgid "Show the instance's last 100 log lines?"
+msgid "Show the instance's last 100 log lines"
 msgstr ""
 
 #: lxc/info.go:44
@@ -5618,15 +5625,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2417
+#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2179
+#: lxc/storage_volume.go:2190
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1502
 msgid "Snapshots:"
 msgstr ""
 
@@ -5731,21 +5738,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:702
+#: lxc/storage_volume.go:703
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:790
+#: lxc/storage_volume.go:791
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:516
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:520
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5753,7 +5760,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5802,18 +5809,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1070 lxc/config_trust.go:515
+#: lxc/cluster.go:1071 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1736 lxc/warning.go:216
+#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1747 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
 msgid "Taken at"
 msgstr ""
 
@@ -5970,12 +5977,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1340
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1306
+#: lxc/storage_volume.go:1317
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -5994,8 +6001,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
-#: lxc/storage_volume.go:978
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:989
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6015,11 +6022,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:739
+#: lxc/cluster.go:740
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:729
+#: lxc/cluster.go:730
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6070,7 +6077,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6085,7 +6092,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1853
+#: lxc/storage_volume.go:1864
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6093,7 +6100,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:394
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6152,7 +6159,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1472
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6174,13 +6181,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:995 lxc/storage_volume.go:1752
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
+#: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1740
+#: lxc/storage.go:724 lxc/storage_volume.go:1751
 msgid "USED BY"
 msgstr ""
 
@@ -6212,7 +6219,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6238,7 +6245,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1141 lxc/config.go:1142
+#: lxc/config.go:1142 lxc/config.go:1143
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6266,7 +6273,7 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1412 lxc/network.go:1413
+#: lxc/network.go:1421 lxc/network.go:1422
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -6318,7 +6325,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2354 lxc/storage_volume.go:2355
+#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6342,7 +6349,7 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1417
+#: lxc/network.go:1426
 msgid "Unset the key as a network property"
 msgstr ""
 
@@ -6370,7 +6377,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2379
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6378,7 +6385,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:247
+#: lxc/storage_volume.go:248
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6391,11 +6398,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1174
+#: lxc/cluster.go:1175
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1176
+#: lxc/cluster.go:1177
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6414,12 +6421,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2641
+#: lxc/export.go:42 lxc/storage_volume.go:2652
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6486,7 +6493,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1576
 msgid "Volume Only"
 msgstr ""
 
@@ -6519,7 +6526,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
 #: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6545,18 +6552,18 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:903
+#: lxc/storage_volume.go:909
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:281
+#: lxc/storage_volume.go:282
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
-#: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
+#: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
@@ -6566,7 +6573,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1172
+#: lxc/cluster.go:1173
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -6729,7 +6736,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6751,11 +6758,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:1140
+#: lxc/config.go:995 lxc/config.go:1141
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1049
+#: lxc/config.go:1050
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -6834,8 +6841,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:768
-#: lxc/cluster.go:1085 lxc/cluster.go:1297 lxc/cluster.go:1327
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
+#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -6859,8 +6866,8 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1104
-#: lxc/network.go:1339 lxc/network_forward.go:87
+#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1113
+#: lxc/network.go:1348 lxc/network_forward.go:87
 #: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -6873,11 +6880,11 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1411
+#: lxc/network.go:791 lxc/network.go:1420
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1243
+#: lxc/network.go:1252
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
@@ -6922,7 +6929,7 @@ msgstr ""
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1182
+#: lxc/network.go:1191
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -6973,7 +6980,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2800
+#: lxc/storage_volume.go:2811
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7008,13 +7015,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:1958
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:806
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7022,51 +7029,51 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2551
+#: lxc/storage_volume.go:2562
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2634
+#: lxc/storage_volume.go:2645
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2415
+#: lxc/storage_volume.go:2426
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:609
+#: lxc/storage_volume.go:610
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:718
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2353
+#: lxc/storage_volume.go:2364
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2085
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2232
+#: lxc/storage_volume.go:2243
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1221
+#: lxc/storage_volume.go:1232
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1858
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:387
+#: lxc/storage_volume.go:388
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7172,7 +7179,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1601
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7184,7 +7191,7 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:891
+#: lxc/cluster.go:892
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -7256,7 +7263,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:772
+#: lxc/cluster.go:773
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7305,13 +7312,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1229
+#: lxc/config.go:1230
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1053
+#: lxc/config.go:1054
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7648,7 +7655,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:614
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7656,13 +7663,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2804
+#: lxc/storage_volume.go:2815
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2419
+#: lxc/storage_volume.go:2430
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-09 03:18-0300\n"
+"POT-Creation-Date: 2024-12-18 08:40-0700\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1030
+#: lxc/storage_volume.go:1041
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1240
+#: lxc/config.go:1241
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -412,7 +412,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:790
+#: lxc/cluster.go:791
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -585,13 +585,13 @@ msgstr ""
 msgid "Acknowledge warning"
 msgstr ""
 
+#: lxc/query.go:43
+msgid "Action"
+msgstr ""
+
 #: lxc/query.go:76
 #, c-format
 msgid "Action %q isn't supported by this tool"
-msgstr ""
-
-#: lxc/query.go:43
-msgid "Action (defaults to GET)"
 msgstr ""
 
 #: lxc/cluster_group.go:725
@@ -738,7 +738,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1596
+#: lxc/storage_volume.go:1607
 msgid "All projects"
 msgstr ""
 
@@ -760,7 +760,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1371
+#: lxc/cluster.go:1372
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -797,7 +797,7 @@ msgstr ""
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:282 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -849,16 +849,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2708
+#: lxc/storage_volume.go:2719
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2785
+#: lxc/export.go:192 lxc/storage_volume.go:2796
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1538
 msgid "Backups:"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -922,7 +922,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1739
+#: lxc/storage_volume.go:1750
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1007,7 +1007,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1097
+#: lxc/config.go:702 lxc/config.go:1098
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1024,12 +1024,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:492
+#: lxc/storage_volume.go:493
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:446
+#: lxc/storage_volume.go:447
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1105,7 +1105,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1154
+#: lxc/cluster.go:1155
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1133,8 +1133,8 @@ msgstr ""
 #: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
 #: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
-#: lxc/network_forward.go:182 lxc/network_forward.go:264
+#: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
+#: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
 #: lxc/network_forward.go:497 lxc/network_forward.go:649
 #: lxc/network_forward.go:803 lxc/network_forward.go:892
 #: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
@@ -1149,30 +1149,30 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
-#: lxc/storage_volume.go:1952 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2251 lxc/storage_volume.go:2367
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2555
-#: lxc/storage_volume.go:2643 lxc/storage_volume.go:2807
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
+#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
+#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:894
+#: lxc/cluster.go:895
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:926
+#: lxc/cluster.go:927
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:756
+#: lxc/cluster.go:757
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1209,24 +1209,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
+#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
-#: lxc/storage_volume.go:1188
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
+#: lxc/storage_volume.go:1199
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:619
+#: lxc/storage_volume.go:620
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1236,7 +1236,11 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/move.go:65
+#: lxc/move.go:65
+msgid "Copy a stateful instance as stateless"
+msgstr ""
+
+#: lxc/copy.go:60
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1284,7 +1288,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:389 lxc/storage_volume.go:390
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1292,12 +1296,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:396
+#: lxc/storage_volume.go:397
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:398
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1310,7 +1314,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:515
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1333,12 +1337,12 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1235
+#: lxc/cluster.go:1236
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1239
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1353,17 +1357,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1266
+#: lxc/cluster.go:1267
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1445,7 +1449,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1497,7 +1501,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1526,13 +1530,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1738
+#: lxc/storage_volume.go:1749
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1552,7 +1556,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2642
+#: lxc/storage_volume.go:2653
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1648,7 +1652,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1669,16 +1673,16 @@ msgstr ""
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
-#: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
+#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
+#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
-#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
-#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
+#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
+#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1701,8 +1705,8 @@ msgstr ""
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
 #: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1005 lxc/network.go:1106 lxc/network.go:1185
-#: lxc/network.go:1245 lxc/network.go:1341 lxc/network.go:1413
+#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
+#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
 #: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
 #: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
 #: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
@@ -1753,27 +1757,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
-#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
-#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
-#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1949
-#: lxc/storage_volume.go:2076 lxc/storage_volume.go:2234
-#: lxc/storage_volume.go:2355 lxc/storage_volume.go:2417
-#: lxc/storage_volume.go:2553 lxc/storage_volume.go:2636
-#: lxc/storage_volume.go:2802 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1454
+#: lxc/storage_volume.go:1465
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1785,11 +1789,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
+#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1917,7 +1921,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:516
+#: lxc/cluster.go:1072 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1939,7 +1943,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:769 lxc/cluster.go:770
+#: lxc/cluster.go:770 lxc/cluster.go:771
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1959,7 +1963,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1226 lxc/config.go:1227
+#: lxc/config.go:1227 lxc/config.go:1228
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2023,7 +2027,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2031,7 +2035,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2049,11 +2053,12 @@ msgid ""
 "new\n"
 "  LXD cluster, which will have the given name.\n"
 "\n"
-"  It's required that the LXD is already available on the network. You can "
-"check\n"
-"  that by running 'lxc config get core.https_address', and possibly set a "
-"value\n"
-"  for the address if not yet set."
+"  It's required that LXD is already available on the network. You can check\n"
+"  this by running 'lxc config get core.https_address'. If either an IP "
+"address\n"
+"  and port is displayed, or both, LXD is already available on the network. "
+"If\n"
+"  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
 #: lxc/network_zone.go:1427
@@ -2083,12 +2088,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
+#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2098,12 +2103,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
+#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
-#: lxc/storage_volume.go:2199
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
+#: lxc/storage_volume.go:2210
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2113,11 +2118,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1298 lxc/cluster.go:1299
+#: lxc/cluster.go:1299 lxc/cluster.go:1300
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1396
+#: lxc/cluster.go:1397
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2145,8 +2150,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
-#: lxc/storage_volume.go:1564
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Expires at"
 msgstr ""
 
@@ -2170,7 +2175,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2635 lxc/storage_volume.go:2636
+#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2182,11 +2187,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2639
+#: lxc/storage_volume.go:2650
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2768
+#: lxc/export.go:152 lxc/storage_volume.go:2779
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2366,7 +2371,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
+#: lxc/network.go:1046 lxc/network_acl.go:133 lxc/network_zone.go:124
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2376,7 +2381,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1303
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2384,7 +2389,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1301
+#: lxc/cluster.go:1302
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2396,7 +2401,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1331
+#: lxc/cluster.go:1332
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2437,16 +2442,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
-#: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1614 lxc/warning.go:94
+#: lxc/storage_volume.go:1625 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2506,7 +2511,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:996
+#: lxc/config.go:996 lxc/config.go:997
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2570,7 +2575,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1249
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2634,11 +2639,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
+#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:475
+#: lxc/storage_volume.go:476
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2666,7 +2671,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1161
+#: lxc/network.go:1170
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2720,7 +2725,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1163
+#: lxc/network.go:1172
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2732,11 +2737,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1084
+#: lxc/list.go:560 lxc/network.go:1093
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1085
+#: lxc/list.go:561 lxc/network.go:1094
 msgid "IPV6"
 msgstr ""
 
@@ -2766,7 +2771,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2427
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2780,7 +2785,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2437
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2830,7 +2835,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2802
+#: lxc/storage_volume.go:2813
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2838,7 +2843,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2801
+#: lxc/storage_volume.go:2812
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2860,11 +2865,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2809
+#: lxc/storage_volume.go:2820
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2883
+#: lxc/storage_volume.go:2894
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2908,7 +2913,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
+#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2990,7 +2995,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2012
+#: lxc/move.go:148 lxc/storage_volume.go:2023
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2998,7 +3003,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2019
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3016,9 +3021,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
-#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2144 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
+#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3062,9 +3067,9 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
+#: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3076,8 +3081,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1020 lxc/cluster.go:1123
-#: lxc/cluster.go:1231 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
+#: lxc/cluster.go:1232 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3114,7 +3119,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1105 lxc/network.go:1106
+#: lxc/network.go:1114 lxc/network.go:1115
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3126,7 +3131,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:976 lxc/cluster.go:977
+#: lxc/cluster.go:977 lxc/cluster.go:978
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -3174,7 +3179,7 @@ msgstr ""
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1004 lxc/network.go:1005
+#: lxc/network.go:1005 lxc/network.go:1006
 msgid "List available networks"
 msgstr ""
 
@@ -3262,7 +3267,7 @@ msgid ""
 "Fast column layout: nsacPt\n"
 "\n"
 "A single keyword like \"web\" which will list any instance with a name "
-"starting by \"web\".\n"
+"starting with \"web\".\n"
 "A regular expression on the instance name. (e.g. .*web.*01$).\n"
 "A key/value pair referring to a configuration item. For those, the\n"
 "namespace can be abbreviated to the smallest unambiguous identifier.\n"
@@ -3319,7 +3324,8 @@ msgid ""
 "  P - Profiles\n"
 "  s - State\n"
 "  S - Number of snapshots\n"
-"  t - Type (persistent or ephemeral)\n"
+"  t - Type (container or virtual-machine, ephemeral indicated if "
+"applicable)\n"
 "  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
@@ -3368,11 +3374,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1603
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1608
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3431,7 +3437,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1470
+#: lxc/info.go:489 lxc/storage_volume.go:1481
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3452,7 +3458,7 @@ msgstr ""
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1162
+#: lxc/network.go:1171
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3470,7 +3476,7 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1083
+#: lxc/network.go:1092
 msgid "MANAGED"
 msgstr ""
 
@@ -3593,7 +3599,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:955 lxc/config.go:956
+#: lxc/config.go:956 lxc/config.go:957
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3732,7 +3738,7 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:957
+#: lxc/cluster.go:958
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
@@ -3796,7 +3802,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:811 lxc/cluster.go:1367 lxc/cluster_group.go:129
+#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -3859,8 +3865,8 @@ msgstr ""
 
 #: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1139 lxc/network.go:1217 lxc/network.go:1283
-#: lxc/network.go:1375 lxc/network_forward.go:127 lxc/network_forward.go:215
+#: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
+#: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
 #: lxc/network_forward.go:284 lxc/network_forward.go:445
 #: lxc/network_forward.go:530 lxc/network_forward.go:705
 #: lxc/network_forward.go:836 lxc/network_forward.go:929
@@ -3901,12 +3907,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
-#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
-#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1986
-#: lxc/storage_volume.go:2127 lxc/storage_volume.go:2285
-#: lxc/storage_volume.go:2476 lxc/storage_volume.go:2593
+#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
+#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
 msgid "Missing pool name"
 msgstr ""
 
@@ -3925,11 +3931,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:438 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1411
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3966,8 +3972,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
-#: lxc/storage_volume.go:964
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
+#: lxc/storage_volume.go:975
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4004,7 +4010,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4012,11 +4018,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1856
+#: lxc/storage_volume.go:1867
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:518
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4038,12 +4044,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
+#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
 msgid "NAME"
 msgstr ""
 
@@ -4071,7 +4077,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
 #: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4095,8 +4101,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
-#: lxc/storage_volume.go:1562
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1573
 msgid "Name"
 msgstr ""
 
@@ -4104,7 +4110,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4129,7 +4135,7 @@ msgstr ""
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1227
+#: lxc/network.go:1236
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4239,7 +4245,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1161
+#: lxc/cluster.go:1162
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4248,7 +4254,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
+#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4268,11 +4274,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:502 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4286,7 +4292,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2035
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4294,15 +4300,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:343
+#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
+#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2690
+#: lxc/storage_volume.go:2701
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2489
+#: lxc/storage_volume.go:2500
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4314,11 +4321,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1418
+#: lxc/storage_volume.go:1429
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1298
+#: lxc/network.go:735 lxc/network.go:1307
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4327,7 +4334,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1577
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4357,7 +4364,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1767
 msgid "POOL"
 msgstr ""
 
@@ -4373,7 +4380,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1773
 #: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4419,7 +4426,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -4440,16 +4447,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
-#: lxc/storage_volume.go:1189
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
+#: lxc/storage_volume.go:1200
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4566,7 +4573,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1356
+#: lxc/storage_volume.go:1367
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4580,7 +4587,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1225
+#: lxc/storage_volume.go:1236
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4596,7 +4603,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2247
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4617,7 +4624,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1004
+#: lxc/storage_volume.go:1015
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4626,7 +4633,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2081
+#: lxc/storage_volume.go:2092
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4639,13 +4646,13 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2357
+#: lxc/storage_volume.go:2368
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
 "\n"
 "lxc storage volume unset default data size\n"
-"    Remotes the size/quota of a custom volume \"data\" in pool \"default\".\n"
+"    Removes the size/quota of a custom volume \"data\" in pool \"default\".\n"
 "\n"
 "lxc storage volume unset default virtual-machine/data snapshots.expiry\n"
 "    Removes the snapshot expiration period for a virtual machine \"data\" in "
@@ -4725,7 +4732,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4908,7 +4915,7 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1184 lxc/network.go:1185
+#: lxc/network.go:1193 lxc/network.go:1194
 msgid "Rename networks"
 msgstr ""
 
@@ -4924,15 +4931,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1949
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:1959
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2037 lxc/storage_volume.go:2057
+#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4942,11 +4949,11 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:892 lxc/cluster.go:893
+#: lxc/cluster.go:893 lxc/cluster.go:894
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1032
+#: lxc/config.go:1033
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -4969,7 +4976,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1328 lxc/cluster.go:1329
+#: lxc/cluster.go:1329 lxc/cluster.go:1330
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4984,11 +4991,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2552 lxc/storage_volume.go:2553
+#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1394
+#: lxc/cluster.go:1395
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5010,7 +5017,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1087
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5060,7 +5067,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1088
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1097
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5123,7 +5130,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1050 lxc/config.go:1051
+#: lxc/config.go:1051 lxc/config.go:1052
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5187,11 +5194,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1244
+#: lxc/network.go:1253
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1245
+#: lxc/network.go:1254
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5308,11 +5315,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2075
+#: lxc/storage_volume.go:2086
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2076
+#: lxc/storage_volume.go:2087
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5369,7 +5376,7 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1252
+#: lxc/network.go:1261
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5397,7 +5404,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2103
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5466,7 +5473,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1173
+#: lxc/config.go:1173 lxc/config.go:1174
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5498,7 +5505,7 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1340 lxc/network.go:1341
+#: lxc/network.go:1349 lxc/network.go:1350
 msgid "Show network configurations"
 msgstr ""
 
@@ -5546,11 +5553,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2233 lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5573,7 +5580,7 @@ msgid "Show the expanded configuration"
 msgstr ""
 
 #: lxc/info.go:43
-msgid "Show the instance's last 100 log lines?"
+msgid "Show the instance's last 100 log lines"
 msgstr ""
 
 #: lxc/info.go:44
@@ -5618,15 +5625,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2417
+#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2179
+#: lxc/storage_volume.go:2190
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1502
 msgid "Snapshots:"
 msgstr ""
 
@@ -5731,21 +5738,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:702
+#: lxc/storage_volume.go:703
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:790
+#: lxc/storage_volume.go:791
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:516
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:520
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5753,7 +5760,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5802,18 +5809,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1070 lxc/config_trust.go:515
+#: lxc/cluster.go:1071 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1736 lxc/warning.go:216
+#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1747 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
 msgid "Taken at"
 msgstr ""
 
@@ -5970,12 +5977,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1340
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1306
+#: lxc/storage_volume.go:1317
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -5994,8 +6001,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
-#: lxc/storage_volume.go:978
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:989
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6015,11 +6022,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:739
+#: lxc/cluster.go:740
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:729
+#: lxc/cluster.go:730
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6070,7 +6077,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6085,7 +6092,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1853
+#: lxc/storage_volume.go:1864
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6093,7 +6100,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:394
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6152,7 +6159,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1472
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6174,13 +6181,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:995 lxc/storage_volume.go:1752
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
+#: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1740
+#: lxc/storage.go:724 lxc/storage_volume.go:1751
 msgid "USED BY"
 msgstr ""
 
@@ -6212,7 +6219,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6238,7 +6245,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1141 lxc/config.go:1142
+#: lxc/config.go:1142 lxc/config.go:1143
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6266,7 +6273,7 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1412 lxc/network.go:1413
+#: lxc/network.go:1421 lxc/network.go:1422
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -6318,7 +6325,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2354 lxc/storage_volume.go:2355
+#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6342,7 +6349,7 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1417
+#: lxc/network.go:1426
 msgid "Unset the key as a network property"
 msgstr ""
 
@@ -6370,7 +6377,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2379
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6378,7 +6385,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:247
+#: lxc/storage_volume.go:248
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6391,11 +6398,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1174
+#: lxc/cluster.go:1175
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1176
+#: lxc/cluster.go:1177
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6414,12 +6421,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2641
+#: lxc/export.go:42 lxc/storage_volume.go:2652
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6486,7 +6493,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1576
 msgid "Volume Only"
 msgstr ""
 
@@ -6519,7 +6526,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
 #: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6545,18 +6552,18 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:903
+#: lxc/storage_volume.go:909
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:281
+#: lxc/storage_volume.go:282
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
-#: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
+#: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
@@ -6566,7 +6573,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1172
+#: lxc/cluster.go:1173
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -6729,7 +6736,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6751,11 +6758,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:1140
+#: lxc/config.go:995 lxc/config.go:1141
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1049
+#: lxc/config.go:1050
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -6834,8 +6841,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:768
-#: lxc/cluster.go:1085 lxc/cluster.go:1297 lxc/cluster.go:1327
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
+#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -6859,8 +6866,8 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1104
-#: lxc/network.go:1339 lxc/network_forward.go:87
+#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1113
+#: lxc/network.go:1348 lxc/network_forward.go:87
 #: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -6873,11 +6880,11 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1411
+#: lxc/network.go:791 lxc/network.go:1420
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1243
+#: lxc/network.go:1252
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
@@ -6922,7 +6929,7 @@ msgstr ""
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1182
+#: lxc/network.go:1191
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -6973,7 +6980,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2800
+#: lxc/storage_volume.go:2811
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7008,13 +7015,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:1958
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:806
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7022,51 +7029,51 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2551
+#: lxc/storage_volume.go:2562
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2634
+#: lxc/storage_volume.go:2645
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2415
+#: lxc/storage_volume.go:2426
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:609
+#: lxc/storage_volume.go:610
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:718
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2353
+#: lxc/storage_volume.go:2364
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2085
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2232
+#: lxc/storage_volume.go:2243
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1221
+#: lxc/storage_volume.go:1232
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1858
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:387
+#: lxc/storage_volume.go:388
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7172,7 +7179,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1601
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7184,7 +7191,7 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:891
+#: lxc/cluster.go:892
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -7256,7 +7263,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:772
+#: lxc/cluster.go:773
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7305,13 +7312,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1229
+#: lxc/config.go:1230
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1053
+#: lxc/config.go:1054
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7648,7 +7655,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:614
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7656,13 +7663,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2804
+#: lxc/storage_volume.go:2815
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2419
+#: lxc/storage_volume.go:2430
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-09 03:18-0300\n"
+"POT-Creation-Date: 2024-12-18 08:40-0700\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1030
+#: lxc/storage_volume.go:1041
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1240
+#: lxc/config.go:1241
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -412,7 +412,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:790
+#: lxc/cluster.go:791
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -585,13 +585,13 @@ msgstr ""
 msgid "Acknowledge warning"
 msgstr ""
 
+#: lxc/query.go:43
+msgid "Action"
+msgstr ""
+
 #: lxc/query.go:76
 #, c-format
 msgid "Action %q isn't supported by this tool"
-msgstr ""
-
-#: lxc/query.go:43
-msgid "Action (defaults to GET)"
 msgstr ""
 
 #: lxc/cluster_group.go:725
@@ -738,7 +738,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1596
+#: lxc/storage_volume.go:1607
 msgid "All projects"
 msgstr ""
 
@@ -760,7 +760,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1371
+#: lxc/cluster.go:1372
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -797,7 +797,7 @@ msgstr ""
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:282 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -849,16 +849,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2708
+#: lxc/storage_volume.go:2719
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2785
+#: lxc/export.go:192 lxc/storage_volume.go:2796
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1538
 msgid "Backups:"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -922,7 +922,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1739
+#: lxc/storage_volume.go:1750
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1007,7 +1007,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1097
+#: lxc/config.go:702 lxc/config.go:1098
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1024,12 +1024,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:492
+#: lxc/storage_volume.go:493
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:446
+#: lxc/storage_volume.go:447
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1105,7 +1105,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1154
+#: lxc/cluster.go:1155
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1133,8 +1133,8 @@ msgstr ""
 #: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
 #: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
-#: lxc/network_forward.go:182 lxc/network_forward.go:264
+#: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
+#: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
 #: lxc/network_forward.go:497 lxc/network_forward.go:649
 #: lxc/network_forward.go:803 lxc/network_forward.go:892
 #: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
@@ -1149,30 +1149,30 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
-#: lxc/storage_volume.go:1952 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2251 lxc/storage_volume.go:2367
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2555
-#: lxc/storage_volume.go:2643 lxc/storage_volume.go:2807
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
+#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
+#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:894
+#: lxc/cluster.go:895
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:926
+#: lxc/cluster.go:927
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:756
+#: lxc/cluster.go:757
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1209,24 +1209,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
+#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
-#: lxc/storage_volume.go:1188
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
+#: lxc/storage_volume.go:1199
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:619
+#: lxc/storage_volume.go:620
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1236,7 +1236,11 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/move.go:65
+#: lxc/move.go:65
+msgid "Copy a stateful instance as stateless"
+msgstr ""
+
+#: lxc/copy.go:60
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1284,7 +1288,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:389 lxc/storage_volume.go:390
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1292,12 +1296,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:396
+#: lxc/storage_volume.go:397
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:398
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1310,7 +1314,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:515
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1333,12 +1337,12 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1235
+#: lxc/cluster.go:1236
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1239
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1353,17 +1357,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1266
+#: lxc/cluster.go:1267
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1445,7 +1449,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1497,7 +1501,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1526,13 +1530,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1738
+#: lxc/storage_volume.go:1749
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1552,7 +1556,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2642
+#: lxc/storage_volume.go:2653
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1648,7 +1652,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1669,16 +1673,16 @@ msgstr ""
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
-#: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
+#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
+#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
-#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
-#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
+#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
+#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1701,8 +1705,8 @@ msgstr ""
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
 #: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1005 lxc/network.go:1106 lxc/network.go:1185
-#: lxc/network.go:1245 lxc/network.go:1341 lxc/network.go:1413
+#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
+#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
 #: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
 #: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
 #: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
@@ -1753,27 +1757,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
-#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
-#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
-#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1949
-#: lxc/storage_volume.go:2076 lxc/storage_volume.go:2234
-#: lxc/storage_volume.go:2355 lxc/storage_volume.go:2417
-#: lxc/storage_volume.go:2553 lxc/storage_volume.go:2636
-#: lxc/storage_volume.go:2802 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1454
+#: lxc/storage_volume.go:1465
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1785,11 +1789,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
+#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1917,7 +1921,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:516
+#: lxc/cluster.go:1072 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1939,7 +1943,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:769 lxc/cluster.go:770
+#: lxc/cluster.go:770 lxc/cluster.go:771
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1959,7 +1963,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1226 lxc/config.go:1227
+#: lxc/config.go:1227 lxc/config.go:1228
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2023,7 +2027,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2031,7 +2035,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2049,11 +2053,12 @@ msgid ""
 "new\n"
 "  LXD cluster, which will have the given name.\n"
 "\n"
-"  It's required that the LXD is already available on the network. You can "
-"check\n"
-"  that by running 'lxc config get core.https_address', and possibly set a "
-"value\n"
-"  for the address if not yet set."
+"  It's required that LXD is already available on the network. You can check\n"
+"  this by running 'lxc config get core.https_address'. If either an IP "
+"address\n"
+"  and port is displayed, or both, LXD is already available on the network. "
+"If\n"
+"  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
 #: lxc/network_zone.go:1427
@@ -2083,12 +2088,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
+#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2098,12 +2103,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
+#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
-#: lxc/storage_volume.go:2199
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
+#: lxc/storage_volume.go:2210
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2113,11 +2118,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1298 lxc/cluster.go:1299
+#: lxc/cluster.go:1299 lxc/cluster.go:1300
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1396
+#: lxc/cluster.go:1397
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2145,8 +2150,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
-#: lxc/storage_volume.go:1564
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Expires at"
 msgstr ""
 
@@ -2170,7 +2175,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2635 lxc/storage_volume.go:2636
+#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2182,11 +2187,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2639
+#: lxc/storage_volume.go:2650
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2768
+#: lxc/export.go:152 lxc/storage_volume.go:2779
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2366,7 +2371,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
+#: lxc/network.go:1046 lxc/network_acl.go:133 lxc/network_zone.go:124
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2376,7 +2381,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1303
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2384,7 +2389,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1301
+#: lxc/cluster.go:1302
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2396,7 +2401,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1331
+#: lxc/cluster.go:1332
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2437,16 +2442,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
-#: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1614 lxc/warning.go:94
+#: lxc/storage_volume.go:1625 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2506,7 +2511,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:996
+#: lxc/config.go:996 lxc/config.go:997
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2570,7 +2575,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1249
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2634,11 +2639,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
+#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:475
+#: lxc/storage_volume.go:476
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2666,7 +2671,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1161
+#: lxc/network.go:1170
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2720,7 +2725,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1163
+#: lxc/network.go:1172
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2732,11 +2737,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1084
+#: lxc/list.go:560 lxc/network.go:1093
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1085
+#: lxc/list.go:561 lxc/network.go:1094
 msgid "IPV6"
 msgstr ""
 
@@ -2766,7 +2771,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2427
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2780,7 +2785,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2437
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2830,7 +2835,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2802
+#: lxc/storage_volume.go:2813
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2838,7 +2843,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2801
+#: lxc/storage_volume.go:2812
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2860,11 +2865,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2809
+#: lxc/storage_volume.go:2820
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2883
+#: lxc/storage_volume.go:2894
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2908,7 +2913,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
+#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2990,7 +2995,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2012
+#: lxc/move.go:148 lxc/storage_volume.go:2023
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2998,7 +3003,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2019
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3016,9 +3021,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
-#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2144 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
+#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3062,9 +3067,9 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
+#: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3076,8 +3081,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1020 lxc/cluster.go:1123
-#: lxc/cluster.go:1231 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
+#: lxc/cluster.go:1232 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3114,7 +3119,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1105 lxc/network.go:1106
+#: lxc/network.go:1114 lxc/network.go:1115
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3126,7 +3131,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:976 lxc/cluster.go:977
+#: lxc/cluster.go:977 lxc/cluster.go:978
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -3174,7 +3179,7 @@ msgstr ""
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1004 lxc/network.go:1005
+#: lxc/network.go:1005 lxc/network.go:1006
 msgid "List available networks"
 msgstr ""
 
@@ -3262,7 +3267,7 @@ msgid ""
 "Fast column layout: nsacPt\n"
 "\n"
 "A single keyword like \"web\" which will list any instance with a name "
-"starting by \"web\".\n"
+"starting with \"web\".\n"
 "A regular expression on the instance name. (e.g. .*web.*01$).\n"
 "A key/value pair referring to a configuration item. For those, the\n"
 "namespace can be abbreviated to the smallest unambiguous identifier.\n"
@@ -3319,7 +3324,8 @@ msgid ""
 "  P - Profiles\n"
 "  s - State\n"
 "  S - Number of snapshots\n"
-"  t - Type (persistent or ephemeral)\n"
+"  t - Type (container or virtual-machine, ephemeral indicated if "
+"applicable)\n"
 "  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
@@ -3368,11 +3374,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1603
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1608
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3431,7 +3437,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1470
+#: lxc/info.go:489 lxc/storage_volume.go:1481
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3452,7 +3458,7 @@ msgstr ""
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1162
+#: lxc/network.go:1171
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3470,7 +3476,7 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1083
+#: lxc/network.go:1092
 msgid "MANAGED"
 msgstr ""
 
@@ -3593,7 +3599,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:955 lxc/config.go:956
+#: lxc/config.go:956 lxc/config.go:957
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3732,7 +3738,7 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:957
+#: lxc/cluster.go:958
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
@@ -3796,7 +3802,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:811 lxc/cluster.go:1367 lxc/cluster_group.go:129
+#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -3859,8 +3865,8 @@ msgstr ""
 
 #: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1139 lxc/network.go:1217 lxc/network.go:1283
-#: lxc/network.go:1375 lxc/network_forward.go:127 lxc/network_forward.go:215
+#: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
+#: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
 #: lxc/network_forward.go:284 lxc/network_forward.go:445
 #: lxc/network_forward.go:530 lxc/network_forward.go:705
 #: lxc/network_forward.go:836 lxc/network_forward.go:929
@@ -3901,12 +3907,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
-#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
-#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1986
-#: lxc/storage_volume.go:2127 lxc/storage_volume.go:2285
-#: lxc/storage_volume.go:2476 lxc/storage_volume.go:2593
+#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
+#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
 msgid "Missing pool name"
 msgstr ""
 
@@ -3925,11 +3931,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:438 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1411
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3966,8 +3972,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
-#: lxc/storage_volume.go:964
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
+#: lxc/storage_volume.go:975
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4004,7 +4010,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4012,11 +4018,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1856
+#: lxc/storage_volume.go:1867
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:518
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4038,12 +4044,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
+#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
 msgid "NAME"
 msgstr ""
 
@@ -4071,7 +4077,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
 #: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4095,8 +4101,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
-#: lxc/storage_volume.go:1562
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1573
 msgid "Name"
 msgstr ""
 
@@ -4104,7 +4110,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4129,7 +4135,7 @@ msgstr ""
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1227
+#: lxc/network.go:1236
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4239,7 +4245,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1161
+#: lxc/cluster.go:1162
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4248,7 +4254,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
+#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4268,11 +4274,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:502 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4286,7 +4292,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2035
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4294,15 +4300,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:343
+#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
+#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2690
+#: lxc/storage_volume.go:2701
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2489
+#: lxc/storage_volume.go:2500
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4314,11 +4321,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1418
+#: lxc/storage_volume.go:1429
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1298
+#: lxc/network.go:735 lxc/network.go:1307
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4327,7 +4334,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1577
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4357,7 +4364,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1767
 msgid "POOL"
 msgstr ""
 
@@ -4373,7 +4380,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1773
 #: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4419,7 +4426,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -4440,16 +4447,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
-#: lxc/storage_volume.go:1189
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
+#: lxc/storage_volume.go:1200
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4566,7 +4573,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1356
+#: lxc/storage_volume.go:1367
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4580,7 +4587,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1225
+#: lxc/storage_volume.go:1236
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4596,7 +4603,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2247
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4617,7 +4624,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1004
+#: lxc/storage_volume.go:1015
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4626,7 +4633,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2081
+#: lxc/storage_volume.go:2092
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4639,13 +4646,13 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2357
+#: lxc/storage_volume.go:2368
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
 "\n"
 "lxc storage volume unset default data size\n"
-"    Remotes the size/quota of a custom volume \"data\" in pool \"default\".\n"
+"    Removes the size/quota of a custom volume \"data\" in pool \"default\".\n"
 "\n"
 "lxc storage volume unset default virtual-machine/data snapshots.expiry\n"
 "    Removes the snapshot expiration period for a virtual machine \"data\" in "
@@ -4725,7 +4732,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4908,7 +4915,7 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1184 lxc/network.go:1185
+#: lxc/network.go:1193 lxc/network.go:1194
 msgid "Rename networks"
 msgstr ""
 
@@ -4924,15 +4931,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1949
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:1959
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2037 lxc/storage_volume.go:2057
+#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4942,11 +4949,11 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:892 lxc/cluster.go:893
+#: lxc/cluster.go:893 lxc/cluster.go:894
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1032
+#: lxc/config.go:1033
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -4969,7 +4976,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1328 lxc/cluster.go:1329
+#: lxc/cluster.go:1329 lxc/cluster.go:1330
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4984,11 +4991,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2552 lxc/storage_volume.go:2553
+#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1394
+#: lxc/cluster.go:1395
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5010,7 +5017,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1087
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5060,7 +5067,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1088
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1097
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5123,7 +5130,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1050 lxc/config.go:1051
+#: lxc/config.go:1051 lxc/config.go:1052
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5187,11 +5194,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1244
+#: lxc/network.go:1253
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1245
+#: lxc/network.go:1254
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5308,11 +5315,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2075
+#: lxc/storage_volume.go:2086
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2076
+#: lxc/storage_volume.go:2087
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5369,7 +5376,7 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1252
+#: lxc/network.go:1261
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5397,7 +5404,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2103
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5466,7 +5473,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1173
+#: lxc/config.go:1173 lxc/config.go:1174
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5498,7 +5505,7 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1340 lxc/network.go:1341
+#: lxc/network.go:1349 lxc/network.go:1350
 msgid "Show network configurations"
 msgstr ""
 
@@ -5546,11 +5553,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2233 lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5573,7 +5580,7 @@ msgid "Show the expanded configuration"
 msgstr ""
 
 #: lxc/info.go:43
-msgid "Show the instance's last 100 log lines?"
+msgid "Show the instance's last 100 log lines"
 msgstr ""
 
 #: lxc/info.go:44
@@ -5618,15 +5625,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2417
+#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2179
+#: lxc/storage_volume.go:2190
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1502
 msgid "Snapshots:"
 msgstr ""
 
@@ -5731,21 +5738,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:702
+#: lxc/storage_volume.go:703
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:790
+#: lxc/storage_volume.go:791
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:516
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:520
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5753,7 +5760,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5802,18 +5809,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1070 lxc/config_trust.go:515
+#: lxc/cluster.go:1071 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1736 lxc/warning.go:216
+#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1747 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
 msgid "Taken at"
 msgstr ""
 
@@ -5970,12 +5977,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1340
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1306
+#: lxc/storage_volume.go:1317
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -5994,8 +6001,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
-#: lxc/storage_volume.go:978
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:989
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6015,11 +6022,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:739
+#: lxc/cluster.go:740
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:729
+#: lxc/cluster.go:730
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6070,7 +6077,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6085,7 +6092,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1853
+#: lxc/storage_volume.go:1864
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6093,7 +6100,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:394
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6152,7 +6159,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1472
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6174,13 +6181,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:995 lxc/storage_volume.go:1752
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
+#: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1740
+#: lxc/storage.go:724 lxc/storage_volume.go:1751
 msgid "USED BY"
 msgstr ""
 
@@ -6212,7 +6219,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6238,7 +6245,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1141 lxc/config.go:1142
+#: lxc/config.go:1142 lxc/config.go:1143
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6266,7 +6273,7 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1412 lxc/network.go:1413
+#: lxc/network.go:1421 lxc/network.go:1422
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -6318,7 +6325,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2354 lxc/storage_volume.go:2355
+#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6342,7 +6349,7 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1417
+#: lxc/network.go:1426
 msgid "Unset the key as a network property"
 msgstr ""
 
@@ -6370,7 +6377,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2379
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6378,7 +6385,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:247
+#: lxc/storage_volume.go:248
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6391,11 +6398,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1174
+#: lxc/cluster.go:1175
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1176
+#: lxc/cluster.go:1177
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6414,12 +6421,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2641
+#: lxc/export.go:42 lxc/storage_volume.go:2652
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6486,7 +6493,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1576
 msgid "Volume Only"
 msgstr ""
 
@@ -6519,7 +6526,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
 #: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6545,18 +6552,18 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:903
+#: lxc/storage_volume.go:909
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:281
+#: lxc/storage_volume.go:282
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
-#: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
+#: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
@@ -6566,7 +6573,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1172
+#: lxc/cluster.go:1173
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -6729,7 +6736,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6751,11 +6758,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:1140
+#: lxc/config.go:995 lxc/config.go:1141
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1049
+#: lxc/config.go:1050
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -6834,8 +6841,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:768
-#: lxc/cluster.go:1085 lxc/cluster.go:1297 lxc/cluster.go:1327
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
+#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -6859,8 +6866,8 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1104
-#: lxc/network.go:1339 lxc/network_forward.go:87
+#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1113
+#: lxc/network.go:1348 lxc/network_forward.go:87
 #: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -6873,11 +6880,11 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1411
+#: lxc/network.go:791 lxc/network.go:1420
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1243
+#: lxc/network.go:1252
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
@@ -6922,7 +6929,7 @@ msgstr ""
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1182
+#: lxc/network.go:1191
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -6973,7 +6980,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2800
+#: lxc/storage_volume.go:2811
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7008,13 +7015,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:1958
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:806
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7022,51 +7029,51 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2551
+#: lxc/storage_volume.go:2562
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2634
+#: lxc/storage_volume.go:2645
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2415
+#: lxc/storage_volume.go:2426
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:609
+#: lxc/storage_volume.go:610
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:718
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2353
+#: lxc/storage_volume.go:2364
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2085
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2232
+#: lxc/storage_volume.go:2243
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1221
+#: lxc/storage_volume.go:1232
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1858
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:387
+#: lxc/storage_volume.go:388
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7172,7 +7179,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1601
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7184,7 +7191,7 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:891
+#: lxc/cluster.go:892
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -7256,7 +7263,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:772
+#: lxc/cluster.go:773
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7305,13 +7312,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1229
+#: lxc/config.go:1230
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1053
+#: lxc/config.go:1054
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7648,7 +7655,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:614
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7656,13 +7663,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2804
+#: lxc/storage_volume.go:2815
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2419
+#: lxc/storage_volume.go:2430
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-09 03:18-0300\n"
+"POT-Creation-Date: 2024-12-18 08:40-0700\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1030
+#: lxc/storage_volume.go:1041
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1240
+#: lxc/config.go:1241
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -412,7 +412,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:790
+#: lxc/cluster.go:791
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -585,13 +585,13 @@ msgstr ""
 msgid "Acknowledge warning"
 msgstr ""
 
+#: lxc/query.go:43
+msgid "Action"
+msgstr ""
+
 #: lxc/query.go:76
 #, c-format
 msgid "Action %q isn't supported by this tool"
-msgstr ""
-
-#: lxc/query.go:43
-msgid "Action (defaults to GET)"
 msgstr ""
 
 #: lxc/cluster_group.go:725
@@ -738,7 +738,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1596
+#: lxc/storage_volume.go:1607
 msgid "All projects"
 msgstr ""
 
@@ -760,7 +760,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1371
+#: lxc/cluster.go:1372
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -797,7 +797,7 @@ msgstr ""
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:282 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -849,16 +849,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2708
+#: lxc/storage_volume.go:2719
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2785
+#: lxc/export.go:192 lxc/storage_volume.go:2796
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1538
 msgid "Backups:"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -922,7 +922,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1739
+#: lxc/storage_volume.go:1750
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1007,7 +1007,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1097
+#: lxc/config.go:702 lxc/config.go:1098
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1024,12 +1024,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:492
+#: lxc/storage_volume.go:493
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:446
+#: lxc/storage_volume.go:447
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1105,7 +1105,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1154
+#: lxc/cluster.go:1155
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1133,8 +1133,8 @@ msgstr ""
 #: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
 #: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
-#: lxc/network_forward.go:182 lxc/network_forward.go:264
+#: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
+#: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
 #: lxc/network_forward.go:497 lxc/network_forward.go:649
 #: lxc/network_forward.go:803 lxc/network_forward.go:892
 #: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
@@ -1149,30 +1149,30 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
-#: lxc/storage_volume.go:1952 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2251 lxc/storage_volume.go:2367
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2555
-#: lxc/storage_volume.go:2643 lxc/storage_volume.go:2807
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
+#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
+#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:894
+#: lxc/cluster.go:895
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:926
+#: lxc/cluster.go:927
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:756
+#: lxc/cluster.go:757
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1209,24 +1209,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
+#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
-#: lxc/storage_volume.go:1188
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
+#: lxc/storage_volume.go:1199
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:619
+#: lxc/storage_volume.go:620
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1236,7 +1236,11 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/move.go:65
+#: lxc/move.go:65
+msgid "Copy a stateful instance as stateless"
+msgstr ""
+
+#: lxc/copy.go:60
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1284,7 +1288,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:389 lxc/storage_volume.go:390
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1292,12 +1296,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:396
+#: lxc/storage_volume.go:397
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:398
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1310,7 +1314,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:515
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1333,12 +1337,12 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1235
+#: lxc/cluster.go:1236
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1239
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1353,17 +1357,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1266
+#: lxc/cluster.go:1267
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1445,7 +1449,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1497,7 +1501,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1526,13 +1530,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1738
+#: lxc/storage_volume.go:1749
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1552,7 +1556,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2642
+#: lxc/storage_volume.go:2653
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1648,7 +1652,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1669,16 +1673,16 @@ msgstr ""
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
-#: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
+#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
+#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
-#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
-#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
+#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
+#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1701,8 +1705,8 @@ msgstr ""
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
 #: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1005 lxc/network.go:1106 lxc/network.go:1185
-#: lxc/network.go:1245 lxc/network.go:1341 lxc/network.go:1413
+#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
+#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
 #: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
 #: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
 #: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
@@ -1753,27 +1757,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
-#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
-#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
-#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1949
-#: lxc/storage_volume.go:2076 lxc/storage_volume.go:2234
-#: lxc/storage_volume.go:2355 lxc/storage_volume.go:2417
-#: lxc/storage_volume.go:2553 lxc/storage_volume.go:2636
-#: lxc/storage_volume.go:2802 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1454
+#: lxc/storage_volume.go:1465
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1785,11 +1789,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
+#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1917,7 +1921,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:516
+#: lxc/cluster.go:1072 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1939,7 +1943,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:769 lxc/cluster.go:770
+#: lxc/cluster.go:770 lxc/cluster.go:771
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1959,7 +1963,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1226 lxc/config.go:1227
+#: lxc/config.go:1227 lxc/config.go:1228
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2023,7 +2027,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2031,7 +2035,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2049,11 +2053,12 @@ msgid ""
 "new\n"
 "  LXD cluster, which will have the given name.\n"
 "\n"
-"  It's required that the LXD is already available on the network. You can "
-"check\n"
-"  that by running 'lxc config get core.https_address', and possibly set a "
-"value\n"
-"  for the address if not yet set."
+"  It's required that LXD is already available on the network. You can check\n"
+"  this by running 'lxc config get core.https_address'. If either an IP "
+"address\n"
+"  and port is displayed, or both, LXD is already available on the network. "
+"If\n"
+"  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
 #: lxc/network_zone.go:1427
@@ -2083,12 +2088,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
+#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2098,12 +2103,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
+#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
-#: lxc/storage_volume.go:2199
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
+#: lxc/storage_volume.go:2210
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2113,11 +2118,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1298 lxc/cluster.go:1299
+#: lxc/cluster.go:1299 lxc/cluster.go:1300
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1396
+#: lxc/cluster.go:1397
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2145,8 +2150,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
-#: lxc/storage_volume.go:1564
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Expires at"
 msgstr ""
 
@@ -2170,7 +2175,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2635 lxc/storage_volume.go:2636
+#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2182,11 +2187,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2639
+#: lxc/storage_volume.go:2650
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2768
+#: lxc/export.go:152 lxc/storage_volume.go:2779
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2366,7 +2371,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
+#: lxc/network.go:1046 lxc/network_acl.go:133 lxc/network_zone.go:124
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2376,7 +2381,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1303
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2384,7 +2389,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1301
+#: lxc/cluster.go:1302
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2396,7 +2401,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1331
+#: lxc/cluster.go:1332
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2437,16 +2442,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
-#: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1614 lxc/warning.go:94
+#: lxc/storage_volume.go:1625 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2506,7 +2511,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:996
+#: lxc/config.go:996 lxc/config.go:997
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2570,7 +2575,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1249
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2634,11 +2639,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
+#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:475
+#: lxc/storage_volume.go:476
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2666,7 +2671,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1161
+#: lxc/network.go:1170
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2720,7 +2725,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1163
+#: lxc/network.go:1172
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2732,11 +2737,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1084
+#: lxc/list.go:560 lxc/network.go:1093
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1085
+#: lxc/list.go:561 lxc/network.go:1094
 msgid "IPV6"
 msgstr ""
 
@@ -2766,7 +2771,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2427
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2780,7 +2785,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2437
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2830,7 +2835,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2802
+#: lxc/storage_volume.go:2813
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2838,7 +2843,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2801
+#: lxc/storage_volume.go:2812
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2860,11 +2865,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2809
+#: lxc/storage_volume.go:2820
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2883
+#: lxc/storage_volume.go:2894
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2908,7 +2913,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
+#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2990,7 +2995,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2012
+#: lxc/move.go:148 lxc/storage_volume.go:2023
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2998,7 +3003,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2019
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3016,9 +3021,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
-#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2144 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
+#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3062,9 +3067,9 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
+#: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3076,8 +3081,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1020 lxc/cluster.go:1123
-#: lxc/cluster.go:1231 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
+#: lxc/cluster.go:1232 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3114,7 +3119,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1105 lxc/network.go:1106
+#: lxc/network.go:1114 lxc/network.go:1115
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3126,7 +3131,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:976 lxc/cluster.go:977
+#: lxc/cluster.go:977 lxc/cluster.go:978
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -3174,7 +3179,7 @@ msgstr ""
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1004 lxc/network.go:1005
+#: lxc/network.go:1005 lxc/network.go:1006
 msgid "List available networks"
 msgstr ""
 
@@ -3262,7 +3267,7 @@ msgid ""
 "Fast column layout: nsacPt\n"
 "\n"
 "A single keyword like \"web\" which will list any instance with a name "
-"starting by \"web\".\n"
+"starting with \"web\".\n"
 "A regular expression on the instance name. (e.g. .*web.*01$).\n"
 "A key/value pair referring to a configuration item. For those, the\n"
 "namespace can be abbreviated to the smallest unambiguous identifier.\n"
@@ -3319,7 +3324,8 @@ msgid ""
 "  P - Profiles\n"
 "  s - State\n"
 "  S - Number of snapshots\n"
-"  t - Type (persistent or ephemeral)\n"
+"  t - Type (container or virtual-machine, ephemeral indicated if "
+"applicable)\n"
 "  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
@@ -3368,11 +3374,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1603
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1608
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3431,7 +3437,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1470
+#: lxc/info.go:489 lxc/storage_volume.go:1481
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3452,7 +3458,7 @@ msgstr ""
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1162
+#: lxc/network.go:1171
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3470,7 +3476,7 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1083
+#: lxc/network.go:1092
 msgid "MANAGED"
 msgstr ""
 
@@ -3593,7 +3599,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:955 lxc/config.go:956
+#: lxc/config.go:956 lxc/config.go:957
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3732,7 +3738,7 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:957
+#: lxc/cluster.go:958
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
@@ -3796,7 +3802,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:811 lxc/cluster.go:1367 lxc/cluster_group.go:129
+#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -3859,8 +3865,8 @@ msgstr ""
 
 #: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1139 lxc/network.go:1217 lxc/network.go:1283
-#: lxc/network.go:1375 lxc/network_forward.go:127 lxc/network_forward.go:215
+#: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
+#: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
 #: lxc/network_forward.go:284 lxc/network_forward.go:445
 #: lxc/network_forward.go:530 lxc/network_forward.go:705
 #: lxc/network_forward.go:836 lxc/network_forward.go:929
@@ -3901,12 +3907,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
-#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
-#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1986
-#: lxc/storage_volume.go:2127 lxc/storage_volume.go:2285
-#: lxc/storage_volume.go:2476 lxc/storage_volume.go:2593
+#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
+#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
 msgid "Missing pool name"
 msgstr ""
 
@@ -3925,11 +3931,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:438 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1411
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3966,8 +3972,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
-#: lxc/storage_volume.go:964
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
+#: lxc/storage_volume.go:975
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4004,7 +4010,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4012,11 +4018,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1856
+#: lxc/storage_volume.go:1867
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:518
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4038,12 +4044,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
+#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
 msgid "NAME"
 msgstr ""
 
@@ -4071,7 +4077,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
 #: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4095,8 +4101,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
-#: lxc/storage_volume.go:1562
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1573
 msgid "Name"
 msgstr ""
 
@@ -4104,7 +4110,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4129,7 +4135,7 @@ msgstr ""
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1227
+#: lxc/network.go:1236
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4239,7 +4245,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1161
+#: lxc/cluster.go:1162
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4248,7 +4254,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
+#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4268,11 +4274,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:502 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4286,7 +4292,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2035
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4294,15 +4300,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:343
+#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
+#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2690
+#: lxc/storage_volume.go:2701
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2489
+#: lxc/storage_volume.go:2500
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4314,11 +4321,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1418
+#: lxc/storage_volume.go:1429
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1298
+#: lxc/network.go:735 lxc/network.go:1307
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4327,7 +4334,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1577
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4357,7 +4364,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1767
 msgid "POOL"
 msgstr ""
 
@@ -4373,7 +4380,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1773
 #: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4419,7 +4426,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -4440,16 +4447,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
-#: lxc/storage_volume.go:1189
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
+#: lxc/storage_volume.go:1200
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4566,7 +4573,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1356
+#: lxc/storage_volume.go:1367
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4580,7 +4587,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1225
+#: lxc/storage_volume.go:1236
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4596,7 +4603,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2247
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4617,7 +4624,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1004
+#: lxc/storage_volume.go:1015
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4626,7 +4633,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2081
+#: lxc/storage_volume.go:2092
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4639,13 +4646,13 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2357
+#: lxc/storage_volume.go:2368
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
 "\n"
 "lxc storage volume unset default data size\n"
-"    Remotes the size/quota of a custom volume \"data\" in pool \"default\".\n"
+"    Removes the size/quota of a custom volume \"data\" in pool \"default\".\n"
 "\n"
 "lxc storage volume unset default virtual-machine/data snapshots.expiry\n"
 "    Removes the snapshot expiration period for a virtual machine \"data\" in "
@@ -4725,7 +4732,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4908,7 +4915,7 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1184 lxc/network.go:1185
+#: lxc/network.go:1193 lxc/network.go:1194
 msgid "Rename networks"
 msgstr ""
 
@@ -4924,15 +4931,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1949
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:1959
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2037 lxc/storage_volume.go:2057
+#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4942,11 +4949,11 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:892 lxc/cluster.go:893
+#: lxc/cluster.go:893 lxc/cluster.go:894
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1032
+#: lxc/config.go:1033
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -4969,7 +4976,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1328 lxc/cluster.go:1329
+#: lxc/cluster.go:1329 lxc/cluster.go:1330
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4984,11 +4991,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2552 lxc/storage_volume.go:2553
+#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1394
+#: lxc/cluster.go:1395
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5010,7 +5017,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1087
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5060,7 +5067,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1088
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1097
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5123,7 +5130,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1050 lxc/config.go:1051
+#: lxc/config.go:1051 lxc/config.go:1052
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5187,11 +5194,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1244
+#: lxc/network.go:1253
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1245
+#: lxc/network.go:1254
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5308,11 +5315,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2075
+#: lxc/storage_volume.go:2086
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2076
+#: lxc/storage_volume.go:2087
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5369,7 +5376,7 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1252
+#: lxc/network.go:1261
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5397,7 +5404,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2103
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5466,7 +5473,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1173
+#: lxc/config.go:1173 lxc/config.go:1174
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5498,7 +5505,7 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1340 lxc/network.go:1341
+#: lxc/network.go:1349 lxc/network.go:1350
 msgid "Show network configurations"
 msgstr ""
 
@@ -5546,11 +5553,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2233 lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5573,7 +5580,7 @@ msgid "Show the expanded configuration"
 msgstr ""
 
 #: lxc/info.go:43
-msgid "Show the instance's last 100 log lines?"
+msgid "Show the instance's last 100 log lines"
 msgstr ""
 
 #: lxc/info.go:44
@@ -5618,15 +5625,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2417
+#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2179
+#: lxc/storage_volume.go:2190
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1502
 msgid "Snapshots:"
 msgstr ""
 
@@ -5731,21 +5738,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:702
+#: lxc/storage_volume.go:703
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:790
+#: lxc/storage_volume.go:791
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:516
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:520
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5753,7 +5760,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5802,18 +5809,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1070 lxc/config_trust.go:515
+#: lxc/cluster.go:1071 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1736 lxc/warning.go:216
+#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1747 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
 msgid "Taken at"
 msgstr ""
 
@@ -5970,12 +5977,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1340
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1306
+#: lxc/storage_volume.go:1317
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -5994,8 +6001,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
-#: lxc/storage_volume.go:978
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:989
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6015,11 +6022,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:739
+#: lxc/cluster.go:740
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:729
+#: lxc/cluster.go:730
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6070,7 +6077,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6085,7 +6092,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1853
+#: lxc/storage_volume.go:1864
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6093,7 +6100,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:394
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6152,7 +6159,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1472
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6174,13 +6181,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:995 lxc/storage_volume.go:1752
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
+#: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1740
+#: lxc/storage.go:724 lxc/storage_volume.go:1751
 msgid "USED BY"
 msgstr ""
 
@@ -6212,7 +6219,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6238,7 +6245,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1141 lxc/config.go:1142
+#: lxc/config.go:1142 lxc/config.go:1143
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6266,7 +6273,7 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1412 lxc/network.go:1413
+#: lxc/network.go:1421 lxc/network.go:1422
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -6318,7 +6325,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2354 lxc/storage_volume.go:2355
+#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6342,7 +6349,7 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1417
+#: lxc/network.go:1426
 msgid "Unset the key as a network property"
 msgstr ""
 
@@ -6370,7 +6377,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2379
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6378,7 +6385,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:247
+#: lxc/storage_volume.go:248
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6391,11 +6398,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1174
+#: lxc/cluster.go:1175
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1176
+#: lxc/cluster.go:1177
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6414,12 +6421,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2641
+#: lxc/export.go:42 lxc/storage_volume.go:2652
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6486,7 +6493,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1576
 msgid "Volume Only"
 msgstr ""
 
@@ -6519,7 +6526,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
 #: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6545,18 +6552,18 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:903
+#: lxc/storage_volume.go:909
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:281
+#: lxc/storage_volume.go:282
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
-#: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
+#: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
@@ -6566,7 +6573,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1172
+#: lxc/cluster.go:1173
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -6729,7 +6736,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6751,11 +6758,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:1140
+#: lxc/config.go:995 lxc/config.go:1141
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1049
+#: lxc/config.go:1050
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -6834,8 +6841,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:768
-#: lxc/cluster.go:1085 lxc/cluster.go:1297 lxc/cluster.go:1327
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
+#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -6859,8 +6866,8 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1104
-#: lxc/network.go:1339 lxc/network_forward.go:87
+#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1113
+#: lxc/network.go:1348 lxc/network_forward.go:87
 #: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -6873,11 +6880,11 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1411
+#: lxc/network.go:791 lxc/network.go:1420
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1243
+#: lxc/network.go:1252
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
@@ -6922,7 +6929,7 @@ msgstr ""
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1182
+#: lxc/network.go:1191
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -6973,7 +6980,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2800
+#: lxc/storage_volume.go:2811
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7008,13 +7015,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:1958
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:806
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7022,51 +7029,51 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2551
+#: lxc/storage_volume.go:2562
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2634
+#: lxc/storage_volume.go:2645
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2415
+#: lxc/storage_volume.go:2426
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:609
+#: lxc/storage_volume.go:610
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:718
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2353
+#: lxc/storage_volume.go:2364
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2085
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2232
+#: lxc/storage_volume.go:2243
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1221
+#: lxc/storage_volume.go:1232
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1858
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:387
+#: lxc/storage_volume.go:388
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7172,7 +7179,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1601
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7184,7 +7191,7 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:891
+#: lxc/cluster.go:892
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -7256,7 +7263,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:772
+#: lxc/cluster.go:773
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7305,13 +7312,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1229
+#: lxc/config.go:1230
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1053
+#: lxc/config.go:1054
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7648,7 +7655,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:614
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7656,13 +7663,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2804
+#: lxc/storage_volume.go:2815
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2419
+#: lxc/storage_volume.go:2430
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-09 03:18-0300\n"
+"POT-Creation-Date: 2024-12-18 08:40-0700\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -74,7 +74,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:1030
+#: lxc/storage_volume.go:1041
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -100,7 +100,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/config.go:1240
+#: lxc/config.go:1241
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -659,7 +659,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: lxc/cluster.go:790
+#: lxc/cluster.go:791
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -850,16 +850,16 @@ msgstr "Profil %s erstellt\n"
 msgid "Acknowledge warning"
 msgstr ""
 
+#: lxc/query.go:43
+msgid "Action"
+msgstr ""
+
 #: lxc/query.go:76
 #, fuzzy, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr ""
 "Anzeigen von Informationen über entfernte Instanzen wird noch nicht "
 "unterstützt\n"
-
-#: lxc/query.go:43
-msgid "Action (defaults to GET)"
-msgstr "Aktion (Standard: GET)"
 
 #: lxc/cluster_group.go:725
 #, fuzzy
@@ -1013,7 +1013,7 @@ msgstr "entfernte Instanz %s existiert bereits"
 msgid "Aliases:"
 msgstr "Aliasse:\n"
 
-#: lxc/storage_volume.go:1596
+#: lxc/storage_volume.go:1607
 #, fuzzy
 msgid "All projects"
 msgstr "Fehlerhafte Profil URL %s"
@@ -1037,7 +1037,7 @@ msgstr "Architektur: %s\n"
 msgid "Architecture: %v"
 msgstr "Architektur: %s\n"
 
-#: lxc/cluster.go:1371
+#: lxc/cluster.go:1372
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -1079,7 +1079,7 @@ msgstr "Netzwerkschnittstellen an Container anbinden"
 msgid "Attach new storage volumes to instances"
 msgstr "Netzwerkschnittstellen an Container anbinden"
 
-#: lxc/storage_volume.go:282 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -1133,17 +1133,17 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:2708
+#: lxc/storage_volume.go:2719
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/export.go:192 lxc/storage_volume.go:2785
+#: lxc/export.go:192 lxc/storage_volume.go:2796
 #, fuzzy
 msgid "Backup exported successfully!"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/info.go:666 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1538
 msgid "Backups:"
 msgstr ""
 
@@ -1164,7 +1164,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1207,7 +1207,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1739
+#: lxc/storage_volume.go:1750
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1303,7 +1303,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1311,7 +1311,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1097
+#: lxc/config.go:702 lxc/config.go:1098
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1320,12 +1320,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:492
+#: lxc/storage_volume.go:493
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:446
+#: lxc/storage_volume.go:447
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1407,7 +1407,7 @@ msgstr "Profil %s wurde auf %s angewandt\n"
 msgid "Cluster group %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/cluster.go:1154
+#: lxc/cluster.go:1155
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1435,8 +1435,8 @@ msgstr "Gerät %s wurde von %s entfernt\n"
 #: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
 #: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
-#: lxc/network_forward.go:182 lxc/network_forward.go:264
+#: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
+#: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
 #: lxc/network_forward.go:497 lxc/network_forward.go:649
 #: lxc/network_forward.go:803 lxc/network_forward.go:892
 #: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
@@ -1451,30 +1451,30 @@ msgstr "Gerät %s wurde von %s entfernt\n"
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
-#: lxc/storage_volume.go:1952 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2251 lxc/storage_volume.go:2367
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2555
-#: lxc/storage_volume.go:2643 lxc/storage_volume.go:2807
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
+#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
+#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:894
+#: lxc/cluster.go:895
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:926
+#: lxc/cluster.go:927
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:756
+#: lxc/cluster.go:757
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr "Spalten"
@@ -1514,24 +1514,24 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Config key/value to apply to the target instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
+#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
-#: lxc/storage_volume.go:1188
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
+#: lxc/storage_volume.go:1199
 #, fuzzy, c-format
 msgid "Config parsing error: %s"
 msgstr "YAML Analyse Fehler %v\n"
 
-#: lxc/storage_volume.go:619
+#: lxc/storage_volume.go:620
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1478
 #, fuzzy, c-format
 msgid "Content type: %s"
 msgstr "Erstellt: %s"
@@ -1541,7 +1541,12 @@ msgstr "Erstellt: %s"
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/move.go:65
+#: lxc/move.go:65
+#, fuzzy
+msgid "Copy a stateful instance as stateless"
+msgstr "Herunterfahren des Containers erzwingen."
+
+#: lxc/copy.go:60
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1590,7 +1595,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:389 lxc/storage_volume.go:390
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
 #, fuzzy
 msgid "Copy storage volumes"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -1600,13 +1605,13 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Copy the instance without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:396
+#: lxc/storage_volume.go:397
 #, fuzzy
 msgid "Copy the volume without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:398
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1619,7 +1624,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:515
 #, fuzzy, c-format
 msgid "Copying the storage volume: %s"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -1643,12 +1648,12 @@ msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
 msgid "Could not create server cert dir"
 msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
 
-#: lxc/cluster.go:1235
+#: lxc/cluster.go:1236
 #, fuzzy, c-format
 msgid "Could not find certificate file path: %s"
 msgstr "Fingerabdruck des Zertifikats: % x\n"
 
-#: lxc/cluster.go:1239
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1663,17 +1668,17 @@ msgstr "YAML Analyse Fehler %v\n"
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, fuzzy, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr "Fingerabdruck des Zertifikats: % x\n"
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, fuzzy, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr "Fingerabdruck des Zertifikats: % x\n"
 
-#: lxc/cluster.go:1266
+#: lxc/cluster.go:1267
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1766,7 +1771,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Create new custom storage buckets"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
 #, fuzzy
 msgid "Create new custom storage volumes"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -1829,7 +1834,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Create the instance with no profiles applied"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
 #, c-format
 msgid "Created: %s"
 msgstr "Erstellt: %s"
@@ -1859,13 +1864,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1738
+#: lxc/storage_volume.go:1749
 msgid "DESCRIPTION"
 msgstr "BESCHREIBUNG"
 
@@ -1885,7 +1890,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2642
+#: lxc/storage_volume.go:2653
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1991,7 +1996,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
 #, fuzzy
 msgid "Delete storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -2013,16 +2018,16 @@ msgstr ""
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
-#: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
+#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
+#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
-#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
-#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
+#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
+#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -2045,8 +2050,8 @@ msgstr ""
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
 #: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1005 lxc/network.go:1106 lxc/network.go:1185
-#: lxc/network.go:1245 lxc/network.go:1341 lxc/network.go:1413
+#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
+#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
 #: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
 #: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
 #: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
@@ -2097,27 +2102,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
-#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
-#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
-#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1949
-#: lxc/storage_volume.go:2076 lxc/storage_volume.go:2234
-#: lxc/storage_volume.go:2355 lxc/storage_volume.go:2417
-#: lxc/storage_volume.go:2553 lxc/storage_volume.go:2636
-#: lxc/storage_volume.go:2802 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1454
+#: lxc/storage_volume.go:1465
 #, fuzzy, c-format
 msgid "Description: %s"
 msgstr "Fingerabdruck: %s\n"
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -2131,12 +2136,12 @@ msgstr "Netzwerkschnittstellen an Container anbinden"
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
 #, fuzzy
 msgid "Detach storage volumes from instances"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
+#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2277,7 +2282,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:516
+#: lxc/cluster.go:1072 lxc/config_trust.go:516
 #, fuzzy
 msgid "EXPIRES AT"
 msgstr "ABLAUFDATUM"
@@ -2300,7 +2305,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:769 lxc/cluster.go:770
+#: lxc/cluster.go:770 lxc/cluster.go:771
 #, fuzzy
 msgid "Edit cluster member configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
@@ -2324,7 +2329,7 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1226 lxc/config.go:1227
+#: lxc/config.go:1227 lxc/config.go:1228
 #, fuzzy
 msgid "Edit instance UEFI variables"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -2399,7 +2404,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2408,7 +2413,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2426,11 +2431,12 @@ msgid ""
 "new\n"
 "  LXD cluster, which will have the given name.\n"
 "\n"
-"  It's required that the LXD is already available on the network. You can "
-"check\n"
-"  that by running 'lxc config get core.https_address', and possibly set a "
-"value\n"
-"  for the address if not yet set."
+"  It's required that LXD is already available on the network. You can check\n"
+"  this by running 'lxc config get core.https_address'. If either an IP "
+"address\n"
+"  and port is displayed, or both, LXD is already available on the network. "
+"If\n"
+"  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
 #: lxc/network_zone.go:1427
@@ -2461,12 +2467,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
+#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Fehler beim hinzufügen des Alias %s\n"
@@ -2476,12 +2482,12 @@ msgstr "Fehler beim hinzufügen des Alias %s\n"
 msgid "Error unsetting properties: %v"
 msgstr "Fehler beim hinzufügen des Alias %s\n"
 
-#: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
+#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
-#: lxc/storage_volume.go:2199
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
+#: lxc/storage_volume.go:2210
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2491,7 +2497,7 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr "Fehler beim hinzufügen des Alias %s\n"
 
-#: lxc/cluster.go:1298 lxc/cluster.go:1299
+#: lxc/cluster.go:1299 lxc/cluster.go:1300
 #, fuzzy
 msgid "Evacuate cluster member"
 msgstr ""
@@ -2500,7 +2506,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/cluster.go:1396
+#: lxc/cluster.go:1397
 #, fuzzy, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -2532,8 +2538,8 @@ msgstr ""
 "\n"
 "lxc exec <Container> [--env EDITOR=/usr/bin/vim]... <Befehl>\n"
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
-#: lxc/storage_volume.go:1564
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Expires at"
 msgstr ""
 
@@ -2557,7 +2563,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2635 lxc/storage_volume.go:2636
+#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
 #, fuzzy
 msgid "Export custom storage volume"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -2572,12 +2578,12 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Export instances as backup tarballs."
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:2639
+#: lxc/storage_volume.go:2650
 #, fuzzy
 msgid "Export the volume without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/export.go:152 lxc/storage_volume.go:2768
+#: lxc/export.go:152 lxc/storage_volume.go:2779
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -2757,7 +2763,7 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
+#: lxc/network.go:1046 lxc/network_acl.go:133 lxc/network_zone.go:124
 #: lxc/operation.go:137
 #, fuzzy
 msgid "Filtering isn't supported yet"
@@ -2770,7 +2776,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr "Fingerabdruck: %s\n"
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1303
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2778,7 +2784,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1301
+#: lxc/cluster.go:1302
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2790,7 +2796,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1331
+#: lxc/cluster.go:1332
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2832,16 +2838,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
-#: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1614 lxc/warning.go:94
+#: lxc/storage_volume.go:1625 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2902,7 +2908,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "Generiere Nutzerzertifikat. Dies kann wenige Minuten dauern...\n"
 
-#: lxc/config.go:995 lxc/config.go:996
+#: lxc/config.go:996 lxc/config.go:997
 #, fuzzy
 msgid "Get UEFI variables for instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -2974,7 +2980,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Get the key as a storage property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1249
 #, fuzzy
 msgid "Get the key as a storage volume property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -3050,11 +3056,11 @@ msgstr "Profil %s erstellt\n"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
+#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:475
+#: lxc/storage_volume.go:476
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -3082,7 +3088,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1161
+#: lxc/network.go:1170
 msgid "HOSTNAME"
 msgstr ""
 
@@ -3137,7 +3143,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1163
+#: lxc/network.go:1172
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -3151,11 +3157,11 @@ msgstr "Profil %s erstellt\n"
 msgid "IP addresses:"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/list.go:560 lxc/network.go:1084
+#: lxc/list.go:560 lxc/network.go:1093
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1085
+#: lxc/list.go:561 lxc/network.go:1094
 msgid "IPV6"
 msgstr ""
 
@@ -3185,7 +3191,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2427
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3199,7 +3205,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2437
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3251,7 +3257,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:2802
+#: lxc/storage_volume.go:2813
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3259,7 +3265,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2801
+#: lxc/storage_volume.go:2812
 #, fuzzy
 msgid "Import custom storage volumes"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -3283,11 +3289,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:2809
+#: lxc/storage_volume.go:2820
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2883
+#: lxc/storage_volume.go:2894
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -3332,7 +3338,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
+#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3415,7 +3421,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2012
+#: lxc/move.go:148 lxc/storage_volume.go:2023
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "'/' ist kein gültiges Zeichen im Namen eines Sicherungspunktes\n"
@@ -3424,7 +3430,7 @@ msgstr "'/' ist kein gültiges Zeichen im Namen eines Sicherungspunktes\n"
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2019
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3443,9 +3449,9 @@ msgstr "Ungültiges Ziel %s"
 msgid "Invalid protocol: %s"
 msgstr "Ungültiges Ziel %s"
 
-#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
-#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2144 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
+#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Ungültige Quelle %s"
@@ -3494,9 +3500,9 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
+#: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3508,8 +3514,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1020 lxc/cluster.go:1123
-#: lxc/cluster.go:1231 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
+#: lxc/cluster.go:1232 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3547,7 +3553,7 @@ msgstr "Architektur: %s\n"
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1105 lxc/network.go:1106
+#: lxc/network.go:1114 lxc/network.go:1115
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3561,7 +3567,7 @@ msgstr "Aliasse:\n"
 msgid "List all active certificate add tokens"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/cluster.go:976 lxc/cluster.go:977
+#: lxc/cluster.go:977 lxc/cluster.go:978
 #, fuzzy
 msgid "List all active cluster member join tokens"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -3614,7 +3620,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1004 lxc/network.go:1005
+#: lxc/network.go:1005 lxc/network.go:1006
 msgid "List available networks"
 msgstr ""
 
@@ -3706,7 +3712,7 @@ msgid ""
 "Fast column layout: nsacPt\n"
 "\n"
 "A single keyword like \"web\" which will list any instance with a name "
-"starting by \"web\".\n"
+"starting with \"web\".\n"
 "A regular expression on the instance name. (e.g. .*web.*01$).\n"
 "A key/value pair referring to a configuration item. For those, the\n"
 "namespace can be abbreviated to the smallest unambiguous identifier.\n"
@@ -3763,7 +3769,8 @@ msgid ""
 "  P - Profiles\n"
 "  s - State\n"
 "  S - Number of snapshots\n"
-"  t - Type (persistent or ephemeral)\n"
+"  t - Type (container or virtual-machine, ephemeral indicated if "
+"applicable)\n"
 "  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
@@ -3830,12 +3837,12 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "List storage buckets"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1603
 #, fuzzy
 msgid "List storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1608
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3895,7 +3902,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1470
+#: lxc/info.go:489 lxc/storage_volume.go:1481
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3918,7 +3925,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Lower devices"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/network.go:1162
+#: lxc/network.go:1171
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3941,7 +3948,7 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: lxc/network.go:1083
+#: lxc/network.go:1092
 msgid "MANAGED"
 msgstr ""
 
@@ -4073,7 +4080,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:955 lxc/config.go:956
+#: lxc/config.go:956 lxc/config.go:957
 #, fuzzy
 msgid "Manage instance UEFI variables"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -4238,7 +4245,7 @@ msgstr "Profil %s wurde auf %s angewandt\n"
 msgid "Member %q does not have role %q"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/cluster.go:957
+#: lxc/cluster.go:958
 #, fuzzy, c-format
 msgid "Member %s join token:"
 msgstr "Profil %s wurde auf %s angewandt\n"
@@ -4305,7 +4312,7 @@ msgstr "Fingerabdruck des Zertifikats: % x\n"
 msgid "Missing cluster group name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/cluster.go:811 lxc/cluster.go:1367 lxc/cluster_group.go:129
+#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 #, fuzzy
@@ -4378,8 +4385,8 @@ msgstr "Profilname kann nicht geändert werden"
 
 #: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1139 lxc/network.go:1217 lxc/network.go:1283
-#: lxc/network.go:1375 lxc/network_forward.go:127 lxc/network_forward.go:215
+#: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
+#: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
 #: lxc/network_forward.go:284 lxc/network_forward.go:445
 #: lxc/network_forward.go:530 lxc/network_forward.go:705
 #: lxc/network_forward.go:836 lxc/network_forward.go:929
@@ -4423,12 +4430,12 @@ msgstr "Fehlende Zusammenfassung."
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
-#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
-#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1986
-#: lxc/storage_volume.go:2127 lxc/storage_volume.go:2285
-#: lxc/storage_volume.go:2476 lxc/storage_volume.go:2593
+#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
+#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
 #, fuzzy
 msgid "Missing pool name"
 msgstr "Profilname kann nicht geändert werden"
@@ -4449,12 +4456,12 @@ msgstr "Profilname kann nicht geändert werden"
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:438 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
 #, fuzzy
 msgid "Missing source volume name"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1411
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Profilname kann nicht geändert werden"
@@ -4493,8 +4500,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
-#: lxc/storage_volume.go:964
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
+#: lxc/storage_volume.go:975
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4534,7 +4541,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
 #, fuzzy
 msgid "Move storage volumes between pools"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -4544,11 +4551,11 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Move the instance without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:1856
+#: lxc/storage_volume.go:1867
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:518
+#: lxc/storage_volume.go:519
 #, fuzzy, c-format
 msgid "Moving the storage volume: %s"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -4571,12 +4578,12 @@ msgid "Must supply instance name for: "
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
 #: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
+#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
 msgid "NAME"
 msgstr ""
 
@@ -4604,7 +4611,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
 #: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4628,8 +4635,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
-#: lxc/storage_volume.go:1562
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1573
 msgid "Name"
 msgstr ""
 
@@ -4637,7 +4644,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4662,7 +4669,7 @@ msgstr "Profil %s gelöscht\n"
 msgid "Network %s pending on member %s"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network.go:1227
+#: lxc/network.go:1236
 #, fuzzy, c-format
 msgid "Network %s renamed to %s"
 msgstr "Profil %s erstellt\n"
@@ -4775,7 +4782,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1161
+#: lxc/cluster.go:1162
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4785,7 +4792,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
+#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
 #, fuzzy
 msgid "No device found for this storage volume"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -4807,11 +4814,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:502 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4825,7 +4832,7 @@ msgstr "kein Wert in %q gefunden\n"
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2035
 #, fuzzy
 msgid "Not a snapshot name"
 msgstr "'/' ist kein gültiges Zeichen im Namen eines Sicherungspunktes\n"
@@ -4834,15 +4841,16 @@ msgstr "'/' ist kein gültiges Zeichen im Namen eines Sicherungspunktes\n"
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:343
+#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
+#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2690
+#: lxc/storage_volume.go:2701
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2489
+#: lxc/storage_volume.go:2500
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4854,11 +4862,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1418
+#: lxc/storage_volume.go:1429
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1298
+#: lxc/network.go:735 lxc/network.go:1307
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4867,7 +4875,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/info.go:705 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1577
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4897,7 +4905,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1767
 msgid "POOL"
 msgstr ""
 
@@ -4913,7 +4921,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1773
 #: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4961,7 +4969,7 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 #, fuzzy
 msgid "Please provide cluster member name: "
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -4984,16 +4992,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
-#: lxc/storage_volume.go:1189
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
+#: lxc/storage_volume.go:1200
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -5116,7 +5124,7 @@ msgstr "Eigenschaften:\n"
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1356
+#: lxc/storage_volume.go:1367
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -5130,7 +5138,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1225
+#: lxc/storage_volume.go:1236
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5146,7 +5154,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2247
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5167,7 +5175,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1004
+#: lxc/storage_volume.go:1015
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5176,7 +5184,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2081
+#: lxc/storage_volume.go:2092
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5189,13 +5197,13 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2357
+#: lxc/storage_volume.go:2368
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
 "\n"
 "lxc storage volume unset default data size\n"
-"    Remotes the size/quota of a custom volume \"data\" in pool \"default\".\n"
+"    Removes the size/quota of a custom volume \"data\" in pool \"default\".\n"
 "\n"
 "lxc storage volume unset default virtual-machine/data snapshots.expiry\n"
 "    Removes the snapshot expiration period for a virtual machine \"data\" in "
@@ -5280,7 +5288,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 #, fuzzy
 msgid "Refresh and update the existing storage volume copies"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -5482,7 +5490,7 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1184 lxc/network.go:1185
+#: lxc/network.go:1193 lxc/network.go:1194
 msgid "Rename networks"
 msgstr ""
 
@@ -5500,17 +5508,17 @@ msgstr "Fehlerhafte Profil URL %s"
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1949
+#: lxc/storage_volume.go:1960
 #, fuzzy
 msgid "Rename storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:1959
 #, fuzzy
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:2037 lxc/storage_volume.go:2057
+#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5520,11 +5528,11 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:892 lxc/cluster.go:893
+#: lxc/cluster.go:893 lxc/cluster.go:894
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1032
+#: lxc/config.go:1033
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5548,7 +5556,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1328 lxc/cluster.go:1329
+#: lxc/cluster.go:1329 lxc/cluster.go:1330
 #, fuzzy
 msgid "Restore cluster member"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -5565,12 +5573,12 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2552 lxc/storage_volume.go:2553
+#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
 #, fuzzy
 msgid "Restore storage volume snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/cluster.go:1394
+#: lxc/cluster.go:1395
 #, fuzzy, c-format
 msgid "Restoring cluster member: %s"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -5594,7 +5602,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1087
 #, fuzzy
 msgid "Revoke cluster member join token"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -5646,7 +5654,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr "Entferntes Administrator Passwort"
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1088
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1097
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5711,7 +5719,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1050 lxc/config.go:1051
+#: lxc/config.go:1051 lxc/config.go:1052
 #, fuzzy
 msgid "Set UEFI variables for instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -5780,11 +5788,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1244
+#: lxc/network.go:1253
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1245
+#: lxc/network.go:1254
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5909,12 +5917,12 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2075
+#: lxc/storage_volume.go:2086
 #, fuzzy
 msgid "Set storage volume configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_volume.go:2076
+#: lxc/storage_volume.go:2087
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5977,7 +5985,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Set the key as a network peer property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network.go:1252
+#: lxc/network.go:1261
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -6009,7 +6017,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Set the key as a storage property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2103
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -6083,7 +6091,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1173
+#: lxc/config.go:1173 lxc/config.go:1174
 #, fuzzy
 msgid "Show instance UEFI variables"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -6121,7 +6129,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Show network ACL log"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network.go:1340 lxc/network.go:1341
+#: lxc/network.go:1349 lxc/network.go:1350
 msgid "Show network configurations"
 msgstr ""
 
@@ -6177,12 +6185,12 @@ msgstr "Profil %s erstellt\n"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2233 lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
 #, fuzzy
 msgid "Show storage volume configurations"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
 #, fuzzy
 msgid "Show storage volume state information"
 msgstr "Profil %s erstellt\n"
@@ -6207,7 +6215,7 @@ msgstr ""
 
 #: lxc/info.go:43
 #, fuzzy
-msgid "Show the instance's last 100 log lines?"
+msgid "Show the instance's last 100 log lines"
 msgstr "Zeige die letzten 100 Zeilen Protokoll des Containers?"
 
 #: lxc/info.go:44
@@ -6254,16 +6262,16 @@ msgstr "Größe: %.2vMB\n"
 msgid "Size: %s"
 msgstr "Erstellt: %s"
 
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2417
+#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
 #, fuzzy
 msgid "Snapshot storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:2179
+#: lxc/storage_volume.go:2190
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1502
 msgid "Snapshots:"
 msgstr ""
 
@@ -6373,22 +6381,22 @@ msgstr "Profil %s erstellt\n"
 msgid "Storage pool name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: lxc/storage_volume.go:702
+#: lxc/storage_volume.go:703
 #, fuzzy, c-format
 msgid "Storage volume %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_volume.go:790
+#: lxc/storage_volume.go:791
 #, fuzzy, c-format
 msgid "Storage volume %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:516
 #, fuzzy
 msgid "Storage volume copied successfully!"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:520
 #, fuzzy
 msgid "Storage volume moved successfully!"
 msgstr "Profil %s erstellt\n"
@@ -6398,7 +6406,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Store the instance state"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -6447,18 +6455,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr "Abbild mit Fingerabdruck %s importiert\n"
 
-#: lxc/cluster.go:1070 lxc/config_trust.go:515
+#: lxc/cluster.go:1071 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1736 lxc/warning.go:216
+#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1747 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
 msgid "Taken at"
 msgstr ""
 
@@ -6621,12 +6629,12 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1340
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/storage_volume.go:1306
+#: lxc/storage_volume.go:1317
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6645,8 +6653,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
-#: lxc/storage_volume.go:978
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:989
 #, fuzzy
 msgid "The specified device doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
@@ -6669,11 +6677,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/cluster.go:739
+#: lxc/cluster.go:740
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:729
+#: lxc/cluster.go:730
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6726,7 +6734,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1487
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Erstellt: %s"
@@ -6741,7 +6749,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr "unbekannter entfernter Instanz Name: %q"
 
-#: lxc/storage_volume.go:1853
+#: lxc/storage_volume.go:1864
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6749,7 +6757,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:394
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6810,7 +6818,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1472
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6832,13 +6840,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:995 lxc/storage_volume.go:1752
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
+#: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1740
+#: lxc/storage.go:724 lxc/storage_volume.go:1751
 msgid "USED BY"
 msgstr ""
 
@@ -6871,7 +6879,7 @@ msgstr "Unbekannter Befehl %s für Abbild"
 msgid "Unknown channel type for client %q: %s"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6897,7 +6905,7 @@ msgstr "Unbekannter Befehl %s für Abbild"
 msgid "Unknown output type %q"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/config.go:1141 lxc/config.go:1142
+#: lxc/config.go:1142 lxc/config.go:1143
 #, fuzzy
 msgid "Unset UEFI variables for instance"
 msgstr "nicht alle Profile der Quelle sind am Ziel vorhanden."
@@ -6931,7 +6939,7 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Unset network ACL configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network.go:1412 lxc/network.go:1413
+#: lxc/network.go:1421 lxc/network.go:1422
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -6993,7 +7001,7 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2354 lxc/storage_volume.go:2355
+#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
 #, fuzzy
 msgid "Unset storage volume configuration keys"
 msgstr "Alternatives config Verzeichnis."
@@ -7021,7 +7029,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Unset the key as a network peer property"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/network.go:1417
+#: lxc/network.go:1426
 #, fuzzy
 msgid "Unset the key as a network property"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -7054,7 +7062,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Unset the key as a storage property"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2379
 #, fuzzy
 msgid "Unset the key as a storage volume property"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -7063,7 +7071,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:247
+#: lxc/storage_volume.go:248
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -7076,12 +7084,12 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1174
+#: lxc/cluster.go:1175
 #, fuzzy
 msgid "Update cluster certificate"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/cluster.go:1176
+#: lxc/cluster.go:1177
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -7101,12 +7109,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1485
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Erstellt: %s"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2641
+#: lxc/export.go:42 lxc/storage_volume.go:2652
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -7177,7 +7185,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1576
 msgid "Volume Only"
 msgstr ""
 
@@ -7215,7 +7223,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
 #: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -7245,7 +7253,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "You need to specify an image name or use --empty"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/storage_volume.go:903
+#: lxc/storage_volume.go:909
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
@@ -7253,7 +7261,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:281
+#: lxc/storage_volume.go:282
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
@@ -7262,9 +7270,9 @@ msgstr ""
 "lxd %s <Name>\n"
 
 #: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
-#: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
+#: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 #, fuzzy
@@ -7282,7 +7290,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/cluster.go:1172
+#: lxc/cluster.go:1173
 #, fuzzy
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
@@ -7595,7 +7603,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 #, fuzzy
@@ -7638,7 +7646,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config.go:994 lxc/config.go:1140
+#: lxc/config.go:995 lxc/config.go:1141
 #, fuzzy
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
@@ -7646,7 +7654,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config.go:1049
+#: lxc/config.go:1050
 #, fuzzy
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
@@ -7815,8 +7823,8 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:768
-#: lxc/cluster.go:1085 lxc/cluster.go:1297 lxc/cluster.go:1327
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
+#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
 #, fuzzy
 msgid "[<remote>:]<member>"
 msgstr ""
@@ -7868,8 +7876,8 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1104
-#: lxc/network.go:1339 lxc/network_forward.go:87
+#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1113
+#: lxc/network.go:1348 lxc/network_forward.go:87
 #: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
 #, fuzzy
 msgid "[<remote>:]<network>"
@@ -7894,7 +7902,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network.go:791 lxc/network.go:1411
+#: lxc/network.go:791 lxc/network.go:1420
 #, fuzzy
 msgid "[<remote>:]<network> <key>"
 msgstr ""
@@ -7902,7 +7910,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network.go:1243
+#: lxc/network.go:1252
 #, fuzzy
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
@@ -7979,7 +7987,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network.go:1182
+#: lxc/network.go:1191
 #, fuzzy
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
@@ -8078,7 +8086,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:2800
+#: lxc/storage_volume.go:2811
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
@@ -8145,7 +8153,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:1958
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
@@ -8156,7 +8164,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:806
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
@@ -8172,7 +8180,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:2551
+#: lxc/storage_volume.go:2562
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
@@ -8181,7 +8189,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:2634
+#: lxc/storage_volume.go:2645
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
@@ -8190,7 +8198,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:2415
+#: lxc/storage_volume.go:2426
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
@@ -8199,7 +8207,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:609
+#: lxc/storage_volume.go:610
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
@@ -8207,7 +8215,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:718
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
@@ -8216,7 +8224,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
@@ -8224,7 +8232,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:2353
+#: lxc/storage_volume.go:2364
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
@@ -8232,7 +8240,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2085
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
@@ -8240,7 +8248,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:2232
+#: lxc/storage_volume.go:2243
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
@@ -8249,7 +8257,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:1221
+#: lxc/storage_volume.go:1232
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
@@ -8258,7 +8266,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1858
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -8266,7 +8274,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:387
+#: lxc/storage_volume.go:388
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -8480,7 +8488,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1601
 #, fuzzy
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
@@ -8505,7 +8513,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/cluster.go:891
+#: lxc/cluster.go:892
 #, fuzzy
 msgid "[[<remote>:]<member>]"
 msgstr ""
@@ -8582,7 +8590,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:772
+#: lxc/cluster.go:773
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -8631,13 +8639,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1229
+#: lxc/config.go:1230
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1053
+#: lxc/config.go:1054
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -8978,7 +8986,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:614
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -8986,13 +8994,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2804
+#: lxc/storage_volume.go:2815
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2419
+#: lxc/storage_volume.go:2430
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -9059,6 +9067,9 @@ msgstr ""
 #: lxc/image.go:1206
 msgid "yes"
 msgstr ""
+
+#~ msgid "Action (defaults to GET)"
+#~ msgstr "Aktion (Standard: GET)"
 
 #, fuzzy, c-format
 #~ msgid "Failed to create certificate: %w"

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-09 03:18-0300\n"
+"POT-Creation-Date: 2024-12-18 08:40-0700\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1030
+#: lxc/storage_volume.go:1041
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1240
+#: lxc/config.go:1241
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -412,7 +412,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:790
+#: lxc/cluster.go:791
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -585,13 +585,13 @@ msgstr ""
 msgid "Acknowledge warning"
 msgstr ""
 
+#: lxc/query.go:43
+msgid "Action"
+msgstr ""
+
 #: lxc/query.go:76
 #, c-format
 msgid "Action %q isn't supported by this tool"
-msgstr ""
-
-#: lxc/query.go:43
-msgid "Action (defaults to GET)"
 msgstr ""
 
 #: lxc/cluster_group.go:725
@@ -741,7 +741,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1596
+#: lxc/storage_volume.go:1607
 msgid "All projects"
 msgstr ""
 
@@ -763,7 +763,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1371
+#: lxc/cluster.go:1372
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -800,7 +800,7 @@ msgstr ""
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:282 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -852,16 +852,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2708
+#: lxc/storage_volume.go:2719
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2785
+#: lxc/export.go:192 lxc/storage_volume.go:2796
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1538
 msgid "Backups:"
 msgstr ""
 
@@ -882,7 +882,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -925,7 +925,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1739
+#: lxc/storage_volume.go:1750
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1011,7 +1011,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1019,7 +1019,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1097
+#: lxc/config.go:702 lxc/config.go:1098
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1028,12 +1028,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:492
+#: lxc/storage_volume.go:493
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:446
+#: lxc/storage_volume.go:447
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1109,7 +1109,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1154
+#: lxc/cluster.go:1155
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1137,8 +1137,8 @@ msgstr ""
 #: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
 #: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
-#: lxc/network_forward.go:182 lxc/network_forward.go:264
+#: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
+#: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
 #: lxc/network_forward.go:497 lxc/network_forward.go:649
 #: lxc/network_forward.go:803 lxc/network_forward.go:892
 #: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
@@ -1153,30 +1153,30 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
-#: lxc/storage_volume.go:1952 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2251 lxc/storage_volume.go:2367
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2555
-#: lxc/storage_volume.go:2643 lxc/storage_volume.go:2807
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
+#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
+#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:894
+#: lxc/cluster.go:895
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:926
+#: lxc/cluster.go:927
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:756
+#: lxc/cluster.go:757
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1213,24 +1213,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
+#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
-#: lxc/storage_volume.go:1188
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
+#: lxc/storage_volume.go:1199
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:619
+#: lxc/storage_volume.go:620
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1240,7 +1240,11 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/move.go:65
+#: lxc/move.go:65
+msgid "Copy a stateful instance as stateless"
+msgstr ""
+
+#: lxc/copy.go:60
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1288,7 +1292,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:389 lxc/storage_volume.go:390
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1296,12 +1300,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:396
+#: lxc/storage_volume.go:397
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:398
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1314,7 +1318,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:515
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1337,12 +1341,12 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1235
+#: lxc/cluster.go:1236
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1239
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1357,17 +1361,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1266
+#: lxc/cluster.go:1267
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1450,7 +1454,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1504,7 +1508,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1533,13 +1537,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1738
+#: lxc/storage_volume.go:1749
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1559,7 +1563,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2642
+#: lxc/storage_volume.go:2653
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1660,7 +1664,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1681,16 +1685,16 @@ msgstr ""
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
-#: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
+#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
+#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
-#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
-#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
+#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
+#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1713,8 +1717,8 @@ msgstr ""
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
 #: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1005 lxc/network.go:1106 lxc/network.go:1185
-#: lxc/network.go:1245 lxc/network.go:1341 lxc/network.go:1413
+#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
+#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
 #: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
 #: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
 #: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
@@ -1765,27 +1769,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
-#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
-#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
-#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1949
-#: lxc/storage_volume.go:2076 lxc/storage_volume.go:2234
-#: lxc/storage_volume.go:2355 lxc/storage_volume.go:2417
-#: lxc/storage_volume.go:2553 lxc/storage_volume.go:2636
-#: lxc/storage_volume.go:2802 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1454
+#: lxc/storage_volume.go:1465
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "  Χρήση δικτύου:"
@@ -1798,11 +1802,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
+#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1934,7 +1938,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:516
+#: lxc/cluster.go:1072 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1956,7 +1960,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:769 lxc/cluster.go:770
+#: lxc/cluster.go:770 lxc/cluster.go:771
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1977,7 +1981,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1226 lxc/config.go:1227
+#: lxc/config.go:1227 lxc/config.go:1228
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2046,7 +2050,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2054,7 +2058,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2072,11 +2076,12 @@ msgid ""
 "new\n"
 "  LXD cluster, which will have the given name.\n"
 "\n"
-"  It's required that the LXD is already available on the network. You can "
-"check\n"
-"  that by running 'lxc config get core.https_address', and possibly set a "
-"value\n"
-"  for the address if not yet set."
+"  It's required that LXD is already available on the network. You can check\n"
+"  this by running 'lxc config get core.https_address'. If either an IP "
+"address\n"
+"  and port is displayed, or both, LXD is already available on the network. "
+"If\n"
+"  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
 #: lxc/network_zone.go:1427
@@ -2106,12 +2111,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
+#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2121,12 +2126,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
+#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
-#: lxc/storage_volume.go:2199
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
+#: lxc/storage_volume.go:2210
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2136,11 +2141,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1298 lxc/cluster.go:1299
+#: lxc/cluster.go:1299 lxc/cluster.go:1300
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1396
+#: lxc/cluster.go:1397
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2168,8 +2173,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
-#: lxc/storage_volume.go:1564
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Expires at"
 msgstr ""
 
@@ -2193,7 +2198,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2635 lxc/storage_volume.go:2636
+#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2205,11 +2210,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2639
+#: lxc/storage_volume.go:2650
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2768
+#: lxc/export.go:152 lxc/storage_volume.go:2779
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2389,7 +2394,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
+#: lxc/network.go:1046 lxc/network_acl.go:133 lxc/network_zone.go:124
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2399,7 +2404,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1303
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2407,7 +2412,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1301
+#: lxc/cluster.go:1302
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2419,7 +2424,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1331
+#: lxc/cluster.go:1332
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2460,16 +2465,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
-#: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1614 lxc/warning.go:94
+#: lxc/storage_volume.go:1625 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2529,7 +2534,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:996
+#: lxc/config.go:996 lxc/config.go:997
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2599,7 +2604,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1249
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2670,11 +2675,11 @@ msgstr "  Χρήση δικτύου:"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
+#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:475
+#: lxc/storage_volume.go:476
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2702,7 +2707,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1161
+#: lxc/network.go:1170
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2756,7 +2761,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1163
+#: lxc/network.go:1172
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2768,11 +2773,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1084
+#: lxc/list.go:560 lxc/network.go:1093
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1085
+#: lxc/list.go:561 lxc/network.go:1094
 msgid "IPV6"
 msgstr ""
 
@@ -2802,7 +2807,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2427
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2816,7 +2821,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2437
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2866,7 +2871,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2802
+#: lxc/storage_volume.go:2813
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2874,7 +2879,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2801
+#: lxc/storage_volume.go:2812
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2896,11 +2901,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2809
+#: lxc/storage_volume.go:2820
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2883
+#: lxc/storage_volume.go:2894
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2944,7 +2949,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
+#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3026,7 +3031,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2012
+#: lxc/move.go:148 lxc/storage_volume.go:2023
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3034,7 +3039,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2019
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3052,9 +3057,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
-#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2144 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
+#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3098,9 +3103,9 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
+#: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3112,8 +3117,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1020 lxc/cluster.go:1123
-#: lxc/cluster.go:1231 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
+#: lxc/cluster.go:1232 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3150,7 +3155,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1105 lxc/network.go:1106
+#: lxc/network.go:1114 lxc/network.go:1115
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3162,7 +3167,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:976 lxc/cluster.go:977
+#: lxc/cluster.go:977 lxc/cluster.go:978
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -3212,7 +3217,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1004 lxc/network.go:1005
+#: lxc/network.go:1005 lxc/network.go:1006
 msgid "List available networks"
 msgstr ""
 
@@ -3300,7 +3305,7 @@ msgid ""
 "Fast column layout: nsacPt\n"
 "\n"
 "A single keyword like \"web\" which will list any instance with a name "
-"starting by \"web\".\n"
+"starting with \"web\".\n"
 "A regular expression on the instance name. (e.g. .*web.*01$).\n"
 "A key/value pair referring to a configuration item. For those, the\n"
 "namespace can be abbreviated to the smallest unambiguous identifier.\n"
@@ -3357,7 +3362,8 @@ msgid ""
 "  P - Profiles\n"
 "  s - State\n"
 "  S - Number of snapshots\n"
-"  t - Type (persistent or ephemeral)\n"
+"  t - Type (container or virtual-machine, ephemeral indicated if "
+"applicable)\n"
 "  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
@@ -3406,11 +3412,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1603
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1608
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3469,7 +3475,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1470
+#: lxc/info.go:489 lxc/storage_volume.go:1481
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3490,7 +3496,7 @@ msgstr ""
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1162
+#: lxc/network.go:1171
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3508,7 +3514,7 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1083
+#: lxc/network.go:1092
 msgid "MANAGED"
 msgstr ""
 
@@ -3633,7 +3639,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:955 lxc/config.go:956
+#: lxc/config.go:956 lxc/config.go:957
 #, fuzzy
 msgid "Manage instance UEFI variables"
 msgstr "  Χρήση δικτύου:"
@@ -3784,7 +3790,7 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:957
+#: lxc/cluster.go:958
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
@@ -3852,7 +3858,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/cluster.go:811 lxc/cluster.go:1367 lxc/cluster_group.go:129
+#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -3920,8 +3926,8 @@ msgstr ""
 
 #: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1139 lxc/network.go:1217 lxc/network.go:1283
-#: lxc/network.go:1375 lxc/network_forward.go:127 lxc/network_forward.go:215
+#: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
+#: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
 #: lxc/network_forward.go:284 lxc/network_forward.go:445
 #: lxc/network_forward.go:530 lxc/network_forward.go:705
 #: lxc/network_forward.go:836 lxc/network_forward.go:929
@@ -3963,12 +3969,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
-#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
-#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1986
-#: lxc/storage_volume.go:2127 lxc/storage_volume.go:2285
-#: lxc/storage_volume.go:2476 lxc/storage_volume.go:2593
+#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
+#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
 msgid "Missing pool name"
 msgstr ""
 
@@ -3987,11 +3993,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:438 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1411
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "  Χρήση δικτύου:"
@@ -4029,8 +4035,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
-#: lxc/storage_volume.go:964
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
+#: lxc/storage_volume.go:975
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4067,7 +4073,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4075,11 +4081,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1856
+#: lxc/storage_volume.go:1867
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:518
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4101,12 +4107,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
+#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
 msgid "NAME"
 msgstr ""
 
@@ -4134,7 +4140,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
 #: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4158,8 +4164,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
-#: lxc/storage_volume.go:1562
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1573
 msgid "Name"
 msgstr ""
 
@@ -4167,7 +4173,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4192,7 +4198,7 @@ msgstr ""
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1227
+#: lxc/network.go:1236
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4304,7 +4310,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1161
+#: lxc/cluster.go:1162
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4313,7 +4319,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
+#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4333,11 +4339,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:502 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4351,7 +4357,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2035
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4359,15 +4365,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:343
+#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
+#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2690
+#: lxc/storage_volume.go:2701
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2489
+#: lxc/storage_volume.go:2500
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4379,11 +4386,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1418
+#: lxc/storage_volume.go:1429
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1298
+#: lxc/network.go:735 lxc/network.go:1307
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4392,7 +4399,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1577
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4422,7 +4429,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1767
 msgid "POOL"
 msgstr ""
 
@@ -4438,7 +4445,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1773
 #: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4484,7 +4491,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 #, fuzzy
 msgid "Please provide cluster member name: "
 msgstr "  Χρήση δικτύου:"
@@ -4506,16 +4513,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
-#: lxc/storage_volume.go:1189
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
+#: lxc/storage_volume.go:1200
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4632,7 +4639,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1356
+#: lxc/storage_volume.go:1367
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4646,7 +4653,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1225
+#: lxc/storage_volume.go:1236
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4662,7 +4669,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2247
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4683,7 +4690,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1004
+#: lxc/storage_volume.go:1015
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4692,7 +4699,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2081
+#: lxc/storage_volume.go:2092
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4705,13 +4712,13 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2357
+#: lxc/storage_volume.go:2368
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
 "\n"
 "lxc storage volume unset default data size\n"
-"    Remotes the size/quota of a custom volume \"data\" in pool \"default\".\n"
+"    Removes the size/quota of a custom volume \"data\" in pool \"default\".\n"
 "\n"
 "lxc storage volume unset default virtual-machine/data snapshots.expiry\n"
 "    Removes the snapshot expiration period for a virtual machine \"data\" in "
@@ -4791,7 +4798,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4979,7 +4986,7 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1184 lxc/network.go:1185
+#: lxc/network.go:1193 lxc/network.go:1194
 msgid "Rename networks"
 msgstr ""
 
@@ -4995,15 +5002,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1949
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:1959
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2037 lxc/storage_volume.go:2057
+#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5013,11 +5020,11 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:892 lxc/cluster.go:893
+#: lxc/cluster.go:893 lxc/cluster.go:894
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1032
+#: lxc/config.go:1033
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5040,7 +5047,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1328 lxc/cluster.go:1329
+#: lxc/cluster.go:1329 lxc/cluster.go:1330
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5055,11 +5062,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2552 lxc/storage_volume.go:2553
+#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1394
+#: lxc/cluster.go:1395
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5082,7 +5089,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1087
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5132,7 +5139,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1088
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1097
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5195,7 +5202,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1050 lxc/config.go:1051
+#: lxc/config.go:1051 lxc/config.go:1052
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5260,11 +5267,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1244
+#: lxc/network.go:1253
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1245
+#: lxc/network.go:1254
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5387,11 +5394,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2075
+#: lxc/storage_volume.go:2086
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2076
+#: lxc/storage_volume.go:2087
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5451,7 +5458,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Set the key as a network peer property"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network.go:1252
+#: lxc/network.go:1261
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5482,7 +5489,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2103
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5553,7 +5560,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1173
+#: lxc/config.go:1173 lxc/config.go:1174
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5586,7 +5593,7 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network.go:1340 lxc/network.go:1341
+#: lxc/network.go:1349 lxc/network.go:1350
 msgid "Show network configurations"
 msgstr ""
 
@@ -5641,11 +5648,11 @@ msgstr "  Χρήση δικτύου:"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2233 lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5668,7 +5675,7 @@ msgid "Show the expanded configuration"
 msgstr ""
 
 #: lxc/info.go:43
-msgid "Show the instance's last 100 log lines?"
+msgid "Show the instance's last 100 log lines"
 msgstr ""
 
 #: lxc/info.go:44
@@ -5714,15 +5721,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2417
+#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2179
+#: lxc/storage_volume.go:2190
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1502
 msgid "Snapshots:"
 msgstr ""
 
@@ -5827,21 +5834,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:702
+#: lxc/storage_volume.go:703
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:790
+#: lxc/storage_volume.go:791
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:516
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:520
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5849,7 +5856,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5898,18 +5905,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1070 lxc/config_trust.go:515
+#: lxc/cluster.go:1071 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1736 lxc/warning.go:216
+#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1747 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
 msgid "Taken at"
 msgstr ""
 
@@ -6066,12 +6073,12 @@ msgstr "  Χρήση δικτύου:"
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1340
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/storage_volume.go:1306
+#: lxc/storage_volume.go:1317
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6090,8 +6097,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
-#: lxc/storage_volume.go:978
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:989
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6112,11 +6119,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/cluster.go:739
+#: lxc/cluster.go:740
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:729
+#: lxc/cluster.go:730
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6167,7 +6174,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6182,7 +6189,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1853
+#: lxc/storage_volume.go:1864
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6190,7 +6197,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:394
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6249,7 +6256,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1472
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6271,13 +6278,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:995 lxc/storage_volume.go:1752
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
+#: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1740
+#: lxc/storage.go:724 lxc/storage_volume.go:1751
 msgid "USED BY"
 msgstr ""
 
@@ -6309,7 +6316,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6335,7 +6342,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1141 lxc/config.go:1142
+#: lxc/config.go:1142 lxc/config.go:1143
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6364,7 +6371,7 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1412 lxc/network.go:1413
+#: lxc/network.go:1421 lxc/network.go:1422
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -6425,7 +6432,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2354 lxc/storage_volume.go:2355
+#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6452,7 +6459,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Unset the key as a network peer property"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/network.go:1417
+#: lxc/network.go:1426
 #, fuzzy
 msgid "Unset the key as a network property"
 msgstr "  Χρήση δικτύου:"
@@ -6484,7 +6491,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2379
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6492,7 +6499,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:247
+#: lxc/storage_volume.go:248
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6505,11 +6512,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1174
+#: lxc/cluster.go:1175
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1176
+#: lxc/cluster.go:1177
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6528,12 +6535,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1485
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "  Χρήση CPU:"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2641
+#: lxc/export.go:42 lxc/storage_volume.go:2652
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6600,7 +6607,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1576
 msgid "Volume Only"
 msgstr ""
 
@@ -6633,7 +6640,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
 #: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6659,18 +6666,18 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:903
+#: lxc/storage_volume.go:909
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:281
+#: lxc/storage_volume.go:282
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
-#: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
+#: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
@@ -6680,7 +6687,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1172
+#: lxc/cluster.go:1173
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -6843,7 +6850,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6865,11 +6872,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:1140
+#: lxc/config.go:995 lxc/config.go:1141
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1049
+#: lxc/config.go:1050
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -6948,8 +6955,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:768
-#: lxc/cluster.go:1085 lxc/cluster.go:1297 lxc/cluster.go:1327
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
+#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -6973,8 +6980,8 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1104
-#: lxc/network.go:1339 lxc/network_forward.go:87
+#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1113
+#: lxc/network.go:1348 lxc/network_forward.go:87
 #: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -6987,11 +6994,11 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1411
+#: lxc/network.go:791 lxc/network.go:1420
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1243
+#: lxc/network.go:1252
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
@@ -7036,7 +7043,7 @@ msgstr ""
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1182
+#: lxc/network.go:1191
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7087,7 +7094,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2800
+#: lxc/storage_volume.go:2811
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7122,13 +7129,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:1958
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:806
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7136,51 +7143,51 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2551
+#: lxc/storage_volume.go:2562
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2634
+#: lxc/storage_volume.go:2645
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2415
+#: lxc/storage_volume.go:2426
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:609
+#: lxc/storage_volume.go:610
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:718
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2353
+#: lxc/storage_volume.go:2364
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2085
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2232
+#: lxc/storage_volume.go:2243
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1221
+#: lxc/storage_volume.go:1232
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1858
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:387
+#: lxc/storage_volume.go:388
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7286,7 +7293,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1601
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7298,7 +7305,7 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:891
+#: lxc/cluster.go:892
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -7370,7 +7377,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:772
+#: lxc/cluster.go:773
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7419,13 +7426,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1229
+#: lxc/config.go:1230
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1053
+#: lxc/config.go:1054
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7762,7 +7769,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:614
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7770,13 +7777,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2804
+#: lxc/storage_volume.go:2815
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2419
+#: lxc/storage_volume.go:2430
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-09 03:18-0300\n"
+"POT-Creation-Date: 2024-12-18 08:40-0700\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1030
+#: lxc/storage_volume.go:1041
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1240
+#: lxc/config.go:1241
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -412,7 +412,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:790
+#: lxc/cluster.go:791
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -585,13 +585,13 @@ msgstr ""
 msgid "Acknowledge warning"
 msgstr ""
 
+#: lxc/query.go:43
+msgid "Action"
+msgstr ""
+
 #: lxc/query.go:76
 #, c-format
 msgid "Action %q isn't supported by this tool"
-msgstr ""
-
-#: lxc/query.go:43
-msgid "Action (defaults to GET)"
 msgstr ""
 
 #: lxc/cluster_group.go:725
@@ -738,7 +738,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1596
+#: lxc/storage_volume.go:1607
 msgid "All projects"
 msgstr ""
 
@@ -760,7 +760,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1371
+#: lxc/cluster.go:1372
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -797,7 +797,7 @@ msgstr ""
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:282 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -849,16 +849,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2708
+#: lxc/storage_volume.go:2719
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2785
+#: lxc/export.go:192 lxc/storage_volume.go:2796
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1538
 msgid "Backups:"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -922,7 +922,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1739
+#: lxc/storage_volume.go:1750
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1007,7 +1007,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1097
+#: lxc/config.go:702 lxc/config.go:1098
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1024,12 +1024,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:492
+#: lxc/storage_volume.go:493
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:446
+#: lxc/storage_volume.go:447
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1105,7 +1105,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1154
+#: lxc/cluster.go:1155
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1133,8 +1133,8 @@ msgstr ""
 #: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
 #: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
-#: lxc/network_forward.go:182 lxc/network_forward.go:264
+#: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
+#: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
 #: lxc/network_forward.go:497 lxc/network_forward.go:649
 #: lxc/network_forward.go:803 lxc/network_forward.go:892
 #: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
@@ -1149,30 +1149,30 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
-#: lxc/storage_volume.go:1952 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2251 lxc/storage_volume.go:2367
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2555
-#: lxc/storage_volume.go:2643 lxc/storage_volume.go:2807
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
+#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
+#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:894
+#: lxc/cluster.go:895
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:926
+#: lxc/cluster.go:927
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:756
+#: lxc/cluster.go:757
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1209,24 +1209,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
+#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
-#: lxc/storage_volume.go:1188
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
+#: lxc/storage_volume.go:1199
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:619
+#: lxc/storage_volume.go:620
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1236,7 +1236,11 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/move.go:65
+#: lxc/move.go:65
+msgid "Copy a stateful instance as stateless"
+msgstr ""
+
+#: lxc/copy.go:60
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1284,7 +1288,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:389 lxc/storage_volume.go:390
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1292,12 +1296,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:396
+#: lxc/storage_volume.go:397
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:398
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1310,7 +1314,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:515
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1333,12 +1337,12 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1235
+#: lxc/cluster.go:1236
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1239
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1353,17 +1357,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1266
+#: lxc/cluster.go:1267
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1445,7 +1449,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1497,7 +1501,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1526,13 +1530,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1738
+#: lxc/storage_volume.go:1749
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1552,7 +1556,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2642
+#: lxc/storage_volume.go:2653
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1648,7 +1652,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1669,16 +1673,16 @@ msgstr ""
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
-#: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
+#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
+#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
-#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
-#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
+#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
+#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1701,8 +1705,8 @@ msgstr ""
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
 #: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1005 lxc/network.go:1106 lxc/network.go:1185
-#: lxc/network.go:1245 lxc/network.go:1341 lxc/network.go:1413
+#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
+#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
 #: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
 #: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
 #: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
@@ -1753,27 +1757,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
-#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
-#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
-#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1949
-#: lxc/storage_volume.go:2076 lxc/storage_volume.go:2234
-#: lxc/storage_volume.go:2355 lxc/storage_volume.go:2417
-#: lxc/storage_volume.go:2553 lxc/storage_volume.go:2636
-#: lxc/storage_volume.go:2802 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1454
+#: lxc/storage_volume.go:1465
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1785,11 +1789,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
+#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1917,7 +1921,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:516
+#: lxc/cluster.go:1072 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1939,7 +1943,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:769 lxc/cluster.go:770
+#: lxc/cluster.go:770 lxc/cluster.go:771
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1959,7 +1963,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1226 lxc/config.go:1227
+#: lxc/config.go:1227 lxc/config.go:1228
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2023,7 +2027,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2031,7 +2035,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2049,11 +2053,12 @@ msgid ""
 "new\n"
 "  LXD cluster, which will have the given name.\n"
 "\n"
-"  It's required that the LXD is already available on the network. You can "
-"check\n"
-"  that by running 'lxc config get core.https_address', and possibly set a "
-"value\n"
-"  for the address if not yet set."
+"  It's required that LXD is already available on the network. You can check\n"
+"  this by running 'lxc config get core.https_address'. If either an IP "
+"address\n"
+"  and port is displayed, or both, LXD is already available on the network. "
+"If\n"
+"  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
 #: lxc/network_zone.go:1427
@@ -2083,12 +2088,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
+#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2098,12 +2103,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
+#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
-#: lxc/storage_volume.go:2199
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
+#: lxc/storage_volume.go:2210
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2113,11 +2118,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1298 lxc/cluster.go:1299
+#: lxc/cluster.go:1299 lxc/cluster.go:1300
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1396
+#: lxc/cluster.go:1397
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2145,8 +2150,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
-#: lxc/storage_volume.go:1564
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Expires at"
 msgstr ""
 
@@ -2170,7 +2175,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2635 lxc/storage_volume.go:2636
+#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2182,11 +2187,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2639
+#: lxc/storage_volume.go:2650
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2768
+#: lxc/export.go:152 lxc/storage_volume.go:2779
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2366,7 +2371,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
+#: lxc/network.go:1046 lxc/network_acl.go:133 lxc/network_zone.go:124
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2376,7 +2381,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1303
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2384,7 +2389,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1301
+#: lxc/cluster.go:1302
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2396,7 +2401,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1331
+#: lxc/cluster.go:1332
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2437,16 +2442,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
-#: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1614 lxc/warning.go:94
+#: lxc/storage_volume.go:1625 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2506,7 +2511,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:996
+#: lxc/config.go:996 lxc/config.go:997
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2570,7 +2575,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1249
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2634,11 +2639,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
+#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:475
+#: lxc/storage_volume.go:476
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2666,7 +2671,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1161
+#: lxc/network.go:1170
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2720,7 +2725,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1163
+#: lxc/network.go:1172
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2732,11 +2737,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1084
+#: lxc/list.go:560 lxc/network.go:1093
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1085
+#: lxc/list.go:561 lxc/network.go:1094
 msgid "IPV6"
 msgstr ""
 
@@ -2766,7 +2771,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2427
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2780,7 +2785,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2437
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2830,7 +2835,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2802
+#: lxc/storage_volume.go:2813
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2838,7 +2843,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2801
+#: lxc/storage_volume.go:2812
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2860,11 +2865,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2809
+#: lxc/storage_volume.go:2820
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2883
+#: lxc/storage_volume.go:2894
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2908,7 +2913,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
+#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2990,7 +2995,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2012
+#: lxc/move.go:148 lxc/storage_volume.go:2023
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2998,7 +3003,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2019
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3016,9 +3021,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
-#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2144 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
+#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3062,9 +3067,9 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
+#: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3076,8 +3081,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1020 lxc/cluster.go:1123
-#: lxc/cluster.go:1231 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
+#: lxc/cluster.go:1232 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3114,7 +3119,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1105 lxc/network.go:1106
+#: lxc/network.go:1114 lxc/network.go:1115
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3126,7 +3131,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:976 lxc/cluster.go:977
+#: lxc/cluster.go:977 lxc/cluster.go:978
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -3174,7 +3179,7 @@ msgstr ""
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1004 lxc/network.go:1005
+#: lxc/network.go:1005 lxc/network.go:1006
 msgid "List available networks"
 msgstr ""
 
@@ -3262,7 +3267,7 @@ msgid ""
 "Fast column layout: nsacPt\n"
 "\n"
 "A single keyword like \"web\" which will list any instance with a name "
-"starting by \"web\".\n"
+"starting with \"web\".\n"
 "A regular expression on the instance name. (e.g. .*web.*01$).\n"
 "A key/value pair referring to a configuration item. For those, the\n"
 "namespace can be abbreviated to the smallest unambiguous identifier.\n"
@@ -3319,7 +3324,8 @@ msgid ""
 "  P - Profiles\n"
 "  s - State\n"
 "  S - Number of snapshots\n"
-"  t - Type (persistent or ephemeral)\n"
+"  t - Type (container or virtual-machine, ephemeral indicated if "
+"applicable)\n"
 "  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
@@ -3368,11 +3374,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1603
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1608
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3431,7 +3437,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1470
+#: lxc/info.go:489 lxc/storage_volume.go:1481
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3452,7 +3458,7 @@ msgstr ""
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1162
+#: lxc/network.go:1171
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3470,7 +3476,7 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1083
+#: lxc/network.go:1092
 msgid "MANAGED"
 msgstr ""
 
@@ -3593,7 +3599,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:955 lxc/config.go:956
+#: lxc/config.go:956 lxc/config.go:957
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3732,7 +3738,7 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:957
+#: lxc/cluster.go:958
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
@@ -3796,7 +3802,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:811 lxc/cluster.go:1367 lxc/cluster_group.go:129
+#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -3859,8 +3865,8 @@ msgstr ""
 
 #: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1139 lxc/network.go:1217 lxc/network.go:1283
-#: lxc/network.go:1375 lxc/network_forward.go:127 lxc/network_forward.go:215
+#: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
+#: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
 #: lxc/network_forward.go:284 lxc/network_forward.go:445
 #: lxc/network_forward.go:530 lxc/network_forward.go:705
 #: lxc/network_forward.go:836 lxc/network_forward.go:929
@@ -3901,12 +3907,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
-#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
-#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1986
-#: lxc/storage_volume.go:2127 lxc/storage_volume.go:2285
-#: lxc/storage_volume.go:2476 lxc/storage_volume.go:2593
+#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
+#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
 msgid "Missing pool name"
 msgstr ""
 
@@ -3925,11 +3931,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:438 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1411
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3966,8 +3972,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
-#: lxc/storage_volume.go:964
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
+#: lxc/storage_volume.go:975
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4004,7 +4010,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4012,11 +4018,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1856
+#: lxc/storage_volume.go:1867
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:518
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4038,12 +4044,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
+#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
 msgid "NAME"
 msgstr ""
 
@@ -4071,7 +4077,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
 #: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4095,8 +4101,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
-#: lxc/storage_volume.go:1562
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1573
 msgid "Name"
 msgstr ""
 
@@ -4104,7 +4110,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4129,7 +4135,7 @@ msgstr ""
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1227
+#: lxc/network.go:1236
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4239,7 +4245,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1161
+#: lxc/cluster.go:1162
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4248,7 +4254,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
+#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4268,11 +4274,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:502 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4286,7 +4292,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2035
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4294,15 +4300,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:343
+#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
+#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2690
+#: lxc/storage_volume.go:2701
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2489
+#: lxc/storage_volume.go:2500
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4314,11 +4321,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1418
+#: lxc/storage_volume.go:1429
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1298
+#: lxc/network.go:735 lxc/network.go:1307
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4327,7 +4334,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1577
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4357,7 +4364,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1767
 msgid "POOL"
 msgstr ""
 
@@ -4373,7 +4380,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1773
 #: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4419,7 +4426,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -4440,16 +4447,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
-#: lxc/storage_volume.go:1189
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
+#: lxc/storage_volume.go:1200
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4566,7 +4573,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1356
+#: lxc/storage_volume.go:1367
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4580,7 +4587,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1225
+#: lxc/storage_volume.go:1236
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4596,7 +4603,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2247
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4617,7 +4624,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1004
+#: lxc/storage_volume.go:1015
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4626,7 +4633,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2081
+#: lxc/storage_volume.go:2092
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4639,13 +4646,13 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2357
+#: lxc/storage_volume.go:2368
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
 "\n"
 "lxc storage volume unset default data size\n"
-"    Remotes the size/quota of a custom volume \"data\" in pool \"default\".\n"
+"    Removes the size/quota of a custom volume \"data\" in pool \"default\".\n"
 "\n"
 "lxc storage volume unset default virtual-machine/data snapshots.expiry\n"
 "    Removes the snapshot expiration period for a virtual machine \"data\" in "
@@ -4725,7 +4732,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4908,7 +4915,7 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1184 lxc/network.go:1185
+#: lxc/network.go:1193 lxc/network.go:1194
 msgid "Rename networks"
 msgstr ""
 
@@ -4924,15 +4931,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1949
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:1959
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2037 lxc/storage_volume.go:2057
+#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4942,11 +4949,11 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:892 lxc/cluster.go:893
+#: lxc/cluster.go:893 lxc/cluster.go:894
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1032
+#: lxc/config.go:1033
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -4969,7 +4976,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1328 lxc/cluster.go:1329
+#: lxc/cluster.go:1329 lxc/cluster.go:1330
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4984,11 +4991,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2552 lxc/storage_volume.go:2553
+#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1394
+#: lxc/cluster.go:1395
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5010,7 +5017,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1087
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5060,7 +5067,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1088
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1097
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5123,7 +5130,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1050 lxc/config.go:1051
+#: lxc/config.go:1051 lxc/config.go:1052
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5187,11 +5194,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1244
+#: lxc/network.go:1253
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1245
+#: lxc/network.go:1254
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5308,11 +5315,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2075
+#: lxc/storage_volume.go:2086
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2076
+#: lxc/storage_volume.go:2087
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5369,7 +5376,7 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1252
+#: lxc/network.go:1261
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5397,7 +5404,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2103
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5466,7 +5473,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1173
+#: lxc/config.go:1173 lxc/config.go:1174
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5498,7 +5505,7 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1340 lxc/network.go:1341
+#: lxc/network.go:1349 lxc/network.go:1350
 msgid "Show network configurations"
 msgstr ""
 
@@ -5546,11 +5553,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2233 lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5573,7 +5580,7 @@ msgid "Show the expanded configuration"
 msgstr ""
 
 #: lxc/info.go:43
-msgid "Show the instance's last 100 log lines?"
+msgid "Show the instance's last 100 log lines"
 msgstr ""
 
 #: lxc/info.go:44
@@ -5618,15 +5625,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2417
+#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2179
+#: lxc/storage_volume.go:2190
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1502
 msgid "Snapshots:"
 msgstr ""
 
@@ -5731,21 +5738,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:702
+#: lxc/storage_volume.go:703
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:790
+#: lxc/storage_volume.go:791
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:516
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:520
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5753,7 +5760,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5802,18 +5809,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1070 lxc/config_trust.go:515
+#: lxc/cluster.go:1071 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1736 lxc/warning.go:216
+#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1747 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
 msgid "Taken at"
 msgstr ""
 
@@ -5970,12 +5977,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1340
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1306
+#: lxc/storage_volume.go:1317
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -5994,8 +6001,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
-#: lxc/storage_volume.go:978
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:989
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6015,11 +6022,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:739
+#: lxc/cluster.go:740
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:729
+#: lxc/cluster.go:730
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6070,7 +6077,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6085,7 +6092,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1853
+#: lxc/storage_volume.go:1864
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6093,7 +6100,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:394
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6152,7 +6159,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1472
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6174,13 +6181,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:995 lxc/storage_volume.go:1752
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
+#: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1740
+#: lxc/storage.go:724 lxc/storage_volume.go:1751
 msgid "USED BY"
 msgstr ""
 
@@ -6212,7 +6219,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6238,7 +6245,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1141 lxc/config.go:1142
+#: lxc/config.go:1142 lxc/config.go:1143
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6266,7 +6273,7 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1412 lxc/network.go:1413
+#: lxc/network.go:1421 lxc/network.go:1422
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -6318,7 +6325,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2354 lxc/storage_volume.go:2355
+#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6342,7 +6349,7 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1417
+#: lxc/network.go:1426
 msgid "Unset the key as a network property"
 msgstr ""
 
@@ -6370,7 +6377,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2379
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6378,7 +6385,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:247
+#: lxc/storage_volume.go:248
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6391,11 +6398,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1174
+#: lxc/cluster.go:1175
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1176
+#: lxc/cluster.go:1177
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6414,12 +6421,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2641
+#: lxc/export.go:42 lxc/storage_volume.go:2652
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6486,7 +6493,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1576
 msgid "Volume Only"
 msgstr ""
 
@@ -6519,7 +6526,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
 #: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6545,18 +6552,18 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:903
+#: lxc/storage_volume.go:909
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:281
+#: lxc/storage_volume.go:282
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
-#: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
+#: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
@@ -6566,7 +6573,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1172
+#: lxc/cluster.go:1173
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -6729,7 +6736,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6751,11 +6758,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:1140
+#: lxc/config.go:995 lxc/config.go:1141
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1049
+#: lxc/config.go:1050
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -6834,8 +6841,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:768
-#: lxc/cluster.go:1085 lxc/cluster.go:1297 lxc/cluster.go:1327
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
+#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -6859,8 +6866,8 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1104
-#: lxc/network.go:1339 lxc/network_forward.go:87
+#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1113
+#: lxc/network.go:1348 lxc/network_forward.go:87
 #: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -6873,11 +6880,11 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1411
+#: lxc/network.go:791 lxc/network.go:1420
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1243
+#: lxc/network.go:1252
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
@@ -6922,7 +6929,7 @@ msgstr ""
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1182
+#: lxc/network.go:1191
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -6973,7 +6980,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2800
+#: lxc/storage_volume.go:2811
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7008,13 +7015,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:1958
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:806
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7022,51 +7029,51 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2551
+#: lxc/storage_volume.go:2562
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2634
+#: lxc/storage_volume.go:2645
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2415
+#: lxc/storage_volume.go:2426
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:609
+#: lxc/storage_volume.go:610
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:718
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2353
+#: lxc/storage_volume.go:2364
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2085
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2232
+#: lxc/storage_volume.go:2243
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1221
+#: lxc/storage_volume.go:1232
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1858
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:387
+#: lxc/storage_volume.go:388
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7172,7 +7179,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1601
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7184,7 +7191,7 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:891
+#: lxc/cluster.go:892
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -7256,7 +7263,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:772
+#: lxc/cluster.go:773
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7305,13 +7312,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1229
+#: lxc/config.go:1230
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1053
+#: lxc/config.go:1054
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7648,7 +7655,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:614
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7656,13 +7663,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2804
+#: lxc/storage_volume.go:2815
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2419
+#: lxc/storage_volume.go:2430
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-09 03:18-0300\n"
+"POT-Creation-Date: 2024-12-18 08:40-0700\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -79,7 +79,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:1030
+#: lxc/storage_volume.go:1041
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -108,7 +108,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/config.go:1240
+#: lxc/config.go:1241
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -649,7 +649,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/cluster.go:790
+#: lxc/cluster.go:791
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -828,14 +828,14 @@ msgstr ""
 msgid "Acknowledge warning"
 msgstr ""
 
+#: lxc/query.go:43
+msgid "Action"
+msgstr ""
+
 #: lxc/query.go:76
 #, fuzzy, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr "El filtrado no está soportado aún"
-
-#: lxc/query.go:43
-msgid "Action (defaults to GET)"
-msgstr "Accion (predeterminados a GET)"
 
 #: lxc/cluster_group.go:725
 #, fuzzy
@@ -985,7 +985,7 @@ msgstr "El dispostivo ya existe: %s"
 msgid "Aliases:"
 msgstr "Aliases:"
 
-#: lxc/storage_volume.go:1596
+#: lxc/storage_volume.go:1607
 msgid "All projects"
 msgstr ""
 
@@ -1008,7 +1008,7 @@ msgstr "Arquitectura: %s"
 msgid "Architecture: %v"
 msgstr "Arquitectura: %s"
 
-#: lxc/cluster.go:1371
+#: lxc/cluster.go:1372
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -1046,7 +1046,7 @@ msgstr ""
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:282 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -1098,16 +1098,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2708
+#: lxc/storage_volume.go:2719
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/export.go:192 lxc/storage_volume.go:2785
+#: lxc/export.go:192 lxc/storage_volume.go:2796
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1538
 msgid "Backups:"
 msgstr ""
 
@@ -1128,7 +1128,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1172,7 +1172,7 @@ msgstr "CANCELABLE"
 msgid "COMMON NAME"
 msgstr "NOMBRE COMÚN"
 
-#: lxc/storage_volume.go:1739
+#: lxc/storage_volume.go:1750
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1261,7 +1261,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr "No se puede especificar un remote diferente para renombrar."
 
-#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1269,7 +1269,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1097
+#: lxc/config.go:702 lxc/config.go:1098
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1278,12 +1278,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:492
+#: lxc/storage_volume.go:493
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:446
+#: lxc/storage_volume.go:447
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1361,7 +1361,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr "Perfil %s renombrado a %s"
 
-#: lxc/cluster.go:1154
+#: lxc/cluster.go:1155
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1389,8 +1389,8 @@ msgstr "Perfil %s eliminado de %s"
 #: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
 #: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
-#: lxc/network_forward.go:182 lxc/network_forward.go:264
+#: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
+#: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
 #: lxc/network_forward.go:497 lxc/network_forward.go:649
 #: lxc/network_forward.go:803 lxc/network_forward.go:892
 #: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
@@ -1405,30 +1405,30 @@ msgstr "Perfil %s eliminado de %s"
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
-#: lxc/storage_volume.go:1952 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2251 lxc/storage_volume.go:2367
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2555
-#: lxc/storage_volume.go:2643 lxc/storage_volume.go:2807
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
+#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
+#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
 msgid "Cluster member name"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/cluster.go:894
+#: lxc/cluster.go:895
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:926
+#: lxc/cluster.go:927
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:756
+#: lxc/cluster.go:757
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr "Columnas"
@@ -1467,24 +1467,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
+#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
-#: lxc/storage_volume.go:1188
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
+#: lxc/storage_volume.go:1199
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:619
+#: lxc/storage_volume.go:620
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1478
 #, fuzzy, c-format
 msgid "Content type: %s"
 msgstr "Auto actualización: %s"
@@ -1494,7 +1494,11 @@ msgstr "Auto actualización: %s"
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/move.go:65
+#: lxc/move.go:65
+msgid "Copy a stateful instance as stateless"
+msgstr ""
+
+#: lxc/copy.go:60
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1542,7 +1546,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:389 lxc/storage_volume.go:390
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1550,12 +1554,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:396
+#: lxc/storage_volume.go:397
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:398
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1569,7 +1573,7 @@ msgstr "Copiando la imagen: %s"
 msgid "Copying the image: %s"
 msgstr "Copiando la imagen: %s"
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:515
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1593,12 +1597,12 @@ msgstr "Certificado de la huella digital: %s"
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1235
+#: lxc/cluster.go:1236
 #, fuzzy, c-format
 msgid "Could not find certificate file path: %s"
 msgstr "Certificado de la huella digital: %s"
 
-#: lxc/cluster.go:1239
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1613,17 +1617,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, fuzzy, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr "Certificado de la huella digital: %s"
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, fuzzy, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr "Certificado de la huella digital: %s"
 
-#: lxc/cluster.go:1266
+#: lxc/cluster.go:1267
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1712,7 +1716,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr "Perfil %s creado"
 
-#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1766,7 +1770,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
 #, c-format
 msgid "Created: %s"
 msgstr "Creado: %s"
@@ -1796,13 +1800,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1738
+#: lxc/storage_volume.go:1749
 msgid "DESCRIPTION"
 msgstr "DESCRIPCIÓN"
 
@@ -1822,7 +1826,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2642
+#: lxc/storage_volume.go:2653
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1924,7 +1928,7 @@ msgstr "Perfil %s creado"
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1945,16 +1949,16 @@ msgstr ""
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
-#: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
+#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
+#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
-#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
-#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
+#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
+#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1977,8 +1981,8 @@ msgstr ""
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
 #: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1005 lxc/network.go:1106 lxc/network.go:1185
-#: lxc/network.go:1245 lxc/network.go:1341 lxc/network.go:1413
+#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
+#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
 #: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
 #: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
 #: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
@@ -2029,27 +2033,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
-#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
-#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
-#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1949
-#: lxc/storage_volume.go:2076 lxc/storage_volume.go:2234
-#: lxc/storage_volume.go:2355 lxc/storage_volume.go:2417
-#: lxc/storage_volume.go:2553 lxc/storage_volume.go:2636
-#: lxc/storage_volume.go:2802 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr "Descripción"
 
-#: lxc/storage_volume.go:1454
+#: lxc/storage_volume.go:1465
 #, fuzzy, c-format
 msgid "Description: %s"
 msgstr "Huella dactilar: %s"
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Nombre del Miembro del Cluster"
@@ -2062,11 +2066,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
+#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2198,7 +2202,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:516
+#: lxc/cluster.go:1072 lxc/config_trust.go:516
 #, fuzzy
 msgid "EXPIRES AT"
 msgstr "FECHA DE EXPIRACIÓN"
@@ -2221,7 +2225,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:769 lxc/cluster.go:770
+#: lxc/cluster.go:770 lxc/cluster.go:771
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2242,7 +2246,7 @@ msgstr "Perfil %s creado"
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1226 lxc/config.go:1227
+#: lxc/config.go:1227 lxc/config.go:1228
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2311,7 +2315,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2319,7 +2323,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2337,11 +2341,12 @@ msgid ""
 "new\n"
 "  LXD cluster, which will have the given name.\n"
 "\n"
-"  It's required that the LXD is already available on the network. You can "
-"check\n"
-"  that by running 'lxc config get core.https_address', and possibly set a "
-"value\n"
-"  for the address if not yet set."
+"  It's required that LXD is already available on the network. You can check\n"
+"  this by running 'lxc config get core.https_address'. If either an IP "
+"address\n"
+"  and port is displayed, or both, LXD is already available on the network. "
+"If\n"
+"  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
 #: lxc/network_zone.go:1427
@@ -2371,12 +2376,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
+#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Error actualizando el archivo de plantilla: %s"
@@ -2386,12 +2391,12 @@ msgstr "Error actualizando el archivo de plantilla: %s"
 msgid "Error unsetting properties: %v"
 msgstr "Error actualizando el archivo de plantilla: %s"
 
-#: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
+#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
-#: lxc/storage_volume.go:2199
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
+#: lxc/storage_volume.go:2210
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2401,12 +2406,12 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr "Error actualizando el archivo de plantilla: %s"
 
-#: lxc/cluster.go:1298 lxc/cluster.go:1299
+#: lxc/cluster.go:1299 lxc/cluster.go:1300
 #, fuzzy
 msgid "Evacuate cluster member"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:1396
+#: lxc/cluster.go:1397
 #, fuzzy, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "Nombre del Miembro del Cluster"
@@ -2434,8 +2439,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
-#: lxc/storage_volume.go:1564
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 #, fuzzy
 msgid "Expires at"
 msgstr "Expira: %s"
@@ -2460,7 +2465,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2635 lxc/storage_volume.go:2636
+#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2474,11 +2479,11 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Export instances as backup tarballs."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2639
+#: lxc/storage_volume.go:2650
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2768
+#: lxc/export.go:152 lxc/storage_volume.go:2779
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -2658,7 +2663,7 @@ msgstr "Acepta certificado"
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
+#: lxc/network.go:1046 lxc/network_acl.go:133 lxc/network_zone.go:124
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr "El filtrado no está soportado aún"
@@ -2668,7 +2673,7 @@ msgstr "El filtrado no está soportado aún"
 msgid "Fingerprint: %s"
 msgstr "Huella dactilar: %s"
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1303
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2676,7 +2681,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1301
+#: lxc/cluster.go:1302
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2688,7 +2693,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1331
+#: lxc/cluster.go:1332
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2730,16 +2735,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
-#: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1614 lxc/warning.go:94
+#: lxc/storage_volume.go:1625 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2799,7 +2804,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:996
+#: lxc/config.go:996 lxc/config.go:997
 #, fuzzy
 msgid "Get UEFI variables for instance"
 msgstr "Aliases:"
@@ -2870,7 +2875,7 @@ msgstr "Perfil %s creado"
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1249
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2941,11 +2946,11 @@ msgstr "Perfil %s creado"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
+#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:475
+#: lxc/storage_volume.go:476
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2973,7 +2978,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1161
+#: lxc/network.go:1170
 msgid "HOSTNAME"
 msgstr ""
 
@@ -3028,7 +3033,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1163
+#: lxc/network.go:1172
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -3042,11 +3047,11 @@ msgstr "Expira: %s"
 msgid "IP addresses:"
 msgstr "Expira: %s"
 
-#: lxc/list.go:560 lxc/network.go:1084
+#: lxc/list.go:560 lxc/network.go:1093
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1085
+#: lxc/list.go:561 lxc/network.go:1094
 msgid "IPV6"
 msgstr ""
 
@@ -3076,7 +3081,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2427
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3090,7 +3095,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2437
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3140,7 +3145,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2802
+#: lxc/storage_volume.go:2813
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3148,7 +3153,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2801
+#: lxc/storage_volume.go:2812
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -3171,11 +3176,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2809
+#: lxc/storage_volume.go:2820
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2883
+#: lxc/storage_volume.go:2894
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -3221,7 +3226,7 @@ msgstr "Nombre del contenedor es obligatorio"
 msgid "Instance name is: %s"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
+#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
 #, fuzzy
 msgid "Instance name must be specified"
 msgstr "Nombre del contenedor es: %s"
@@ -3304,7 +3309,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2012
+#: lxc/move.go:148 lxc/storage_volume.go:2023
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "Nombre del contenedor es: %s"
@@ -3313,7 +3318,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2019
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3331,9 +3336,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
-#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2144 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
+#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Nombre del contenedor es: %s"
@@ -3378,9 +3383,9 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
+#: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3392,8 +3397,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1020 lxc/cluster.go:1123
-#: lxc/cluster.go:1231 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
+#: lxc/cluster.go:1232 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3431,7 +3436,7 @@ msgstr "Arquitectura: %s"
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1105 lxc/network.go:1106
+#: lxc/network.go:1114 lxc/network.go:1115
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3445,7 +3450,7 @@ msgstr "Aliases:"
 msgid "List all active certificate add tokens"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/cluster.go:976 lxc/cluster.go:977
+#: lxc/cluster.go:977 lxc/cluster.go:978
 #, fuzzy
 msgid "List all active cluster member join tokens"
 msgstr "Nombre del Miembro del Cluster"
@@ -3498,7 +3503,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1004 lxc/network.go:1005
+#: lxc/network.go:1005 lxc/network.go:1006
 msgid "List available networks"
 msgstr ""
 
@@ -3588,7 +3593,7 @@ msgid ""
 "Fast column layout: nsacPt\n"
 "\n"
 "A single keyword like \"web\" which will list any instance with a name "
-"starting by \"web\".\n"
+"starting with \"web\".\n"
 "A regular expression on the instance name. (e.g. .*web.*01$).\n"
 "A key/value pair referring to a configuration item. For those, the\n"
 "namespace can be abbreviated to the smallest unambiguous identifier.\n"
@@ -3645,7 +3650,8 @@ msgid ""
 "  P - Profiles\n"
 "  s - State\n"
 "  S - Number of snapshots\n"
-"  t - Type (persistent or ephemeral)\n"
+"  t - Type (container or virtual-machine, ephemeral indicated if "
+"applicable)\n"
 "  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
@@ -3697,11 +3703,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr "Aliases:"
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1603
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1608
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3761,7 +3767,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1470
+#: lxc/info.go:489 lxc/storage_volume.go:1481
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3782,7 +3788,7 @@ msgstr ""
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1162
+#: lxc/network.go:1171
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3801,7 +3807,7 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr "Cacheado: %s"
 
-#: lxc/network.go:1083
+#: lxc/network.go:1092
 msgid "MANAGED"
 msgstr ""
 
@@ -3926,7 +3932,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:955 lxc/config.go:956
+#: lxc/config.go:956 lxc/config.go:957
 #, fuzzy
 msgid "Manage instance UEFI variables"
 msgstr "Nombre del Miembro del Cluster"
@@ -4078,7 +4084,7 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:957
+#: lxc/cluster.go:958
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
@@ -4145,7 +4151,7 @@ msgstr "Certificado de la huella digital: %s"
 msgid "Missing cluster group name"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/cluster.go:811 lxc/cluster.go:1367 lxc/cluster_group.go:129
+#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 #, fuzzy
@@ -4217,8 +4223,8 @@ msgstr "Nombre del contenedor es: %s"
 
 #: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1139 lxc/network.go:1217 lxc/network.go:1283
-#: lxc/network.go:1375 lxc/network_forward.go:127 lxc/network_forward.go:215
+#: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
+#: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
 #: lxc/network_forward.go:284 lxc/network_forward.go:445
 #: lxc/network_forward.go:530 lxc/network_forward.go:705
 #: lxc/network_forward.go:836 lxc/network_forward.go:929
@@ -4262,12 +4268,12 @@ msgstr "Nombre del contenedor es: %s"
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
-#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
-#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1986
-#: lxc/storage_volume.go:2127 lxc/storage_volume.go:2285
-#: lxc/storage_volume.go:2476 lxc/storage_volume.go:2593
+#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
+#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
 msgid "Missing pool name"
 msgstr ""
 
@@ -4287,11 +4293,11 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:438 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1411
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Nombre del contenedor es: %s"
@@ -4331,8 +4337,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
-#: lxc/storage_volume.go:964
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
+#: lxc/storage_volume.go:975
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4370,7 +4376,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4378,11 +4384,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1856
+#: lxc/storage_volume.go:1867
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:518
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4404,12 +4410,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
+#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
 msgid "NAME"
 msgstr ""
 
@@ -4437,7 +4443,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
 #: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4461,8 +4467,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
-#: lxc/storage_volume.go:1562
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1573
 msgid "Name"
 msgstr ""
 
@@ -4470,7 +4476,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4495,7 +4501,7 @@ msgstr ""
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1227
+#: lxc/network.go:1236
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4605,7 +4611,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1161
+#: lxc/cluster.go:1162
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4614,7 +4620,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
+#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4634,11 +4640,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:502 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4652,7 +4658,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2035
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4660,15 +4666,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:343
+#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
+#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2690
+#: lxc/storage_volume.go:2701
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2489
+#: lxc/storage_volume.go:2500
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4680,11 +4687,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1418
+#: lxc/storage_volume.go:1429
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1298
+#: lxc/network.go:735 lxc/network.go:1307
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4693,7 +4700,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1577
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4723,7 +4730,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1767
 msgid "POOL"
 msgstr ""
 
@@ -4739,7 +4746,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1773
 #: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4785,7 +4792,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 #, fuzzy
 msgid "Please provide cluster member name: "
 msgstr "Nombre del Miembro del Cluster"
@@ -4807,16 +4814,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
-#: lxc/storage_volume.go:1189
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
+#: lxc/storage_volume.go:1200
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4937,7 +4944,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1356
+#: lxc/storage_volume.go:1367
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4951,7 +4958,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1225
+#: lxc/storage_volume.go:1236
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4967,7 +4974,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2247
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4988,7 +4995,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1004
+#: lxc/storage_volume.go:1015
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4997,7 +5004,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2081
+#: lxc/storage_volume.go:2092
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5010,13 +5017,13 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2357
+#: lxc/storage_volume.go:2368
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
 "\n"
 "lxc storage volume unset default data size\n"
-"    Remotes the size/quota of a custom volume \"data\" in pool \"default\".\n"
+"    Removes the size/quota of a custom volume \"data\" in pool \"default\".\n"
 "\n"
 "lxc storage volume unset default virtual-machine/data snapshots.expiry\n"
 "    Removes the snapshot expiration period for a virtual machine \"data\" in "
@@ -5098,7 +5105,7 @@ msgstr "Aliases:"
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -5289,7 +5296,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1184 lxc/network.go:1185
+#: lxc/network.go:1193 lxc/network.go:1194
 msgid "Rename networks"
 msgstr ""
 
@@ -5305,15 +5312,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1949
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:1959
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2037 lxc/storage_volume.go:2057
+#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5323,11 +5330,11 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:892 lxc/cluster.go:893
+#: lxc/cluster.go:893 lxc/cluster.go:894
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1032
+#: lxc/config.go:1033
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5351,7 +5358,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1328 lxc/cluster.go:1329
+#: lxc/cluster.go:1329 lxc/cluster.go:1330
 #, fuzzy
 msgid "Restore cluster member"
 msgstr "Nombre del Miembro del Cluster"
@@ -5368,11 +5375,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2552 lxc/storage_volume.go:2553
+#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1394
+#: lxc/cluster.go:1395
 #, fuzzy, c-format
 msgid "Restoring cluster member: %s"
 msgstr "Nombre del Miembro del Cluster"
@@ -5395,7 +5402,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1087
 #, fuzzy
 msgid "Revoke cluster member join token"
 msgstr "Nombre del Miembro del Cluster"
@@ -5447,7 +5454,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1088
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1097
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5510,7 +5517,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1050 lxc/config.go:1051
+#: lxc/config.go:1051 lxc/config.go:1052
 #, fuzzy
 msgid "Set UEFI variables for instance"
 msgstr "Aliases:"
@@ -5576,11 +5583,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1244
+#: lxc/network.go:1253
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1245
+#: lxc/network.go:1254
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5703,11 +5710,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2075
+#: lxc/storage_volume.go:2086
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2076
+#: lxc/storage_volume.go:2087
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5767,7 +5774,7 @@ msgstr "Perfil %s creado"
 msgid "Set the key as a network peer property"
 msgstr "Perfil %s creado"
 
-#: lxc/network.go:1252
+#: lxc/network.go:1261
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5798,7 +5805,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2103
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5869,7 +5876,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1173
+#: lxc/config.go:1173 lxc/config.go:1174
 #, fuzzy
 msgid "Show instance UEFI variables"
 msgstr "Dispositivo %s añadido a %s"
@@ -5903,7 +5910,7 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr "Perfil %s creado"
 
-#: lxc/network.go:1340 lxc/network.go:1341
+#: lxc/network.go:1349 lxc/network.go:1350
 msgid "Show network configurations"
 msgstr ""
 
@@ -5958,11 +5965,11 @@ msgstr "Perfil %s creado"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2233 lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5985,7 +5992,7 @@ msgid "Show the expanded configuration"
 msgstr ""
 
 #: lxc/info.go:43
-msgid "Show the instance's last 100 log lines?"
+msgid "Show the instance's last 100 log lines"
 msgstr ""
 
 #: lxc/info.go:44
@@ -6031,15 +6038,15 @@ msgstr "Auto actualización: %s"
 msgid "Size: %s"
 msgstr "Auto actualización: %s"
 
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2417
+#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2179
+#: lxc/storage_volume.go:2190
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1502
 msgid "Snapshots:"
 msgstr ""
 
@@ -6145,21 +6152,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:702
+#: lxc/storage_volume.go:703
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:790
+#: lxc/storage_volume.go:791
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:516
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:520
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -6167,7 +6174,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -6216,18 +6223,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr "Contenedor publicado con huella digital: %s"
 
-#: lxc/cluster.go:1070 lxc/config_trust.go:515
+#: lxc/cluster.go:1071 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1736 lxc/warning.go:216
+#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1747 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
 msgid "Taken at"
 msgstr ""
 
@@ -6386,12 +6393,12 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1340
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/storage_volume.go:1306
+#: lxc/storage_volume.go:1317
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6410,8 +6417,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
-#: lxc/storage_volume.go:978
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:989
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6432,11 +6439,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/cluster.go:739
+#: lxc/cluster.go:740
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:729
+#: lxc/cluster.go:730
 #, fuzzy
 msgid "This LXD server is not available on the network"
 msgstr "El directorio importado no está disponible en esta plataforma"
@@ -6488,7 +6495,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1487
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Auto actualización: %s"
@@ -6503,7 +6510,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1853
+#: lxc/storage_volume.go:1864
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6511,7 +6518,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:394
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6572,7 +6579,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1472
 #, fuzzy, c-format
 msgid "Type: %s"
 msgstr "Expira: %s"
@@ -6594,13 +6601,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:995 lxc/storage_volume.go:1752
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
+#: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1740
+#: lxc/storage.go:724 lxc/storage_volume.go:1751
 msgid "USED BY"
 msgstr ""
 
@@ -6632,7 +6639,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6658,7 +6665,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1141 lxc/config.go:1142
+#: lxc/config.go:1142 lxc/config.go:1143
 #, fuzzy
 msgid "Unset UEFI variables for instance"
 msgstr "Aliases:"
@@ -6688,7 +6695,7 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1412 lxc/network.go:1413
+#: lxc/network.go:1421 lxc/network.go:1422
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -6749,7 +6756,7 @@ msgstr "Perfil %s creado"
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2354 lxc/storage_volume.go:2355
+#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6776,7 +6783,7 @@ msgstr "Perfil %s creado"
 msgid "Unset the key as a network peer property"
 msgstr "Perfil %s creado"
 
-#: lxc/network.go:1417
+#: lxc/network.go:1426
 #, fuzzy
 msgid "Unset the key as a network property"
 msgstr "Perfil %s creado"
@@ -6808,7 +6815,7 @@ msgstr "Perfil %s creado"
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2379
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6816,7 +6823,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:247
+#: lxc/storage_volume.go:248
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6829,12 +6836,12 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1174
+#: lxc/cluster.go:1175
 #, fuzzy
 msgid "Update cluster certificate"
 msgstr "Acepta certificado"
 
-#: lxc/cluster.go:1176
+#: lxc/cluster.go:1177
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6853,12 +6860,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1485
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Auto actualización: %s"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2641
+#: lxc/export.go:42 lxc/storage_volume.go:2652
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6925,7 +6932,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1576
 msgid "Volume Only"
 msgstr ""
 
@@ -6958,7 +6965,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
 #: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6984,20 +6991,20 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:903
+#: lxc/storage_volume.go:909
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:281
+#: lxc/storage_volume.go:282
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
 #: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
-#: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
+#: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 #, fuzzy
@@ -7009,7 +7016,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:1172
+#: lxc/cluster.go:1173
 #, fuzzy
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7207,7 +7214,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 #, fuzzy
@@ -7234,12 +7241,12 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config.go:994 lxc/config.go:1140
+#: lxc/config.go:995 lxc/config.go:1141
 #, fuzzy
 msgid "[<remote>:]<instance> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/config.go:1049
+#: lxc/config.go:1050
 #, fuzzy
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7336,8 +7343,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:768
-#: lxc/cluster.go:1085 lxc/cluster.go:1297 lxc/cluster.go:1327
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
+#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
 #, fuzzy
 msgid "[<remote>:]<member>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7367,8 +7374,8 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1104
-#: lxc/network.go:1339 lxc/network_forward.go:87
+#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1113
+#: lxc/network.go:1348 lxc/network_forward.go:87
 #: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
 #, fuzzy
 msgid "[<remote>:]<network>"
@@ -7384,12 +7391,12 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network.go:791 lxc/network.go:1411
+#: lxc/network.go:791 lxc/network.go:1420
 #, fuzzy
 msgid "[<remote>:]<network> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network.go:1243
+#: lxc/network.go:1252
 #, fuzzy
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7442,7 +7449,7 @@ msgstr ""
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/network.go:1182
+#: lxc/network.go:1191
 #, fuzzy
 msgid "[<remote>:]<network> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7505,7 +7512,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<pool>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2800
+#: lxc/storage_volume.go:2811
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7548,14 +7555,14 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:1958
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:806
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7565,62 +7572,62 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2551
+#: lxc/storage_volume.go:2562
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2634
+#: lxc/storage_volume.go:2645
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2415
+#: lxc/storage_volume.go:2426
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:609
+#: lxc/storage_volume.go:610
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:718
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2353
+#: lxc/storage_volume.go:2364
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2085
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2232
+#: lxc/storage_volume.go:2243
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1221
+#: lxc/storage_volume.go:1232
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1858
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:387
+#: lxc/storage_volume.go:388
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7752,7 +7759,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1601
 #, fuzzy
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7767,7 +7774,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:891
+#: lxc/cluster.go:892
 #, fuzzy
 msgid "[[<remote>:]<member>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7840,7 +7847,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:772
+#: lxc/cluster.go:773
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7889,13 +7896,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1229
+#: lxc/config.go:1230
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1053
+#: lxc/config.go:1054
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -8232,7 +8239,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:614
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -8240,13 +8247,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2804
+#: lxc/storage_volume.go:2815
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2419
+#: lxc/storage_volume.go:2430
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -8313,6 +8320,9 @@ msgstr ""
 #: lxc/image.go:1206
 msgid "yes"
 msgstr ""
+
+#~ msgid "Action (defaults to GET)"
+#~ msgstr "Accion (predeterminados a GET)"
 
 #, fuzzy, c-format
 #~ msgid "Failed to create certificate: %w"

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-09 03:18-0300\n"
+"POT-Creation-Date: 2024-12-18 08:40-0700\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1030
+#: lxc/storage_volume.go:1041
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1240
+#: lxc/config.go:1241
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -412,7 +412,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:790
+#: lxc/cluster.go:791
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -585,13 +585,13 @@ msgstr ""
 msgid "Acknowledge warning"
 msgstr ""
 
+#: lxc/query.go:43
+msgid "Action"
+msgstr ""
+
 #: lxc/query.go:76
 #, c-format
 msgid "Action %q isn't supported by this tool"
-msgstr ""
-
-#: lxc/query.go:43
-msgid "Action (defaults to GET)"
 msgstr ""
 
 #: lxc/cluster_group.go:725
@@ -738,7 +738,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1596
+#: lxc/storage_volume.go:1607
 msgid "All projects"
 msgstr ""
 
@@ -760,7 +760,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1371
+#: lxc/cluster.go:1372
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -797,7 +797,7 @@ msgstr ""
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:282 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -849,16 +849,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2708
+#: lxc/storage_volume.go:2719
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2785
+#: lxc/export.go:192 lxc/storage_volume.go:2796
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1538
 msgid "Backups:"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -922,7 +922,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1739
+#: lxc/storage_volume.go:1750
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1007,7 +1007,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1097
+#: lxc/config.go:702 lxc/config.go:1098
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1024,12 +1024,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:492
+#: lxc/storage_volume.go:493
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:446
+#: lxc/storage_volume.go:447
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1105,7 +1105,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1154
+#: lxc/cluster.go:1155
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1133,8 +1133,8 @@ msgstr ""
 #: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
 #: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
-#: lxc/network_forward.go:182 lxc/network_forward.go:264
+#: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
+#: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
 #: lxc/network_forward.go:497 lxc/network_forward.go:649
 #: lxc/network_forward.go:803 lxc/network_forward.go:892
 #: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
@@ -1149,30 +1149,30 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
-#: lxc/storage_volume.go:1952 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2251 lxc/storage_volume.go:2367
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2555
-#: lxc/storage_volume.go:2643 lxc/storage_volume.go:2807
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
+#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
+#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:894
+#: lxc/cluster.go:895
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:926
+#: lxc/cluster.go:927
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:756
+#: lxc/cluster.go:757
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1209,24 +1209,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
+#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
-#: lxc/storage_volume.go:1188
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
+#: lxc/storage_volume.go:1199
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:619
+#: lxc/storage_volume.go:620
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1236,7 +1236,11 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/move.go:65
+#: lxc/move.go:65
+msgid "Copy a stateful instance as stateless"
+msgstr ""
+
+#: lxc/copy.go:60
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1284,7 +1288,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:389 lxc/storage_volume.go:390
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1292,12 +1296,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:396
+#: lxc/storage_volume.go:397
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:398
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1310,7 +1314,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:515
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1333,12 +1337,12 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1235
+#: lxc/cluster.go:1236
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1239
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1353,17 +1357,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1266
+#: lxc/cluster.go:1267
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1445,7 +1449,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1497,7 +1501,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1526,13 +1530,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1738
+#: lxc/storage_volume.go:1749
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1552,7 +1556,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2642
+#: lxc/storage_volume.go:2653
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1648,7 +1652,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1669,16 +1673,16 @@ msgstr ""
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
-#: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
+#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
+#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
-#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
-#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
+#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
+#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1701,8 +1705,8 @@ msgstr ""
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
 #: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1005 lxc/network.go:1106 lxc/network.go:1185
-#: lxc/network.go:1245 lxc/network.go:1341 lxc/network.go:1413
+#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
+#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
 #: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
 #: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
 #: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
@@ -1753,27 +1757,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
-#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
-#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
-#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1949
-#: lxc/storage_volume.go:2076 lxc/storage_volume.go:2234
-#: lxc/storage_volume.go:2355 lxc/storage_volume.go:2417
-#: lxc/storage_volume.go:2553 lxc/storage_volume.go:2636
-#: lxc/storage_volume.go:2802 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1454
+#: lxc/storage_volume.go:1465
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1785,11 +1789,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
+#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1917,7 +1921,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:516
+#: lxc/cluster.go:1072 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1939,7 +1943,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:769 lxc/cluster.go:770
+#: lxc/cluster.go:770 lxc/cluster.go:771
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1959,7 +1963,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1226 lxc/config.go:1227
+#: lxc/config.go:1227 lxc/config.go:1228
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2023,7 +2027,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2031,7 +2035,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2049,11 +2053,12 @@ msgid ""
 "new\n"
 "  LXD cluster, which will have the given name.\n"
 "\n"
-"  It's required that the LXD is already available on the network. You can "
-"check\n"
-"  that by running 'lxc config get core.https_address', and possibly set a "
-"value\n"
-"  for the address if not yet set."
+"  It's required that LXD is already available on the network. You can check\n"
+"  this by running 'lxc config get core.https_address'. If either an IP "
+"address\n"
+"  and port is displayed, or both, LXD is already available on the network. "
+"If\n"
+"  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
 #: lxc/network_zone.go:1427
@@ -2083,12 +2088,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
+#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2098,12 +2103,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
+#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
-#: lxc/storage_volume.go:2199
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
+#: lxc/storage_volume.go:2210
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2113,11 +2118,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1298 lxc/cluster.go:1299
+#: lxc/cluster.go:1299 lxc/cluster.go:1300
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1396
+#: lxc/cluster.go:1397
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2145,8 +2150,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
-#: lxc/storage_volume.go:1564
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Expires at"
 msgstr ""
 
@@ -2170,7 +2175,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2635 lxc/storage_volume.go:2636
+#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2182,11 +2187,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2639
+#: lxc/storage_volume.go:2650
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2768
+#: lxc/export.go:152 lxc/storage_volume.go:2779
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2366,7 +2371,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
+#: lxc/network.go:1046 lxc/network_acl.go:133 lxc/network_zone.go:124
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2376,7 +2381,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1303
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2384,7 +2389,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1301
+#: lxc/cluster.go:1302
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2396,7 +2401,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1331
+#: lxc/cluster.go:1332
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2437,16 +2442,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
-#: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1614 lxc/warning.go:94
+#: lxc/storage_volume.go:1625 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2506,7 +2511,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:996
+#: lxc/config.go:996 lxc/config.go:997
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2570,7 +2575,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1249
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2634,11 +2639,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
+#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:475
+#: lxc/storage_volume.go:476
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2666,7 +2671,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1161
+#: lxc/network.go:1170
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2720,7 +2725,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1163
+#: lxc/network.go:1172
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2732,11 +2737,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1084
+#: lxc/list.go:560 lxc/network.go:1093
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1085
+#: lxc/list.go:561 lxc/network.go:1094
 msgid "IPV6"
 msgstr ""
 
@@ -2766,7 +2771,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2427
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2780,7 +2785,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2437
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2830,7 +2835,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2802
+#: lxc/storage_volume.go:2813
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2838,7 +2843,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2801
+#: lxc/storage_volume.go:2812
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2860,11 +2865,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2809
+#: lxc/storage_volume.go:2820
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2883
+#: lxc/storage_volume.go:2894
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2908,7 +2913,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
+#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2990,7 +2995,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2012
+#: lxc/move.go:148 lxc/storage_volume.go:2023
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2998,7 +3003,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2019
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3016,9 +3021,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
-#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2144 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
+#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3062,9 +3067,9 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
+#: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3076,8 +3081,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1020 lxc/cluster.go:1123
-#: lxc/cluster.go:1231 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
+#: lxc/cluster.go:1232 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3114,7 +3119,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1105 lxc/network.go:1106
+#: lxc/network.go:1114 lxc/network.go:1115
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3126,7 +3131,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:976 lxc/cluster.go:977
+#: lxc/cluster.go:977 lxc/cluster.go:978
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -3174,7 +3179,7 @@ msgstr ""
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1004 lxc/network.go:1005
+#: lxc/network.go:1005 lxc/network.go:1006
 msgid "List available networks"
 msgstr ""
 
@@ -3262,7 +3267,7 @@ msgid ""
 "Fast column layout: nsacPt\n"
 "\n"
 "A single keyword like \"web\" which will list any instance with a name "
-"starting by \"web\".\n"
+"starting with \"web\".\n"
 "A regular expression on the instance name. (e.g. .*web.*01$).\n"
 "A key/value pair referring to a configuration item. For those, the\n"
 "namespace can be abbreviated to the smallest unambiguous identifier.\n"
@@ -3319,7 +3324,8 @@ msgid ""
 "  P - Profiles\n"
 "  s - State\n"
 "  S - Number of snapshots\n"
-"  t - Type (persistent or ephemeral)\n"
+"  t - Type (container or virtual-machine, ephemeral indicated if "
+"applicable)\n"
 "  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
@@ -3368,11 +3374,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1603
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1608
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3431,7 +3437,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1470
+#: lxc/info.go:489 lxc/storage_volume.go:1481
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3452,7 +3458,7 @@ msgstr ""
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1162
+#: lxc/network.go:1171
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3470,7 +3476,7 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1083
+#: lxc/network.go:1092
 msgid "MANAGED"
 msgstr ""
 
@@ -3593,7 +3599,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:955 lxc/config.go:956
+#: lxc/config.go:956 lxc/config.go:957
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3732,7 +3738,7 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:957
+#: lxc/cluster.go:958
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
@@ -3796,7 +3802,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:811 lxc/cluster.go:1367 lxc/cluster_group.go:129
+#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -3859,8 +3865,8 @@ msgstr ""
 
 #: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1139 lxc/network.go:1217 lxc/network.go:1283
-#: lxc/network.go:1375 lxc/network_forward.go:127 lxc/network_forward.go:215
+#: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
+#: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
 #: lxc/network_forward.go:284 lxc/network_forward.go:445
 #: lxc/network_forward.go:530 lxc/network_forward.go:705
 #: lxc/network_forward.go:836 lxc/network_forward.go:929
@@ -3901,12 +3907,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
-#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
-#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1986
-#: lxc/storage_volume.go:2127 lxc/storage_volume.go:2285
-#: lxc/storage_volume.go:2476 lxc/storage_volume.go:2593
+#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
+#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
 msgid "Missing pool name"
 msgstr ""
 
@@ -3925,11 +3931,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:438 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1411
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3966,8 +3972,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
-#: lxc/storage_volume.go:964
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
+#: lxc/storage_volume.go:975
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4004,7 +4010,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4012,11 +4018,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1856
+#: lxc/storage_volume.go:1867
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:518
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4038,12 +4044,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
+#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
 msgid "NAME"
 msgstr ""
 
@@ -4071,7 +4077,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
 #: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4095,8 +4101,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
-#: lxc/storage_volume.go:1562
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1573
 msgid "Name"
 msgstr ""
 
@@ -4104,7 +4110,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4129,7 +4135,7 @@ msgstr ""
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1227
+#: lxc/network.go:1236
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4239,7 +4245,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1161
+#: lxc/cluster.go:1162
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4248,7 +4254,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
+#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4268,11 +4274,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:502 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4286,7 +4292,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2035
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4294,15 +4300,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:343
+#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
+#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2690
+#: lxc/storage_volume.go:2701
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2489
+#: lxc/storage_volume.go:2500
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4314,11 +4321,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1418
+#: lxc/storage_volume.go:1429
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1298
+#: lxc/network.go:735 lxc/network.go:1307
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4327,7 +4334,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1577
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4357,7 +4364,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1767
 msgid "POOL"
 msgstr ""
 
@@ -4373,7 +4380,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1773
 #: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4419,7 +4426,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -4440,16 +4447,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
-#: lxc/storage_volume.go:1189
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
+#: lxc/storage_volume.go:1200
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4566,7 +4573,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1356
+#: lxc/storage_volume.go:1367
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4580,7 +4587,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1225
+#: lxc/storage_volume.go:1236
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4596,7 +4603,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2247
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4617,7 +4624,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1004
+#: lxc/storage_volume.go:1015
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4626,7 +4633,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2081
+#: lxc/storage_volume.go:2092
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4639,13 +4646,13 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2357
+#: lxc/storage_volume.go:2368
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
 "\n"
 "lxc storage volume unset default data size\n"
-"    Remotes the size/quota of a custom volume \"data\" in pool \"default\".\n"
+"    Removes the size/quota of a custom volume \"data\" in pool \"default\".\n"
 "\n"
 "lxc storage volume unset default virtual-machine/data snapshots.expiry\n"
 "    Removes the snapshot expiration period for a virtual machine \"data\" in "
@@ -4725,7 +4732,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4908,7 +4915,7 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1184 lxc/network.go:1185
+#: lxc/network.go:1193 lxc/network.go:1194
 msgid "Rename networks"
 msgstr ""
 
@@ -4924,15 +4931,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1949
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:1959
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2037 lxc/storage_volume.go:2057
+#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4942,11 +4949,11 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:892 lxc/cluster.go:893
+#: lxc/cluster.go:893 lxc/cluster.go:894
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1032
+#: lxc/config.go:1033
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -4969,7 +4976,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1328 lxc/cluster.go:1329
+#: lxc/cluster.go:1329 lxc/cluster.go:1330
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4984,11 +4991,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2552 lxc/storage_volume.go:2553
+#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1394
+#: lxc/cluster.go:1395
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5010,7 +5017,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1087
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5060,7 +5067,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1088
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1097
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5123,7 +5130,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1050 lxc/config.go:1051
+#: lxc/config.go:1051 lxc/config.go:1052
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5187,11 +5194,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1244
+#: lxc/network.go:1253
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1245
+#: lxc/network.go:1254
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5308,11 +5315,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2075
+#: lxc/storage_volume.go:2086
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2076
+#: lxc/storage_volume.go:2087
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5369,7 +5376,7 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1252
+#: lxc/network.go:1261
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5397,7 +5404,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2103
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5466,7 +5473,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1173
+#: lxc/config.go:1173 lxc/config.go:1174
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5498,7 +5505,7 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1340 lxc/network.go:1341
+#: lxc/network.go:1349 lxc/network.go:1350
 msgid "Show network configurations"
 msgstr ""
 
@@ -5546,11 +5553,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2233 lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5573,7 +5580,7 @@ msgid "Show the expanded configuration"
 msgstr ""
 
 #: lxc/info.go:43
-msgid "Show the instance's last 100 log lines?"
+msgid "Show the instance's last 100 log lines"
 msgstr ""
 
 #: lxc/info.go:44
@@ -5618,15 +5625,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2417
+#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2179
+#: lxc/storage_volume.go:2190
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1502
 msgid "Snapshots:"
 msgstr ""
 
@@ -5731,21 +5738,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:702
+#: lxc/storage_volume.go:703
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:790
+#: lxc/storage_volume.go:791
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:516
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:520
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5753,7 +5760,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5802,18 +5809,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1070 lxc/config_trust.go:515
+#: lxc/cluster.go:1071 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1736 lxc/warning.go:216
+#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1747 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
 msgid "Taken at"
 msgstr ""
 
@@ -5970,12 +5977,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1340
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1306
+#: lxc/storage_volume.go:1317
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -5994,8 +6001,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
-#: lxc/storage_volume.go:978
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:989
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6015,11 +6022,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:739
+#: lxc/cluster.go:740
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:729
+#: lxc/cluster.go:730
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6070,7 +6077,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6085,7 +6092,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1853
+#: lxc/storage_volume.go:1864
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6093,7 +6100,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:394
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6152,7 +6159,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1472
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6174,13 +6181,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:995 lxc/storage_volume.go:1752
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
+#: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1740
+#: lxc/storage.go:724 lxc/storage_volume.go:1751
 msgid "USED BY"
 msgstr ""
 
@@ -6212,7 +6219,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6238,7 +6245,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1141 lxc/config.go:1142
+#: lxc/config.go:1142 lxc/config.go:1143
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6266,7 +6273,7 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1412 lxc/network.go:1413
+#: lxc/network.go:1421 lxc/network.go:1422
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -6318,7 +6325,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2354 lxc/storage_volume.go:2355
+#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6342,7 +6349,7 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1417
+#: lxc/network.go:1426
 msgid "Unset the key as a network property"
 msgstr ""
 
@@ -6370,7 +6377,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2379
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6378,7 +6385,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:247
+#: lxc/storage_volume.go:248
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6391,11 +6398,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1174
+#: lxc/cluster.go:1175
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1176
+#: lxc/cluster.go:1177
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6414,12 +6421,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2641
+#: lxc/export.go:42 lxc/storage_volume.go:2652
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6486,7 +6493,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1576
 msgid "Volume Only"
 msgstr ""
 
@@ -6519,7 +6526,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
 #: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6545,18 +6552,18 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:903
+#: lxc/storage_volume.go:909
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:281
+#: lxc/storage_volume.go:282
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
-#: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
+#: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
@@ -6566,7 +6573,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1172
+#: lxc/cluster.go:1173
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -6729,7 +6736,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6751,11 +6758,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:1140
+#: lxc/config.go:995 lxc/config.go:1141
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1049
+#: lxc/config.go:1050
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -6834,8 +6841,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:768
-#: lxc/cluster.go:1085 lxc/cluster.go:1297 lxc/cluster.go:1327
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
+#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -6859,8 +6866,8 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1104
-#: lxc/network.go:1339 lxc/network_forward.go:87
+#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1113
+#: lxc/network.go:1348 lxc/network_forward.go:87
 #: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -6873,11 +6880,11 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1411
+#: lxc/network.go:791 lxc/network.go:1420
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1243
+#: lxc/network.go:1252
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
@@ -6922,7 +6929,7 @@ msgstr ""
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1182
+#: lxc/network.go:1191
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -6973,7 +6980,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2800
+#: lxc/storage_volume.go:2811
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7008,13 +7015,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:1958
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:806
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7022,51 +7029,51 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2551
+#: lxc/storage_volume.go:2562
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2634
+#: lxc/storage_volume.go:2645
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2415
+#: lxc/storage_volume.go:2426
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:609
+#: lxc/storage_volume.go:610
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:718
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2353
+#: lxc/storage_volume.go:2364
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2085
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2232
+#: lxc/storage_volume.go:2243
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1221
+#: lxc/storage_volume.go:1232
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1858
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:387
+#: lxc/storage_volume.go:388
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7172,7 +7179,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1601
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7184,7 +7191,7 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:891
+#: lxc/cluster.go:892
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -7256,7 +7263,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:772
+#: lxc/cluster.go:773
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7305,13 +7312,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1229
+#: lxc/config.go:1230
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1053
+#: lxc/config.go:1054
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7648,7 +7655,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:614
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7656,13 +7663,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2804
+#: lxc/storage_volume.go:2815
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2419
+#: lxc/storage_volume.go:2430
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-09 03:18-0300\n"
+"POT-Creation-Date: 2024-12-18 08:40-0700\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1030
+#: lxc/storage_volume.go:1041
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1240
+#: lxc/config.go:1241
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -412,7 +412,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:790
+#: lxc/cluster.go:791
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -585,13 +585,13 @@ msgstr ""
 msgid "Acknowledge warning"
 msgstr ""
 
+#: lxc/query.go:43
+msgid "Action"
+msgstr ""
+
 #: lxc/query.go:76
 #, c-format
 msgid "Action %q isn't supported by this tool"
-msgstr ""
-
-#: lxc/query.go:43
-msgid "Action (defaults to GET)"
 msgstr ""
 
 #: lxc/cluster_group.go:725
@@ -738,7 +738,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1596
+#: lxc/storage_volume.go:1607
 msgid "All projects"
 msgstr ""
 
@@ -760,7 +760,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1371
+#: lxc/cluster.go:1372
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -797,7 +797,7 @@ msgstr ""
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:282 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -849,16 +849,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2708
+#: lxc/storage_volume.go:2719
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2785
+#: lxc/export.go:192 lxc/storage_volume.go:2796
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1538
 msgid "Backups:"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -922,7 +922,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1739
+#: lxc/storage_volume.go:1750
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1007,7 +1007,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1097
+#: lxc/config.go:702 lxc/config.go:1098
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1024,12 +1024,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:492
+#: lxc/storage_volume.go:493
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:446
+#: lxc/storage_volume.go:447
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1105,7 +1105,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1154
+#: lxc/cluster.go:1155
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1133,8 +1133,8 @@ msgstr ""
 #: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
 #: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
-#: lxc/network_forward.go:182 lxc/network_forward.go:264
+#: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
+#: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
 #: lxc/network_forward.go:497 lxc/network_forward.go:649
 #: lxc/network_forward.go:803 lxc/network_forward.go:892
 #: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
@@ -1149,30 +1149,30 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
-#: lxc/storage_volume.go:1952 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2251 lxc/storage_volume.go:2367
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2555
-#: lxc/storage_volume.go:2643 lxc/storage_volume.go:2807
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
+#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
+#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:894
+#: lxc/cluster.go:895
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:926
+#: lxc/cluster.go:927
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:756
+#: lxc/cluster.go:757
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1209,24 +1209,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
+#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
-#: lxc/storage_volume.go:1188
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
+#: lxc/storage_volume.go:1199
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:619
+#: lxc/storage_volume.go:620
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1236,7 +1236,11 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/move.go:65
+#: lxc/move.go:65
+msgid "Copy a stateful instance as stateless"
+msgstr ""
+
+#: lxc/copy.go:60
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1284,7 +1288,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:389 lxc/storage_volume.go:390
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1292,12 +1296,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:396
+#: lxc/storage_volume.go:397
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:398
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1310,7 +1314,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:515
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1333,12 +1337,12 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1235
+#: lxc/cluster.go:1236
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1239
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1353,17 +1357,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1266
+#: lxc/cluster.go:1267
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1445,7 +1449,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1497,7 +1501,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1526,13 +1530,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1738
+#: lxc/storage_volume.go:1749
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1552,7 +1556,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2642
+#: lxc/storage_volume.go:2653
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1648,7 +1652,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1669,16 +1673,16 @@ msgstr ""
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
-#: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
+#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
+#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
-#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
-#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
+#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
+#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1701,8 +1705,8 @@ msgstr ""
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
 #: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1005 lxc/network.go:1106 lxc/network.go:1185
-#: lxc/network.go:1245 lxc/network.go:1341 lxc/network.go:1413
+#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
+#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
 #: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
 #: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
 #: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
@@ -1753,27 +1757,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
-#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
-#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
-#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1949
-#: lxc/storage_volume.go:2076 lxc/storage_volume.go:2234
-#: lxc/storage_volume.go:2355 lxc/storage_volume.go:2417
-#: lxc/storage_volume.go:2553 lxc/storage_volume.go:2636
-#: lxc/storage_volume.go:2802 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1454
+#: lxc/storage_volume.go:1465
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1785,11 +1789,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
+#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1917,7 +1921,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:516
+#: lxc/cluster.go:1072 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1939,7 +1943,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:769 lxc/cluster.go:770
+#: lxc/cluster.go:770 lxc/cluster.go:771
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1959,7 +1963,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1226 lxc/config.go:1227
+#: lxc/config.go:1227 lxc/config.go:1228
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2023,7 +2027,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2031,7 +2035,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2049,11 +2053,12 @@ msgid ""
 "new\n"
 "  LXD cluster, which will have the given name.\n"
 "\n"
-"  It's required that the LXD is already available on the network. You can "
-"check\n"
-"  that by running 'lxc config get core.https_address', and possibly set a "
-"value\n"
-"  for the address if not yet set."
+"  It's required that LXD is already available on the network. You can check\n"
+"  this by running 'lxc config get core.https_address'. If either an IP "
+"address\n"
+"  and port is displayed, or both, LXD is already available on the network. "
+"If\n"
+"  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
 #: lxc/network_zone.go:1427
@@ -2083,12 +2088,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
+#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2098,12 +2103,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
+#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
-#: lxc/storage_volume.go:2199
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
+#: lxc/storage_volume.go:2210
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2113,11 +2118,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1298 lxc/cluster.go:1299
+#: lxc/cluster.go:1299 lxc/cluster.go:1300
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1396
+#: lxc/cluster.go:1397
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2145,8 +2150,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
-#: lxc/storage_volume.go:1564
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Expires at"
 msgstr ""
 
@@ -2170,7 +2175,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2635 lxc/storage_volume.go:2636
+#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2182,11 +2187,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2639
+#: lxc/storage_volume.go:2650
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2768
+#: lxc/export.go:152 lxc/storage_volume.go:2779
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2366,7 +2371,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
+#: lxc/network.go:1046 lxc/network_acl.go:133 lxc/network_zone.go:124
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2376,7 +2381,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1303
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2384,7 +2389,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1301
+#: lxc/cluster.go:1302
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2396,7 +2401,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1331
+#: lxc/cluster.go:1332
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2437,16 +2442,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
-#: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1614 lxc/warning.go:94
+#: lxc/storage_volume.go:1625 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2506,7 +2511,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:996
+#: lxc/config.go:996 lxc/config.go:997
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2570,7 +2575,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1249
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2634,11 +2639,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
+#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:475
+#: lxc/storage_volume.go:476
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2666,7 +2671,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1161
+#: lxc/network.go:1170
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2720,7 +2725,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1163
+#: lxc/network.go:1172
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2732,11 +2737,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1084
+#: lxc/list.go:560 lxc/network.go:1093
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1085
+#: lxc/list.go:561 lxc/network.go:1094
 msgid "IPV6"
 msgstr ""
 
@@ -2766,7 +2771,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2427
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2780,7 +2785,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2437
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2830,7 +2835,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2802
+#: lxc/storage_volume.go:2813
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2838,7 +2843,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2801
+#: lxc/storage_volume.go:2812
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2860,11 +2865,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2809
+#: lxc/storage_volume.go:2820
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2883
+#: lxc/storage_volume.go:2894
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2908,7 +2913,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
+#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2990,7 +2995,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2012
+#: lxc/move.go:148 lxc/storage_volume.go:2023
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2998,7 +3003,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2019
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3016,9 +3021,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
-#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2144 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
+#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3062,9 +3067,9 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
+#: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3076,8 +3081,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1020 lxc/cluster.go:1123
-#: lxc/cluster.go:1231 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
+#: lxc/cluster.go:1232 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3114,7 +3119,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1105 lxc/network.go:1106
+#: lxc/network.go:1114 lxc/network.go:1115
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3126,7 +3131,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:976 lxc/cluster.go:977
+#: lxc/cluster.go:977 lxc/cluster.go:978
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -3174,7 +3179,7 @@ msgstr ""
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1004 lxc/network.go:1005
+#: lxc/network.go:1005 lxc/network.go:1006
 msgid "List available networks"
 msgstr ""
 
@@ -3262,7 +3267,7 @@ msgid ""
 "Fast column layout: nsacPt\n"
 "\n"
 "A single keyword like \"web\" which will list any instance with a name "
-"starting by \"web\".\n"
+"starting with \"web\".\n"
 "A regular expression on the instance name. (e.g. .*web.*01$).\n"
 "A key/value pair referring to a configuration item. For those, the\n"
 "namespace can be abbreviated to the smallest unambiguous identifier.\n"
@@ -3319,7 +3324,8 @@ msgid ""
 "  P - Profiles\n"
 "  s - State\n"
 "  S - Number of snapshots\n"
-"  t - Type (persistent or ephemeral)\n"
+"  t - Type (container or virtual-machine, ephemeral indicated if "
+"applicable)\n"
 "  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
@@ -3368,11 +3374,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1603
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1608
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3431,7 +3437,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1470
+#: lxc/info.go:489 lxc/storage_volume.go:1481
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3452,7 +3458,7 @@ msgstr ""
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1162
+#: lxc/network.go:1171
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3470,7 +3476,7 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1083
+#: lxc/network.go:1092
 msgid "MANAGED"
 msgstr ""
 
@@ -3593,7 +3599,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:955 lxc/config.go:956
+#: lxc/config.go:956 lxc/config.go:957
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3732,7 +3738,7 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:957
+#: lxc/cluster.go:958
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
@@ -3796,7 +3802,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:811 lxc/cluster.go:1367 lxc/cluster_group.go:129
+#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -3859,8 +3865,8 @@ msgstr ""
 
 #: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1139 lxc/network.go:1217 lxc/network.go:1283
-#: lxc/network.go:1375 lxc/network_forward.go:127 lxc/network_forward.go:215
+#: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
+#: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
 #: lxc/network_forward.go:284 lxc/network_forward.go:445
 #: lxc/network_forward.go:530 lxc/network_forward.go:705
 #: lxc/network_forward.go:836 lxc/network_forward.go:929
@@ -3901,12 +3907,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
-#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
-#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1986
-#: lxc/storage_volume.go:2127 lxc/storage_volume.go:2285
-#: lxc/storage_volume.go:2476 lxc/storage_volume.go:2593
+#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
+#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
 msgid "Missing pool name"
 msgstr ""
 
@@ -3925,11 +3931,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:438 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1411
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3966,8 +3972,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
-#: lxc/storage_volume.go:964
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
+#: lxc/storage_volume.go:975
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4004,7 +4010,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4012,11 +4018,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1856
+#: lxc/storage_volume.go:1867
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:518
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4038,12 +4044,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
+#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
 msgid "NAME"
 msgstr ""
 
@@ -4071,7 +4077,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
 #: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4095,8 +4101,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
-#: lxc/storage_volume.go:1562
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1573
 msgid "Name"
 msgstr ""
 
@@ -4104,7 +4110,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4129,7 +4135,7 @@ msgstr ""
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1227
+#: lxc/network.go:1236
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4239,7 +4245,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1161
+#: lxc/cluster.go:1162
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4248,7 +4254,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
+#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4268,11 +4274,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:502 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4286,7 +4292,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2035
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4294,15 +4300,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:343
+#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
+#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2690
+#: lxc/storage_volume.go:2701
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2489
+#: lxc/storage_volume.go:2500
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4314,11 +4321,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1418
+#: lxc/storage_volume.go:1429
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1298
+#: lxc/network.go:735 lxc/network.go:1307
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4327,7 +4334,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1577
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4357,7 +4364,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1767
 msgid "POOL"
 msgstr ""
 
@@ -4373,7 +4380,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1773
 #: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4419,7 +4426,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -4440,16 +4447,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
-#: lxc/storage_volume.go:1189
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
+#: lxc/storage_volume.go:1200
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4566,7 +4573,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1356
+#: lxc/storage_volume.go:1367
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4580,7 +4587,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1225
+#: lxc/storage_volume.go:1236
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4596,7 +4603,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2247
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4617,7 +4624,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1004
+#: lxc/storage_volume.go:1015
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4626,7 +4633,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2081
+#: lxc/storage_volume.go:2092
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4639,13 +4646,13 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2357
+#: lxc/storage_volume.go:2368
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
 "\n"
 "lxc storage volume unset default data size\n"
-"    Remotes the size/quota of a custom volume \"data\" in pool \"default\".\n"
+"    Removes the size/quota of a custom volume \"data\" in pool \"default\".\n"
 "\n"
 "lxc storage volume unset default virtual-machine/data snapshots.expiry\n"
 "    Removes the snapshot expiration period for a virtual machine \"data\" in "
@@ -4725,7 +4732,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4908,7 +4915,7 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1184 lxc/network.go:1185
+#: lxc/network.go:1193 lxc/network.go:1194
 msgid "Rename networks"
 msgstr ""
 
@@ -4924,15 +4931,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1949
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:1959
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2037 lxc/storage_volume.go:2057
+#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4942,11 +4949,11 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:892 lxc/cluster.go:893
+#: lxc/cluster.go:893 lxc/cluster.go:894
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1032
+#: lxc/config.go:1033
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -4969,7 +4976,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1328 lxc/cluster.go:1329
+#: lxc/cluster.go:1329 lxc/cluster.go:1330
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4984,11 +4991,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2552 lxc/storage_volume.go:2553
+#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1394
+#: lxc/cluster.go:1395
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5010,7 +5017,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1087
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5060,7 +5067,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1088
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1097
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5123,7 +5130,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1050 lxc/config.go:1051
+#: lxc/config.go:1051 lxc/config.go:1052
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5187,11 +5194,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1244
+#: lxc/network.go:1253
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1245
+#: lxc/network.go:1254
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5308,11 +5315,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2075
+#: lxc/storage_volume.go:2086
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2076
+#: lxc/storage_volume.go:2087
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5369,7 +5376,7 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1252
+#: lxc/network.go:1261
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5397,7 +5404,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2103
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5466,7 +5473,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1173
+#: lxc/config.go:1173 lxc/config.go:1174
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5498,7 +5505,7 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1340 lxc/network.go:1341
+#: lxc/network.go:1349 lxc/network.go:1350
 msgid "Show network configurations"
 msgstr ""
 
@@ -5546,11 +5553,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2233 lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5573,7 +5580,7 @@ msgid "Show the expanded configuration"
 msgstr ""
 
 #: lxc/info.go:43
-msgid "Show the instance's last 100 log lines?"
+msgid "Show the instance's last 100 log lines"
 msgstr ""
 
 #: lxc/info.go:44
@@ -5618,15 +5625,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2417
+#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2179
+#: lxc/storage_volume.go:2190
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1502
 msgid "Snapshots:"
 msgstr ""
 
@@ -5731,21 +5738,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:702
+#: lxc/storage_volume.go:703
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:790
+#: lxc/storage_volume.go:791
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:516
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:520
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5753,7 +5760,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5802,18 +5809,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1070 lxc/config_trust.go:515
+#: lxc/cluster.go:1071 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1736 lxc/warning.go:216
+#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1747 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
 msgid "Taken at"
 msgstr ""
 
@@ -5970,12 +5977,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1340
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1306
+#: lxc/storage_volume.go:1317
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -5994,8 +6001,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
-#: lxc/storage_volume.go:978
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:989
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6015,11 +6022,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:739
+#: lxc/cluster.go:740
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:729
+#: lxc/cluster.go:730
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6070,7 +6077,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6085,7 +6092,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1853
+#: lxc/storage_volume.go:1864
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6093,7 +6100,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:394
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6152,7 +6159,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1472
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6174,13 +6181,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:995 lxc/storage_volume.go:1752
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
+#: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1740
+#: lxc/storage.go:724 lxc/storage_volume.go:1751
 msgid "USED BY"
 msgstr ""
 
@@ -6212,7 +6219,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6238,7 +6245,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1141 lxc/config.go:1142
+#: lxc/config.go:1142 lxc/config.go:1143
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6266,7 +6273,7 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1412 lxc/network.go:1413
+#: lxc/network.go:1421 lxc/network.go:1422
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -6318,7 +6325,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2354 lxc/storage_volume.go:2355
+#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6342,7 +6349,7 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1417
+#: lxc/network.go:1426
 msgid "Unset the key as a network property"
 msgstr ""
 
@@ -6370,7 +6377,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2379
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6378,7 +6385,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:247
+#: lxc/storage_volume.go:248
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6391,11 +6398,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1174
+#: lxc/cluster.go:1175
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1176
+#: lxc/cluster.go:1177
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6414,12 +6421,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2641
+#: lxc/export.go:42 lxc/storage_volume.go:2652
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6486,7 +6493,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1576
 msgid "Volume Only"
 msgstr ""
 
@@ -6519,7 +6526,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
 #: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6545,18 +6552,18 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:903
+#: lxc/storage_volume.go:909
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:281
+#: lxc/storage_volume.go:282
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
-#: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
+#: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
@@ -6566,7 +6573,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1172
+#: lxc/cluster.go:1173
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -6729,7 +6736,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6751,11 +6758,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:1140
+#: lxc/config.go:995 lxc/config.go:1141
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1049
+#: lxc/config.go:1050
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -6834,8 +6841,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:768
-#: lxc/cluster.go:1085 lxc/cluster.go:1297 lxc/cluster.go:1327
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
+#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -6859,8 +6866,8 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1104
-#: lxc/network.go:1339 lxc/network_forward.go:87
+#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1113
+#: lxc/network.go:1348 lxc/network_forward.go:87
 #: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -6873,11 +6880,11 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1411
+#: lxc/network.go:791 lxc/network.go:1420
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1243
+#: lxc/network.go:1252
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
@@ -6922,7 +6929,7 @@ msgstr ""
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1182
+#: lxc/network.go:1191
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -6973,7 +6980,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2800
+#: lxc/storage_volume.go:2811
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7008,13 +7015,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:1958
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:806
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7022,51 +7029,51 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2551
+#: lxc/storage_volume.go:2562
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2634
+#: lxc/storage_volume.go:2645
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2415
+#: lxc/storage_volume.go:2426
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:609
+#: lxc/storage_volume.go:610
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:718
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2353
+#: lxc/storage_volume.go:2364
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2085
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2232
+#: lxc/storage_volume.go:2243
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1221
+#: lxc/storage_volume.go:1232
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1858
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:387
+#: lxc/storage_volume.go:388
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7172,7 +7179,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1601
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7184,7 +7191,7 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:891
+#: lxc/cluster.go:892
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -7256,7 +7263,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:772
+#: lxc/cluster.go:773
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7305,13 +7312,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1229
+#: lxc/config.go:1230
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1053
+#: lxc/config.go:1054
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7648,7 +7655,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:614
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7656,13 +7663,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2804
+#: lxc/storage_volume.go:2815
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2419
+#: lxc/storage_volume.go:2430
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-09 03:18-0300\n"
+"POT-Creation-Date: 2024-12-18 08:40-0700\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -75,7 +75,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:1030
+#: lxc/storage_volume.go:1041
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -100,7 +100,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/config.go:1240
+#: lxc/config.go:1241
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -656,7 +656,7 @@ msgstr ""
 "###\n"
 "### Notez que le nom est affiché mais ne peut être modifié"
 
-#: lxc/cluster.go:790
+#: lxc/cluster.go:791
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -848,14 +848,14 @@ msgstr "Afficher la configuration étendue"
 msgid "Acknowledge warning"
 msgstr "Accusé réception d'avertissement"
 
+#: lxc/query.go:43
+msgid "Action"
+msgstr ""
+
 #: lxc/query.go:76
 #, fuzzy, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr "Le type d'authentification '%s' n'est pas supporté par le serveur"
-
-#: lxc/query.go:43
-msgid "Action (defaults to GET)"
-msgstr "Action (GET par défaut)"
 
 #: lxc/cluster_group.go:725
 #, fuzzy
@@ -1017,7 +1017,7 @@ msgstr "le serveur distant %s existe déjà"
 msgid "Aliases:"
 msgstr "Alias :"
 
-#: lxc/storage_volume.go:1596
+#: lxc/storage_volume.go:1607
 #, fuzzy
 msgid "All projects"
 msgstr "Rendre l'image publique"
@@ -1041,7 +1041,7 @@ msgstr "Architecture : %s"
 msgid "Architecture: %v"
 msgstr "Architecture : %s"
 
-#: lxc/cluster.go:1371
+#: lxc/cluster.go:1372
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -1082,7 +1082,7 @@ msgstr ""
 msgid "Attach new storage volumes to instances"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/storage_volume.go:282 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -1136,17 +1136,17 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/storage_volume.go:2708
+#: lxc/storage_volume.go:2719
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Copie de l'image : %s"
 
-#: lxc/export.go:192 lxc/storage_volume.go:2785
+#: lxc/export.go:192 lxc/storage_volume.go:2796
 #, fuzzy
 msgid "Backup exported successfully!"
 msgstr "Image copiée avec succès !"
 
-#: lxc/info.go:666 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1538
 msgid "Backups:"
 msgstr ""
 
@@ -1167,7 +1167,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr "Clé de configuration invalide"
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1210,7 +1210,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr "COMMON NAME"
 
-#: lxc/storage_volume.go:1739
+#: lxc/storage_volume.go:1750
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1299,7 +1299,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1308,7 +1308,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "impossible de spécifier uid/gid/mode en mode récursif"
 
-#: lxc/config.go:702 lxc/config.go:1097
+#: lxc/config.go:702 lxc/config.go:1098
 #, fuzzy, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1318,12 +1318,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:492
+#: lxc/storage_volume.go:493
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:446
+#: lxc/storage_volume.go:447
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1401,7 +1401,7 @@ msgstr "Profils %s appliqués à %s"
 msgid "Cluster group %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
 
-#: lxc/cluster.go:1154
+#: lxc/cluster.go:1155
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1429,8 +1429,8 @@ msgstr "Périphérique %s retiré de %s"
 #: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
 #: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
-#: lxc/network_forward.go:182 lxc/network_forward.go:264
+#: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
+#: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
 #: lxc/network_forward.go:497 lxc/network_forward.go:649
 #: lxc/network_forward.go:803 lxc/network_forward.go:892
 #: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
@@ -1445,30 +1445,30 @@ msgstr "Périphérique %s retiré de %s"
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
-#: lxc/storage_volume.go:1952 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2251 lxc/storage_volume.go:2367
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2555
-#: lxc/storage_volume.go:2643 lxc/storage_volume.go:2807
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
+#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
+#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:894
+#: lxc/cluster.go:895
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:926
+#: lxc/cluster.go:927
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:756
+#: lxc/cluster.go:757
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr "Colonnes"
@@ -1516,24 +1516,24 @@ msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 msgid "Config key/value to apply to the target instance"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 
-#: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
+#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
-#: lxc/storage_volume.go:1188
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
+#: lxc/storage_volume.go:1199
 #, c-format
 msgid "Config parsing error: %s"
 msgstr "Erreur lors de la lecture de la configuration : %s"
 
-#: lxc/storage_volume.go:619
+#: lxc/storage_volume.go:620
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1478
 #, fuzzy, c-format
 msgid "Content type: %s"
 msgstr "État : %s"
@@ -1543,7 +1543,12 @@ msgstr "État : %s"
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/move.go:65
+#: lxc/move.go:65
+#, fuzzy
+msgid "Copy a stateful instance as stateless"
+msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
+
+#: lxc/copy.go:60
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1592,7 +1597,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:389 lxc/storage_volume.go:390
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
 #, fuzzy
 msgid "Copy storage volumes"
 msgstr "Copie de l'image : %s"
@@ -1602,13 +1607,13 @@ msgstr "Copie de l'image : %s"
 msgid "Copy the instance without its snapshots"
 msgstr "Copiez le conteneur sans ses instantanés"
 
-#: lxc/storage_volume.go:396
+#: lxc/storage_volume.go:397
 #, fuzzy
 msgid "Copy the volume without its snapshots"
 msgstr "Copiez le conteneur sans ses instantanés"
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:398
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1622,7 +1627,7 @@ msgstr "Copie de l'image : %s"
 msgid "Copying the image: %s"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:515
 #, fuzzy, c-format
 msgid "Copying the storage volume: %s"
 msgstr "Copie de l'image : %s"
@@ -1646,12 +1651,12 @@ msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
 msgid "Could not create server cert dir"
 msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
 
-#: lxc/cluster.go:1235
+#: lxc/cluster.go:1236
 #, fuzzy, c-format
 msgid "Could not find certificate file path: %s"
 msgstr "Impossible d'assainir le chemin %s"
 
-#: lxc/cluster.go:1239
+#: lxc/cluster.go:1240
 #, fuzzy, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr "Impossible d'assainir le chemin %s"
@@ -1666,17 +1671,17 @@ msgstr "Erreur lors de la lecture de la configuration : %s"
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, fuzzy, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr "Impossible d'assainir le chemin %s"
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, fuzzy, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr "Impossible d'assainir le chemin %s"
 
-#: lxc/cluster.go:1266
+#: lxc/cluster.go:1267
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1786,7 +1791,7 @@ msgstr "Copie de l'image : %s"
 msgid "Create new custom storage buckets"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
 #, fuzzy
 msgid "Create new custom storage volumes"
 msgstr "Copie de l'image : %s"
@@ -1849,7 +1854,7 @@ msgstr "Copie de l'image : %s"
 msgid "Create the instance with no profiles applied"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
 #, c-format
 msgid "Created: %s"
 msgstr "Créé : %s"
@@ -1879,13 +1884,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1738
+#: lxc/storage_volume.go:1749
 msgid "DESCRIPTION"
 msgstr "DESCRIPTION"
 
@@ -1905,7 +1910,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2642
+#: lxc/storage_volume.go:2653
 #, fuzzy
 msgid "Define a compression algorithm: for backup or none"
 msgstr "Définir un algorithme de compression : pour image ou aucun"
@@ -2016,7 +2021,7 @@ msgstr "Copie de l'image : %s"
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
 #, fuzzy
 msgid "Delete storage volumes"
 msgstr "Copie de l'image : %s"
@@ -2039,16 +2044,16 @@ msgstr "Récupération de l'image : %s"
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
-#: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
+#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
+#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
-#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
-#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
+#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
+#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -2071,8 +2076,8 @@ msgstr "Récupération de l'image : %s"
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
 #: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1005 lxc/network.go:1106 lxc/network.go:1185
-#: lxc/network.go:1245 lxc/network.go:1341 lxc/network.go:1413
+#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
+#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
 #: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
 #: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
 #: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
@@ -2123,27 +2128,27 @@ msgstr "Récupération de l'image : %s"
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
-#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
-#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
-#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1949
-#: lxc/storage_volume.go:2076 lxc/storage_volume.go:2234
-#: lxc/storage_volume.go:2355 lxc/storage_volume.go:2417
-#: lxc/storage_volume.go:2553 lxc/storage_volume.go:2636
-#: lxc/storage_volume.go:2802 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1454
+#: lxc/storage_volume.go:1465
 #, fuzzy, c-format
 msgid "Description: %s"
 msgstr "Empreinte : %s"
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -2156,12 +2161,12 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
 #, fuzzy
 msgid "Detach storage volumes from instances"
 msgstr "Clé de configuration invalide"
 
-#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
+#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2298,7 +2303,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr "ÉPHÉMÈRE"
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:516
+#: lxc/cluster.go:1072 lxc/config_trust.go:516
 #, fuzzy
 msgid "EXPIRES AT"
 msgstr "DATE D'EXPIRATION"
@@ -2321,7 +2326,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:769 lxc/cluster.go:770
+#: lxc/cluster.go:770 lxc/cluster.go:771
 #, fuzzy
 msgid "Edit cluster member configurations as YAML"
 msgstr "Clé de configuration invalide"
@@ -2345,7 +2350,7 @@ msgstr "Clé de configuration invalide"
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1226 lxc/config.go:1227
+#: lxc/config.go:1227 lxc/config.go:1228
 #, fuzzy
 msgid "Edit instance UEFI variables"
 msgstr "L'arrêt du conteneur a échoué !"
@@ -2421,7 +2426,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2430,7 +2435,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2448,11 +2453,12 @@ msgid ""
 "new\n"
 "  LXD cluster, which will have the given name.\n"
 "\n"
-"  It's required that the LXD is already available on the network. You can "
-"check\n"
-"  that by running 'lxc config get core.https_address', and possibly set a "
-"value\n"
-"  for the address if not yet set."
+"  It's required that LXD is already available on the network. You can check\n"
+"  this by running 'lxc config get core.https_address'. If either an IP "
+"address\n"
+"  and port is displayed, or both, LXD is already available on the network. "
+"If\n"
+"  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
 #: lxc/network_zone.go:1427
@@ -2483,12 +2489,12 @@ msgstr "Récupération de l'image : %s"
 msgid "Error retrieving aliases: %w"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
+#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Récupération de l'image : %s"
@@ -2498,12 +2504,12 @@ msgstr "Récupération de l'image : %s"
 msgid "Error unsetting properties: %v"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
+#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
-#: lxc/storage_volume.go:2199
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
+#: lxc/storage_volume.go:2210
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2513,7 +2519,7 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr "Erreur de mise à jour du modèle de fichier : %s"
 
-#: lxc/cluster.go:1298 lxc/cluster.go:1299
+#: lxc/cluster.go:1299 lxc/cluster.go:1300
 #, fuzzy
 msgid "Evacuate cluster member"
 msgstr ""
@@ -2525,7 +2531,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/cluster.go:1396
+#: lxc/cluster.go:1397
 #, fuzzy, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -2562,8 +2568,8 @@ msgstr ""
 "sélectionné si à la fois stdin et stdout sont des terminaux (stderr\n"
 "est ignoré)."
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
-#: lxc/storage_volume.go:1564
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 #, fuzzy
 msgid "Expires at"
 msgstr "Expire : %s"
@@ -2589,7 +2595,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2635 lxc/storage_volume.go:2636
+#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
 #, fuzzy
 msgid "Export custom storage volume"
 msgstr "Copie de l'image : %s"
@@ -2604,12 +2610,12 @@ msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 msgid "Export instances as backup tarballs."
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: lxc/storage_volume.go:2639
+#: lxc/storage_volume.go:2650
 #, fuzzy
 msgid "Export the volume without its snapshots"
 msgstr "Copiez le conteneur sans ses instantanés"
 
-#: lxc/export.go:152 lxc/storage_volume.go:2768
+#: lxc/export.go:152 lxc/storage_volume.go:2779
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Import de l'image : %s"
@@ -2792,7 +2798,7 @@ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr "Mode rapide (identique à --columns=nsacPt"
 
-#: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
+#: lxc/network.go:1046 lxc/network_acl.go:133 lxc/network_zone.go:124
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2802,7 +2808,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr "Empreinte : %s"
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1303
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2810,7 +2816,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1301
+#: lxc/cluster.go:1302
 #, fuzzy
 msgid "Force evacuation without user confirmation"
 msgstr "Requérir une confirmation de l'utilisateur"
@@ -2823,7 +2829,7 @@ msgstr "Forcer l'allocation d'un pseudo-terminal"
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1331
+#: lxc/cluster.go:1332
 #, fuzzy
 msgid "Force restoration without user confirmation"
 msgstr "Requérir une confirmation de l'utilisateur"
@@ -2867,16 +2873,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
-#: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1614 lxc/warning.go:94
+#: lxc/storage_volume.go:1625 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2936,7 +2942,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "Génération d'un certificat client. Ceci peut prendre une minute…"
 
-#: lxc/config.go:995 lxc/config.go:996
+#: lxc/config.go:996 lxc/config.go:997
 #, fuzzy
 msgid "Get UEFI variables for instance"
 msgstr "Création du conteneur"
@@ -3008,7 +3014,7 @@ msgstr "Copie de l'image : %s"
 msgid "Get the key as a storage property"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1249
 #, fuzzy
 msgid "Get the key as a storage volume property"
 msgstr "Copie de l'image : %s"
@@ -3086,11 +3092,11 @@ msgstr "Clé de configuration invalide"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
+#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:475
+#: lxc/storage_volume.go:476
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -3118,7 +3124,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1161
+#: lxc/network.go:1170
 #, fuzzy
 msgid "HOSTNAME"
 msgstr "NOM"
@@ -3175,7 +3181,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1163
+#: lxc/network.go:1172
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -3189,11 +3195,11 @@ msgstr "Expire : %s"
 msgid "IP addresses:"
 msgstr "Expire : %s"
 
-#: lxc/list.go:560 lxc/network.go:1084
+#: lxc/list.go:560 lxc/network.go:1093
 msgid "IPV4"
 msgstr "IPv4"
 
-#: lxc/list.go:561 lxc/network.go:1085
+#: lxc/list.go:561 lxc/network.go:1094
 msgid "IPV6"
 msgstr "IPv6"
 
@@ -3223,7 +3229,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2427
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3240,7 +3246,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2437
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3294,7 +3300,7 @@ msgstr "Image copiée avec succès !"
 msgid "Immediately attach to the console"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: lxc/storage_volume.go:2802
+#: lxc/storage_volume.go:2813
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3302,7 +3308,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2801
+#: lxc/storage_volume.go:2812
 #, fuzzy
 msgid "Import custom storage volumes"
 msgstr "Copie de l'image : %s"
@@ -3327,11 +3333,11 @@ msgstr "Import de l'image : %s"
 msgid "Import instance backups"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/storage_volume.go:2809
+#: lxc/storage_volume.go:2820
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2883
+#: lxc/storage_volume.go:2894
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
@@ -3378,7 +3384,7 @@ msgstr "Le nom du conteneur est obligatoire"
 msgid "Instance name is: %s"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
+#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
 #, fuzzy
 msgid "Instance name must be specified"
 msgstr "Le nom du conteneur est : %s"
@@ -3461,7 +3467,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2012
+#: lxc/move.go:148 lxc/storage_volume.go:2023
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "'/' n'est pas autorisé dans le nom d'un instantané"
@@ -3470,7 +3476,7 @@ msgstr "'/' n'est pas autorisé dans le nom d'un instantané"
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2019
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3489,9 +3495,9 @@ msgstr "Cible invalide %s"
 msgid "Invalid protocol: %s"
 msgstr "Cible invalide %s"
 
-#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
-#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2144 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
+#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Le nom du conteneur est : %s"
@@ -3537,9 +3543,9 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
+#: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3551,8 +3557,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1020 lxc/cluster.go:1123
-#: lxc/cluster.go:1231 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
+#: lxc/cluster.go:1232 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3590,7 +3596,7 @@ msgstr "Architecture : %s"
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1105 lxc/network.go:1106
+#: lxc/network.go:1114 lxc/network.go:1115
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3604,7 +3610,7 @@ msgstr "Alias :"
 msgid "List all active certificate add tokens"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/cluster.go:976 lxc/cluster.go:977
+#: lxc/cluster.go:977 lxc/cluster.go:978
 #, fuzzy
 msgid "List all active cluster member join tokens"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -3657,7 +3663,7 @@ msgstr "Nom du réseau"
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1004 lxc/network.go:1005
+#: lxc/network.go:1005 lxc/network.go:1006
 msgid "List available networks"
 msgstr ""
 
@@ -3749,7 +3755,7 @@ msgid ""
 "Fast column layout: nsacPt\n"
 "\n"
 "A single keyword like \"web\" which will list any instance with a name "
-"starting by \"web\".\n"
+"starting with \"web\".\n"
 "A regular expression on the instance name. (e.g. .*web.*01$).\n"
 "A key/value pair referring to a configuration item. For those, the\n"
 "namespace can be abbreviated to the smallest unambiguous identifier.\n"
@@ -3806,7 +3812,8 @@ msgid ""
 "  P - Profiles\n"
 "  s - State\n"
 "  S - Number of snapshots\n"
-"  t - Type (persistent or ephemeral)\n"
+"  t - Type (container or virtual-machine, ephemeral indicated if "
+"applicable)\n"
 "  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
@@ -3919,12 +3926,12 @@ msgstr "Copie de l'image : %s"
 msgid "List storage buckets"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1603
 #, fuzzy
 msgid "List storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1608
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3984,7 +3991,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1470
+#: lxc/info.go:489 lxc/storage_volume.go:1481
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -4007,7 +4014,7 @@ msgstr "Création du conteneur"
 msgid "Lower devices"
 msgstr "Création du conteneur"
 
-#: lxc/network.go:1162
+#: lxc/network.go:1171
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -4026,7 +4033,7 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr "Créé : %s"
 
-#: lxc/network.go:1083
+#: lxc/network.go:1092
 msgid "MANAGED"
 msgstr "GÉRÉ"
 
@@ -4157,7 +4164,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:955 lxc/config.go:956
+#: lxc/config.go:956 lxc/config.go:957
 #, fuzzy
 msgid "Manage instance UEFI variables"
 msgstr "L'arrêt du conteneur a échoué !"
@@ -4322,7 +4329,7 @@ msgstr "Profil %s ajouté à %s"
 msgid "Member %q does not have role %q"
 msgstr "Profil %s ajouté à %s"
 
-#: lxc/cluster.go:957
+#: lxc/cluster.go:958
 #, fuzzy, c-format
 msgid "Member %s join token:"
 msgstr "Profil %s ajouté à %s"
@@ -4391,7 +4398,7 @@ msgstr "Empreinte du certificat : %s"
 msgid "Missing cluster group name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/cluster.go:811 lxc/cluster.go:1367 lxc/cluster_group.go:129
+#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 #, fuzzy
@@ -4464,8 +4471,8 @@ msgstr "Nom du réseau"
 
 #: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1139 lxc/network.go:1217 lxc/network.go:1283
-#: lxc/network.go:1375 lxc/network_forward.go:127 lxc/network_forward.go:215
+#: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
+#: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
 #: lxc/network_forward.go:284 lxc/network_forward.go:445
 #: lxc/network_forward.go:530 lxc/network_forward.go:705
 #: lxc/network_forward.go:836 lxc/network_forward.go:929
@@ -4510,12 +4517,12 @@ msgstr "Résumé manquant."
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
-#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
-#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1986
-#: lxc/storage_volume.go:2127 lxc/storage_volume.go:2285
-#: lxc/storage_volume.go:2476 lxc/storage_volume.go:2593
+#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
+#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
 #, fuzzy
 msgid "Missing pool name"
 msgstr "Nom de l'ensemble de stockage"
@@ -4536,12 +4543,12 @@ msgstr "Nom de l'ensemble de stockage"
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:438 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
 #, fuzzy
 msgid "Missing source volume name"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1411
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Nom de l'ensemble de stockage"
@@ -4582,8 +4589,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
-#: lxc/storage_volume.go:964
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
+#: lxc/storage_volume.go:975
 #, fuzzy
 msgid "More than one device matches, specify the device name"
 msgstr "Plus d'un périphérique correspond, spécifier le nom du périphérique."
@@ -4624,7 +4631,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
 #, fuzzy
 msgid "Move storage volumes between pools"
 msgstr "Copie de l'image : %s"
@@ -4634,11 +4641,11 @@ msgstr "Copie de l'image : %s"
 msgid "Move the instance without its snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/storage_volume.go:1856
+#: lxc/storage_volume.go:1867
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:518
+#: lxc/storage_volume.go:519
 #, fuzzy, c-format
 msgid "Moving the storage volume: %s"
 msgstr "Copie de l'image : %s"
@@ -4661,12 +4668,12 @@ msgid "Must supply instance name for: "
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
 #: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
+#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
 msgid "NAME"
 msgstr "NOM"
 
@@ -4694,7 +4701,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
 #: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4718,8 +4725,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
-#: lxc/storage_volume.go:1562
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1573
 #, fuzzy
 msgid "Name"
 msgstr "Nom : %s"
@@ -4728,7 +4735,7 @@ msgstr "Nom : %s"
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
 #, c-format
 msgid "Name: %s"
 msgstr "Nom : %s"
@@ -4753,7 +4760,7 @@ msgstr "Le réseau %s a été supprimé"
 msgid "Network %s pending on member %s"
 msgstr "Le réseau %s a été créé"
 
-#: lxc/network.go:1227
+#: lxc/network.go:1236
 #, fuzzy, c-format
 msgid "Network %s renamed to %s"
 msgstr "Le réseau %s a été créé"
@@ -4867,7 +4874,7 @@ msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1161
+#: lxc/cluster.go:1162
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4876,7 +4883,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr "Aucun périphérique existant pour ce réseau"
 
-#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
+#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
 #, fuzzy
 msgid "No device found for this storage volume"
 msgstr "Aucun périphérique existant pour ce réseau"
@@ -4898,11 +4905,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr "vous devez spécifier un nom de conteneur source"
 
-#: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:502 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4916,7 +4923,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2035
 #, fuzzy
 msgid "Not a snapshot name"
 msgstr "'/' n'est pas autorisé dans le nom d'un instantané"
@@ -4925,19 +4932,20 @@ msgstr "'/' n'est pas autorisé dans le nom d'un instantané"
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:343
+#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
+#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
 #, fuzzy
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 "Seuls les volumes \"personnalisés\" peuvent être attachés aux conteneurs."
 
-#: lxc/storage_volume.go:2690
+#: lxc/storage_volume.go:2701
 #, fuzzy
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 "Seuls les volumes \"personnalisés\" peuvent être attachés aux conteneurs."
 
-#: lxc/storage_volume.go:2489
+#: lxc/storage_volume.go:2500
 #, fuzzy
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
@@ -4952,13 +4960,13 @@ msgstr "Seules les URLs https sont supportées par simplestreams"
 msgid "Only https:// is supported for remote image import"
 msgstr "Seul https:// est supporté par l'import d'images distantes."
 
-#: lxc/storage_volume.go:1418
+#: lxc/storage_volume.go:1429
 #, fuzzy
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 "Seuls les volumes \"personnalisés\" peuvent être attachés aux conteneurs."
 
-#: lxc/network.go:735 lxc/network.go:1298
+#: lxc/network.go:735 lxc/network.go:1307
 #, fuzzy
 msgid "Only managed networks can be modified"
 msgstr "Seuls les réseaux gérés par LXD peuvent être modifiés."
@@ -4968,7 +4976,7 @@ msgstr "Seuls les réseaux gérés par LXD peuvent être modifiés."
 msgid "Operation %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: lxc/info.go:705 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1577
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4999,7 +5007,7 @@ msgstr "PID"
 msgid "PID: %d"
 msgstr "Pid : %d"
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1767
 msgid "POOL"
 msgstr ""
 
@@ -5015,7 +5023,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr "PROFILS"
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1773
 #: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -5064,7 +5072,7 @@ msgstr "Chemin vers un dossier de configuration serveur alternatif"
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 #, fuzzy
 msgid "Please provide cluster member name: "
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -5087,16 +5095,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
-#: lxc/storage_volume.go:1189
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
+#: lxc/storage_volume.go:1200
 #, fuzzy
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr "Appuyer sur Entrée pour ouvrir à nouveau l'éditeur"
@@ -5219,7 +5227,7 @@ msgstr "Propriétés :"
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1356
+#: lxc/storage_volume.go:1367
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -5233,7 +5241,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1225
+#: lxc/storage_volume.go:1236
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5249,7 +5257,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2247
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5270,7 +5278,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1004
+#: lxc/storage_volume.go:1015
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5279,7 +5287,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2081
+#: lxc/storage_volume.go:2092
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5292,13 +5300,13 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2357
+#: lxc/storage_volume.go:2368
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
 "\n"
 "lxc storage volume unset default data size\n"
-"    Remotes the size/quota of a custom volume \"data\" in pool \"default\".\n"
+"    Removes the size/quota of a custom volume \"data\" in pool \"default\".\n"
 "\n"
 "lxc storage volume unset default virtual-machine/data snapshots.expiry\n"
 "    Removes the snapshot expiration period for a virtual machine \"data\" in "
@@ -5385,7 +5393,7 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Recursively transfer files"
 msgstr "Pousser ou récupérer des fichiers récursivement"
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 #, fuzzy
 msgid "Refresh and update the existing storage volume copies"
 msgstr "Copie de l'image : %s"
@@ -5590,7 +5598,7 @@ msgstr "Forcer le conteneur à s'arrêter"
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1184 lxc/network.go:1185
+#: lxc/network.go:1193 lxc/network.go:1194
 msgid "Rename networks"
 msgstr ""
 
@@ -5607,17 +5615,17 @@ msgstr "Créé : %s"
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1949
+#: lxc/storage_volume.go:1960
 #, fuzzy
 msgid "Rename storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:1959
 #, fuzzy
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:2037 lxc/storage_volume.go:2057
+#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5627,11 +5635,11 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:892 lxc/cluster.go:893
+#: lxc/cluster.go:893 lxc/cluster.go:894
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1032
+#: lxc/config.go:1033
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5656,7 +5664,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr "Le pendant de `lxc pause` est `lxc start`."
 
-#: lxc/cluster.go:1328 lxc/cluster.go:1329
+#: lxc/cluster.go:1329 lxc/cluster.go:1330
 #, fuzzy
 msgid "Restore cluster member"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -5689,12 +5697,12 @@ msgstr ""
 "Exemple :\n"
 "    lxc snapshot u1 snap0"
 
-#: lxc/storage_volume.go:2552 lxc/storage_volume.go:2553
+#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
 #, fuzzy
 msgid "Restore storage volume snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/cluster.go:1394
+#: lxc/cluster.go:1395
 #, fuzzy, c-format
 msgid "Restoring cluster member: %s"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -5718,7 +5726,7 @@ msgstr "Récupération de l'image : %s"
 msgid "Revoke certificate add token"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1087
 #, fuzzy
 msgid "Revoke cluster member join token"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -5770,7 +5778,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr "Mot de passe de l'administrateur distant"
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1088
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1097
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr "ÉTAT"
@@ -5838,7 +5846,7 @@ msgstr "Protocole du serveur (lxd ou simplestreams)"
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1050 lxc/config.go:1051
+#: lxc/config.go:1051 lxc/config.go:1052
 #, fuzzy
 msgid "Set UEFI variables for instance"
 msgstr "Création du conteneur"
@@ -5907,12 +5915,12 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1244
+#: lxc/network.go:1253
 #, fuzzy
 msgid "Set network configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network.go:1245
+#: lxc/network.go:1254
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -6038,12 +6046,12 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2075
+#: lxc/storage_volume.go:2086
 #, fuzzy
 msgid "Set storage volume configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/storage_volume.go:2076
+#: lxc/storage_volume.go:2087
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -6106,7 +6114,7 @@ msgstr "Nom du réseau"
 msgid "Set the key as a network peer property"
 msgstr "Nom du réseau"
 
-#: lxc/network.go:1252
+#: lxc/network.go:1261
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -6138,7 +6146,7 @@ msgstr "Copie de l'image : %s"
 msgid "Set the key as a storage property"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2103
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "Copie de l'image : %s"
@@ -6212,7 +6220,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1173
+#: lxc/config.go:1173 lxc/config.go:1174
 #, fuzzy
 msgid "Show instance UEFI variables"
 msgstr "L'arrêt du conteneur a échoué !"
@@ -6252,7 +6260,7 @@ msgstr "Afficher la configuration étendue"
 msgid "Show network ACL log"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/network.go:1340 lxc/network.go:1341
+#: lxc/network.go:1349 lxc/network.go:1350
 #, fuzzy
 msgid "Show network configurations"
 msgstr "Afficher la configuration étendue"
@@ -6311,12 +6319,12 @@ msgstr "Afficher la configuration étendue"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2233 lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
 #, fuzzy
 msgid "Show storage volume configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
 #, fuzzy
 msgid "Show storage volume state information"
 msgstr "Afficher la configuration étendue"
@@ -6342,7 +6350,7 @@ msgstr "Afficher la configuration étendue"
 
 #: lxc/info.go:43
 #, fuzzy
-msgid "Show the instance's last 100 log lines?"
+msgid "Show the instance's last 100 log lines"
 msgstr "Afficher les 100 dernières lignes du journal du conteneur ?"
 
 #: lxc/info.go:44
@@ -6389,16 +6397,16 @@ msgstr "Taille : %.2f Mo"
 msgid "Size: %s"
 msgstr "État : %s"
 
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2417
+#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
 #, fuzzy
 msgid "Snapshot storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:2179
+#: lxc/storage_volume.go:2190
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1502
 msgid "Snapshots:"
 msgstr "Instantanés :"
 
@@ -6509,22 +6517,22 @@ msgstr "Le réseau %s a été créé"
 msgid "Storage pool name"
 msgstr "Nom de l'ensemble de stockage"
 
-#: lxc/storage_volume.go:702
+#: lxc/storage_volume.go:703
 #, fuzzy, c-format
 msgid "Storage volume %s created"
 msgstr "Profil %s créé"
 
-#: lxc/storage_volume.go:790
+#: lxc/storage_volume.go:791
 #, fuzzy, c-format
 msgid "Storage volume %s deleted"
 msgstr "Profil %s supprimé"
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:516
 #, fuzzy
 msgid "Storage volume copied successfully!"
 msgstr "Image copiée avec succès !"
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:520
 #, fuzzy
 msgid "Storage volume moved successfully!"
 msgstr "Image copiée avec succès !"
@@ -6534,7 +6542,7 @@ msgstr "Image copiée avec succès !"
 msgid "Store the instance state"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -6585,18 +6593,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr "Image importée avec l'empreinte : %s"
 
-#: lxc/cluster.go:1070 lxc/config_trust.go:515
+#: lxc/cluster.go:1071 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1736 lxc/warning.go:216
+#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1747 lxc/warning.go:216
 msgid "TYPE"
 msgstr "TYPE"
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
 #, fuzzy
 msgid "Taken at"
 msgstr "pris à %s"
@@ -6763,12 +6771,12 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1340
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/storage_volume.go:1306
+#: lxc/storage_volume.go:1317
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6787,8 +6795,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
-#: lxc/storage_volume.go:978
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:989
 msgid "The specified device doesn't exist"
 msgstr "Le périphérique indiqué n'existe pas"
 
@@ -6809,11 +6817,11 @@ msgstr "Il n'existe pas d'\"image\".  Vouliez-vous un alias ?"
 msgid "There is no config key to set on an instance snapshot."
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/cluster.go:739
+#: lxc/cluster.go:740
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:729
+#: lxc/cluster.go:730
 #, fuzzy
 msgid "This LXD server is not available on the network"
 msgstr "L'importation de répertoire n'est pas disponible sur cette plateforme"
@@ -6869,7 +6877,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1487
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Publié : %s"
@@ -6884,7 +6892,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr "Transfert de l'image : %s"
 
-#: lxc/storage_volume.go:1853
+#: lxc/storage_volume.go:1864
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6892,7 +6900,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:394
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6954,7 +6962,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1472
 #, fuzzy, c-format
 msgid "Type: %s"
 msgstr "Expire : %s"
@@ -6976,13 +6984,13 @@ msgstr "DATE DE PUBLICATION"
 msgid "URL"
 msgstr "URL"
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:995 lxc/storage_volume.go:1752
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
+#: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1740
+#: lxc/storage.go:724 lxc/storage_volume.go:1751
 msgid "USED BY"
 msgstr "UTILISÉ PAR"
 
@@ -7015,7 +7023,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -7041,7 +7049,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1141 lxc/config.go:1142
+#: lxc/config.go:1142 lxc/config.go:1143
 #, fuzzy
 msgid "Unset UEFI variables for instance"
 msgstr "tous les profils de la source n'existent pas sur la cible"
@@ -7075,7 +7083,7 @@ msgstr "Clé de configuration invalide"
 msgid "Unset network ACL configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network.go:1412 lxc/network.go:1413
+#: lxc/network.go:1421 lxc/network.go:1422
 #, fuzzy
 msgid "Unset network configuration keys"
 msgstr "Clé de configuration invalide"
@@ -7140,7 +7148,7 @@ msgstr "Clé de configuration invalide"
 msgid "Unset storage pool configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/storage_volume.go:2354 lxc/storage_volume.go:2355
+#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
 #, fuzzy
 msgid "Unset storage volume configuration keys"
 msgstr "Clé de configuration invalide"
@@ -7168,7 +7176,7 @@ msgstr "Nom du réseau"
 msgid "Unset the key as a network peer property"
 msgstr "Nom du réseau"
 
-#: lxc/network.go:1417
+#: lxc/network.go:1426
 #, fuzzy
 msgid "Unset the key as a network property"
 msgstr "Nom du réseau"
@@ -7201,7 +7209,7 @@ msgstr "Copie de l'image : %s"
 msgid "Unset the key as a storage property"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2379
 #, fuzzy
 msgid "Unset the key as a storage volume property"
 msgstr "Copie de l'image : %s"
@@ -7210,7 +7218,7 @@ msgstr "Copie de l'image : %s"
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:247
+#: lxc/storage_volume.go:248
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -7223,12 +7231,12 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1174
+#: lxc/cluster.go:1175
 #, fuzzy
 msgid "Update cluster certificate"
 msgstr "Accepter le certificat"
 
-#: lxc/cluster.go:1176
+#: lxc/cluster.go:1177
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -7248,12 +7256,12 @@ msgstr "Publié : %s"
 msgid "Upper devices"
 msgstr "Création du conteneur"
 
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Usage: %s"
 msgstr "Utilisation : %s"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2641
+#: lxc/export.go:42 lxc/storage_volume.go:2652
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -7322,7 +7330,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1576
 msgid "Volume Only"
 msgstr ""
 
@@ -7360,7 +7368,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
 #: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -7390,7 +7398,7 @@ msgstr "vous devez spécifier un nom de conteneur source"
 msgid "You need to specify an image name or use --empty"
 msgstr "vous devez spécifier un nom de conteneur source"
 
-#: lxc/storage_volume.go:903
+#: lxc/storage_volume.go:909
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
@@ -7398,7 +7406,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:281
+#: lxc/storage_volume.go:282
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
@@ -7407,9 +7415,9 @@ msgstr ""
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
 #: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
-#: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
+#: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 #, fuzzy
@@ -7424,7 +7432,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:1172
+#: lxc/cluster.go:1173
 #, fuzzy
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
@@ -7764,7 +7772,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 #, fuzzy
@@ -7810,7 +7818,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:994 lxc/config.go:1140
+#: lxc/config.go:995 lxc/config.go:1141
 #, fuzzy
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
@@ -7818,7 +7826,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:1049
+#: lxc/config.go:1050
 #, fuzzy
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
@@ -8026,8 +8034,8 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:768
-#: lxc/cluster.go:1085 lxc/cluster.go:1297 lxc/cluster.go:1327
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
+#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
 #, fuzzy
 msgid "[<remote>:]<member>"
 msgstr ""
@@ -8091,8 +8099,8 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1104
-#: lxc/network.go:1339 lxc/network_forward.go:87
+#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1113
+#: lxc/network.go:1348 lxc/network_forward.go:87
 #: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
 #, fuzzy
 msgid "[<remote>:]<network>"
@@ -8117,7 +8125,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:791 lxc/network.go:1411
+#: lxc/network.go:791 lxc/network.go:1420
 #, fuzzy
 msgid "[<remote>:]<network> <key>"
 msgstr ""
@@ -8125,7 +8133,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:1243
+#: lxc/network.go:1252
 #, fuzzy
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
@@ -8202,7 +8210,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:1182
+#: lxc/network.go:1191
 #, fuzzy
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
@@ -8301,7 +8309,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2800
+#: lxc/storage_volume.go:2811
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
@@ -8368,7 +8376,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:1958
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
@@ -8382,7 +8390,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:806
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
@@ -8398,7 +8406,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2551
+#: lxc/storage_volume.go:2562
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
@@ -8410,7 +8418,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:2634
+#: lxc/storage_volume.go:2645
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
@@ -8422,7 +8430,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:2415
+#: lxc/storage_volume.go:2426
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
@@ -8434,7 +8442,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:609
+#: lxc/storage_volume.go:610
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
@@ -8442,7 +8450,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:718
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
@@ -8454,7 +8462,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
@@ -8462,7 +8470,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2353
+#: lxc/storage_volume.go:2364
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
@@ -8470,7 +8478,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2085
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
@@ -8478,7 +8486,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2232
+#: lxc/storage_volume.go:2243
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
@@ -8490,7 +8498,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:1221
+#: lxc/storage_volume.go:1232
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
@@ -8502,7 +8510,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1858
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -8510,7 +8518,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:387
+#: lxc/storage_volume.go:388
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -8736,7 +8744,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1601
 #, fuzzy
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
@@ -8764,7 +8772,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:891
+#: lxc/cluster.go:892
 #, fuzzy
 msgid "[[<remote>:]<member>]"
 msgstr ""
@@ -8845,7 +8853,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:772
+#: lxc/cluster.go:773
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -8894,13 +8902,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1229
+#: lxc/config.go:1230
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1053
+#: lxc/config.go:1054
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -9259,7 +9267,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:614
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -9267,13 +9275,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2804
+#: lxc/storage_volume.go:2815
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2419
+#: lxc/storage_volume.go:2430
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -9341,6 +9349,9 @@ msgstr "o"
 #: lxc/image.go:1206
 msgid "yes"
 msgstr "oui"
+
+#~ msgid "Action (defaults to GET)"
+#~ msgstr "Action (GET par défaut)"
 
 #, fuzzy, c-format
 #~ msgid "Failed to create certificate: %w"

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-09 03:18-0300\n"
+"POT-Creation-Date: 2024-12-18 08:40-0700\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -50,7 +50,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1030
+#: lxc/storage_volume.go:1041
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -64,7 +64,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1240
+#: lxc/config.go:1241
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -413,7 +413,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:790
+#: lxc/cluster.go:791
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -586,13 +586,13 @@ msgstr ""
 msgid "Acknowledge warning"
 msgstr ""
 
+#: lxc/query.go:43
+msgid "Action"
+msgstr ""
+
 #: lxc/query.go:76
 #, c-format
 msgid "Action %q isn't supported by this tool"
-msgstr ""
-
-#: lxc/query.go:43
-msgid "Action (defaults to GET)"
 msgstr ""
 
 #: lxc/cluster_group.go:725
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1596
+#: lxc/storage_volume.go:1607
 msgid "All projects"
 msgstr ""
 
@@ -761,7 +761,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1371
+#: lxc/cluster.go:1372
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -798,7 +798,7 @@ msgstr ""
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:282 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -850,16 +850,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2708
+#: lxc/storage_volume.go:2719
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2785
+#: lxc/export.go:192 lxc/storage_volume.go:2796
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1538
 msgid "Backups:"
 msgstr ""
 
@@ -880,7 +880,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -923,7 +923,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1739
+#: lxc/storage_volume.go:1750
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1008,7 +1008,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1016,7 +1016,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1097
+#: lxc/config.go:702 lxc/config.go:1098
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1025,12 +1025,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:492
+#: lxc/storage_volume.go:493
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:446
+#: lxc/storage_volume.go:447
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1106,7 +1106,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1154
+#: lxc/cluster.go:1155
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1134,8 +1134,8 @@ msgstr ""
 #: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
 #: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
-#: lxc/network_forward.go:182 lxc/network_forward.go:264
+#: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
+#: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
 #: lxc/network_forward.go:497 lxc/network_forward.go:649
 #: lxc/network_forward.go:803 lxc/network_forward.go:892
 #: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
@@ -1150,30 +1150,30 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
-#: lxc/storage_volume.go:1952 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2251 lxc/storage_volume.go:2367
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2555
-#: lxc/storage_volume.go:2643 lxc/storage_volume.go:2807
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
+#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
+#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:894
+#: lxc/cluster.go:895
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:926
+#: lxc/cluster.go:927
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:756
+#: lxc/cluster.go:757
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1210,24 +1210,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
+#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
-#: lxc/storage_volume.go:1188
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
+#: lxc/storage_volume.go:1199
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:619
+#: lxc/storage_volume.go:620
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1237,7 +1237,11 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/move.go:65
+#: lxc/move.go:65
+msgid "Copy a stateful instance as stateless"
+msgstr ""
+
+#: lxc/copy.go:60
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1285,7 +1289,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:389 lxc/storage_volume.go:390
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1293,12 +1297,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:396
+#: lxc/storage_volume.go:397
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:398
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1311,7 +1315,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:515
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1334,12 +1338,12 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1235
+#: lxc/cluster.go:1236
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1239
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1354,17 +1358,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1266
+#: lxc/cluster.go:1267
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1446,7 +1450,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1498,7 +1502,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1527,13 +1531,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1738
+#: lxc/storage_volume.go:1749
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1553,7 +1557,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2642
+#: lxc/storage_volume.go:2653
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1649,7 +1653,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1670,16 +1674,16 @@ msgstr ""
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
-#: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
+#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
+#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
-#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
-#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
+#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
+#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1702,8 +1706,8 @@ msgstr ""
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
 #: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1005 lxc/network.go:1106 lxc/network.go:1185
-#: lxc/network.go:1245 lxc/network.go:1341 lxc/network.go:1413
+#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
+#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
 #: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
 #: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
 #: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
@@ -1754,27 +1758,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
-#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
-#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
-#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1949
-#: lxc/storage_volume.go:2076 lxc/storage_volume.go:2234
-#: lxc/storage_volume.go:2355 lxc/storage_volume.go:2417
-#: lxc/storage_volume.go:2553 lxc/storage_volume.go:2636
-#: lxc/storage_volume.go:2802 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1454
+#: lxc/storage_volume.go:1465
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1786,11 +1790,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
+#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1918,7 +1922,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:516
+#: lxc/cluster.go:1072 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1940,7 +1944,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:769 lxc/cluster.go:770
+#: lxc/cluster.go:770 lxc/cluster.go:771
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1960,7 +1964,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1226 lxc/config.go:1227
+#: lxc/config.go:1227 lxc/config.go:1228
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2024,7 +2028,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2032,7 +2036,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2050,11 +2054,12 @@ msgid ""
 "new\n"
 "  LXD cluster, which will have the given name.\n"
 "\n"
-"  It's required that the LXD is already available on the network. You can "
-"check\n"
-"  that by running 'lxc config get core.https_address', and possibly set a "
-"value\n"
-"  for the address if not yet set."
+"  It's required that LXD is already available on the network. You can check\n"
+"  this by running 'lxc config get core.https_address'. If either an IP "
+"address\n"
+"  and port is displayed, or both, LXD is already available on the network. "
+"If\n"
+"  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
 #: lxc/network_zone.go:1427
@@ -2084,12 +2089,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
+#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2099,12 +2104,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
+#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
-#: lxc/storage_volume.go:2199
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
+#: lxc/storage_volume.go:2210
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2114,11 +2119,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1298 lxc/cluster.go:1299
+#: lxc/cluster.go:1299 lxc/cluster.go:1300
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1396
+#: lxc/cluster.go:1397
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2146,8 +2151,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
-#: lxc/storage_volume.go:1564
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Expires at"
 msgstr ""
 
@@ -2171,7 +2176,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2635 lxc/storage_volume.go:2636
+#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2183,11 +2188,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2639
+#: lxc/storage_volume.go:2650
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2768
+#: lxc/export.go:152 lxc/storage_volume.go:2779
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2367,7 +2372,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
+#: lxc/network.go:1046 lxc/network_acl.go:133 lxc/network_zone.go:124
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2377,7 +2382,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1303
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2385,7 +2390,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1301
+#: lxc/cluster.go:1302
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2397,7 +2402,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1331
+#: lxc/cluster.go:1332
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2438,16 +2443,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
-#: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1614 lxc/warning.go:94
+#: lxc/storage_volume.go:1625 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2507,7 +2512,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:996
+#: lxc/config.go:996 lxc/config.go:997
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2571,7 +2576,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1249
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2635,11 +2640,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
+#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:475
+#: lxc/storage_volume.go:476
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2667,7 +2672,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1161
+#: lxc/network.go:1170
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2721,7 +2726,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1163
+#: lxc/network.go:1172
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2733,11 +2738,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1084
+#: lxc/list.go:560 lxc/network.go:1093
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1085
+#: lxc/list.go:561 lxc/network.go:1094
 msgid "IPV6"
 msgstr ""
 
@@ -2767,7 +2772,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2427
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2781,7 +2786,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2437
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2831,7 +2836,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2802
+#: lxc/storage_volume.go:2813
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2839,7 +2844,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2801
+#: lxc/storage_volume.go:2812
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2861,11 +2866,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2809
+#: lxc/storage_volume.go:2820
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2883
+#: lxc/storage_volume.go:2894
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2909,7 +2914,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
+#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2991,7 +2996,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2012
+#: lxc/move.go:148 lxc/storage_volume.go:2023
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2999,7 +3004,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2019
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3017,9 +3022,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
-#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2144 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
+#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3063,9 +3068,9 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
+#: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3077,8 +3082,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1020 lxc/cluster.go:1123
-#: lxc/cluster.go:1231 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
+#: lxc/cluster.go:1232 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3115,7 +3120,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1105 lxc/network.go:1106
+#: lxc/network.go:1114 lxc/network.go:1115
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3127,7 +3132,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:976 lxc/cluster.go:977
+#: lxc/cluster.go:977 lxc/cluster.go:978
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -3175,7 +3180,7 @@ msgstr ""
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1004 lxc/network.go:1005
+#: lxc/network.go:1005 lxc/network.go:1006
 msgid "List available networks"
 msgstr ""
 
@@ -3263,7 +3268,7 @@ msgid ""
 "Fast column layout: nsacPt\n"
 "\n"
 "A single keyword like \"web\" which will list any instance with a name "
-"starting by \"web\".\n"
+"starting with \"web\".\n"
 "A regular expression on the instance name. (e.g. .*web.*01$).\n"
 "A key/value pair referring to a configuration item. For those, the\n"
 "namespace can be abbreviated to the smallest unambiguous identifier.\n"
@@ -3320,7 +3325,8 @@ msgid ""
 "  P - Profiles\n"
 "  s - State\n"
 "  S - Number of snapshots\n"
-"  t - Type (persistent or ephemeral)\n"
+"  t - Type (container or virtual-machine, ephemeral indicated if "
+"applicable)\n"
 "  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
@@ -3369,11 +3375,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1603
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1608
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3432,7 +3438,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1470
+#: lxc/info.go:489 lxc/storage_volume.go:1481
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3453,7 +3459,7 @@ msgstr ""
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1162
+#: lxc/network.go:1171
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3471,7 +3477,7 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1083
+#: lxc/network.go:1092
 msgid "MANAGED"
 msgstr ""
 
@@ -3594,7 +3600,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:955 lxc/config.go:956
+#: lxc/config.go:956 lxc/config.go:957
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3733,7 +3739,7 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:957
+#: lxc/cluster.go:958
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
@@ -3797,7 +3803,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:811 lxc/cluster.go:1367 lxc/cluster_group.go:129
+#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -3860,8 +3866,8 @@ msgstr ""
 
 #: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1139 lxc/network.go:1217 lxc/network.go:1283
-#: lxc/network.go:1375 lxc/network_forward.go:127 lxc/network_forward.go:215
+#: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
+#: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
 #: lxc/network_forward.go:284 lxc/network_forward.go:445
 #: lxc/network_forward.go:530 lxc/network_forward.go:705
 #: lxc/network_forward.go:836 lxc/network_forward.go:929
@@ -3902,12 +3908,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
-#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
-#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1986
-#: lxc/storage_volume.go:2127 lxc/storage_volume.go:2285
-#: lxc/storage_volume.go:2476 lxc/storage_volume.go:2593
+#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
+#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
 msgid "Missing pool name"
 msgstr ""
 
@@ -3926,11 +3932,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:438 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1411
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3967,8 +3973,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
-#: lxc/storage_volume.go:964
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
+#: lxc/storage_volume.go:975
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4005,7 +4011,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4013,11 +4019,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1856
+#: lxc/storage_volume.go:1867
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:518
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4039,12 +4045,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
+#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
 msgid "NAME"
 msgstr ""
 
@@ -4072,7 +4078,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
 #: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4096,8 +4102,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
-#: lxc/storage_volume.go:1562
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1573
 msgid "Name"
 msgstr ""
 
@@ -4105,7 +4111,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4130,7 +4136,7 @@ msgstr ""
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1227
+#: lxc/network.go:1236
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4240,7 +4246,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1161
+#: lxc/cluster.go:1162
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4249,7 +4255,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
+#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4269,11 +4275,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:502 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4287,7 +4293,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2035
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4295,15 +4301,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:343
+#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
+#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2690
+#: lxc/storage_volume.go:2701
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2489
+#: lxc/storage_volume.go:2500
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4315,11 +4322,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1418
+#: lxc/storage_volume.go:1429
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1298
+#: lxc/network.go:735 lxc/network.go:1307
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4328,7 +4335,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1577
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4358,7 +4365,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1767
 msgid "POOL"
 msgstr ""
 
@@ -4374,7 +4381,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1773
 #: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4420,7 +4427,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -4441,16 +4448,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
-#: lxc/storage_volume.go:1189
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
+#: lxc/storage_volume.go:1200
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4567,7 +4574,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1356
+#: lxc/storage_volume.go:1367
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4581,7 +4588,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1225
+#: lxc/storage_volume.go:1236
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4597,7 +4604,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2247
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4618,7 +4625,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1004
+#: lxc/storage_volume.go:1015
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4627,7 +4634,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2081
+#: lxc/storage_volume.go:2092
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4640,13 +4647,13 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2357
+#: lxc/storage_volume.go:2368
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
 "\n"
 "lxc storage volume unset default data size\n"
-"    Remotes the size/quota of a custom volume \"data\" in pool \"default\".\n"
+"    Removes the size/quota of a custom volume \"data\" in pool \"default\".\n"
 "\n"
 "lxc storage volume unset default virtual-machine/data snapshots.expiry\n"
 "    Removes the snapshot expiration period for a virtual machine \"data\" in "
@@ -4726,7 +4733,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4909,7 +4916,7 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1184 lxc/network.go:1185
+#: lxc/network.go:1193 lxc/network.go:1194
 msgid "Rename networks"
 msgstr ""
 
@@ -4925,15 +4932,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1949
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:1959
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2037 lxc/storage_volume.go:2057
+#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4943,11 +4950,11 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:892 lxc/cluster.go:893
+#: lxc/cluster.go:893 lxc/cluster.go:894
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1032
+#: lxc/config.go:1033
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -4970,7 +4977,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1328 lxc/cluster.go:1329
+#: lxc/cluster.go:1329 lxc/cluster.go:1330
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4985,11 +4992,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2552 lxc/storage_volume.go:2553
+#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1394
+#: lxc/cluster.go:1395
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5011,7 +5018,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1087
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5061,7 +5068,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1088
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1097
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5124,7 +5131,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1050 lxc/config.go:1051
+#: lxc/config.go:1051 lxc/config.go:1052
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5188,11 +5195,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1244
+#: lxc/network.go:1253
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1245
+#: lxc/network.go:1254
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5309,11 +5316,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2075
+#: lxc/storage_volume.go:2086
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2076
+#: lxc/storage_volume.go:2087
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5370,7 +5377,7 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1252
+#: lxc/network.go:1261
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5398,7 +5405,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2103
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5467,7 +5474,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1173
+#: lxc/config.go:1173 lxc/config.go:1174
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5499,7 +5506,7 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1340 lxc/network.go:1341
+#: lxc/network.go:1349 lxc/network.go:1350
 msgid "Show network configurations"
 msgstr ""
 
@@ -5547,11 +5554,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2233 lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5574,7 +5581,7 @@ msgid "Show the expanded configuration"
 msgstr ""
 
 #: lxc/info.go:43
-msgid "Show the instance's last 100 log lines?"
+msgid "Show the instance's last 100 log lines"
 msgstr ""
 
 #: lxc/info.go:44
@@ -5619,15 +5626,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2417
+#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2179
+#: lxc/storage_volume.go:2190
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1502
 msgid "Snapshots:"
 msgstr ""
 
@@ -5732,21 +5739,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:702
+#: lxc/storage_volume.go:703
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:790
+#: lxc/storage_volume.go:791
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:516
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:520
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5754,7 +5761,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5803,18 +5810,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1070 lxc/config_trust.go:515
+#: lxc/cluster.go:1071 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1736 lxc/warning.go:216
+#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1747 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
 msgid "Taken at"
 msgstr ""
 
@@ -5971,12 +5978,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1340
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1306
+#: lxc/storage_volume.go:1317
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -5995,8 +6002,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
-#: lxc/storage_volume.go:978
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:989
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6016,11 +6023,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:739
+#: lxc/cluster.go:740
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:729
+#: lxc/cluster.go:730
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6071,7 +6078,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6086,7 +6093,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1853
+#: lxc/storage_volume.go:1864
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6094,7 +6101,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:394
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6153,7 +6160,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1472
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6175,13 +6182,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:995 lxc/storage_volume.go:1752
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
+#: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1740
+#: lxc/storage.go:724 lxc/storage_volume.go:1751
 msgid "USED BY"
 msgstr ""
 
@@ -6213,7 +6220,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6239,7 +6246,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1141 lxc/config.go:1142
+#: lxc/config.go:1142 lxc/config.go:1143
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6267,7 +6274,7 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1412 lxc/network.go:1413
+#: lxc/network.go:1421 lxc/network.go:1422
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -6319,7 +6326,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2354 lxc/storage_volume.go:2355
+#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6343,7 +6350,7 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1417
+#: lxc/network.go:1426
 msgid "Unset the key as a network property"
 msgstr ""
 
@@ -6371,7 +6378,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2379
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6379,7 +6386,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:247
+#: lxc/storage_volume.go:248
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6392,11 +6399,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1174
+#: lxc/cluster.go:1175
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1176
+#: lxc/cluster.go:1177
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6415,12 +6422,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2641
+#: lxc/export.go:42 lxc/storage_volume.go:2652
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6487,7 +6494,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1576
 msgid "Volume Only"
 msgstr ""
 
@@ -6520,7 +6527,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
 #: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6546,18 +6553,18 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:903
+#: lxc/storage_volume.go:909
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:281
+#: lxc/storage_volume.go:282
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
-#: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
+#: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
@@ -6567,7 +6574,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1172
+#: lxc/cluster.go:1173
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -6730,7 +6737,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6752,11 +6759,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:1140
+#: lxc/config.go:995 lxc/config.go:1141
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1049
+#: lxc/config.go:1050
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -6835,8 +6842,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:768
-#: lxc/cluster.go:1085 lxc/cluster.go:1297 lxc/cluster.go:1327
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
+#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -6860,8 +6867,8 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1104
-#: lxc/network.go:1339 lxc/network_forward.go:87
+#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1113
+#: lxc/network.go:1348 lxc/network_forward.go:87
 #: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -6874,11 +6881,11 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1411
+#: lxc/network.go:791 lxc/network.go:1420
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1243
+#: lxc/network.go:1252
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
@@ -6923,7 +6930,7 @@ msgstr ""
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1182
+#: lxc/network.go:1191
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -6974,7 +6981,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2800
+#: lxc/storage_volume.go:2811
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7009,13 +7016,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:1958
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:806
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7023,51 +7030,51 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2551
+#: lxc/storage_volume.go:2562
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2634
+#: lxc/storage_volume.go:2645
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2415
+#: lxc/storage_volume.go:2426
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:609
+#: lxc/storage_volume.go:610
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:718
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2353
+#: lxc/storage_volume.go:2364
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2085
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2232
+#: lxc/storage_volume.go:2243
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1221
+#: lxc/storage_volume.go:1232
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1858
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:387
+#: lxc/storage_volume.go:388
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7173,7 +7180,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1601
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7185,7 +7192,7 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:891
+#: lxc/cluster.go:892
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -7257,7 +7264,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:772
+#: lxc/cluster.go:773
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7306,13 +7313,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1229
+#: lxc/config.go:1230
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1053
+#: lxc/config.go:1054
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7649,7 +7656,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:614
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7657,13 +7664,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2804
+#: lxc/storage_volume.go:2815
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2419
+#: lxc/storage_volume.go:2430
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-09 03:18-0300\n"
+"POT-Creation-Date: 2024-12-18 08:40-0700\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1030
+#: lxc/storage_volume.go:1041
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1240
+#: lxc/config.go:1241
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -412,7 +412,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:790
+#: lxc/cluster.go:791
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -585,13 +585,13 @@ msgstr ""
 msgid "Acknowledge warning"
 msgstr ""
 
+#: lxc/query.go:43
+msgid "Action"
+msgstr ""
+
 #: lxc/query.go:76
 #, c-format
 msgid "Action %q isn't supported by this tool"
-msgstr ""
-
-#: lxc/query.go:43
-msgid "Action (defaults to GET)"
 msgstr ""
 
 #: lxc/cluster_group.go:725
@@ -738,7 +738,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1596
+#: lxc/storage_volume.go:1607
 msgid "All projects"
 msgstr ""
 
@@ -760,7 +760,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1371
+#: lxc/cluster.go:1372
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -797,7 +797,7 @@ msgstr ""
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:282 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -849,16 +849,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2708
+#: lxc/storage_volume.go:2719
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2785
+#: lxc/export.go:192 lxc/storage_volume.go:2796
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1538
 msgid "Backups:"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -922,7 +922,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1739
+#: lxc/storage_volume.go:1750
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1007,7 +1007,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1097
+#: lxc/config.go:702 lxc/config.go:1098
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1024,12 +1024,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:492
+#: lxc/storage_volume.go:493
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:446
+#: lxc/storage_volume.go:447
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1105,7 +1105,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1154
+#: lxc/cluster.go:1155
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1133,8 +1133,8 @@ msgstr ""
 #: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
 #: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
-#: lxc/network_forward.go:182 lxc/network_forward.go:264
+#: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
+#: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
 #: lxc/network_forward.go:497 lxc/network_forward.go:649
 #: lxc/network_forward.go:803 lxc/network_forward.go:892
 #: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
@@ -1149,30 +1149,30 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
-#: lxc/storage_volume.go:1952 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2251 lxc/storage_volume.go:2367
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2555
-#: lxc/storage_volume.go:2643 lxc/storage_volume.go:2807
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
+#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
+#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:894
+#: lxc/cluster.go:895
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:926
+#: lxc/cluster.go:927
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:756
+#: lxc/cluster.go:757
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1209,24 +1209,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
+#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
-#: lxc/storage_volume.go:1188
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
+#: lxc/storage_volume.go:1199
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:619
+#: lxc/storage_volume.go:620
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1236,7 +1236,11 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/move.go:65
+#: lxc/move.go:65
+msgid "Copy a stateful instance as stateless"
+msgstr ""
+
+#: lxc/copy.go:60
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1284,7 +1288,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:389 lxc/storage_volume.go:390
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1292,12 +1296,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:396
+#: lxc/storage_volume.go:397
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:398
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1310,7 +1314,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:515
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1333,12 +1337,12 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1235
+#: lxc/cluster.go:1236
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1239
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1353,17 +1357,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1266
+#: lxc/cluster.go:1267
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1445,7 +1449,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1497,7 +1501,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1526,13 +1530,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1738
+#: lxc/storage_volume.go:1749
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1552,7 +1556,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2642
+#: lxc/storage_volume.go:2653
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1648,7 +1652,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1669,16 +1673,16 @@ msgstr ""
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
-#: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
+#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
+#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
-#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
-#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
+#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
+#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1701,8 +1705,8 @@ msgstr ""
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
 #: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1005 lxc/network.go:1106 lxc/network.go:1185
-#: lxc/network.go:1245 lxc/network.go:1341 lxc/network.go:1413
+#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
+#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
 #: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
 #: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
 #: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
@@ -1753,27 +1757,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
-#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
-#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
-#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1949
-#: lxc/storage_volume.go:2076 lxc/storage_volume.go:2234
-#: lxc/storage_volume.go:2355 lxc/storage_volume.go:2417
-#: lxc/storage_volume.go:2553 lxc/storage_volume.go:2636
-#: lxc/storage_volume.go:2802 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1454
+#: lxc/storage_volume.go:1465
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1785,11 +1789,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
+#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1917,7 +1921,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:516
+#: lxc/cluster.go:1072 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1939,7 +1943,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:769 lxc/cluster.go:770
+#: lxc/cluster.go:770 lxc/cluster.go:771
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1959,7 +1963,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1226 lxc/config.go:1227
+#: lxc/config.go:1227 lxc/config.go:1228
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2023,7 +2027,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2031,7 +2035,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2049,11 +2053,12 @@ msgid ""
 "new\n"
 "  LXD cluster, which will have the given name.\n"
 "\n"
-"  It's required that the LXD is already available on the network. You can "
-"check\n"
-"  that by running 'lxc config get core.https_address', and possibly set a "
-"value\n"
-"  for the address if not yet set."
+"  It's required that LXD is already available on the network. You can check\n"
+"  this by running 'lxc config get core.https_address'. If either an IP "
+"address\n"
+"  and port is displayed, or both, LXD is already available on the network. "
+"If\n"
+"  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
 #: lxc/network_zone.go:1427
@@ -2083,12 +2088,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
+#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2098,12 +2103,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
+#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
-#: lxc/storage_volume.go:2199
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
+#: lxc/storage_volume.go:2210
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2113,11 +2118,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1298 lxc/cluster.go:1299
+#: lxc/cluster.go:1299 lxc/cluster.go:1300
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1396
+#: lxc/cluster.go:1397
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2145,8 +2150,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
-#: lxc/storage_volume.go:1564
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Expires at"
 msgstr ""
 
@@ -2170,7 +2175,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2635 lxc/storage_volume.go:2636
+#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2182,11 +2187,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2639
+#: lxc/storage_volume.go:2650
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2768
+#: lxc/export.go:152 lxc/storage_volume.go:2779
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2366,7 +2371,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
+#: lxc/network.go:1046 lxc/network_acl.go:133 lxc/network_zone.go:124
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2376,7 +2381,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1303
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2384,7 +2389,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1301
+#: lxc/cluster.go:1302
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2396,7 +2401,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1331
+#: lxc/cluster.go:1332
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2437,16 +2442,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
-#: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1614 lxc/warning.go:94
+#: lxc/storage_volume.go:1625 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2506,7 +2511,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:996
+#: lxc/config.go:996 lxc/config.go:997
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2570,7 +2575,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1249
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2634,11 +2639,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
+#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:475
+#: lxc/storage_volume.go:476
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2666,7 +2671,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1161
+#: lxc/network.go:1170
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2720,7 +2725,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1163
+#: lxc/network.go:1172
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2732,11 +2737,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1084
+#: lxc/list.go:560 lxc/network.go:1093
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1085
+#: lxc/list.go:561 lxc/network.go:1094
 msgid "IPV6"
 msgstr ""
 
@@ -2766,7 +2771,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2427
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2780,7 +2785,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2437
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2830,7 +2835,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2802
+#: lxc/storage_volume.go:2813
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2838,7 +2843,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2801
+#: lxc/storage_volume.go:2812
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2860,11 +2865,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2809
+#: lxc/storage_volume.go:2820
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2883
+#: lxc/storage_volume.go:2894
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2908,7 +2913,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
+#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2990,7 +2995,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2012
+#: lxc/move.go:148 lxc/storage_volume.go:2023
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2998,7 +3003,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2019
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3016,9 +3021,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
-#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2144 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
+#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3062,9 +3067,9 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
+#: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3076,8 +3081,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1020 lxc/cluster.go:1123
-#: lxc/cluster.go:1231 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
+#: lxc/cluster.go:1232 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3114,7 +3119,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1105 lxc/network.go:1106
+#: lxc/network.go:1114 lxc/network.go:1115
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3126,7 +3131,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:976 lxc/cluster.go:977
+#: lxc/cluster.go:977 lxc/cluster.go:978
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -3174,7 +3179,7 @@ msgstr ""
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1004 lxc/network.go:1005
+#: lxc/network.go:1005 lxc/network.go:1006
 msgid "List available networks"
 msgstr ""
 
@@ -3262,7 +3267,7 @@ msgid ""
 "Fast column layout: nsacPt\n"
 "\n"
 "A single keyword like \"web\" which will list any instance with a name "
-"starting by \"web\".\n"
+"starting with \"web\".\n"
 "A regular expression on the instance name. (e.g. .*web.*01$).\n"
 "A key/value pair referring to a configuration item. For those, the\n"
 "namespace can be abbreviated to the smallest unambiguous identifier.\n"
@@ -3319,7 +3324,8 @@ msgid ""
 "  P - Profiles\n"
 "  s - State\n"
 "  S - Number of snapshots\n"
-"  t - Type (persistent or ephemeral)\n"
+"  t - Type (container or virtual-machine, ephemeral indicated if "
+"applicable)\n"
 "  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
@@ -3368,11 +3374,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1603
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1608
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3431,7 +3437,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1470
+#: lxc/info.go:489 lxc/storage_volume.go:1481
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3452,7 +3458,7 @@ msgstr ""
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1162
+#: lxc/network.go:1171
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3470,7 +3476,7 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1083
+#: lxc/network.go:1092
 msgid "MANAGED"
 msgstr ""
 
@@ -3593,7 +3599,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:955 lxc/config.go:956
+#: lxc/config.go:956 lxc/config.go:957
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3732,7 +3738,7 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:957
+#: lxc/cluster.go:958
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
@@ -3796,7 +3802,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:811 lxc/cluster.go:1367 lxc/cluster_group.go:129
+#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -3859,8 +3865,8 @@ msgstr ""
 
 #: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1139 lxc/network.go:1217 lxc/network.go:1283
-#: lxc/network.go:1375 lxc/network_forward.go:127 lxc/network_forward.go:215
+#: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
+#: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
 #: lxc/network_forward.go:284 lxc/network_forward.go:445
 #: lxc/network_forward.go:530 lxc/network_forward.go:705
 #: lxc/network_forward.go:836 lxc/network_forward.go:929
@@ -3901,12 +3907,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
-#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
-#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1986
-#: lxc/storage_volume.go:2127 lxc/storage_volume.go:2285
-#: lxc/storage_volume.go:2476 lxc/storage_volume.go:2593
+#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
+#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
 msgid "Missing pool name"
 msgstr ""
 
@@ -3925,11 +3931,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:438 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1411
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3966,8 +3972,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
-#: lxc/storage_volume.go:964
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
+#: lxc/storage_volume.go:975
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4004,7 +4010,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4012,11 +4018,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1856
+#: lxc/storage_volume.go:1867
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:518
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4038,12 +4044,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
+#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
 msgid "NAME"
 msgstr ""
 
@@ -4071,7 +4077,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
 #: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4095,8 +4101,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
-#: lxc/storage_volume.go:1562
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1573
 msgid "Name"
 msgstr ""
 
@@ -4104,7 +4110,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4129,7 +4135,7 @@ msgstr ""
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1227
+#: lxc/network.go:1236
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4239,7 +4245,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1161
+#: lxc/cluster.go:1162
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4248,7 +4254,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
+#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4268,11 +4274,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:502 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4286,7 +4292,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2035
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4294,15 +4300,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:343
+#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
+#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2690
+#: lxc/storage_volume.go:2701
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2489
+#: lxc/storage_volume.go:2500
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4314,11 +4321,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1418
+#: lxc/storage_volume.go:1429
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1298
+#: lxc/network.go:735 lxc/network.go:1307
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4327,7 +4334,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1577
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4357,7 +4364,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1767
 msgid "POOL"
 msgstr ""
 
@@ -4373,7 +4380,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1773
 #: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4419,7 +4426,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -4440,16 +4447,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
-#: lxc/storage_volume.go:1189
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
+#: lxc/storage_volume.go:1200
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4566,7 +4573,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1356
+#: lxc/storage_volume.go:1367
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4580,7 +4587,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1225
+#: lxc/storage_volume.go:1236
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4596,7 +4603,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2247
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4617,7 +4624,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1004
+#: lxc/storage_volume.go:1015
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4626,7 +4633,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2081
+#: lxc/storage_volume.go:2092
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4639,13 +4646,13 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2357
+#: lxc/storage_volume.go:2368
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
 "\n"
 "lxc storage volume unset default data size\n"
-"    Remotes the size/quota of a custom volume \"data\" in pool \"default\".\n"
+"    Removes the size/quota of a custom volume \"data\" in pool \"default\".\n"
 "\n"
 "lxc storage volume unset default virtual-machine/data snapshots.expiry\n"
 "    Removes the snapshot expiration period for a virtual machine \"data\" in "
@@ -4725,7 +4732,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4908,7 +4915,7 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1184 lxc/network.go:1185
+#: lxc/network.go:1193 lxc/network.go:1194
 msgid "Rename networks"
 msgstr ""
 
@@ -4924,15 +4931,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1949
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:1959
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2037 lxc/storage_volume.go:2057
+#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4942,11 +4949,11 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:892 lxc/cluster.go:893
+#: lxc/cluster.go:893 lxc/cluster.go:894
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1032
+#: lxc/config.go:1033
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -4969,7 +4976,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1328 lxc/cluster.go:1329
+#: lxc/cluster.go:1329 lxc/cluster.go:1330
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4984,11 +4991,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2552 lxc/storage_volume.go:2553
+#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1394
+#: lxc/cluster.go:1395
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5010,7 +5017,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1087
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5060,7 +5067,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1088
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1097
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5123,7 +5130,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1050 lxc/config.go:1051
+#: lxc/config.go:1051 lxc/config.go:1052
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5187,11 +5194,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1244
+#: lxc/network.go:1253
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1245
+#: lxc/network.go:1254
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5308,11 +5315,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2075
+#: lxc/storage_volume.go:2086
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2076
+#: lxc/storage_volume.go:2087
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5369,7 +5376,7 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1252
+#: lxc/network.go:1261
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5397,7 +5404,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2103
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5466,7 +5473,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1173
+#: lxc/config.go:1173 lxc/config.go:1174
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5498,7 +5505,7 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1340 lxc/network.go:1341
+#: lxc/network.go:1349 lxc/network.go:1350
 msgid "Show network configurations"
 msgstr ""
 
@@ -5546,11 +5553,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2233 lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5573,7 +5580,7 @@ msgid "Show the expanded configuration"
 msgstr ""
 
 #: lxc/info.go:43
-msgid "Show the instance's last 100 log lines?"
+msgid "Show the instance's last 100 log lines"
 msgstr ""
 
 #: lxc/info.go:44
@@ -5618,15 +5625,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2417
+#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2179
+#: lxc/storage_volume.go:2190
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1502
 msgid "Snapshots:"
 msgstr ""
 
@@ -5731,21 +5738,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:702
+#: lxc/storage_volume.go:703
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:790
+#: lxc/storage_volume.go:791
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:516
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:520
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5753,7 +5760,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5802,18 +5809,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1070 lxc/config_trust.go:515
+#: lxc/cluster.go:1071 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1736 lxc/warning.go:216
+#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1747 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
 msgid "Taken at"
 msgstr ""
 
@@ -5970,12 +5977,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1340
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1306
+#: lxc/storage_volume.go:1317
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -5994,8 +6001,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
-#: lxc/storage_volume.go:978
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:989
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6015,11 +6022,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:739
+#: lxc/cluster.go:740
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:729
+#: lxc/cluster.go:730
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6070,7 +6077,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6085,7 +6092,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1853
+#: lxc/storage_volume.go:1864
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6093,7 +6100,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:394
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6152,7 +6159,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1472
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6174,13 +6181,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:995 lxc/storage_volume.go:1752
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
+#: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1740
+#: lxc/storage.go:724 lxc/storage_volume.go:1751
 msgid "USED BY"
 msgstr ""
 
@@ -6212,7 +6219,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6238,7 +6245,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1141 lxc/config.go:1142
+#: lxc/config.go:1142 lxc/config.go:1143
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6266,7 +6273,7 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1412 lxc/network.go:1413
+#: lxc/network.go:1421 lxc/network.go:1422
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -6318,7 +6325,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2354 lxc/storage_volume.go:2355
+#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6342,7 +6349,7 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1417
+#: lxc/network.go:1426
 msgid "Unset the key as a network property"
 msgstr ""
 
@@ -6370,7 +6377,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2379
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6378,7 +6385,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:247
+#: lxc/storage_volume.go:248
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6391,11 +6398,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1174
+#: lxc/cluster.go:1175
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1176
+#: lxc/cluster.go:1177
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6414,12 +6421,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2641
+#: lxc/export.go:42 lxc/storage_volume.go:2652
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6486,7 +6493,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1576
 msgid "Volume Only"
 msgstr ""
 
@@ -6519,7 +6526,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
 #: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6545,18 +6552,18 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:903
+#: lxc/storage_volume.go:909
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:281
+#: lxc/storage_volume.go:282
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
-#: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
+#: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
@@ -6566,7 +6573,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1172
+#: lxc/cluster.go:1173
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -6729,7 +6736,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6751,11 +6758,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:1140
+#: lxc/config.go:995 lxc/config.go:1141
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1049
+#: lxc/config.go:1050
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -6834,8 +6841,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:768
-#: lxc/cluster.go:1085 lxc/cluster.go:1297 lxc/cluster.go:1327
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
+#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -6859,8 +6866,8 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1104
-#: lxc/network.go:1339 lxc/network_forward.go:87
+#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1113
+#: lxc/network.go:1348 lxc/network_forward.go:87
 #: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -6873,11 +6880,11 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1411
+#: lxc/network.go:791 lxc/network.go:1420
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1243
+#: lxc/network.go:1252
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
@@ -6922,7 +6929,7 @@ msgstr ""
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1182
+#: lxc/network.go:1191
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -6973,7 +6980,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2800
+#: lxc/storage_volume.go:2811
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7008,13 +7015,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:1958
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:806
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7022,51 +7029,51 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2551
+#: lxc/storage_volume.go:2562
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2634
+#: lxc/storage_volume.go:2645
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2415
+#: lxc/storage_volume.go:2426
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:609
+#: lxc/storage_volume.go:610
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:718
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2353
+#: lxc/storage_volume.go:2364
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2085
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2232
+#: lxc/storage_volume.go:2243
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1221
+#: lxc/storage_volume.go:1232
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1858
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:387
+#: lxc/storage_volume.go:388
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7172,7 +7179,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1601
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7184,7 +7191,7 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:891
+#: lxc/cluster.go:892
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -7256,7 +7263,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:772
+#: lxc/cluster.go:773
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7305,13 +7312,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1229
+#: lxc/config.go:1230
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1053
+#: lxc/config.go:1054
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7648,7 +7655,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:614
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7656,13 +7663,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2804
+#: lxc/storage_volume.go:2815
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2419
+#: lxc/storage_volume.go:2430
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-09 03:18-0300\n"
+"POT-Creation-Date: 2024-12-18 08:40-0700\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1030
+#: lxc/storage_volume.go:1041
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1240
+#: lxc/config.go:1241
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -412,7 +412,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:790
+#: lxc/cluster.go:791
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -585,13 +585,13 @@ msgstr ""
 msgid "Acknowledge warning"
 msgstr ""
 
+#: lxc/query.go:43
+msgid "Action"
+msgstr ""
+
 #: lxc/query.go:76
 #, c-format
 msgid "Action %q isn't supported by this tool"
-msgstr ""
-
-#: lxc/query.go:43
-msgid "Action (defaults to GET)"
 msgstr ""
 
 #: lxc/cluster_group.go:725
@@ -738,7 +738,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1596
+#: lxc/storage_volume.go:1607
 msgid "All projects"
 msgstr ""
 
@@ -760,7 +760,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1371
+#: lxc/cluster.go:1372
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -797,7 +797,7 @@ msgstr ""
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:282 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -849,16 +849,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2708
+#: lxc/storage_volume.go:2719
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2785
+#: lxc/export.go:192 lxc/storage_volume.go:2796
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1538
 msgid "Backups:"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -922,7 +922,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1739
+#: lxc/storage_volume.go:1750
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1007,7 +1007,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1097
+#: lxc/config.go:702 lxc/config.go:1098
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1024,12 +1024,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:492
+#: lxc/storage_volume.go:493
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:446
+#: lxc/storage_volume.go:447
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1105,7 +1105,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1154
+#: lxc/cluster.go:1155
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1133,8 +1133,8 @@ msgstr ""
 #: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
 #: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
-#: lxc/network_forward.go:182 lxc/network_forward.go:264
+#: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
+#: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
 #: lxc/network_forward.go:497 lxc/network_forward.go:649
 #: lxc/network_forward.go:803 lxc/network_forward.go:892
 #: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
@@ -1149,30 +1149,30 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
-#: lxc/storage_volume.go:1952 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2251 lxc/storage_volume.go:2367
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2555
-#: lxc/storage_volume.go:2643 lxc/storage_volume.go:2807
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
+#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
+#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:894
+#: lxc/cluster.go:895
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:926
+#: lxc/cluster.go:927
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:756
+#: lxc/cluster.go:757
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1209,24 +1209,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
+#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
-#: lxc/storage_volume.go:1188
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
+#: lxc/storage_volume.go:1199
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:619
+#: lxc/storage_volume.go:620
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1236,7 +1236,11 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/move.go:65
+#: lxc/move.go:65
+msgid "Copy a stateful instance as stateless"
+msgstr ""
+
+#: lxc/copy.go:60
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1284,7 +1288,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:389 lxc/storage_volume.go:390
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1292,12 +1296,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:396
+#: lxc/storage_volume.go:397
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:398
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1310,7 +1314,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:515
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1333,12 +1337,12 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1235
+#: lxc/cluster.go:1236
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1239
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1353,17 +1357,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1266
+#: lxc/cluster.go:1267
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1445,7 +1449,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1497,7 +1501,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1526,13 +1530,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1738
+#: lxc/storage_volume.go:1749
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1552,7 +1556,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2642
+#: lxc/storage_volume.go:2653
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1648,7 +1652,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1669,16 +1673,16 @@ msgstr ""
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
-#: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
+#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
+#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
-#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
-#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
+#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
+#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1701,8 +1705,8 @@ msgstr ""
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
 #: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1005 lxc/network.go:1106 lxc/network.go:1185
-#: lxc/network.go:1245 lxc/network.go:1341 lxc/network.go:1413
+#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
+#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
 #: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
 #: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
 #: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
@@ -1753,27 +1757,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
-#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
-#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
-#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1949
-#: lxc/storage_volume.go:2076 lxc/storage_volume.go:2234
-#: lxc/storage_volume.go:2355 lxc/storage_volume.go:2417
-#: lxc/storage_volume.go:2553 lxc/storage_volume.go:2636
-#: lxc/storage_volume.go:2802 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1454
+#: lxc/storage_volume.go:1465
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1785,11 +1789,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
+#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1917,7 +1921,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:516
+#: lxc/cluster.go:1072 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1939,7 +1943,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:769 lxc/cluster.go:770
+#: lxc/cluster.go:770 lxc/cluster.go:771
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1959,7 +1963,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1226 lxc/config.go:1227
+#: lxc/config.go:1227 lxc/config.go:1228
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2023,7 +2027,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2031,7 +2035,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2049,11 +2053,12 @@ msgid ""
 "new\n"
 "  LXD cluster, which will have the given name.\n"
 "\n"
-"  It's required that the LXD is already available on the network. You can "
-"check\n"
-"  that by running 'lxc config get core.https_address', and possibly set a "
-"value\n"
-"  for the address if not yet set."
+"  It's required that LXD is already available on the network. You can check\n"
+"  this by running 'lxc config get core.https_address'. If either an IP "
+"address\n"
+"  and port is displayed, or both, LXD is already available on the network. "
+"If\n"
+"  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
 #: lxc/network_zone.go:1427
@@ -2083,12 +2088,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
+#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2098,12 +2103,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
+#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
-#: lxc/storage_volume.go:2199
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
+#: lxc/storage_volume.go:2210
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2113,11 +2118,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1298 lxc/cluster.go:1299
+#: lxc/cluster.go:1299 lxc/cluster.go:1300
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1396
+#: lxc/cluster.go:1397
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2145,8 +2150,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
-#: lxc/storage_volume.go:1564
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Expires at"
 msgstr ""
 
@@ -2170,7 +2175,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2635 lxc/storage_volume.go:2636
+#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2182,11 +2187,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2639
+#: lxc/storage_volume.go:2650
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2768
+#: lxc/export.go:152 lxc/storage_volume.go:2779
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2366,7 +2371,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
+#: lxc/network.go:1046 lxc/network_acl.go:133 lxc/network_zone.go:124
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2376,7 +2381,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1303
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2384,7 +2389,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1301
+#: lxc/cluster.go:1302
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2396,7 +2401,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1331
+#: lxc/cluster.go:1332
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2437,16 +2442,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
-#: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1614 lxc/warning.go:94
+#: lxc/storage_volume.go:1625 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2506,7 +2511,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:996
+#: lxc/config.go:996 lxc/config.go:997
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2570,7 +2575,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1249
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2634,11 +2639,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
+#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:475
+#: lxc/storage_volume.go:476
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2666,7 +2671,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1161
+#: lxc/network.go:1170
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2720,7 +2725,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1163
+#: lxc/network.go:1172
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2732,11 +2737,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1084
+#: lxc/list.go:560 lxc/network.go:1093
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1085
+#: lxc/list.go:561 lxc/network.go:1094
 msgid "IPV6"
 msgstr ""
 
@@ -2766,7 +2771,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2427
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2780,7 +2785,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2437
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2830,7 +2835,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2802
+#: lxc/storage_volume.go:2813
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2838,7 +2843,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2801
+#: lxc/storage_volume.go:2812
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2860,11 +2865,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2809
+#: lxc/storage_volume.go:2820
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2883
+#: lxc/storage_volume.go:2894
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2908,7 +2913,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
+#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2990,7 +2995,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2012
+#: lxc/move.go:148 lxc/storage_volume.go:2023
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2998,7 +3003,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2019
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3016,9 +3021,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
-#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2144 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
+#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3062,9 +3067,9 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
+#: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3076,8 +3081,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1020 lxc/cluster.go:1123
-#: lxc/cluster.go:1231 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
+#: lxc/cluster.go:1232 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3114,7 +3119,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1105 lxc/network.go:1106
+#: lxc/network.go:1114 lxc/network.go:1115
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3126,7 +3131,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:976 lxc/cluster.go:977
+#: lxc/cluster.go:977 lxc/cluster.go:978
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -3174,7 +3179,7 @@ msgstr ""
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1004 lxc/network.go:1005
+#: lxc/network.go:1005 lxc/network.go:1006
 msgid "List available networks"
 msgstr ""
 
@@ -3262,7 +3267,7 @@ msgid ""
 "Fast column layout: nsacPt\n"
 "\n"
 "A single keyword like \"web\" which will list any instance with a name "
-"starting by \"web\".\n"
+"starting with \"web\".\n"
 "A regular expression on the instance name. (e.g. .*web.*01$).\n"
 "A key/value pair referring to a configuration item. For those, the\n"
 "namespace can be abbreviated to the smallest unambiguous identifier.\n"
@@ -3319,7 +3324,8 @@ msgid ""
 "  P - Profiles\n"
 "  s - State\n"
 "  S - Number of snapshots\n"
-"  t - Type (persistent or ephemeral)\n"
+"  t - Type (container or virtual-machine, ephemeral indicated if "
+"applicable)\n"
 "  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
@@ -3368,11 +3374,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1603
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1608
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3431,7 +3437,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1470
+#: lxc/info.go:489 lxc/storage_volume.go:1481
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3452,7 +3458,7 @@ msgstr ""
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1162
+#: lxc/network.go:1171
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3470,7 +3476,7 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1083
+#: lxc/network.go:1092
 msgid "MANAGED"
 msgstr ""
 
@@ -3593,7 +3599,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:955 lxc/config.go:956
+#: lxc/config.go:956 lxc/config.go:957
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3732,7 +3738,7 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:957
+#: lxc/cluster.go:958
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
@@ -3796,7 +3802,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:811 lxc/cluster.go:1367 lxc/cluster_group.go:129
+#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -3859,8 +3865,8 @@ msgstr ""
 
 #: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1139 lxc/network.go:1217 lxc/network.go:1283
-#: lxc/network.go:1375 lxc/network_forward.go:127 lxc/network_forward.go:215
+#: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
+#: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
 #: lxc/network_forward.go:284 lxc/network_forward.go:445
 #: lxc/network_forward.go:530 lxc/network_forward.go:705
 #: lxc/network_forward.go:836 lxc/network_forward.go:929
@@ -3901,12 +3907,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
-#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
-#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1986
-#: lxc/storage_volume.go:2127 lxc/storage_volume.go:2285
-#: lxc/storage_volume.go:2476 lxc/storage_volume.go:2593
+#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
+#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
 msgid "Missing pool name"
 msgstr ""
 
@@ -3925,11 +3931,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:438 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1411
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3966,8 +3972,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
-#: lxc/storage_volume.go:964
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
+#: lxc/storage_volume.go:975
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4004,7 +4010,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4012,11 +4018,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1856
+#: lxc/storage_volume.go:1867
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:518
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4038,12 +4044,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
+#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
 msgid "NAME"
 msgstr ""
 
@@ -4071,7 +4077,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
 #: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4095,8 +4101,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
-#: lxc/storage_volume.go:1562
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1573
 msgid "Name"
 msgstr ""
 
@@ -4104,7 +4110,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4129,7 +4135,7 @@ msgstr ""
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1227
+#: lxc/network.go:1236
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4239,7 +4245,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1161
+#: lxc/cluster.go:1162
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4248,7 +4254,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
+#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4268,11 +4274,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:502 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4286,7 +4292,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2035
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4294,15 +4300,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:343
+#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
+#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2690
+#: lxc/storage_volume.go:2701
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2489
+#: lxc/storage_volume.go:2500
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4314,11 +4321,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1418
+#: lxc/storage_volume.go:1429
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1298
+#: lxc/network.go:735 lxc/network.go:1307
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4327,7 +4334,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1577
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4357,7 +4364,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1767
 msgid "POOL"
 msgstr ""
 
@@ -4373,7 +4380,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1773
 #: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4419,7 +4426,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -4440,16 +4447,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
-#: lxc/storage_volume.go:1189
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
+#: lxc/storage_volume.go:1200
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4566,7 +4573,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1356
+#: lxc/storage_volume.go:1367
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4580,7 +4587,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1225
+#: lxc/storage_volume.go:1236
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4596,7 +4603,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2247
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4617,7 +4624,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1004
+#: lxc/storage_volume.go:1015
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4626,7 +4633,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2081
+#: lxc/storage_volume.go:2092
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4639,13 +4646,13 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2357
+#: lxc/storage_volume.go:2368
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
 "\n"
 "lxc storage volume unset default data size\n"
-"    Remotes the size/quota of a custom volume \"data\" in pool \"default\".\n"
+"    Removes the size/quota of a custom volume \"data\" in pool \"default\".\n"
 "\n"
 "lxc storage volume unset default virtual-machine/data snapshots.expiry\n"
 "    Removes the snapshot expiration period for a virtual machine \"data\" in "
@@ -4725,7 +4732,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4908,7 +4915,7 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1184 lxc/network.go:1185
+#: lxc/network.go:1193 lxc/network.go:1194
 msgid "Rename networks"
 msgstr ""
 
@@ -4924,15 +4931,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1949
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:1959
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2037 lxc/storage_volume.go:2057
+#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4942,11 +4949,11 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:892 lxc/cluster.go:893
+#: lxc/cluster.go:893 lxc/cluster.go:894
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1032
+#: lxc/config.go:1033
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -4969,7 +4976,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1328 lxc/cluster.go:1329
+#: lxc/cluster.go:1329 lxc/cluster.go:1330
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4984,11 +4991,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2552 lxc/storage_volume.go:2553
+#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1394
+#: lxc/cluster.go:1395
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5010,7 +5017,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1087
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5060,7 +5067,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1088
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1097
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5123,7 +5130,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1050 lxc/config.go:1051
+#: lxc/config.go:1051 lxc/config.go:1052
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5187,11 +5194,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1244
+#: lxc/network.go:1253
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1245
+#: lxc/network.go:1254
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5308,11 +5315,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2075
+#: lxc/storage_volume.go:2086
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2076
+#: lxc/storage_volume.go:2087
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5369,7 +5376,7 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1252
+#: lxc/network.go:1261
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5397,7 +5404,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2103
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5466,7 +5473,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1173
+#: lxc/config.go:1173 lxc/config.go:1174
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5498,7 +5505,7 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1340 lxc/network.go:1341
+#: lxc/network.go:1349 lxc/network.go:1350
 msgid "Show network configurations"
 msgstr ""
 
@@ -5546,11 +5553,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2233 lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5573,7 +5580,7 @@ msgid "Show the expanded configuration"
 msgstr ""
 
 #: lxc/info.go:43
-msgid "Show the instance's last 100 log lines?"
+msgid "Show the instance's last 100 log lines"
 msgstr ""
 
 #: lxc/info.go:44
@@ -5618,15 +5625,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2417
+#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2179
+#: lxc/storage_volume.go:2190
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1502
 msgid "Snapshots:"
 msgstr ""
 
@@ -5731,21 +5738,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:702
+#: lxc/storage_volume.go:703
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:790
+#: lxc/storage_volume.go:791
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:516
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:520
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5753,7 +5760,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5802,18 +5809,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1070 lxc/config_trust.go:515
+#: lxc/cluster.go:1071 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1736 lxc/warning.go:216
+#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1747 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
 msgid "Taken at"
 msgstr ""
 
@@ -5970,12 +5977,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1340
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1306
+#: lxc/storage_volume.go:1317
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -5994,8 +6001,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
-#: lxc/storage_volume.go:978
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:989
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6015,11 +6022,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:739
+#: lxc/cluster.go:740
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:729
+#: lxc/cluster.go:730
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6070,7 +6077,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6085,7 +6092,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1853
+#: lxc/storage_volume.go:1864
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6093,7 +6100,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:394
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6152,7 +6159,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1472
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6174,13 +6181,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:995 lxc/storage_volume.go:1752
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
+#: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1740
+#: lxc/storage.go:724 lxc/storage_volume.go:1751
 msgid "USED BY"
 msgstr ""
 
@@ -6212,7 +6219,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6238,7 +6245,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1141 lxc/config.go:1142
+#: lxc/config.go:1142 lxc/config.go:1143
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6266,7 +6273,7 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1412 lxc/network.go:1413
+#: lxc/network.go:1421 lxc/network.go:1422
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -6318,7 +6325,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2354 lxc/storage_volume.go:2355
+#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6342,7 +6349,7 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1417
+#: lxc/network.go:1426
 msgid "Unset the key as a network property"
 msgstr ""
 
@@ -6370,7 +6377,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2379
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6378,7 +6385,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:247
+#: lxc/storage_volume.go:248
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6391,11 +6398,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1174
+#: lxc/cluster.go:1175
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1176
+#: lxc/cluster.go:1177
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6414,12 +6421,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2641
+#: lxc/export.go:42 lxc/storage_volume.go:2652
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6486,7 +6493,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1576
 msgid "Volume Only"
 msgstr ""
 
@@ -6519,7 +6526,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
 #: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6545,18 +6552,18 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:903
+#: lxc/storage_volume.go:909
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:281
+#: lxc/storage_volume.go:282
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
-#: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
+#: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
@@ -6566,7 +6573,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1172
+#: lxc/cluster.go:1173
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -6729,7 +6736,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6751,11 +6758,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:1140
+#: lxc/config.go:995 lxc/config.go:1141
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1049
+#: lxc/config.go:1050
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -6834,8 +6841,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:768
-#: lxc/cluster.go:1085 lxc/cluster.go:1297 lxc/cluster.go:1327
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
+#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -6859,8 +6866,8 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1104
-#: lxc/network.go:1339 lxc/network_forward.go:87
+#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1113
+#: lxc/network.go:1348 lxc/network_forward.go:87
 #: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -6873,11 +6880,11 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1411
+#: lxc/network.go:791 lxc/network.go:1420
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1243
+#: lxc/network.go:1252
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
@@ -6922,7 +6929,7 @@ msgstr ""
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1182
+#: lxc/network.go:1191
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -6973,7 +6980,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2800
+#: lxc/storage_volume.go:2811
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7008,13 +7015,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:1958
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:806
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7022,51 +7029,51 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2551
+#: lxc/storage_volume.go:2562
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2634
+#: lxc/storage_volume.go:2645
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2415
+#: lxc/storage_volume.go:2426
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:609
+#: lxc/storage_volume.go:610
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:718
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2353
+#: lxc/storage_volume.go:2364
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2085
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2232
+#: lxc/storage_volume.go:2243
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1221
+#: lxc/storage_volume.go:1232
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1858
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:387
+#: lxc/storage_volume.go:388
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7172,7 +7179,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1601
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7184,7 +7191,7 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:891
+#: lxc/cluster.go:892
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -7256,7 +7263,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:772
+#: lxc/cluster.go:773
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7305,13 +7312,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1229
+#: lxc/config.go:1230
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1053
+#: lxc/config.go:1054
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7648,7 +7655,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:614
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7656,13 +7663,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2804
+#: lxc/storage_volume.go:2815
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2419
+#: lxc/storage_volume.go:2430
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-09 03:18-0300\n"
+"POT-Creation-Date: 2024-12-18 08:40-0700\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -79,7 +79,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:1030
+#: lxc/storage_volume.go:1041
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -108,7 +108,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/config.go:1240
+#: lxc/config.go:1241
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -654,7 +654,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/cluster.go:790
+#: lxc/cluster.go:791
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -830,14 +830,14 @@ msgstr ""
 msgid "Acknowledge warning"
 msgstr ""
 
+#: lxc/query.go:43
+msgid "Action"
+msgstr ""
+
 #: lxc/query.go:76
 #, fuzzy, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr "'%s' non è un tipo di file supportato."
-
-#: lxc/query.go:43
-msgid "Action (defaults to GET)"
-msgstr "Azione (default a GET)"
 
 #: lxc/cluster_group.go:725
 #, fuzzy
@@ -987,7 +987,7 @@ msgstr "il remote %s esiste già"
 msgid "Aliases:"
 msgstr "Alias:"
 
-#: lxc/storage_volume.go:1596
+#: lxc/storage_volume.go:1607
 msgid "All projects"
 msgstr ""
 
@@ -1010,7 +1010,7 @@ msgstr "Architettura: %s"
 msgid "Architecture: %v"
 msgstr "Architettura: %s"
 
-#: lxc/cluster.go:1371
+#: lxc/cluster.go:1372
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -1048,7 +1048,7 @@ msgstr ""
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:282 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -1100,16 +1100,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2708
+#: lxc/storage_volume.go:2719
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/export.go:192 lxc/storage_volume.go:2785
+#: lxc/export.go:192 lxc/storage_volume.go:2796
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1538
 msgid "Backups:"
 msgstr ""
 
@@ -1130,7 +1130,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr "Proprietà errata: %s"
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1173,7 +1173,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr "NOME COMUNE"
 
-#: lxc/storage_volume.go:1739
+#: lxc/storage_volume.go:1750
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1259,7 +1259,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1267,7 +1267,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1097
+#: lxc/config.go:702 lxc/config.go:1098
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1276,12 +1276,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:492
+#: lxc/storage_volume.go:493
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:446
+#: lxc/storage_volume.go:447
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1359,7 +1359,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1154
+#: lxc/cluster.go:1155
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1387,8 +1387,8 @@ msgstr ""
 #: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
 #: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
-#: lxc/network_forward.go:182 lxc/network_forward.go:264
+#: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
+#: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
 #: lxc/network_forward.go:497 lxc/network_forward.go:649
 #: lxc/network_forward.go:803 lxc/network_forward.go:892
 #: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
@@ -1403,30 +1403,30 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
-#: lxc/storage_volume.go:1952 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2251 lxc/storage_volume.go:2367
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2555
-#: lxc/storage_volume.go:2643 lxc/storage_volume.go:2807
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
+#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
+#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:894
+#: lxc/cluster.go:895
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:926
+#: lxc/cluster.go:927
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:756
+#: lxc/cluster.go:757
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr "Colonne"
@@ -1463,24 +1463,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
+#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
-#: lxc/storage_volume.go:1188
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
+#: lxc/storage_volume.go:1199
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:619
+#: lxc/storage_volume.go:620
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1478
 #, fuzzy, c-format
 msgid "Content type: %s"
 msgstr "Aggiornamento automatico: %s"
@@ -1490,7 +1490,12 @@ msgstr "Aggiornamento automatico: %s"
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/move.go:65
+#: lxc/move.go:65
+#, fuzzy
+msgid "Copy a stateful instance as stateless"
+msgstr "Creazione del container in corso"
+
+#: lxc/copy.go:60
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1538,7 +1543,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:389 lxc/storage_volume.go:390
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1546,12 +1551,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:396
+#: lxc/storage_volume.go:397
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:398
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1564,7 +1569,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:515
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1587,12 +1592,12 @@ msgstr "Certificato del client salvato dal server: "
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1235
+#: lxc/cluster.go:1236
 #, fuzzy, c-format
 msgid "Could not find certificate file path: %s"
 msgstr "Certificato del client salvato dal server: "
 
-#: lxc/cluster.go:1239
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1607,17 +1612,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, fuzzy, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr "Certificato del client salvato dal server: "
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, fuzzy, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr "Certificato del client salvato dal server: "
 
-#: lxc/cluster.go:1266
+#: lxc/cluster.go:1267
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1707,7 +1712,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1762,7 +1767,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1792,13 +1797,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1738
+#: lxc/storage_volume.go:1749
 msgid "DESCRIPTION"
 msgstr "DESCRIZIONE"
 
@@ -1818,7 +1823,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2642
+#: lxc/storage_volume.go:2653
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1919,7 +1924,7 @@ msgstr "Il nome del container è: %s"
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1940,16 +1945,16 @@ msgstr ""
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
-#: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
+#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
+#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
-#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
-#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
+#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
+#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1972,8 +1977,8 @@ msgstr ""
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
 #: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1005 lxc/network.go:1106 lxc/network.go:1185
-#: lxc/network.go:1245 lxc/network.go:1341 lxc/network.go:1413
+#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
+#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
 #: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
 #: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
 #: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
@@ -2024,27 +2029,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
-#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
-#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
-#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1949
-#: lxc/storage_volume.go:2076 lxc/storage_volume.go:2234
-#: lxc/storage_volume.go:2355 lxc/storage_volume.go:2417
-#: lxc/storage_volume.go:2553 lxc/storage_volume.go:2636
-#: lxc/storage_volume.go:2802 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1454
+#: lxc/storage_volume.go:1465
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Il nome del container è: %s"
@@ -2057,11 +2062,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
+#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2195,7 +2200,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:516
+#: lxc/cluster.go:1072 lxc/config_trust.go:516
 #, fuzzy
 msgid "EXPIRES AT"
 msgstr "DATA DI SCADENZA"
@@ -2218,7 +2223,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:769 lxc/cluster.go:770
+#: lxc/cluster.go:770 lxc/cluster.go:771
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2239,7 +2244,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1226 lxc/config.go:1227
+#: lxc/config.go:1227 lxc/config.go:1228
 #, fuzzy
 msgid "Edit instance UEFI variables"
 msgstr "Creazione del container in corso"
@@ -2308,7 +2313,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2316,7 +2321,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2334,11 +2339,12 @@ msgid ""
 "new\n"
 "  LXD cluster, which will have the given name.\n"
 "\n"
-"  It's required that the LXD is already available on the network. You can "
-"check\n"
-"  that by running 'lxc config get core.https_address', and possibly set a "
-"value\n"
-"  for the address if not yet set."
+"  It's required that LXD is already available on the network. You can check\n"
+"  this by running 'lxc config get core.https_address'. If either an IP "
+"address\n"
+"  and port is displayed, or both, LXD is already available on the network. "
+"If\n"
+"  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
 #: lxc/network_zone.go:1427
@@ -2368,12 +2374,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
+#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2383,12 +2389,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
+#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
-#: lxc/storage_volume.go:2199
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
+#: lxc/storage_volume.go:2210
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2398,12 +2404,12 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1298 lxc/cluster.go:1299
+#: lxc/cluster.go:1299 lxc/cluster.go:1300
 #, fuzzy
 msgid "Evacuate cluster member"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:1396
+#: lxc/cluster.go:1397
 #, fuzzy, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "Il nome del container è: %s"
@@ -2431,8 +2437,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
-#: lxc/storage_volume.go:1564
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Expires at"
 msgstr ""
 
@@ -2456,7 +2462,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2635 lxc/storage_volume.go:2636
+#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2470,11 +2476,11 @@ msgstr "Creazione del container in corso"
 msgid "Export instances as backup tarballs."
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2639
+#: lxc/storage_volume.go:2650
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2768
+#: lxc/export.go:152 lxc/storage_volume.go:2779
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Creazione del container in corso"
@@ -2654,7 +2660,7 @@ msgstr "Accetta certificato"
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
+#: lxc/network.go:1046 lxc/network_acl.go:133 lxc/network_zone.go:124
 #: lxc/operation.go:137
 #, fuzzy
 msgid "Filtering isn't supported yet"
@@ -2665,7 +2671,7 @@ msgstr "'%s' non è un tipo di file supportato."
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1303
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2673,7 +2679,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1301
+#: lxc/cluster.go:1302
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2685,7 +2691,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1331
+#: lxc/cluster.go:1332
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2727,16 +2733,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
-#: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1614 lxc/warning.go:94
+#: lxc/storage_volume.go:1625 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2796,7 +2802,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:996
+#: lxc/config.go:996 lxc/config.go:997
 #, fuzzy
 msgid "Get UEFI variables for instance"
 msgstr "Creazione del container in corso"
@@ -2865,7 +2871,7 @@ msgstr "Il nome del container è: %s"
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1249
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2935,11 +2941,11 @@ msgstr "Il nome del container è: %s"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
+#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:475
+#: lxc/storage_volume.go:476
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2967,7 +2973,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1161
+#: lxc/network.go:1170
 msgid "HOSTNAME"
 msgstr ""
 
@@ -3022,7 +3028,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1163
+#: lxc/network.go:1172
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -3034,11 +3040,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1084
+#: lxc/list.go:560 lxc/network.go:1093
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1085
+#: lxc/list.go:561 lxc/network.go:1094
 msgid "IPV6"
 msgstr ""
 
@@ -3068,7 +3074,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2427
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3082,7 +3088,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2437
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3133,7 +3139,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2802
+#: lxc/storage_volume.go:2813
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3141,7 +3147,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2801
+#: lxc/storage_volume.go:2812
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -3164,11 +3170,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2809
+#: lxc/storage_volume.go:2820
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2883
+#: lxc/storage_volume.go:2894
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Creazione del container in corso"
@@ -3213,7 +3219,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr "Il nome del container è: %s"
 
-#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
+#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
 #, fuzzy
 msgid "Instance name must be specified"
 msgstr "Il nome del container è: %s"
@@ -3296,7 +3302,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2012
+#: lxc/move.go:148 lxc/storage_volume.go:2023
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "'/' non è permesso nel nome di uno snapshot"
@@ -3305,7 +3311,7 @@ msgstr "'/' non è permesso nel nome di uno snapshot"
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2019
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3324,9 +3330,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr "Proprietà errata: %s"
 
-#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
-#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2144 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
+#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Il nome del container è: %s"
@@ -3371,9 +3377,9 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
+#: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3385,8 +3391,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1020 lxc/cluster.go:1123
-#: lxc/cluster.go:1231 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
+#: lxc/cluster.go:1232 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3424,7 +3430,7 @@ msgstr "Architettura: %s"
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1105 lxc/network.go:1106
+#: lxc/network.go:1114 lxc/network.go:1115
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3438,7 +3444,7 @@ msgstr "Alias:"
 msgid "List all active certificate add tokens"
 msgstr "Il nome del container è: %s"
 
-#: lxc/cluster.go:976 lxc/cluster.go:977
+#: lxc/cluster.go:977 lxc/cluster.go:978
 #, fuzzy
 msgid "List all active cluster member join tokens"
 msgstr "Il nome del container è: %s"
@@ -3491,7 +3497,7 @@ msgstr "Creazione del container in corso"
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1004 lxc/network.go:1005
+#: lxc/network.go:1005 lxc/network.go:1006
 msgid "List available networks"
 msgstr ""
 
@@ -3582,7 +3588,7 @@ msgid ""
 "Fast column layout: nsacPt\n"
 "\n"
 "A single keyword like \"web\" which will list any instance with a name "
-"starting by \"web\".\n"
+"starting with \"web\".\n"
 "A regular expression on the instance name. (e.g. .*web.*01$).\n"
 "A key/value pair referring to a configuration item. For those, the\n"
 "namespace can be abbreviated to the smallest unambiguous identifier.\n"
@@ -3639,7 +3645,8 @@ msgid ""
 "  P - Profiles\n"
 "  s - State\n"
 "  S - Number of snapshots\n"
-"  t - Type (persistent or ephemeral)\n"
+"  t - Type (container or virtual-machine, ephemeral indicated if "
+"applicable)\n"
 "  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
@@ -3691,11 +3698,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1603
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1608
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3755,7 +3762,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1470
+#: lxc/info.go:489 lxc/storage_volume.go:1481
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3778,7 +3785,7 @@ msgstr "Creazione del container in corso"
 msgid "Lower devices"
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:1162
+#: lxc/network.go:1171
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3796,7 +3803,7 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1083
+#: lxc/network.go:1092
 msgid "MANAGED"
 msgstr ""
 
@@ -3924,7 +3931,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:955 lxc/config.go:956
+#: lxc/config.go:956 lxc/config.go:957
 #, fuzzy
 msgid "Manage instance UEFI variables"
 msgstr "Creazione del container in corso"
@@ -4078,7 +4085,7 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:957
+#: lxc/cluster.go:958
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
@@ -4144,7 +4151,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/cluster.go:811 lxc/cluster.go:1367 lxc/cluster_group.go:129
+#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 #, fuzzy
@@ -4216,8 +4223,8 @@ msgstr "Il nome del container è: %s"
 
 #: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1139 lxc/network.go:1217 lxc/network.go:1283
-#: lxc/network.go:1375 lxc/network_forward.go:127 lxc/network_forward.go:215
+#: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
+#: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
 #: lxc/network_forward.go:284 lxc/network_forward.go:445
 #: lxc/network_forward.go:530 lxc/network_forward.go:705
 #: lxc/network_forward.go:836 lxc/network_forward.go:929
@@ -4261,12 +4268,12 @@ msgstr "Il nome del container è: %s"
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
-#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
-#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1986
-#: lxc/storage_volume.go:2127 lxc/storage_volume.go:2285
-#: lxc/storage_volume.go:2476 lxc/storage_volume.go:2593
+#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
+#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
 msgid "Missing pool name"
 msgstr ""
 
@@ -4286,11 +4293,11 @@ msgstr "Il nome del container è: %s"
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:438 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1411
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Il nome del container è: %s"
@@ -4329,8 +4336,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
-#: lxc/storage_volume.go:964
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
+#: lxc/storage_volume.go:975
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4368,7 +4375,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4376,11 +4383,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1856
+#: lxc/storage_volume.go:1867
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:518
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4402,12 +4409,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
+#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
 msgid "NAME"
 msgstr ""
 
@@ -4435,7 +4442,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
 #: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4459,8 +4466,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
-#: lxc/storage_volume.go:1562
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1573
 msgid "Name"
 msgstr ""
 
@@ -4468,7 +4475,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4493,7 +4500,7 @@ msgstr ""
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1227
+#: lxc/network.go:1236
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4603,7 +4610,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1161
+#: lxc/cluster.go:1162
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4612,7 +4619,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
+#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4633,11 +4640,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr "Occorre specificare un nome di container come origine"
 
-#: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:502 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4651,7 +4658,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2035
 #, fuzzy
 msgid "Not a snapshot name"
 msgstr "'/' non è permesso nel nome di uno snapshot"
@@ -4660,15 +4667,16 @@ msgstr "'/' non è permesso nel nome di uno snapshot"
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:343
+#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
+#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2690
+#: lxc/storage_volume.go:2701
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2489
+#: lxc/storage_volume.go:2500
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4680,11 +4688,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1418
+#: lxc/storage_volume.go:1429
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1298
+#: lxc/network.go:735 lxc/network.go:1307
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4693,7 +4701,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1577
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4723,7 +4731,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1767
 msgid "POOL"
 msgstr ""
 
@@ -4739,7 +4747,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1773
 #: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4786,7 +4794,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 #, fuzzy
 msgid "Please provide cluster member name: "
 msgstr "Il nome del container è: %s"
@@ -4808,16 +4816,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
-#: lxc/storage_volume.go:1189
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
+#: lxc/storage_volume.go:1200
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4936,7 +4944,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1356
+#: lxc/storage_volume.go:1367
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4950,7 +4958,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1225
+#: lxc/storage_volume.go:1236
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4966,7 +4974,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2247
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4987,7 +4995,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1004
+#: lxc/storage_volume.go:1015
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4996,7 +5004,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2081
+#: lxc/storage_volume.go:2092
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5009,13 +5017,13 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2357
+#: lxc/storage_volume.go:2368
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
 "\n"
 "lxc storage volume unset default data size\n"
-"    Remotes the size/quota of a custom volume \"data\" in pool \"default\".\n"
+"    Removes the size/quota of a custom volume \"data\" in pool \"default\".\n"
 "\n"
 "lxc storage volume unset default virtual-machine/data snapshots.expiry\n"
 "    Removes the snapshot expiration period for a virtual machine \"data\" in "
@@ -5098,7 +5106,7 @@ msgstr "Creazione del container in corso"
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -5290,7 +5298,7 @@ msgstr "Creazione del container in corso"
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1184 lxc/network.go:1185
+#: lxc/network.go:1193 lxc/network.go:1194
 msgid "Rename networks"
 msgstr ""
 
@@ -5306,15 +5314,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1949
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:1959
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2037 lxc/storage_volume.go:2057
+#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5324,11 +5332,11 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:892 lxc/cluster.go:893
+#: lxc/cluster.go:893 lxc/cluster.go:894
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1032
+#: lxc/config.go:1033
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5352,7 +5360,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1328 lxc/cluster.go:1329
+#: lxc/cluster.go:1329 lxc/cluster.go:1330
 #, fuzzy
 msgid "Restore cluster member"
 msgstr "Il nome del container è: %s"
@@ -5369,11 +5377,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2552 lxc/storage_volume.go:2553
+#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1394
+#: lxc/cluster.go:1395
 #, fuzzy, c-format
 msgid "Restoring cluster member: %s"
 msgstr "Il nome del container è: %s"
@@ -5396,7 +5404,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr "Il nome del container è: %s"
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1087
 #, fuzzy
 msgid "Revoke cluster member join token"
 msgstr "Il nome del container è: %s"
@@ -5448,7 +5456,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1088
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1097
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5511,7 +5519,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1050 lxc/config.go:1051
+#: lxc/config.go:1051 lxc/config.go:1052
 #, fuzzy
 msgid "Set UEFI variables for instance"
 msgstr "Creazione del container in corso"
@@ -5577,11 +5585,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1244
+#: lxc/network.go:1253
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1245
+#: lxc/network.go:1254
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5702,11 +5710,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2075
+#: lxc/storage_volume.go:2086
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2076
+#: lxc/storage_volume.go:2087
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5764,7 +5772,7 @@ msgstr "Il nome del container è: %s"
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1252
+#: lxc/network.go:1261
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5795,7 +5803,7 @@ msgstr "Creazione del container in corso"
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2103
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5866,7 +5874,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1173
+#: lxc/config.go:1173 lxc/config.go:1174
 #, fuzzy
 msgid "Show instance UEFI variables"
 msgstr "errore di processamento degli alias %s\n"
@@ -5900,7 +5908,7 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr "Il nome del container è: %s"
 
-#: lxc/network.go:1340 lxc/network.go:1341
+#: lxc/network.go:1349 lxc/network.go:1350
 msgid "Show network configurations"
 msgstr ""
 
@@ -5955,11 +5963,11 @@ msgstr "Il nome del container è: %s"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2233 lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5982,8 +5990,9 @@ msgid "Show the expanded configuration"
 msgstr ""
 
 #: lxc/info.go:43
-msgid "Show the instance's last 100 log lines?"
-msgstr ""
+#, fuzzy
+msgid "Show the instance's last 100 log lines"
+msgstr "Creazione del container in corso"
 
 #: lxc/info.go:44
 msgid "Show the resources available to the server"
@@ -6028,15 +6037,15 @@ msgstr "Aggiornamento automatico: %s"
 msgid "Size: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2417
+#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2179
+#: lxc/storage_volume.go:2190
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1502
 msgid "Snapshots:"
 msgstr ""
 
@@ -6143,21 +6152,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:702
+#: lxc/storage_volume.go:703
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:790
+#: lxc/storage_volume.go:791
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:516
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:520
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -6166,7 +6175,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -6215,18 +6224,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1070 lxc/config_trust.go:515
+#: lxc/cluster.go:1071 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1736 lxc/warning.go:216
+#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1747 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
 #, fuzzy
 msgid "Taken at"
 msgstr "salvato alle %s"
@@ -6385,12 +6394,12 @@ msgstr "Il nome del container è: %s"
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1340
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "Il nome del container è: %s"
 
-#: lxc/storage_volume.go:1306
+#: lxc/storage_volume.go:1317
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6409,8 +6418,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
-#: lxc/storage_volume.go:978
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:989
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6431,11 +6440,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr "Il nome del container è: %s"
 
-#: lxc/cluster.go:739
+#: lxc/cluster.go:740
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:729
+#: lxc/cluster.go:730
 #, fuzzy
 msgid "This LXD server is not available on the network"
 msgstr "Import da directory non disponibile su questa piattaforma"
@@ -6487,7 +6496,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1487
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Aggiornamento automatico: %s"
@@ -6502,7 +6511,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1853
+#: lxc/storage_volume.go:1864
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6510,7 +6519,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:394
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6570,7 +6579,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1472
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6592,13 +6601,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:995 lxc/storage_volume.go:1752
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
+#: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1740
+#: lxc/storage.go:724 lxc/storage_volume.go:1751
 msgid "USED BY"
 msgstr ""
 
@@ -6631,7 +6640,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6657,7 +6666,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1141 lxc/config.go:1142
+#: lxc/config.go:1142 lxc/config.go:1143
 #, fuzzy
 msgid "Unset UEFI variables for instance"
 msgstr "non tutti i profili dell'origine esistono nella destinazione"
@@ -6688,7 +6697,7 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1412 lxc/network.go:1413
+#: lxc/network.go:1421 lxc/network.go:1422
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -6746,7 +6755,7 @@ msgstr "Il nome del container è: %s"
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2354 lxc/storage_volume.go:2355
+#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6771,7 +6780,7 @@ msgstr "Il nome del container è: %s"
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1417
+#: lxc/network.go:1426
 msgid "Unset the key as a network property"
 msgstr ""
 
@@ -6802,7 +6811,7 @@ msgstr "Il nome del container è: %s"
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2379
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6810,7 +6819,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:247
+#: lxc/storage_volume.go:248
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6823,12 +6832,12 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1174
+#: lxc/cluster.go:1175
 #, fuzzy
 msgid "Update cluster certificate"
 msgstr "Accetta certificato"
 
-#: lxc/cluster.go:1176
+#: lxc/cluster.go:1177
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6848,12 +6857,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1485
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2641
+#: lxc/export.go:42 lxc/storage_volume.go:2652
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6920,7 +6929,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1576
 msgid "Volume Only"
 msgstr ""
 
@@ -6953,7 +6962,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
 #: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6982,20 +6991,20 @@ msgstr "Occorre specificare un nome di container come origine"
 msgid "You need to specify an image name or use --empty"
 msgstr "Occorre specificare un nome di container come origine"
 
-#: lxc/storage_volume.go:903
+#: lxc/storage_volume.go:909
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:281
+#: lxc/storage_volume.go:282
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "Creazione del container in corso"
 
 #: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
-#: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
+#: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 #, fuzzy
@@ -7007,7 +7016,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:1172
+#: lxc/cluster.go:1173
 #, fuzzy
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr "Creazione del container in corso"
@@ -7205,7 +7214,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 #, fuzzy
@@ -7232,12 +7241,12 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/config.go:994 lxc/config.go:1140
+#: lxc/config.go:995 lxc/config.go:1141
 #, fuzzy
 msgid "[<remote>:]<instance> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/config.go:1049
+#: lxc/config.go:1050
 #, fuzzy
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr "Creazione del container in corso"
@@ -7334,8 +7343,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:768
-#: lxc/cluster.go:1085 lxc/cluster.go:1297 lxc/cluster.go:1327
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
+#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
 #, fuzzy
 msgid "[<remote>:]<member>"
 msgstr "Creazione del container in corso"
@@ -7365,8 +7374,8 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1104
-#: lxc/network.go:1339 lxc/network_forward.go:87
+#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1113
+#: lxc/network.go:1348 lxc/network_forward.go:87
 #: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
 #, fuzzy
 msgid "[<remote>:]<network>"
@@ -7382,12 +7391,12 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:791 lxc/network.go:1411
+#: lxc/network.go:791 lxc/network.go:1420
 #, fuzzy
 msgid "[<remote>:]<network> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:1243
+#: lxc/network.go:1252
 #, fuzzy
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr "Creazione del container in corso"
@@ -7440,7 +7449,7 @@ msgstr ""
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/network.go:1182
+#: lxc/network.go:1191
 #, fuzzy
 msgid "[<remote>:]<network> <new-name>"
 msgstr "Creazione del container in corso"
@@ -7503,7 +7512,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<pool>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2800
+#: lxc/storage_volume.go:2811
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "Creazione del container in corso"
@@ -7546,14 +7555,14 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:1958
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:806
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr "Creazione del container in corso"
@@ -7563,62 +7572,62 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2551
+#: lxc/storage_volume.go:2562
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2634
+#: lxc/storage_volume.go:2645
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2415
+#: lxc/storage_volume.go:2426
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:609
+#: lxc/storage_volume.go:610
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:718
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2353
+#: lxc/storage_volume.go:2364
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2085
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2232
+#: lxc/storage_volume.go:2243
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1221
+#: lxc/storage_volume.go:1232
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1858
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:387
+#: lxc/storage_volume.go:388
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr "Creazione del container in corso"
@@ -7750,7 +7759,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1601
 #, fuzzy
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr "Creazione del container in corso"
@@ -7765,7 +7774,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:891
+#: lxc/cluster.go:892
 #, fuzzy
 msgid "[[<remote>:]<member>]"
 msgstr "Creazione del container in corso"
@@ -7838,7 +7847,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:772
+#: lxc/cluster.go:773
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7887,13 +7896,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1229
+#: lxc/config.go:1230
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1053
+#: lxc/config.go:1054
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -8230,7 +8239,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:614
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -8238,13 +8247,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2804
+#: lxc/storage_volume.go:2815
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2419
+#: lxc/storage_volume.go:2430
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -8312,6 +8321,9 @@ msgstr ""
 #: lxc/image.go:1206
 msgid "yes"
 msgstr "si"
+
+#~ msgid "Action (defaults to GET)"
+#~ msgstr "Azione (default a GET)"
 
 #, fuzzy, c-format
 #~ msgid "Failed to create certificate: %w"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-09 03:18-0300\n"
+"POT-Creation-Date: 2024-12-18 08:40-0700\n"
 "PO-Revision-Date: 2023-03-10 15:14+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -71,7 +71,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:1030
+#: lxc/storage_volume.go:1041
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -95,7 +95,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/config.go:1240
+#: lxc/config.go:1241
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -644,7 +644,7 @@ msgstr ""
 "###\n"
 "### Note that the name is shown but cannot be changed"
 
-#: lxc/cluster.go:790
+#: lxc/cluster.go:791
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -821,14 +821,14 @@ msgstr "拡張した設定を表示する"
 msgid "Acknowledge warning"
 msgstr "警告を確認します"
 
+#: lxc/query.go:43
+msgid "Action"
+msgstr ""
+
 #: lxc/query.go:76
 #, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr "%q はこのツールではサポートされていません"
-
-#: lxc/query.go:43
-msgid "Action (defaults to GET)"
-msgstr "使用するHTTPのメソッド (デフォルト: GET)"
 
 #: lxc/cluster_group.go:725
 #, fuzzy
@@ -995,7 +995,7 @@ msgstr "エイリアス %s は既に存在します"
 msgid "Aliases:"
 msgstr "エイリアス:"
 
-#: lxc/storage_volume.go:1596
+#: lxc/storage_volume.go:1607
 msgid "All projects"
 msgstr "すべてのプロジェクト"
 
@@ -1017,7 +1017,7 @@ msgstr "アーキテクチャ: %s"
 msgid "Architecture: %v"
 msgstr "アーキテクチャ: %v"
 
-#: lxc/cluster.go:1371
+#: lxc/cluster.go:1372
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -1055,7 +1055,7 @@ msgstr "新たなネットワークインターフェースをインスタンス
 msgid "Attach new storage volumes to instances"
 msgstr "新たにストレージボリュームをインスタンスに追加します"
 
-#: lxc/storage_volume.go:282 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
 msgid "Attach new storage volumes to profiles"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
 
@@ -1111,16 +1111,16 @@ msgstr "BASE IMAGE"
 msgid "Backing up instance: %s"
 msgstr "インスタンスのバックアップ中: %s"
 
-#: lxc/storage_volume.go:2708
+#: lxc/storage_volume.go:2719
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr "ストレージボリュームのバックアップ中: %s"
 
-#: lxc/export.go:192 lxc/storage_volume.go:2785
+#: lxc/export.go:192 lxc/storage_volume.go:2796
 msgid "Backup exported successfully!"
 msgstr "バックアップのエクスポートが成功しました!"
 
-#: lxc/info.go:666 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1538
 msgid "Backups:"
 msgstr "バックアップ:"
 
@@ -1143,7 +1143,7 @@ msgstr "不適切なキー/値のペア: %s"
 msgid "Bad key=value pair: %q"
 msgstr "不適切な キー=値 のペア: %s"
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr "不適切な キー=値 のペア: %s"
@@ -1186,7 +1186,7 @@ msgstr "CANCELABLE"
 msgid "COMMON NAME"
 msgstr "COMMON NAME"
 
-#: lxc/storage_volume.go:1739
+#: lxc/storage_volume.go:1750
 msgid "CONTENT-TYPE"
 msgstr "CONTENT-TYPE"
 
@@ -1272,7 +1272,7 @@ msgstr "--project と --all-project は同時に指定できません"
 msgid "Can't specify a different remote for rename"
 msgstr "リネームの場合は異なるリモートを指定できません"
 
-#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr "クラスタでない場合はカラムとして L は指定できません"
 
@@ -1280,7 +1280,7 @@ msgstr "クラスタでない場合はカラムとして L は指定できませ
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "再帰 (recursive) モードでは uid/gid/mode を指定できません"
 
-#: lxc/config.go:702 lxc/config.go:1097
+#: lxc/config.go:702 lxc/config.go:1098
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr "キー '%s' が設定されていないので削除できません"
@@ -1289,14 +1289,14 @@ msgstr "キー '%s' が設定されていないので削除できません"
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:492
+#: lxc/storage_volume.go:493
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 "コピー先のサーバーがクラスターに属していない場合は --destination-target は指"
 "定できません"
 
-#: lxc/storage_volume.go:446
+#: lxc/storage_volume.go:447
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 "コピー元のサーバーがクラスターに属していない場合は --target は指定できません"
@@ -1375,7 +1375,7 @@ msgstr "クラスターグループ %s は現在 %s に適用されていませ�
 msgid "Cluster group %s renamed to %s"
 msgstr "クラスタグループ名 %s を %s に変更しました"
 
-#: lxc/cluster.go:1154
+#: lxc/cluster.go:1155
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr "%s:%s のクラスターに join するためのトークンが削除されました"
@@ -1403,8 +1403,8 @@ msgstr "クラスターメンバー %s がグループ %s から削除されま�
 #: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
 #: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
-#: lxc/network_forward.go:182 lxc/network_forward.go:264
+#: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
+#: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
 #: lxc/network_forward.go:497 lxc/network_forward.go:649
 #: lxc/network_forward.go:803 lxc/network_forward.go:892
 #: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
@@ -1419,30 +1419,30 @@ msgstr "クラスターメンバー %s がグループ %s から削除されま�
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
-#: lxc/storage_volume.go:1952 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2251 lxc/storage_volume.go:2367
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2555
-#: lxc/storage_volume.go:2643 lxc/storage_volume.go:2807
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
+#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
+#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
 msgid "Cluster member name"
 msgstr "クラスタメンバ名"
 
-#: lxc/cluster.go:894
+#: lxc/cluster.go:895
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:926
+#: lxc/cluster.go:927
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:756
+#: lxc/cluster.go:757
 msgid "Clustering enabled"
 msgstr "クラスタリングが有効になりました"
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr "カラムレイアウト"
@@ -1483,24 +1483,24 @@ msgstr "新しいプロジェクトに適用するキー/値の設定"
 msgid "Config key/value to apply to the target instance"
 msgstr "移動先のインスタンスに適用するキー/値の設定"
 
-#: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
+#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
-#: lxc/storage_volume.go:1188
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
+#: lxc/storage_volume.go:1199
 #, c-format
 msgid "Config parsing error: %s"
 msgstr "設定の構文エラー: %s"
 
-#: lxc/storage_volume.go:619
+#: lxc/storage_volume.go:620
 msgid "Content type, block or filesystem"
 msgstr "ストレージボリュームのタイプ、block もしくは filesystem"
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Content type: %s"
 msgstr "コンテンツタイプ: %s"
@@ -1510,7 +1510,12 @@ msgstr "コンテンツタイプ: %s"
 msgid "Control: %s (%s)"
 msgstr "コントロール: %s (%s)"
 
-#: lxc/copy.go:60 lxc/move.go:65
+#: lxc/move.go:65
+#, fuzzy
+msgid "Copy a stateful instance as stateless"
+msgstr "ステートフルなインスタンスをステートレスにコピーします"
+
+#: lxc/copy.go:60
 msgid "Copy a stateful instance stateless"
 msgstr "ステートフルなインスタンスをステートレスにコピーします"
 
@@ -1573,7 +1578,7 @@ msgstr "プロファイルに継承されたデバイスをコピーし、設定
 msgid "Copy profiles"
 msgstr "プロファイルをコピーします"
 
-#: lxc/storage_volume.go:389 lxc/storage_volume.go:390
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
 msgid "Copy storage volumes"
 msgstr "ストレージボリュームをコピーします"
 
@@ -1581,12 +1586,12 @@ msgstr "ストレージボリュームをコピーします"
 msgid "Copy the instance without its snapshots"
 msgstr "インスタンスをコピーします。スナップショットはコピーしません"
 
-#: lxc/storage_volume.go:396
+#: lxc/storage_volume.go:397
 msgid "Copy the volume without its snapshots"
 msgstr "ボリュームをコピーします (スナップショットはコピーしません)"
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:398
 msgid "Copy to a project different from the source"
 msgstr "コピー／移動元とは異なるプロジェクトにコピーします"
 
@@ -1599,7 +1604,7 @@ msgstr "仮想マシンイメージをコピーします"
 msgid "Copying the image: %s"
 msgstr "イメージのコピー中: %s"
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:515
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr "ストレージボリュームのコピー中: %s"
@@ -1622,12 +1627,12 @@ msgstr "サーバ証明書ファイル %q をクローズできません: %w"
 msgid "Could not create server cert dir"
 msgstr "サーバ証明書格納用のディレクトリを作成できません"
 
-#: lxc/cluster.go:1235
+#: lxc/cluster.go:1236
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr "証明書のファイルパスが見つかりません: %s"
 
-#: lxc/cluster.go:1239
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr "証明書の鍵のパスが見つかりません: %s"
@@ -1642,17 +1647,17 @@ msgstr "設定の構文エラー: %s"
 msgid "Could not parse identity: %s"
 msgstr "設定キーを設定できません: %s"
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr "証明書ファイル %s をエラーで読み込めません: %v"
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr "秘密鍵ファイル %s をエラーで読み込めません: %v"
 
-#: lxc/cluster.go:1266
+#: lxc/cluster.go:1267
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr "リモート '%s' に対する新しいリモート証明書がエラーで書き込めません: %v"
@@ -1743,7 +1748,7 @@ msgstr "ストレージバケットに対する鍵を作成します"
 msgid "Create new custom storage buckets"
 msgstr "新たにカスタムストレージバケットを作成します"
 
-#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
 msgid "Create new custom storage volumes"
 msgstr "新たにカスタムストレージボリュームを作成します"
 
@@ -1795,7 +1800,7 @@ msgstr "ストレージプールを作成します"
 msgid "Create the instance with no profiles applied"
 msgstr "プロファイルを適用しないインスタンスを作成します"
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
 #, c-format
 msgid "Created: %s"
 msgstr "作成日時: %s"
@@ -1824,13 +1829,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr "DEFAULT TARGET ADDRESS"
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1738
+#: lxc/storage_volume.go:1749
 msgid "DESCRIPTION"
 msgstr "DESCRIPTION"
 
@@ -1850,7 +1855,7 @@ msgstr "DRM:"
 msgid "Default VLAN ID"
 msgstr "デフォルト VLAN ID"
 
-#: lxc/storage_volume.go:2642
+#: lxc/storage_volume.go:2653
 msgid "Define a compression algorithm: for backup or none"
 msgstr "圧縮アルゴリズムを指定します: backup or none"
 
@@ -1949,7 +1954,7 @@ msgstr "ストレージバケットを削除します"
 msgid "Delete storage pools"
 msgstr "ストレージプールを削除します"
 
-#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
 msgid "Delete storage volumes"
 msgstr "ストレージボリュームを削除します"
 
@@ -1970,16 +1975,16 @@ msgstr "警告を削除します"
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
-#: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
+#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
+#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
-#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
-#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
+#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
+#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -2002,8 +2007,8 @@ msgstr "警告を削除します"
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
 #: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1005 lxc/network.go:1106 lxc/network.go:1185
-#: lxc/network.go:1245 lxc/network.go:1341 lxc/network.go:1413
+#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
+#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
 #: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
 #: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
 #: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
@@ -2054,27 +2059,27 @@ msgstr "警告を削除します"
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
-#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
-#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
-#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1949
-#: lxc/storage_volume.go:2076 lxc/storage_volume.go:2234
-#: lxc/storage_volume.go:2355 lxc/storage_volume.go:2417
-#: lxc/storage_volume.go:2553 lxc/storage_volume.go:2636
-#: lxc/storage_volume.go:2802 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr "説明"
 
-#: lxc/storage_volume.go:1454
+#: lxc/storage_volume.go:1465
 #, c-format
 msgid "Description: %s"
 msgstr "説明: %s"
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
 msgid "Destination cluster member name"
 msgstr "コピー先のクラスターメンバー名"
 
@@ -2086,11 +2091,11 @@ msgstr "インスタンスからネットワークインターフェースを取
 msgid "Detach network interfaces from profiles"
 msgstr "プロファイルからネットワークインターフェースを取り外します"
 
-#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
 msgid "Detach storage volumes from instances"
 msgstr "インスタンスからストレージボリュームを取り外します"
 
-#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
+#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
 msgid "Detach storage volumes from profiles"
 msgstr "プロファイルからストレージボリュームを取り外します"
 
@@ -2226,7 +2231,7 @@ msgstr "ENTRIES"
 msgid "EPHEMERAL"
 msgstr "EPHEMERAL"
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:516
+#: lxc/cluster.go:1072 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr "EXPIRES AT"
 
@@ -2251,7 +2256,7 @@ msgstr "クラスタグループを編集します"
 msgid "Edit an identity as YAML"
 msgstr "ストレージバケットの設定をYAMLで編集します"
 
-#: lxc/cluster.go:769 lxc/cluster.go:770
+#: lxc/cluster.go:770 lxc/cluster.go:771
 msgid "Edit cluster member configurations as YAML"
 msgstr "クラスターメンバーの設定をYAMLファイルで編集します"
 
@@ -2273,7 +2278,7 @@ msgstr "プロファイル設定をYAMLで編集します"
 msgid "Edit image properties"
 msgstr "イメージのプロパティを編集します"
 
-#: lxc/config.go:1226 lxc/config.go:1227
+#: lxc/config.go:1227 lxc/config.go:1228
 #, fuzzy
 msgid "Edit instance UEFI variables"
 msgstr "インスタンスのメタデータファイルを編集します"
@@ -2338,7 +2343,7 @@ msgstr "ストレージバケットの設定をYAMLで編集します"
 msgid "Edit storage pool configurations as YAML"
 msgstr "ストレージプールの設定をYAMLで編集します"
 
-#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
 msgid "Edit storage volume configurations as YAML"
 msgstr "ストレージボリュームの設定をYAMLで編集します"
 
@@ -2346,7 +2351,7 @@ msgstr "ストレージボリュームの設定をYAMLで編集します"
 msgid "Edit trust configurations as YAML"
 msgstr "信頼済みクライアント設定をYAMLで編集します"
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2359,6 +2364,7 @@ msgstr ""
 "クラスタリングで動作していないLXDサーバ上でクラスタリングを有効にします"
 
 #: lxc/cluster.go:677
+#, fuzzy
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2366,11 +2372,12 @@ msgid ""
 "new\n"
 "  LXD cluster, which will have the given name.\n"
 "\n"
-"  It's required that the LXD is already available on the network. You can "
-"check\n"
-"  that by running 'lxc config get core.https_address', and possibly set a "
-"value\n"
-"  for the address if not yet set."
+"  It's required that LXD is already available on the network. You can check\n"
+"  this by running 'lxc config get core.https_address'. If either an IP "
+"address\n"
+"  and port is displayed, or both, LXD is already available on the network. "
+"If\n"
+"  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 "クラスタリングで動作していない単一動作のLXDインスタンス上でクラスタリングを有"
 "効にします\n"
@@ -2409,12 +2416,12 @@ msgstr "イメージの取得中: %s"
 msgid "Error retrieving aliases: %w"
 msgstr "イメージの取得中: %s"
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
+#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "イメージの取得中: %s"
@@ -2424,12 +2431,12 @@ msgstr "イメージの取得中: %s"
 msgid "Error unsetting properties: %v"
 msgstr "イメージのプロパティを削除します"
 
-#: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
+#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
-#: lxc/storage_volume.go:2199
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
+#: lxc/storage_volume.go:2210
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2439,11 +2446,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr "テンプレートファイル更新のエラー: %s"
 
-#: lxc/cluster.go:1298 lxc/cluster.go:1299
+#: lxc/cluster.go:1299 lxc/cluster.go:1300
 msgid "Evacuate cluster member"
 msgstr "クラスターのメンバーを待避させます"
 
-#: lxc/cluster.go:1396
+#: lxc/cluster.go:1397
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "クラスターメンバーを待避させています: %s"
@@ -2482,8 +2489,8 @@ msgstr ""
 "デフォルトのモードは non-interactive です。もし標準入出力が両方ともターミナル"
 "の場合は interactive モードが選択されます (標準エラー出力は無視されます)。"
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
-#: lxc/storage_volume.go:1564
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Expires at"
 msgstr "失効日時"
 
@@ -2510,7 +2517,7 @@ msgstr ""
 "\n"
 "出力先はオプショナルで、デフォルトは現在のディレクトリです。"
 
-#: lxc/storage_volume.go:2635 lxc/storage_volume.go:2636
+#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
 msgid "Export custom storage volume"
 msgstr "カスタムストレージボリュームをエクスポートします"
 
@@ -2522,12 +2529,12 @@ msgstr "インスタンスのバックアップをエクスポートします"
 msgid "Export instances as backup tarballs."
 msgstr "インスタンスを tarball 形式のバックアップとしてエクスポートします。"
 
-#: lxc/storage_volume.go:2639
+#: lxc/storage_volume.go:2650
 msgid "Export the volume without its snapshots"
 msgstr ""
 "ボリュームをエクスポートします (スナップショットはエクスポートしません)"
 
-#: lxc/export.go:152 lxc/storage_volume.go:2768
+#: lxc/export.go:152 lxc/storage_volume.go:2779
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr "バックアップのエクスポート中: %s"
@@ -2707,7 +2714,7 @@ msgstr "サーバー証明書 %q の書き込みに失敗しました: %w"
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr "Fast モード (--columns=nsacPt と同じ)"
 
-#: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
+#: lxc/network.go:1046 lxc/network_acl.go:133 lxc/network_zone.go:124
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr "情報表示のフィルタリングはまだサポートされていません"
@@ -2717,7 +2724,7 @@ msgstr "情報表示のフィルタリングはまだサポートされていま
 msgid "Fingerprint: %s"
 msgstr "証明書のフィンガープリント: %s"
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1303
 msgid "Force a particular evacuation action"
 msgstr "特定の待避アクションを強制します"
 
@@ -2725,7 +2732,7 @@ msgstr "特定の待避アクションを強制します"
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1301
+#: lxc/cluster.go:1302
 msgid "Force evacuation without user confirmation"
 msgstr "ユーザーの確認なしで強制的に待避させます"
 
@@ -2737,7 +2744,7 @@ msgstr "強制的に擬似端末を割り当てます"
 msgid "Force removing a member, even if degraded"
 msgstr "degraded 状態であっても強制的にメンバを削除します"
 
-#: lxc/cluster.go:1331
+#: lxc/cluster.go:1332
 #, fuzzy
 msgid "Force restoration without user confirmation"
 msgstr "ユーザーの確認なしで強制的に待避させます"
@@ -2794,16 +2801,16 @@ msgstr ""
 "本当に強制的に %s を削除してもよろしいですか? (yes/no): "
 
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
-#: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1614 lxc/warning.go:94
+#: lxc/storage_volume.go:1625 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr "フォーマット (csv|json|table|yaml|compact)"
 
@@ -2863,7 +2870,7 @@ msgstr "すべてのコマンドに対する man ページを作成します"
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "クライアント証明書を生成します。1分ぐらいかかります..."
 
-#: lxc/config.go:995 lxc/config.go:996
+#: lxc/config.go:996 lxc/config.go:997
 #, fuzzy
 msgid "Get UEFI variables for instance"
 msgstr "インスタンスからファイルをマウントします"
@@ -2936,7 +2943,7 @@ msgstr "ストレージバケットに対する鍵を作成します"
 msgid "Get the key as a storage property"
 msgstr "ストレージバケットに対する鍵を作成します"
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1249
 #, fuzzy
 msgid "Get the key as a storage volume property"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
@@ -3001,11 +3008,11 @@ msgstr "ストレージバケットの設定値を取得します"
 msgid "Get values for storage pool configuration keys"
 msgstr "ストレージプールの設定値を取得します"
 
-#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
+#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
 msgid "Get values for storage volume configuration keys"
 msgstr "ストレージボリュームの設定値を取得します"
 
-#: lxc/storage_volume.go:475
+#: lxc/storage_volume.go:476
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr "指定したコピー先 %q がコピー元のボリュームの場所 %q と一致しません"
@@ -3034,7 +3041,7 @@ msgstr "コマンドを実行する際のグループ ID (GID) (デフォルト 
 msgid "HARDWARE ADDRESS"
 msgstr "MAC ADDRESS"
 
-#: lxc/network.go:1161
+#: lxc/network.go:1170
 msgid "HOSTNAME"
 msgstr "HOSTNAME"
 
@@ -3088,7 +3095,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr "IMAGES"
 
-#: lxc/network.go:1163
+#: lxc/network.go:1172
 msgid "IP ADDRESS"
 msgstr "IP ADDRESS"
 
@@ -3100,11 +3107,11 @@ msgstr "IP アドレス"
 msgid "IP addresses:"
 msgstr "IP アドレス:"
 
-#: lxc/list.go:560 lxc/network.go:1084
+#: lxc/list.go:560 lxc/network.go:1093
 msgid "IPV4"
 msgstr "IPV4"
 
-#: lxc/list.go:561 lxc/network.go:1085
+#: lxc/list.go:561 lxc/network.go:1094
 msgid "IPV6"
 msgstr "IPV6"
 
@@ -3137,7 +3144,7 @@ msgstr ""
 "存在するスナップショット名の場合は既存のスナップショットを削除したあとに新し"
 "いスナップショットを作成します"
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2427
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 "存在するスナップショット名の場合は既存のスナップショットを削除したあとに新し"
@@ -3153,7 +3160,7 @@ msgstr "初めてこのマシンで LXD を使う場合、lxd init と実行す�
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr "設定されている自動でのインスタンスの有効期限設定を無視します"
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2437
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr "設定されている自動でのストレージボリュームの有効期限設定を無視します"
 
@@ -3203,7 +3210,7 @@ msgstr "イメージの更新が成功しました!"
 msgid "Immediately attach to the console"
 msgstr "起動直後にインスタンスのコンソールに接続します"
 
-#: lxc/storage_volume.go:2802
+#: lxc/storage_volume.go:2813
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 "カスタムボリュームのバックアップをスナップショットを含んだ状態でインポートし"
@@ -3214,7 +3221,7 @@ msgid "Import backups of instances including their snapshots."
 msgstr ""
 "インスタンスのバックアップをスナップショットを含んだ状態でインポートします。"
 
-#: lxc/storage_volume.go:2801
+#: lxc/storage_volume.go:2812
 msgid "Import custom storage volumes"
 msgstr "新たにカスタムストレージボリュームをインポートします"
 
@@ -3241,11 +3248,11 @@ msgstr "イメージをイメージストアにインポートします"
 msgid "Import instance backups"
 msgstr "インスタンスのバックアップをインポートします"
 
-#: lxc/storage_volume.go:2809
+#: lxc/storage_volume.go:2820
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2883
+#: lxc/storage_volume.go:2894
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr "カスタムボリュームのインポート中: %s"
@@ -3289,7 +3296,7 @@ msgstr "インスタンス名を指定する必要があります"
 msgid "Instance name is: %s"
 msgstr "インスタンス名: %s"
 
-#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
+#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
 #, fuzzy
 msgid "Instance name must be specified"
 msgstr "インスタンス名: %s"
@@ -3376,7 +3383,7 @@ msgid ""
 msgstr ""
 "'%s' は不正な名前です。空文字列は maxWidth を指定しているときのみ指定できます"
 
-#: lxc/move.go:148 lxc/storage_volume.go:2012
+#: lxc/move.go:148 lxc/storage_volume.go:2023
 msgid "Invalid new snapshot name"
 msgstr "不適切な新しいスナップショット名"
 
@@ -3386,7 +3393,7 @@ msgstr ""
 "新しいスナップショット名が不正です。親のスナップショット名はソースと同じでな"
 "ければいけません"
 
-#: lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2019
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 "新しいスナップショット名が不正です。親のボリュームはソースと同じでなければな"
@@ -3406,9 +3413,9 @@ msgstr "不正なパス %s"
 msgid "Invalid protocol: %s"
 msgstr "不正なプロトコル: %s"
 
-#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
-#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2144 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
+#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
 msgid "Invalid snapshot name"
 msgstr "不正なスナップショット名"
 
@@ -3452,9 +3459,9 @@ msgstr "LIMIT"
 msgid "LISTEN ADDRESS"
 msgstr "LISTEN ADDRESS"
 
-#: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
+#: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
 msgid "LOCATION"
 msgstr "LOCATION"
 
@@ -3468,8 +3475,8 @@ msgstr ""
 "LXD は spicy か remote-viewer がインストールされている場合は自動的にどちらか"
 "を使います。"
 
-#: lxc/cluster.go:167 lxc/cluster.go:1020 lxc/cluster.go:1123
-#: lxc/cluster.go:1231 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
+#: lxc/cluster.go:1232 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr "LXD サーバはクラスタの一部ではありません"
 
@@ -3507,7 +3514,7 @@ msgstr "リンクを検出: %v"
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr "リンクスピード: %dMbit/s (%s duplex)"
 
-#: lxc/network.go:1105 lxc/network.go:1106
+#: lxc/network.go:1114 lxc/network.go:1115
 msgid "List DHCP leases"
 msgstr "DHCP のリースを一覧表示します"
 
@@ -3519,7 +3526,7 @@ msgstr "エイリアスを一覧表示します"
 msgid "List all active certificate add tokens"
 msgstr "有効な証明書追加トークンをすべて一覧表示します"
 
-#: lxc/cluster.go:976 lxc/cluster.go:977
+#: lxc/cluster.go:977 lxc/cluster.go:978
 msgid "List all active cluster member join tokens"
 msgstr "有効なクラスターへの join トークンをすべて一覧表示します"
 
@@ -3567,7 +3574,7 @@ msgstr "利用可能なネットワークゾーンレコードを一覧表示し
 msgid "List available network zoneS"
 msgstr "利用可能なネットワークゾーンを一覧表示します"
 
-#: lxc/network.go:1004 lxc/network.go:1005
+#: lxc/network.go:1005 lxc/network.go:1006
 msgid "List available networks"
 msgstr "利用可能なネットワークを一覧表示します"
 
@@ -3678,7 +3685,7 @@ msgid "List instances"
 msgstr "インスタンスを一覧表示します"
 
 #: lxc/list.go:49
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "List instances\n"
 "\n"
@@ -3686,7 +3693,7 @@ msgid ""
 "Fast column layout: nsacPt\n"
 "\n"
 "A single keyword like \"web\" which will list any instance with a name "
-"starting by \"web\".\n"
+"starting with \"web\".\n"
 "A regular expression on the instance name. (e.g. .*web.*01$).\n"
 "A key/value pair referring to a configuration item. For those, the\n"
 "namespace can be abbreviated to the smallest unambiguous identifier.\n"
@@ -3743,7 +3750,8 @@ msgid ""
 "  P - Profiles\n"
 "  s - State\n"
 "  S - Number of snapshots\n"
-"  t - Type (persistent or ephemeral)\n"
+"  t - Type (container or virtual-machine, ephemeral indicated if "
+"applicable)\n"
 "  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
@@ -3872,11 +3880,11 @@ msgstr "ストレージバケットの鍵を一覧表示します"
 msgid "List storage buckets"
 msgstr "ストレージバケットを一覧表示します"
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1603
 msgid "List storage volumes"
 msgstr "ストレージボリュームを一覧表示します"
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1608
 #, fuzzy
 msgid ""
 "List storage volumes\n"
@@ -3968,7 +3976,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr "バックグラウンド操作の一覧表示、表示、削除を行います"
 
-#: lxc/info.go:489 lxc/storage_volume.go:1470
+#: lxc/info.go:489 lxc/storage_volume.go:1481
 #, c-format
 msgid "Location: %s"
 msgstr "ロケーション: %s"
@@ -3989,7 +3997,7 @@ msgstr "Lower device"
 msgid "Lower devices"
 msgstr "Lower devices"
 
-#: lxc/network.go:1162
+#: lxc/network.go:1171
 msgid "MAC ADDRESS"
 msgstr "MAC ADDRESS"
 
@@ -4007,7 +4015,7 @@ msgstr "MAC アドレス: %s"
 msgid "MAD: %s (%s)"
 msgstr "MAD: %s (%s)"
 
-#: lxc/network.go:1083
+#: lxc/network.go:1092
 msgid "MANAGED"
 msgstr "MANAGED"
 
@@ -4146,7 +4154,7 @@ msgstr ""
 "イメージは全ハッシュ文字列、一意に定まるハッシュの短縮表現、(設定され\n"
 "ている場合は) エイリアスで参照できます。"
 
-#: lxc/config.go:955 lxc/config.go:956
+#: lxc/config.go:956 lxc/config.go:957
 #, fuzzy
 msgid "Manage instance UEFI variables"
 msgstr "インスタンスのメタデータファイルを管理します"
@@ -4292,7 +4300,7 @@ msgstr "メンバー %q はすでにロール %q を持っています"
 msgid "Member %q does not have role %q"
 msgstr "メンバー %q はロール %q を持っていません"
 
-#: lxc/cluster.go:957
+#: lxc/cluster.go:958
 #, c-format
 msgid "Member %s join token:"
 msgstr "メンバ %s の join トークン:"
@@ -4356,7 +4364,7 @@ msgstr "証明書のフィンガープリントがありません"
 msgid "Missing cluster group name"
 msgstr "クラスターグループ名がありません"
 
-#: lxc/cluster.go:811 lxc/cluster.go:1367 lxc/cluster_group.go:129
+#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -4423,8 +4431,8 @@ msgstr "ネットワーク ACL 名を指定する必要があります"
 
 #: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1139 lxc/network.go:1217 lxc/network.go:1283
-#: lxc/network.go:1375 lxc/network_forward.go:127 lxc/network_forward.go:215
+#: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
+#: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
 #: lxc/network_forward.go:284 lxc/network_forward.go:445
 #: lxc/network_forward.go:530 lxc/network_forward.go:705
 #: lxc/network_forward.go:836 lxc/network_forward.go:929
@@ -4465,12 +4473,12 @@ msgstr "ピア名を指定する必要があります"
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
-#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
-#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1986
-#: lxc/storage_volume.go:2127 lxc/storage_volume.go:2285
-#: lxc/storage_volume.go:2476 lxc/storage_volume.go:2593
+#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
+#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
 msgid "Missing pool name"
 msgstr "ストレージプール名を指定する必要があります"
 
@@ -4489,11 +4497,11 @@ msgstr "プロジェクト名を指定する必要があります"
 msgid "Missing source profile name"
 msgstr "コピー元のプロファイル名を指定する必要があります"
 
-#: lxc/storage_volume.go:438 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
 msgid "Missing source volume name"
 msgstr "コピー元のボリューム名を指定する必要があります"
 
-#: lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1411
 msgid "Missing storage pool name"
 msgstr "ストレージプール名を指定する必要があります"
 
@@ -4533,8 +4541,8 @@ msgstr ""
 "\n"
 "デフォルトではすべてのタイプのメッセージをモニタリングします。"
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
-#: lxc/storage_volume.go:964
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
+#: lxc/storage_volume.go:975
 msgid "More than one device matches, specify the device name"
 msgstr "複数のデバイスとマッチします。デバイス名を指定してください"
 
@@ -4584,7 +4592,7 @@ msgstr ""
 "\n"
 "すべての LXD バージョンとの互換性のため、pull 転送モードがデフォルトです。\n"
 
-#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
 msgid "Move storage volumes between pools"
 msgstr "プール間でストレージボリュームを移動します"
 
@@ -4592,11 +4600,11 @@ msgstr "プール間でストレージボリュームを移動します"
 msgid "Move the instance without its snapshots"
 msgstr "インスタンスを移動します。スナップショットは移動しません"
 
-#: lxc/storage_volume.go:1856
+#: lxc/storage_volume.go:1867
 msgid "Move to a project different from the source"
 msgstr "コピー／移動元とは異なるプロジェクトに移動します"
 
-#: lxc/storage_volume.go:518
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr "ストレージボリュームの移動中: %s"
@@ -4620,12 +4628,12 @@ msgid "Must supply instance name for: "
 msgstr "インスタンス名を指定する必要があります: "
 
 #: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
+#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
 msgid "NAME"
 msgstr "NAME"
 
@@ -4654,7 +4662,7 @@ msgstr "NIC:"
 msgid "NICs:"
 msgstr "NICs:"
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
 #: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4678,8 +4686,8 @@ msgstr "NVIDIA 情報:"
 msgid "NVRM Version: %v"
 msgstr "NVRM バージョン: %v"
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
-#: lxc/storage_volume.go:1562
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1573
 msgid "Name"
 msgstr "名前"
 
@@ -4687,7 +4695,7 @@ msgstr "名前"
 msgid "Name of the project to use for this remote:"
 msgstr "このリモートで使うプロジェクト名:"
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
 #, c-format
 msgid "Name: %s"
 msgstr "名前: %s"
@@ -4712,7 +4720,7 @@ msgstr "ネットワーク %s を削除しました"
 msgid "Network %s pending on member %s"
 msgstr "ネットワーク %s はメンバ %s 上でペンディング状態です"
 
-#: lxc/network.go:1227
+#: lxc/network.go:1236
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr "ネットワーク名 %s を %s に変更しました"
@@ -4824,7 +4832,7 @@ msgstr "指定するデバイスに適用する新しいキー/値"
 msgid "No certificate add token for member %s on remote: %s"
 msgstr "メンバー %s に対する証明書追加トークンがリモートにありません: %s"
 
-#: lxc/cluster.go:1161
+#: lxc/cluster.go:1162
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4834,7 +4842,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr "このネットワークに対するデバイスがありません"
 
-#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
+#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
 msgid "No device found for this storage volume"
 msgstr "このストレージボリュームに対するデバイスがありません"
 
@@ -4856,11 +4864,11 @@ msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 "--target オプションを使うときはコピー先のインスタンス名を指定してください"
 
-#: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
 msgid "No storage pool for source volume specified"
 msgstr "コピー元のボリュームに対するストレージプールが指定されていません"
 
-#: lxc/storage_volume.go:502 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
 msgid "No storage pool for target volume specified"
 msgstr "コピー先のボリュームに対するストレージプールが指定されていません"
 
@@ -4874,7 +4882,7 @@ msgstr "%q に設定する値が指定されていません"
 msgid "Node %d:\n"
 msgstr "ノード %d:\n"
 
-#: lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2035
 msgid "Not a snapshot name"
 msgstr "スナップショット名ではありません"
 
@@ -4882,15 +4890,16 @@ msgstr "スナップショット名ではありません"
 msgid "OVN:"
 msgstr "OVN:"
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:343
+#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
+#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr "\"カスタム\" のボリュームのみがインスタンスにアタッチできます"
 
-#: lxc/storage_volume.go:2690
+#: lxc/storage_volume.go:2701
 msgid "Only \"custom\" volumes can be exported"
 msgstr "\"カスタム\" のボリュームのみがエクスポートできます"
 
-#: lxc/storage_volume.go:2489
+#: lxc/storage_volume.go:2500
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr "\"カスタム\" のボリュームのみがスナップショットを取得できます"
 
@@ -4902,11 +4911,11 @@ msgstr "simplestreams は https の URL のみサポートします"
 msgid "Only https:// is supported for remote image import"
 msgstr "リモートイメージのインポートは https:// のみをサポートします"
 
-#: lxc/storage_volume.go:1418
+#: lxc/storage_volume.go:1429
 msgid "Only instance or custom volumes are supported"
 msgstr "インスタンスもしくはカスタムボリュームのみをサポートしています"
 
-#: lxc/network.go:735 lxc/network.go:1298
+#: lxc/network.go:735 lxc/network.go:1307
 msgid "Only managed networks can be modified"
 msgstr "管理対象のネットワークのみ変更できます"
 
@@ -4915,7 +4924,7 @@ msgstr "管理対象のネットワークのみ変更できます"
 msgid "Operation %s deleted"
 msgstr "バックグラウンド操作 %s を削除しました"
 
-#: lxc/info.go:705 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1577
 msgid "Optimized Storage"
 msgstr "最適化されたストレージ"
 
@@ -4945,7 +4954,7 @@ msgstr "PID"
 msgid "PID: %d"
 msgstr "PID: %d"
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1767
 msgid "POOL"
 msgstr ""
 
@@ -4961,7 +4970,7 @@ msgstr "PROCESSES"
 msgid "PROFILES"
 msgstr "PROFILES"
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1773
 #: lxc/warning.go:213
 msgid "PROJECT"
 msgstr "PROJECT"
@@ -5007,7 +5016,7 @@ msgstr "別のサーバアドレスを指定してください（空の場合は
 msgid "Please provide client name: "
 msgstr "クライアント名を入力してください: "
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Please provide cluster member name: "
 msgstr "クラスターメンバー名を入力してください: "
 
@@ -5029,16 +5038,16 @@ msgstr "ポート:"
 msgid "Press ctrl+c to finish"
 msgstr "終了するには ctrl+c を押してください"
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
-#: lxc/storage_volume.go:1189
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
+#: lxc/storage_volume.go:1200
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 "再度エディタを開くためには Enter キーを、変更を取り消すには ctrl+c を入力しま"
@@ -5157,7 +5166,7 @@ msgstr "プロパティ:"
 msgid "Property not found"
 msgstr "プロパティが見つかりません"
 
-#: lxc/storage_volume.go:1356
+#: lxc/storage_volume.go:1367
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -5171,7 +5180,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1225
+#: lxc/storage_volume.go:1236
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5187,7 +5196,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2247
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5208,7 +5217,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1004
+#: lxc/storage_volume.go:1015
 #, fuzzy
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
@@ -5220,7 +5229,7 @@ msgstr ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    pool.yaml の内容でストレージボリュームを更新します。"
 
-#: lxc/storage_volume.go:2081
+#: lxc/storage_volume.go:2092
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5233,18 +5242,21 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2357
+#: lxc/storage_volume.go:2368
+#, fuzzy
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
 "\n"
 "lxc storage volume unset default data size\n"
-"    Remotes the size/quota of a custom volume \"data\" in pool \"default\".\n"
+"    Removes the size/quota of a custom volume \"data\" in pool \"default\".\n"
 "\n"
 "lxc storage volume unset default virtual-machine/data snapshots.expiry\n"
 "    Removes the snapshot expiration period for a virtual machine \"data\" in "
 "pool \"default\"."
 msgstr ""
+"lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
+"    pool.yaml の内容でストレージボリュームを更新します。"
 
 #: lxc/remote.go:106
 msgid "Public image server"
@@ -5321,7 +5333,7 @@ msgstr "インスタンスを一覧表示します"
 msgid "Recursively transfer files"
 msgstr "再帰的にファイルを転送します"
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Refresh and update the existing storage volume copies"
 msgstr "既存のストレージボリュームのコピーの再読込と更新"
 
@@ -5510,7 +5522,7 @@ msgstr "インスタンスまたはインスタンスのスナップショット
 msgid "Rename network ACLs"
 msgstr "ネットワーク ACL 名を変更します"
 
-#: lxc/network.go:1184 lxc/network.go:1185
+#: lxc/network.go:1193 lxc/network.go:1194
 msgid "Rename networks"
 msgstr "ネットワーク名を変更します"
 
@@ -5526,16 +5538,16 @@ msgstr "プロジェクト名を変更します"
 msgid "Rename remotes"
 msgstr "リモートサーバ名を変更します"
 
-#: lxc/storage_volume.go:1949
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes"
 msgstr "ストレージボリューム名を変更します"
 
-#: lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:1959
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 "ストレージボリューム名とストレージボリュームのスナップショット名を変更します"
 
-#: lxc/storage_volume.go:2037 lxc/storage_volume.go:2057
+#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr "ストレージボリューム名 \"%s\" を \"%s\" に変更しました"
@@ -5545,11 +5557,11 @@ msgstr "ストレージボリューム名 \"%s\" を \"%s\" に変更しまし�
 msgid "Render: %s (%s)"
 msgstr "レンダー: %s (%s)"
 
-#: lxc/cluster.go:892 lxc/cluster.go:893
+#: lxc/cluster.go:893 lxc/cluster.go:894
 msgid "Request a join token for adding a cluster member"
 msgstr "クラスターメンバーに join するためのトークンを要求します"
 
-#: lxc/config.go:1032
+#: lxc/config.go:1033
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5575,7 +5587,7 @@ msgstr ""
 "\n"
 "\"lxc pause\" の反対のコマンドは \"lxc start\" です。"
 
-#: lxc/cluster.go:1328 lxc/cluster.go:1329
+#: lxc/cluster.go:1329 lxc/cluster.go:1330
 msgid "Restore cluster member"
 msgstr "クラスターメンバーをリストアします"
 
@@ -5593,11 +5605,11 @@ msgstr ""
 "\n"
 "--stateful オプションを指定すると、インスタンスの実行状態もリストアします。"
 
-#: lxc/storage_volume.go:2552 lxc/storage_volume.go:2553
+#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
 msgid "Restore storage volume snapshots"
 msgstr "スナップショットからストレージボリュームをリストアします"
 
-#: lxc/cluster.go:1394
+#: lxc/cluster.go:1395
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr "クラスターメンバーをリストアしています: %s"
@@ -5620,7 +5632,7 @@ msgstr "イメージの取得中: %s"
 msgid "Revoke certificate add token"
 msgstr "証明書追加トークンを失効（Revoke）させます"
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1087
 msgid "Revoke cluster member join token"
 msgstr "クラスターメンバーに join するためのトークンを失効（Revoke）させます"
 
@@ -5671,7 +5683,7 @@ msgstr "SSH クライアントが %q に接続されました"
 msgid "SSH client disconnected %q"
 msgstr "SSH クライアントが切断されました %q"
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1088
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1097
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr "STATE"
@@ -5735,7 +5747,7 @@ msgstr "サーバのプロトコル (lxd or simplestreams)"
 msgid "Server version: %s\n"
 msgstr "サーバのバージョン: %s\n"
 
-#: lxc/config.go:1050 lxc/config.go:1051
+#: lxc/config.go:1051 lxc/config.go:1052
 #, fuzzy
 msgid "Set UEFI variables for instance"
 msgstr "インスタンスからファイルをマウントします"
@@ -5816,11 +5828,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 
-#: lxc/network.go:1244
+#: lxc/network.go:1253
 msgid "Set network configuration keys"
 msgstr "ネットワークの設定項目を設定します"
 
-#: lxc/network.go:1245
+#: lxc/network.go:1254
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5973,11 +5985,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行うには次の形式でも設定できます:\n"
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 
-#: lxc/storage_volume.go:2075
+#: lxc/storage_volume.go:2086
 msgid "Set storage volume configuration keys"
 msgstr "ストレージボリュームの設定項目を設定します"
 
-#: lxc/storage_volume.go:2076
+#: lxc/storage_volume.go:2087
 #, fuzzy
 msgid ""
 "Set storage volume configuration keys\n"
@@ -6046,7 +6058,7 @@ msgstr "ネットワークロードバランサーの設定を行います"
 msgid "Set the key as a network peer property"
 msgstr "ネットワークピアの設定を行います"
 
-#: lxc/network.go:1252
+#: lxc/network.go:1261
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -6078,7 +6090,7 @@ msgstr "ストレージバケットに対する鍵を作成します"
 msgid "Set the key as a storage property"
 msgstr "ストレージバケットに対する鍵を作成します"
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2103
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
@@ -6150,7 +6162,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr "イメージのプロパティを表示します"
 
-#: lxc/config.go:1172 lxc/config.go:1173
+#: lxc/config.go:1173 lxc/config.go:1174
 #, fuzzy
 msgid "Show instance UEFI variables"
 msgstr "インスタンスのメタデータファイルを表示します"
@@ -6183,7 +6195,7 @@ msgstr "ネットワーク ACL の設定を表示します"
 msgid "Show network ACL log"
 msgstr "ネットワーク ACL ログを表示します"
 
-#: lxc/network.go:1340 lxc/network.go:1341
+#: lxc/network.go:1349 lxc/network.go:1350
 msgid "Show network configurations"
 msgstr "ネットワークの設定を表示します"
 
@@ -6231,11 +6243,11 @@ msgstr "ストレージバケットの鍵の設定を表示する"
 msgid "Show storage pool configurations and resources"
 msgstr "ストレージプールの設定とリソースを表示します"
 
-#: lxc/storage_volume.go:2233 lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
 msgid "Show storage volume configurations"
 msgstr "ストレージボリュームの設定を表示する"
 
-#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
 msgid "Show storage volume state information"
 msgstr "ストレージボリュームの状態を表示します"
 
@@ -6258,7 +6270,8 @@ msgid "Show the expanded configuration"
 msgstr "拡張した設定を表示する"
 
 #: lxc/info.go:43
-msgid "Show the instance's last 100 log lines?"
+#, fuzzy
+msgid "Show the instance's last 100 log lines"
 msgstr "インスタンスログの最後の 100 行を表示しますか?"
 
 #: lxc/info.go:44
@@ -6303,15 +6316,15 @@ msgstr "サイズ: %.2fMB"
 msgid "Size: %s"
 msgstr "サイズ: %s"
 
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2417
+#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
 msgid "Snapshot storage volumes"
 msgstr "ストレージボリュームのスナップショットを取得します"
 
-#: lxc/storage_volume.go:2179
+#: lxc/storage_volume.go:2190
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr "スナップショットは読み取り専用です。設定を変更することはできません"
 
-#: lxc/info.go:619 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1502
 msgid "Snapshots:"
 msgstr "スナップショット:"
 
@@ -6416,21 +6429,21 @@ msgstr "ストレージプール %s はメンバ %s 上でペンディング状�
 msgid "Storage pool name"
 msgstr "ストレージプール名"
 
-#: lxc/storage_volume.go:702
+#: lxc/storage_volume.go:703
 #, c-format
 msgid "Storage volume %s created"
 msgstr "ストレージボリューム %s を作成しました"
 
-#: lxc/storage_volume.go:790
+#: lxc/storage_volume.go:791
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr "ストレージボリューム %s を削除しました"
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:516
 msgid "Storage volume copied successfully!"
 msgstr "ストレージボリュームのコピーが成功しました!"
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:520
 msgid "Storage volume moved successfully!"
 msgstr "ストレージボリュームの移動が成功しました!"
 
@@ -6438,7 +6451,7 @@ msgstr "ストレージボリュームの移動が成功しました!"
 msgid "Store the instance state"
 msgstr "インスタンスの状態を保存します"
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr "リモート %s に対するクラスター証明書の更新に成功しました"
@@ -6487,18 +6500,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr "イメージは以下のフィンガープリントでインポートされました: %s"
 
-#: lxc/cluster.go:1070 lxc/config_trust.go:515
+#: lxc/cluster.go:1071 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr "TOKEN"
 
 #: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1736 lxc/warning.go:216
+#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1747 lxc/warning.go:216
 msgid "TYPE"
 msgstr "TYPE"
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
 msgid "Taken at"
 msgstr "取得日時"
 
@@ -6661,12 +6674,12 @@ msgstr "設定 %q はクラスタメンバー %q には存在しません"
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1340
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: lxc/storage_volume.go:1306
+#: lxc/storage_volume.go:1317
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6687,8 +6700,8 @@ msgstr "サーバには新しい v2 resource API が実装されていません"
 msgid "The source LXD server is not clustered"
 msgstr "移動元の LXD サーバはクラスタに属していません"
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
-#: lxc/storage_volume.go:978
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:989
 msgid "The specified device doesn't exist"
 msgstr "指定したデバイスが存在しません"
 
@@ -6711,11 +6724,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
 
-#: lxc/cluster.go:739
+#: lxc/cluster.go:740
 msgid "This LXD server is already clustered"
 msgstr "LXD サーバはすでにクラスターに属しています"
 
-#: lxc/cluster.go:729
+#: lxc/cluster.go:730
 msgid "This LXD server is not available on the network"
 msgstr "この LXD サーバはネットワークから利用できません"
 
@@ -6784,7 +6797,7 @@ msgstr ""
 "--target オプションは、コピー先のリモートサーバがクラスタに属していなければな"
 "りません"
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Total: %s"
 msgstr "合計: %s"
@@ -6799,7 +6812,7 @@ msgstr "合計: %v"
 msgid "Transceiver type: %s"
 msgstr "トランシーバータイプ: %s"
 
-#: lxc/storage_volume.go:1853
+#: lxc/storage_volume.go:1864
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpull)"
 
@@ -6807,7 +6820,7 @@ msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpu
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpull)"
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:394
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpull)。"
 
@@ -6869,7 +6882,7 @@ msgstr ""
 "フィカル出力の場合は 'vga'"
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1472
 #, c-format
 msgid "Type: %s"
 msgstr "タイプ: %s"
@@ -6891,13 +6904,13 @@ msgstr "UPLOAD DATE"
 msgid "URL"
 msgstr "URL"
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:995 lxc/storage_volume.go:1752
 msgid "USAGE"
 msgstr "USAGE"
 
-#: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
+#: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1740
+#: lxc/storage.go:724 lxc/storage_volume.go:1751
 msgid "USED BY"
 msgstr "USED BY"
 
@@ -6929,7 +6942,7 @@ msgstr "未知の証明書タイプ %q"
 msgid "Unknown channel type for client %q: %s"
 msgstr "クライアント %q の未知のチャンネルタイプ: %s"
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6955,7 +6968,7 @@ msgstr "未知の設定: %s"
 msgid "Unknown output type %q"
 msgstr "未知の出力タイプ: %q"
 
-#: lxc/config.go:1141 lxc/config.go:1142
+#: lxc/config.go:1142 lxc/config.go:1143
 #, fuzzy
 msgid "Unset UEFI variables for instance"
 msgstr "移動先のインスタンスのすべてのプロファイルを削除します"
@@ -6984,7 +6997,7 @@ msgstr "インスタンスもしくはサーバの設定を削除します"
 msgid "Unset network ACL configuration keys"
 msgstr "ネットワーク ACL の設定を削除します"
 
-#: lxc/network.go:1412 lxc/network.go:1413
+#: lxc/network.go:1421 lxc/network.go:1422
 msgid "Unset network configuration keys"
 msgstr "ネットワークの設定を削除します"
 
@@ -7036,7 +7049,7 @@ msgstr "ストレージバケットの設定を削除します"
 msgid "Unset storage pool configuration keys"
 msgstr "ストレージプールの設定を削除します"
 
-#: lxc/storage_volume.go:2354 lxc/storage_volume.go:2355
+#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
 msgid "Unset storage volume configuration keys"
 msgstr "ストレージボリュームの設定を削除します"
 
@@ -7063,7 +7076,7 @@ msgstr "ネットワークロードバランサーの設定を削除します"
 msgid "Unset the key as a network peer property"
 msgstr "ネットワークピアの設定を削除します"
 
-#: lxc/network.go:1417
+#: lxc/network.go:1426
 #, fuzzy
 msgid "Unset the key as a network property"
 msgstr "ネットワークピアの設定を削除します"
@@ -7096,7 +7109,7 @@ msgstr "ストレージバケットに対する鍵を作成します"
 msgid "Unset the key as a storage property"
 msgstr "ストレージバケットに対する鍵を作成します"
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2379
 #, fuzzy
 msgid "Unset the key as a storage volume property"
 msgstr "新しいストレージボリュームをプロファイルに追加します"
@@ -7105,7 +7118,7 @@ msgstr "新しいストレージボリュームをプロファイルに追加し
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:247
+#: lxc/storage_volume.go:248
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -7118,11 +7131,11 @@ msgstr "サポートされていないインスタンスタイプです: %s"
 msgid "Up delay"
 msgstr "Up delay"
 
-#: lxc/cluster.go:1174
+#: lxc/cluster.go:1175
 msgid "Update cluster certificate"
 msgstr "クラスター証明書を更新します"
 
-#: lxc/cluster.go:1176
+#: lxc/cluster.go:1177
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -7143,12 +7156,12 @@ msgstr "アップロード日時: %s"
 msgid "Upper devices"
 msgstr "上位デバイス"
 
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Usage: %s"
 msgstr "使い方: %s"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2641
+#: lxc/export.go:42 lxc/storage_volume.go:2652
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -7220,7 +7233,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr "現在のプロジェクトを切り替えます"
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1576
 msgid "Volume Only"
 msgstr "Volume Only"
 
@@ -7255,7 +7268,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
 #: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -7284,18 +7297,18 @@ msgid "You need to specify an image name or use --empty"
 msgstr ""
 "--target オプションを使うときはコピー先のインスタンス名を指定してください"
 
-#: lxc/storage_volume.go:903
+#: lxc/storage_volume.go:909
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr "[<remote:>]<pool> <volume> <profile> [<device name>]"
 
-#: lxc/storage_volume.go:281
+#: lxc/storage_volume.go:282
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 
 #: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
-#: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
+#: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
@@ -7305,7 +7318,7 @@ msgstr "[<remote>:]"
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr "[<remote>:] <backup file> [<instance name>]"
 
-#: lxc/cluster.go:1172
+#: lxc/cluster.go:1173
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr "[<remote>:] <cert.crt> <cert.key>"
 
@@ -7474,7 +7487,7 @@ msgstr "[<remote>:]<image> [<target>]"
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "[<remote>:]<image> [[<remote>:]<image>...]"
 
-#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -7496,12 +7509,12 @@ msgstr "[<remote>:]<instance> <device> <type> [key=value...]"
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr "[<remote>:]<instance> <device> [key=value...]"
 
-#: lxc/config.go:994 lxc/config.go:1140
+#: lxc/config.go:995 lxc/config.go:1141
 #, fuzzy
 msgid "[<remote>:]<instance> <key>"
 msgstr "[<remote>:][<instance>] <key>"
 
-#: lxc/config.go:1049
+#: lxc/config.go:1050
 #, fuzzy
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr "[<remote>:][<instance>] <key>=<value>..."
@@ -7585,8 +7598,8 @@ msgid ""
 msgstr ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:768
-#: lxc/cluster.go:1085 lxc/cluster.go:1297 lxc/cluster.go:1327
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
+#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
 msgid "[<remote>:]<member>"
 msgstr "[<remote>:]<member>"
 
@@ -7610,8 +7623,8 @@ msgstr "[<remote>:]<member> <new-name>"
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr "[<remote>:]<member> <role[,role...]>"
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1104
-#: lxc/network.go:1339 lxc/network_forward.go:87
+#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1113
+#: lxc/network.go:1348 lxc/network_forward.go:87
 #: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr "[<remote>:]<network>"
@@ -7624,11 +7637,11 @@ msgstr "[<remote>:]<network> <instance> [<device name>]"
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 
-#: lxc/network.go:791 lxc/network.go:1411
+#: lxc/network.go:791 lxc/network.go:1420
 msgid "[<remote>:]<network> <key>"
 msgstr "[<remote>:]<network> <key>"
 
-#: lxc/network.go:1243
+#: lxc/network.go:1252
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr "[<remote>:]<network> <key>=<value>..."
 
@@ -7679,7 +7692,7 @@ msgstr ""
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 
-#: lxc/network.go:1182
+#: lxc/network.go:1191
 msgid "[<remote>:]<network> <new-name>"
 msgstr "[<remote>:]<network> <new-name>"
 
@@ -7733,7 +7746,7 @@ msgstr "[<remote>:]<operation>"
 msgid "[<remote>:]<pool>"
 msgstr "[<remote>:]<pool>"
 
-#: lxc/storage_volume.go:2800
+#: lxc/storage_volume.go:2811
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "[<remote>:]<pool> <backup file> [<volume name>]"
 
@@ -7768,7 +7781,7 @@ msgstr "[<remote>:]<pool> <key>"
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr "[<remote>:]<pool> <key> <value>"
 
-#: lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:1958
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
@@ -7776,7 +7789,7 @@ msgstr ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:806
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr "[<remote>:]<pool> <volume> <instance> [<device name>]"
 
@@ -7784,56 +7797,56 @@ msgstr "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 
-#: lxc/storage_volume.go:2551
+#: lxc/storage_volume.go:2562
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr "[<remote>:]<pool> <volume> <snapshot>"
 
-#: lxc/storage_volume.go:2634
+#: lxc/storage_volume.go:2645
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "[<remote>:]<pool> <volume> [<path>]"
 
-#: lxc/storage_volume.go:2415
+#: lxc/storage_volume.go:2426
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr "[<remote>:]<pool> <volume> [<snapshot>]"
 
-#: lxc/storage_volume.go:609
+#: lxc/storage_volume.go:610
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr "[<remote>:]<pool> <volume> [key=value...]"
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:718
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr "[<remote>:]<pool> <volume>[/<snapshot>]"
 
-#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr "[<remote>:]<pool> <volume>"
 
-#: lxc/storage_volume.go:2353
+#: lxc/storage_volume.go:2364
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr "[<remote>:]<pool> <volume>"
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2085
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr "[<remote>:]<pool> <volume> <key>=<value>..."
 
-#: lxc/storage_volume.go:2232
+#: lxc/storage_volume.go:2243
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr "[<remote>:]<pool> <volume>[/<snapshot>]"
 
-#: lxc/storage_volume.go:1221
+#: lxc/storage_volume.go:1232
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1858
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 
-#: lxc/storage_volume.go:387
+#: lxc/storage_volume.go:388
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 
@@ -7941,7 +7954,7 @@ msgstr "[<remote>:][<instance>] <key>"
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr "[<remote>:][<instance>] <key>=<value>..."
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1601
 #, fuzzy
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr "[<remote>:]<pool> [<filter>...]"
@@ -7955,7 +7968,7 @@ msgstr "[<remote>:]<warning-uuid>"
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr "[<remote>] <IP|FQDN|URL|token>"
 
-#: lxc/cluster.go:891
+#: lxc/cluster.go:892
 msgid "[[<remote>:]<member>]"
 msgstr "[[<remote>:]<member>]"
 
@@ -8042,7 +8055,7 @@ msgstr ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    profile.yaml の内容でプロファイルを更新します"
 
-#: lxc/cluster.go:772
+#: lxc/cluster.go:773
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -8122,7 +8135,7 @@ msgstr ""
 "lxc config set core.trust_password=blah\n"
 "    サーバの認証パスワードを blah に設定します。"
 
-#: lxc/config.go:1229
+#: lxc/config.go:1230
 #, fuzzy
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
@@ -8131,7 +8144,7 @@ msgstr ""
 "lxc config edit <instance> < instance.yaml\n"
 "    インスタンスの設定を config.yaml を使って更新します。"
 
-#: lxc/config.go:1053
+#: lxc/config.go:1054
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -8622,7 +8635,7 @@ msgstr ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    pool.yaml の内容でストレージプールを更新します。"
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:614
 #, fuzzy
 msgid ""
 "lxc storage volume create p1 v1\n"
@@ -8635,7 +8648,7 @@ msgstr ""
 "lxc init ubuntu:22.04 u1 < config.yaml\n"
 "    config.yaml の設定を使ってインスタンスを作成します"
 
-#: lxc/storage_volume.go:2804
+#: lxc/storage_volume.go:2815
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
@@ -8643,7 +8656,7 @@ msgstr ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tbackup0.tar.gz を使って新しいカスタムボリュームを作成します。"
 
-#: lxc/storage_volume.go:2419
+#: lxc/storage_volume.go:2430
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -8712,6 +8725,9 @@ msgstr "y"
 #: lxc/image.go:1206
 msgid "yes"
 msgstr "yes"
+
+#~ msgid "Action (defaults to GET)"
+#~ msgstr "使用するHTTPのメソッド (デフォルト: GET)"
 
 #, c-format
 #~ msgid "Failed to create certificate: %w"

--- a/po/ka.po
+++ b/po/ka.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-09 03:18-0300\n"
+"POT-Creation-Date: 2024-12-18 08:40-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -46,7 +46,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1030
+#: lxc/storage_volume.go:1041
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -60,7 +60,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1240
+#: lxc/config.go:1241
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -409,7 +409,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:790
+#: lxc/cluster.go:791
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -582,13 +582,13 @@ msgstr ""
 msgid "Acknowledge warning"
 msgstr ""
 
+#: lxc/query.go:43
+msgid "Action"
+msgstr ""
+
 #: lxc/query.go:76
 #, c-format
 msgid "Action %q isn't supported by this tool"
-msgstr ""
-
-#: lxc/query.go:43
-msgid "Action (defaults to GET)"
 msgstr ""
 
 #: lxc/cluster_group.go:725
@@ -735,7 +735,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1596
+#: lxc/storage_volume.go:1607
 msgid "All projects"
 msgstr ""
 
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1371
+#: lxc/cluster.go:1372
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -794,7 +794,7 @@ msgstr ""
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:282 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -846,16 +846,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2708
+#: lxc/storage_volume.go:2719
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2785
+#: lxc/export.go:192 lxc/storage_volume.go:2796
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1538
 msgid "Backups:"
 msgstr ""
 
@@ -876,7 +876,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -919,7 +919,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1739
+#: lxc/storage_volume.go:1750
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1004,7 +1004,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1012,7 +1012,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1097
+#: lxc/config.go:702 lxc/config.go:1098
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1021,12 +1021,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:492
+#: lxc/storage_volume.go:493
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:446
+#: lxc/storage_volume.go:447
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1102,7 +1102,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1154
+#: lxc/cluster.go:1155
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1130,8 +1130,8 @@ msgstr ""
 #: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
 #: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
-#: lxc/network_forward.go:182 lxc/network_forward.go:264
+#: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
+#: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
 #: lxc/network_forward.go:497 lxc/network_forward.go:649
 #: lxc/network_forward.go:803 lxc/network_forward.go:892
 #: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
@@ -1146,30 +1146,30 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
-#: lxc/storage_volume.go:1952 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2251 lxc/storage_volume.go:2367
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2555
-#: lxc/storage_volume.go:2643 lxc/storage_volume.go:2807
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
+#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
+#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:894
+#: lxc/cluster.go:895
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:926
+#: lxc/cluster.go:927
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:756
+#: lxc/cluster.go:757
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1206,24 +1206,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
+#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
-#: lxc/storage_volume.go:1188
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
+#: lxc/storage_volume.go:1199
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:619
+#: lxc/storage_volume.go:620
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1233,7 +1233,11 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/move.go:65
+#: lxc/move.go:65
+msgid "Copy a stateful instance as stateless"
+msgstr ""
+
+#: lxc/copy.go:60
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1281,7 +1285,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:389 lxc/storage_volume.go:390
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1289,12 +1293,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:396
+#: lxc/storage_volume.go:397
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:398
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1307,7 +1311,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:515
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1330,12 +1334,12 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1235
+#: lxc/cluster.go:1236
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1239
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1350,17 +1354,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1266
+#: lxc/cluster.go:1267
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1442,7 +1446,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1494,7 +1498,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1523,13 +1527,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1738
+#: lxc/storage_volume.go:1749
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1549,7 +1553,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2642
+#: lxc/storage_volume.go:2653
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1645,7 +1649,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1666,16 +1670,16 @@ msgstr ""
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
-#: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
+#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
+#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
-#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
-#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
+#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
+#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1698,8 +1702,8 @@ msgstr ""
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
 #: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1005 lxc/network.go:1106 lxc/network.go:1185
-#: lxc/network.go:1245 lxc/network.go:1341 lxc/network.go:1413
+#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
+#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
 #: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
 #: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
 #: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
@@ -1750,27 +1754,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
-#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
-#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
-#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1949
-#: lxc/storage_volume.go:2076 lxc/storage_volume.go:2234
-#: lxc/storage_volume.go:2355 lxc/storage_volume.go:2417
-#: lxc/storage_volume.go:2553 lxc/storage_volume.go:2636
-#: lxc/storage_volume.go:2802 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1454
+#: lxc/storage_volume.go:1465
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1782,11 +1786,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
+#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1914,7 +1918,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:516
+#: lxc/cluster.go:1072 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1936,7 +1940,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:769 lxc/cluster.go:770
+#: lxc/cluster.go:770 lxc/cluster.go:771
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1956,7 +1960,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1226 lxc/config.go:1227
+#: lxc/config.go:1227 lxc/config.go:1228
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2020,7 +2024,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2028,7 +2032,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2046,11 +2050,12 @@ msgid ""
 "new\n"
 "  LXD cluster, which will have the given name.\n"
 "\n"
-"  It's required that the LXD is already available on the network. You can "
-"check\n"
-"  that by running 'lxc config get core.https_address', and possibly set a "
-"value\n"
-"  for the address if not yet set."
+"  It's required that LXD is already available on the network. You can check\n"
+"  this by running 'lxc config get core.https_address'. If either an IP "
+"address\n"
+"  and port is displayed, or both, LXD is already available on the network. "
+"If\n"
+"  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
 #: lxc/network_zone.go:1427
@@ -2080,12 +2085,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
+#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2095,12 +2100,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
+#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
-#: lxc/storage_volume.go:2199
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
+#: lxc/storage_volume.go:2210
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2110,11 +2115,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1298 lxc/cluster.go:1299
+#: lxc/cluster.go:1299 lxc/cluster.go:1300
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1396
+#: lxc/cluster.go:1397
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2142,8 +2147,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
-#: lxc/storage_volume.go:1564
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Expires at"
 msgstr ""
 
@@ -2167,7 +2172,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2635 lxc/storage_volume.go:2636
+#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2179,11 +2184,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2639
+#: lxc/storage_volume.go:2650
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2768
+#: lxc/export.go:152 lxc/storage_volume.go:2779
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2363,7 +2368,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
+#: lxc/network.go:1046 lxc/network_acl.go:133 lxc/network_zone.go:124
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2373,7 +2378,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1303
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2381,7 +2386,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1301
+#: lxc/cluster.go:1302
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2393,7 +2398,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1331
+#: lxc/cluster.go:1332
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2434,16 +2439,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
-#: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1614 lxc/warning.go:94
+#: lxc/storage_volume.go:1625 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2503,7 +2508,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:996
+#: lxc/config.go:996 lxc/config.go:997
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2567,7 +2572,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1249
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2631,11 +2636,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
+#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:475
+#: lxc/storage_volume.go:476
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2663,7 +2668,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1161
+#: lxc/network.go:1170
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2717,7 +2722,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1163
+#: lxc/network.go:1172
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2729,11 +2734,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1084
+#: lxc/list.go:560 lxc/network.go:1093
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1085
+#: lxc/list.go:561 lxc/network.go:1094
 msgid "IPV6"
 msgstr ""
 
@@ -2763,7 +2768,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2427
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2777,7 +2782,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2437
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2827,7 +2832,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2802
+#: lxc/storage_volume.go:2813
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2835,7 +2840,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2801
+#: lxc/storage_volume.go:2812
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2857,11 +2862,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2809
+#: lxc/storage_volume.go:2820
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2883
+#: lxc/storage_volume.go:2894
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2905,7 +2910,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
+#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2987,7 +2992,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2012
+#: lxc/move.go:148 lxc/storage_volume.go:2023
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2995,7 +3000,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2019
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3013,9 +3018,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
-#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2144 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
+#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3059,9 +3064,9 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
+#: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3073,8 +3078,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1020 lxc/cluster.go:1123
-#: lxc/cluster.go:1231 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
+#: lxc/cluster.go:1232 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3111,7 +3116,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1105 lxc/network.go:1106
+#: lxc/network.go:1114 lxc/network.go:1115
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3123,7 +3128,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:976 lxc/cluster.go:977
+#: lxc/cluster.go:977 lxc/cluster.go:978
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -3171,7 +3176,7 @@ msgstr ""
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1004 lxc/network.go:1005
+#: lxc/network.go:1005 lxc/network.go:1006
 msgid "List available networks"
 msgstr ""
 
@@ -3259,7 +3264,7 @@ msgid ""
 "Fast column layout: nsacPt\n"
 "\n"
 "A single keyword like \"web\" which will list any instance with a name "
-"starting by \"web\".\n"
+"starting with \"web\".\n"
 "A regular expression on the instance name. (e.g. .*web.*01$).\n"
 "A key/value pair referring to a configuration item. For those, the\n"
 "namespace can be abbreviated to the smallest unambiguous identifier.\n"
@@ -3316,7 +3321,8 @@ msgid ""
 "  P - Profiles\n"
 "  s - State\n"
 "  S - Number of snapshots\n"
-"  t - Type (persistent or ephemeral)\n"
+"  t - Type (container or virtual-machine, ephemeral indicated if "
+"applicable)\n"
 "  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
@@ -3365,11 +3371,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1603
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1608
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3428,7 +3434,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1470
+#: lxc/info.go:489 lxc/storage_volume.go:1481
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3449,7 +3455,7 @@ msgstr ""
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1162
+#: lxc/network.go:1171
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3467,7 +3473,7 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1083
+#: lxc/network.go:1092
 msgid "MANAGED"
 msgstr ""
 
@@ -3590,7 +3596,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:955 lxc/config.go:956
+#: lxc/config.go:956 lxc/config.go:957
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3729,7 +3735,7 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:957
+#: lxc/cluster.go:958
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
@@ -3793,7 +3799,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:811 lxc/cluster.go:1367 lxc/cluster_group.go:129
+#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -3856,8 +3862,8 @@ msgstr ""
 
 #: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1139 lxc/network.go:1217 lxc/network.go:1283
-#: lxc/network.go:1375 lxc/network_forward.go:127 lxc/network_forward.go:215
+#: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
+#: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
 #: lxc/network_forward.go:284 lxc/network_forward.go:445
 #: lxc/network_forward.go:530 lxc/network_forward.go:705
 #: lxc/network_forward.go:836 lxc/network_forward.go:929
@@ -3898,12 +3904,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
-#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
-#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1986
-#: lxc/storage_volume.go:2127 lxc/storage_volume.go:2285
-#: lxc/storage_volume.go:2476 lxc/storage_volume.go:2593
+#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
+#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
 msgid "Missing pool name"
 msgstr ""
 
@@ -3922,11 +3928,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:438 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1411
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3963,8 +3969,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
-#: lxc/storage_volume.go:964
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
+#: lxc/storage_volume.go:975
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4001,7 +4007,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4009,11 +4015,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1856
+#: lxc/storage_volume.go:1867
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:518
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4035,12 +4041,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
+#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
 msgid "NAME"
 msgstr ""
 
@@ -4068,7 +4074,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
 #: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4092,8 +4098,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
-#: lxc/storage_volume.go:1562
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1573
 msgid "Name"
 msgstr ""
 
@@ -4101,7 +4107,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4126,7 +4132,7 @@ msgstr ""
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1227
+#: lxc/network.go:1236
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4236,7 +4242,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1161
+#: lxc/cluster.go:1162
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4245,7 +4251,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
+#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4265,11 +4271,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:502 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4283,7 +4289,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2035
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4291,15 +4297,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:343
+#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
+#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2690
+#: lxc/storage_volume.go:2701
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2489
+#: lxc/storage_volume.go:2500
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4311,11 +4318,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1418
+#: lxc/storage_volume.go:1429
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1298
+#: lxc/network.go:735 lxc/network.go:1307
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4324,7 +4331,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1577
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4354,7 +4361,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1767
 msgid "POOL"
 msgstr ""
 
@@ -4370,7 +4377,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1773
 #: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4416,7 +4423,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -4437,16 +4444,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
-#: lxc/storage_volume.go:1189
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
+#: lxc/storage_volume.go:1200
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4563,7 +4570,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1356
+#: lxc/storage_volume.go:1367
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4577,7 +4584,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1225
+#: lxc/storage_volume.go:1236
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4593,7 +4600,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2247
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4614,7 +4621,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1004
+#: lxc/storage_volume.go:1015
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4623,7 +4630,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2081
+#: lxc/storage_volume.go:2092
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4636,13 +4643,13 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2357
+#: lxc/storage_volume.go:2368
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
 "\n"
 "lxc storage volume unset default data size\n"
-"    Remotes the size/quota of a custom volume \"data\" in pool \"default\".\n"
+"    Removes the size/quota of a custom volume \"data\" in pool \"default\".\n"
 "\n"
 "lxc storage volume unset default virtual-machine/data snapshots.expiry\n"
 "    Removes the snapshot expiration period for a virtual machine \"data\" in "
@@ -4722,7 +4729,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4905,7 +4912,7 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1184 lxc/network.go:1185
+#: lxc/network.go:1193 lxc/network.go:1194
 msgid "Rename networks"
 msgstr ""
 
@@ -4921,15 +4928,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1949
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:1959
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2037 lxc/storage_volume.go:2057
+#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4939,11 +4946,11 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:892 lxc/cluster.go:893
+#: lxc/cluster.go:893 lxc/cluster.go:894
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1032
+#: lxc/config.go:1033
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -4966,7 +4973,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1328 lxc/cluster.go:1329
+#: lxc/cluster.go:1329 lxc/cluster.go:1330
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4981,11 +4988,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2552 lxc/storage_volume.go:2553
+#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1394
+#: lxc/cluster.go:1395
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5007,7 +5014,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1087
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5057,7 +5064,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1088
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1097
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5120,7 +5127,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1050 lxc/config.go:1051
+#: lxc/config.go:1051 lxc/config.go:1052
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5184,11 +5191,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1244
+#: lxc/network.go:1253
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1245
+#: lxc/network.go:1254
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5305,11 +5312,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2075
+#: lxc/storage_volume.go:2086
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2076
+#: lxc/storage_volume.go:2087
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5366,7 +5373,7 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1252
+#: lxc/network.go:1261
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5394,7 +5401,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2103
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5463,7 +5470,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1173
+#: lxc/config.go:1173 lxc/config.go:1174
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5495,7 +5502,7 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1340 lxc/network.go:1341
+#: lxc/network.go:1349 lxc/network.go:1350
 msgid "Show network configurations"
 msgstr ""
 
@@ -5543,11 +5550,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2233 lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5570,7 +5577,7 @@ msgid "Show the expanded configuration"
 msgstr ""
 
 #: lxc/info.go:43
-msgid "Show the instance's last 100 log lines?"
+msgid "Show the instance's last 100 log lines"
 msgstr ""
 
 #: lxc/info.go:44
@@ -5615,15 +5622,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2417
+#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2179
+#: lxc/storage_volume.go:2190
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1502
 msgid "Snapshots:"
 msgstr ""
 
@@ -5728,21 +5735,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:702
+#: lxc/storage_volume.go:703
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:790
+#: lxc/storage_volume.go:791
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:516
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:520
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5750,7 +5757,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5799,18 +5806,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1070 lxc/config_trust.go:515
+#: lxc/cluster.go:1071 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1736 lxc/warning.go:216
+#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1747 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
 msgid "Taken at"
 msgstr ""
 
@@ -5967,12 +5974,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1340
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1306
+#: lxc/storage_volume.go:1317
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -5991,8 +5998,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
-#: lxc/storage_volume.go:978
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:989
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6012,11 +6019,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:739
+#: lxc/cluster.go:740
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:729
+#: lxc/cluster.go:730
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6067,7 +6074,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6082,7 +6089,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1853
+#: lxc/storage_volume.go:1864
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6090,7 +6097,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:394
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6149,7 +6156,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1472
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6171,13 +6178,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:995 lxc/storage_volume.go:1752
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
+#: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1740
+#: lxc/storage.go:724 lxc/storage_volume.go:1751
 msgid "USED BY"
 msgstr ""
 
@@ -6209,7 +6216,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6235,7 +6242,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1141 lxc/config.go:1142
+#: lxc/config.go:1142 lxc/config.go:1143
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6263,7 +6270,7 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1412 lxc/network.go:1413
+#: lxc/network.go:1421 lxc/network.go:1422
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -6315,7 +6322,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2354 lxc/storage_volume.go:2355
+#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6339,7 +6346,7 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1417
+#: lxc/network.go:1426
 msgid "Unset the key as a network property"
 msgstr ""
 
@@ -6367,7 +6374,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2379
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6375,7 +6382,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:247
+#: lxc/storage_volume.go:248
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6388,11 +6395,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1174
+#: lxc/cluster.go:1175
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1176
+#: lxc/cluster.go:1177
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6411,12 +6418,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2641
+#: lxc/export.go:42 lxc/storage_volume.go:2652
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6483,7 +6490,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1576
 msgid "Volume Only"
 msgstr ""
 
@@ -6516,7 +6523,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
 #: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6542,18 +6549,18 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:903
+#: lxc/storage_volume.go:909
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:281
+#: lxc/storage_volume.go:282
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
-#: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
+#: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
@@ -6563,7 +6570,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1172
+#: lxc/cluster.go:1173
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -6726,7 +6733,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6748,11 +6755,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:1140
+#: lxc/config.go:995 lxc/config.go:1141
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1049
+#: lxc/config.go:1050
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -6831,8 +6838,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:768
-#: lxc/cluster.go:1085 lxc/cluster.go:1297 lxc/cluster.go:1327
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
+#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -6856,8 +6863,8 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1104
-#: lxc/network.go:1339 lxc/network_forward.go:87
+#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1113
+#: lxc/network.go:1348 lxc/network_forward.go:87
 #: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -6870,11 +6877,11 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1411
+#: lxc/network.go:791 lxc/network.go:1420
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1243
+#: lxc/network.go:1252
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
@@ -6919,7 +6926,7 @@ msgstr ""
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1182
+#: lxc/network.go:1191
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -6970,7 +6977,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2800
+#: lxc/storage_volume.go:2811
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7005,13 +7012,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:1958
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:806
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7019,51 +7026,51 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2551
+#: lxc/storage_volume.go:2562
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2634
+#: lxc/storage_volume.go:2645
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2415
+#: lxc/storage_volume.go:2426
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:609
+#: lxc/storage_volume.go:610
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:718
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2353
+#: lxc/storage_volume.go:2364
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2085
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2232
+#: lxc/storage_volume.go:2243
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1221
+#: lxc/storage_volume.go:1232
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1858
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:387
+#: lxc/storage_volume.go:388
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7169,7 +7176,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1601
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7181,7 +7188,7 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:891
+#: lxc/cluster.go:892
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -7253,7 +7260,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:772
+#: lxc/cluster.go:773
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7302,13 +7309,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1229
+#: lxc/config.go:1230
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1053
+#: lxc/config.go:1054
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7645,7 +7652,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:614
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7653,13 +7660,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2804
+#: lxc/storage_volume.go:2815
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2419
+#: lxc/storage_volume.go:2430
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-09 03:18-0300\n"
+"POT-Creation-Date: 2024-12-18 08:40-0700\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1030
+#: lxc/storage_volume.go:1041
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1240
+#: lxc/config.go:1241
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -412,7 +412,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:790
+#: lxc/cluster.go:791
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -585,13 +585,13 @@ msgstr ""
 msgid "Acknowledge warning"
 msgstr ""
 
+#: lxc/query.go:43
+msgid "Action"
+msgstr ""
+
 #: lxc/query.go:76
 #, c-format
 msgid "Action %q isn't supported by this tool"
-msgstr ""
-
-#: lxc/query.go:43
-msgid "Action (defaults to GET)"
 msgstr ""
 
 #: lxc/cluster_group.go:725
@@ -738,7 +738,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1596
+#: lxc/storage_volume.go:1607
 msgid "All projects"
 msgstr ""
 
@@ -760,7 +760,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1371
+#: lxc/cluster.go:1372
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -797,7 +797,7 @@ msgstr ""
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:282 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -849,16 +849,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2708
+#: lxc/storage_volume.go:2719
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2785
+#: lxc/export.go:192 lxc/storage_volume.go:2796
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1538
 msgid "Backups:"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -922,7 +922,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1739
+#: lxc/storage_volume.go:1750
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1007,7 +1007,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1097
+#: lxc/config.go:702 lxc/config.go:1098
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1024,12 +1024,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:492
+#: lxc/storage_volume.go:493
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:446
+#: lxc/storage_volume.go:447
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1105,7 +1105,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1154
+#: lxc/cluster.go:1155
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1133,8 +1133,8 @@ msgstr ""
 #: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
 #: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
-#: lxc/network_forward.go:182 lxc/network_forward.go:264
+#: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
+#: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
 #: lxc/network_forward.go:497 lxc/network_forward.go:649
 #: lxc/network_forward.go:803 lxc/network_forward.go:892
 #: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
@@ -1149,30 +1149,30 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
-#: lxc/storage_volume.go:1952 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2251 lxc/storage_volume.go:2367
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2555
-#: lxc/storage_volume.go:2643 lxc/storage_volume.go:2807
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
+#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
+#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:894
+#: lxc/cluster.go:895
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:926
+#: lxc/cluster.go:927
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:756
+#: lxc/cluster.go:757
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1209,24 +1209,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
+#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
-#: lxc/storage_volume.go:1188
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
+#: lxc/storage_volume.go:1199
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:619
+#: lxc/storage_volume.go:620
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1236,7 +1236,11 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/move.go:65
+#: lxc/move.go:65
+msgid "Copy a stateful instance as stateless"
+msgstr ""
+
+#: lxc/copy.go:60
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1284,7 +1288,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:389 lxc/storage_volume.go:390
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1292,12 +1296,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:396
+#: lxc/storage_volume.go:397
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:398
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1310,7 +1314,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:515
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1333,12 +1337,12 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1235
+#: lxc/cluster.go:1236
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1239
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1353,17 +1357,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1266
+#: lxc/cluster.go:1267
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1445,7 +1449,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1497,7 +1501,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1526,13 +1530,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1738
+#: lxc/storage_volume.go:1749
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1552,7 +1556,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2642
+#: lxc/storage_volume.go:2653
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1648,7 +1652,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1669,16 +1673,16 @@ msgstr ""
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
-#: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
+#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
+#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
-#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
-#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
+#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
+#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1701,8 +1705,8 @@ msgstr ""
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
 #: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1005 lxc/network.go:1106 lxc/network.go:1185
-#: lxc/network.go:1245 lxc/network.go:1341 lxc/network.go:1413
+#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
+#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
 #: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
 #: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
 #: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
@@ -1753,27 +1757,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
-#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
-#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
-#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1949
-#: lxc/storage_volume.go:2076 lxc/storage_volume.go:2234
-#: lxc/storage_volume.go:2355 lxc/storage_volume.go:2417
-#: lxc/storage_volume.go:2553 lxc/storage_volume.go:2636
-#: lxc/storage_volume.go:2802 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1454
+#: lxc/storage_volume.go:1465
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1785,11 +1789,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
+#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1917,7 +1921,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:516
+#: lxc/cluster.go:1072 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1939,7 +1943,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:769 lxc/cluster.go:770
+#: lxc/cluster.go:770 lxc/cluster.go:771
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1959,7 +1963,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1226 lxc/config.go:1227
+#: lxc/config.go:1227 lxc/config.go:1228
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2023,7 +2027,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2031,7 +2035,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2049,11 +2053,12 @@ msgid ""
 "new\n"
 "  LXD cluster, which will have the given name.\n"
 "\n"
-"  It's required that the LXD is already available on the network. You can "
-"check\n"
-"  that by running 'lxc config get core.https_address', and possibly set a "
-"value\n"
-"  for the address if not yet set."
+"  It's required that LXD is already available on the network. You can check\n"
+"  this by running 'lxc config get core.https_address'. If either an IP "
+"address\n"
+"  and port is displayed, or both, LXD is already available on the network. "
+"If\n"
+"  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
 #: lxc/network_zone.go:1427
@@ -2083,12 +2088,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
+#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2098,12 +2103,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
+#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
-#: lxc/storage_volume.go:2199
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
+#: lxc/storage_volume.go:2210
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2113,11 +2118,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1298 lxc/cluster.go:1299
+#: lxc/cluster.go:1299 lxc/cluster.go:1300
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1396
+#: lxc/cluster.go:1397
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2145,8 +2150,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
-#: lxc/storage_volume.go:1564
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Expires at"
 msgstr ""
 
@@ -2170,7 +2175,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2635 lxc/storage_volume.go:2636
+#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2182,11 +2187,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2639
+#: lxc/storage_volume.go:2650
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2768
+#: lxc/export.go:152 lxc/storage_volume.go:2779
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2366,7 +2371,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
+#: lxc/network.go:1046 lxc/network_acl.go:133 lxc/network_zone.go:124
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2376,7 +2381,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1303
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2384,7 +2389,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1301
+#: lxc/cluster.go:1302
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2396,7 +2401,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1331
+#: lxc/cluster.go:1332
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2437,16 +2442,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
-#: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1614 lxc/warning.go:94
+#: lxc/storage_volume.go:1625 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2506,7 +2511,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:996
+#: lxc/config.go:996 lxc/config.go:997
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2570,7 +2575,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1249
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2634,11 +2639,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
+#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:475
+#: lxc/storage_volume.go:476
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2666,7 +2671,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1161
+#: lxc/network.go:1170
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2720,7 +2725,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1163
+#: lxc/network.go:1172
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2732,11 +2737,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1084
+#: lxc/list.go:560 lxc/network.go:1093
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1085
+#: lxc/list.go:561 lxc/network.go:1094
 msgid "IPV6"
 msgstr ""
 
@@ -2766,7 +2771,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2427
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2780,7 +2785,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2437
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2830,7 +2835,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2802
+#: lxc/storage_volume.go:2813
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2838,7 +2843,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2801
+#: lxc/storage_volume.go:2812
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2860,11 +2865,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2809
+#: lxc/storage_volume.go:2820
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2883
+#: lxc/storage_volume.go:2894
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2908,7 +2913,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
+#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2990,7 +2995,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2012
+#: lxc/move.go:148 lxc/storage_volume.go:2023
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2998,7 +3003,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2019
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3016,9 +3021,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
-#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2144 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
+#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3062,9 +3067,9 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
+#: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3076,8 +3081,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1020 lxc/cluster.go:1123
-#: lxc/cluster.go:1231 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
+#: lxc/cluster.go:1232 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3114,7 +3119,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1105 lxc/network.go:1106
+#: lxc/network.go:1114 lxc/network.go:1115
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3126,7 +3131,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:976 lxc/cluster.go:977
+#: lxc/cluster.go:977 lxc/cluster.go:978
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -3174,7 +3179,7 @@ msgstr ""
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1004 lxc/network.go:1005
+#: lxc/network.go:1005 lxc/network.go:1006
 msgid "List available networks"
 msgstr ""
 
@@ -3262,7 +3267,7 @@ msgid ""
 "Fast column layout: nsacPt\n"
 "\n"
 "A single keyword like \"web\" which will list any instance with a name "
-"starting by \"web\".\n"
+"starting with \"web\".\n"
 "A regular expression on the instance name. (e.g. .*web.*01$).\n"
 "A key/value pair referring to a configuration item. For those, the\n"
 "namespace can be abbreviated to the smallest unambiguous identifier.\n"
@@ -3319,7 +3324,8 @@ msgid ""
 "  P - Profiles\n"
 "  s - State\n"
 "  S - Number of snapshots\n"
-"  t - Type (persistent or ephemeral)\n"
+"  t - Type (container or virtual-machine, ephemeral indicated if "
+"applicable)\n"
 "  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
@@ -3368,11 +3374,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1603
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1608
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3431,7 +3437,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1470
+#: lxc/info.go:489 lxc/storage_volume.go:1481
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3452,7 +3458,7 @@ msgstr ""
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1162
+#: lxc/network.go:1171
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3470,7 +3476,7 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1083
+#: lxc/network.go:1092
 msgid "MANAGED"
 msgstr ""
 
@@ -3593,7 +3599,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:955 lxc/config.go:956
+#: lxc/config.go:956 lxc/config.go:957
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3732,7 +3738,7 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:957
+#: lxc/cluster.go:958
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
@@ -3796,7 +3802,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:811 lxc/cluster.go:1367 lxc/cluster_group.go:129
+#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -3859,8 +3865,8 @@ msgstr ""
 
 #: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1139 lxc/network.go:1217 lxc/network.go:1283
-#: lxc/network.go:1375 lxc/network_forward.go:127 lxc/network_forward.go:215
+#: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
+#: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
 #: lxc/network_forward.go:284 lxc/network_forward.go:445
 #: lxc/network_forward.go:530 lxc/network_forward.go:705
 #: lxc/network_forward.go:836 lxc/network_forward.go:929
@@ -3901,12 +3907,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
-#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
-#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1986
-#: lxc/storage_volume.go:2127 lxc/storage_volume.go:2285
-#: lxc/storage_volume.go:2476 lxc/storage_volume.go:2593
+#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
+#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
 msgid "Missing pool name"
 msgstr ""
 
@@ -3925,11 +3931,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:438 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1411
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3966,8 +3972,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
-#: lxc/storage_volume.go:964
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
+#: lxc/storage_volume.go:975
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4004,7 +4010,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4012,11 +4018,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1856
+#: lxc/storage_volume.go:1867
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:518
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4038,12 +4044,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
+#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
 msgid "NAME"
 msgstr ""
 
@@ -4071,7 +4077,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
 #: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4095,8 +4101,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
-#: lxc/storage_volume.go:1562
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1573
 msgid "Name"
 msgstr ""
 
@@ -4104,7 +4110,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4129,7 +4135,7 @@ msgstr ""
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1227
+#: lxc/network.go:1236
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4239,7 +4245,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1161
+#: lxc/cluster.go:1162
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4248,7 +4254,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
+#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4268,11 +4274,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:502 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4286,7 +4292,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2035
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4294,15 +4300,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:343
+#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
+#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2690
+#: lxc/storage_volume.go:2701
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2489
+#: lxc/storage_volume.go:2500
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4314,11 +4321,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1418
+#: lxc/storage_volume.go:1429
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1298
+#: lxc/network.go:735 lxc/network.go:1307
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4327,7 +4334,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1577
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4357,7 +4364,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1767
 msgid "POOL"
 msgstr ""
 
@@ -4373,7 +4380,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1773
 #: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4419,7 +4426,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -4440,16 +4447,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
-#: lxc/storage_volume.go:1189
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
+#: lxc/storage_volume.go:1200
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4566,7 +4573,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1356
+#: lxc/storage_volume.go:1367
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4580,7 +4587,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1225
+#: lxc/storage_volume.go:1236
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4596,7 +4603,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2247
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4617,7 +4624,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1004
+#: lxc/storage_volume.go:1015
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4626,7 +4633,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2081
+#: lxc/storage_volume.go:2092
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4639,13 +4646,13 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2357
+#: lxc/storage_volume.go:2368
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
 "\n"
 "lxc storage volume unset default data size\n"
-"    Remotes the size/quota of a custom volume \"data\" in pool \"default\".\n"
+"    Removes the size/quota of a custom volume \"data\" in pool \"default\".\n"
 "\n"
 "lxc storage volume unset default virtual-machine/data snapshots.expiry\n"
 "    Removes the snapshot expiration period for a virtual machine \"data\" in "
@@ -4725,7 +4732,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4908,7 +4915,7 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1184 lxc/network.go:1185
+#: lxc/network.go:1193 lxc/network.go:1194
 msgid "Rename networks"
 msgstr ""
 
@@ -4924,15 +4931,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1949
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:1959
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2037 lxc/storage_volume.go:2057
+#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4942,11 +4949,11 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:892 lxc/cluster.go:893
+#: lxc/cluster.go:893 lxc/cluster.go:894
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1032
+#: lxc/config.go:1033
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -4969,7 +4976,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1328 lxc/cluster.go:1329
+#: lxc/cluster.go:1329 lxc/cluster.go:1330
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4984,11 +4991,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2552 lxc/storage_volume.go:2553
+#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1394
+#: lxc/cluster.go:1395
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5010,7 +5017,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1087
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5060,7 +5067,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1088
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1097
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5123,7 +5130,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1050 lxc/config.go:1051
+#: lxc/config.go:1051 lxc/config.go:1052
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5187,11 +5194,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1244
+#: lxc/network.go:1253
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1245
+#: lxc/network.go:1254
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5308,11 +5315,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2075
+#: lxc/storage_volume.go:2086
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2076
+#: lxc/storage_volume.go:2087
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5369,7 +5376,7 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1252
+#: lxc/network.go:1261
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5397,7 +5404,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2103
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5466,7 +5473,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1173
+#: lxc/config.go:1173 lxc/config.go:1174
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5498,7 +5505,7 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1340 lxc/network.go:1341
+#: lxc/network.go:1349 lxc/network.go:1350
 msgid "Show network configurations"
 msgstr ""
 
@@ -5546,11 +5553,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2233 lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5573,7 +5580,7 @@ msgid "Show the expanded configuration"
 msgstr ""
 
 #: lxc/info.go:43
-msgid "Show the instance's last 100 log lines?"
+msgid "Show the instance's last 100 log lines"
 msgstr ""
 
 #: lxc/info.go:44
@@ -5618,15 +5625,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2417
+#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2179
+#: lxc/storage_volume.go:2190
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1502
 msgid "Snapshots:"
 msgstr ""
 
@@ -5731,21 +5738,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:702
+#: lxc/storage_volume.go:703
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:790
+#: lxc/storage_volume.go:791
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:516
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:520
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5753,7 +5760,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5802,18 +5809,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1070 lxc/config_trust.go:515
+#: lxc/cluster.go:1071 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1736 lxc/warning.go:216
+#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1747 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
 msgid "Taken at"
 msgstr ""
 
@@ -5970,12 +5977,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1340
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1306
+#: lxc/storage_volume.go:1317
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -5994,8 +6001,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
-#: lxc/storage_volume.go:978
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:989
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6015,11 +6022,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:739
+#: lxc/cluster.go:740
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:729
+#: lxc/cluster.go:730
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6070,7 +6077,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6085,7 +6092,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1853
+#: lxc/storage_volume.go:1864
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6093,7 +6100,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:394
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6152,7 +6159,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1472
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6174,13 +6181,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:995 lxc/storage_volume.go:1752
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
+#: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1740
+#: lxc/storage.go:724 lxc/storage_volume.go:1751
 msgid "USED BY"
 msgstr ""
 
@@ -6212,7 +6219,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6238,7 +6245,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1141 lxc/config.go:1142
+#: lxc/config.go:1142 lxc/config.go:1143
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6266,7 +6273,7 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1412 lxc/network.go:1413
+#: lxc/network.go:1421 lxc/network.go:1422
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -6318,7 +6325,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2354 lxc/storage_volume.go:2355
+#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6342,7 +6349,7 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1417
+#: lxc/network.go:1426
 msgid "Unset the key as a network property"
 msgstr ""
 
@@ -6370,7 +6377,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2379
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6378,7 +6385,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:247
+#: lxc/storage_volume.go:248
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6391,11 +6398,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1174
+#: lxc/cluster.go:1175
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1176
+#: lxc/cluster.go:1177
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6414,12 +6421,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2641
+#: lxc/export.go:42 lxc/storage_volume.go:2652
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6486,7 +6493,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1576
 msgid "Volume Only"
 msgstr ""
 
@@ -6519,7 +6526,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
 #: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6545,18 +6552,18 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:903
+#: lxc/storage_volume.go:909
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:281
+#: lxc/storage_volume.go:282
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
-#: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
+#: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
@@ -6566,7 +6573,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1172
+#: lxc/cluster.go:1173
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -6729,7 +6736,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6751,11 +6758,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:1140
+#: lxc/config.go:995 lxc/config.go:1141
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1049
+#: lxc/config.go:1050
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -6834,8 +6841,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:768
-#: lxc/cluster.go:1085 lxc/cluster.go:1297 lxc/cluster.go:1327
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
+#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -6859,8 +6866,8 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1104
-#: lxc/network.go:1339 lxc/network_forward.go:87
+#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1113
+#: lxc/network.go:1348 lxc/network_forward.go:87
 #: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -6873,11 +6880,11 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1411
+#: lxc/network.go:791 lxc/network.go:1420
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1243
+#: lxc/network.go:1252
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
@@ -6922,7 +6929,7 @@ msgstr ""
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1182
+#: lxc/network.go:1191
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -6973,7 +6980,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2800
+#: lxc/storage_volume.go:2811
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7008,13 +7015,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:1958
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:806
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7022,51 +7029,51 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2551
+#: lxc/storage_volume.go:2562
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2634
+#: lxc/storage_volume.go:2645
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2415
+#: lxc/storage_volume.go:2426
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:609
+#: lxc/storage_volume.go:610
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:718
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2353
+#: lxc/storage_volume.go:2364
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2085
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2232
+#: lxc/storage_volume.go:2243
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1221
+#: lxc/storage_volume.go:1232
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1858
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:387
+#: lxc/storage_volume.go:388
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7172,7 +7179,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1601
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7184,7 +7191,7 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:891
+#: lxc/cluster.go:892
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -7256,7 +7263,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:772
+#: lxc/cluster.go:773
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7305,13 +7312,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1229
+#: lxc/config.go:1230
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1053
+#: lxc/config.go:1054
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7648,7 +7655,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:614
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7656,13 +7663,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2804
+#: lxc/storage_volume.go:2815
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2419
+#: lxc/storage_volume.go:2430
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-        "POT-Creation-Date: 2024-12-09 03:18-0300\n"
+        "POT-Creation-Date: 2024-12-18 08:40-0700\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -44,7 +44,7 @@ msgid   "### This is a YAML representation of a storage pool.\n"
         "###   zfs.pool_name: default"
 msgstr  ""
 
-#: lxc/storage_volume.go:1030
+#: lxc/storage_volume.go:1041
 msgid   "### This is a YAML representation of a storage volume.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -57,7 +57,7 @@ msgid   "### This is a YAML representation of a storage volume.\n"
         "###   size: \"61203283968\""
 msgstr  ""
 
-#: lxc/config.go:1240
+#: lxc/config.go:1241
 msgid   "### This is a YAML representation of the UEFI variables configuration.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -381,7 +381,7 @@ msgid   "### This is a YAML representation of the project.\n"
         "### Note that the name is shown but cannot be changed"
 msgstr  ""
 
-#: lxc/cluster.go:790
+#: lxc/cluster.go:791
 msgid   "### This is a yaml representation of the cluster member.\n"
         "### Any line starting with a '# will be ignored."
 msgstr  ""
@@ -551,13 +551,13 @@ msgstr  ""
 msgid   "Acknowledge warning"
 msgstr  ""
 
+#: lxc/query.go:43
+msgid   "Action"
+msgstr  ""
+
 #: lxc/query.go:76
 #, c-format
 msgid   "Action %q isn't supported by this tool"
-msgstr  ""
-
-#: lxc/query.go:43
-msgid   "Action (defaults to GET)"
 msgstr  ""
 
 #: lxc/cluster_group.go:725
@@ -697,7 +697,7 @@ msgstr  ""
 msgid   "Aliases:"
 msgstr  ""
 
-#: lxc/storage_volume.go:1596
+#: lxc/storage_volume.go:1607
 msgid   "All projects"
 msgstr  ""
 
@@ -719,7 +719,7 @@ msgstr  ""
 msgid   "Architecture: %v"
 msgstr  ""
 
-#: lxc/cluster.go:1371
+#: lxc/cluster.go:1372
 #, c-format
 msgid   "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr  ""
@@ -756,7 +756,7 @@ msgstr  ""
 msgid   "Attach new storage volumes to instances"
 msgstr  ""
 
-#: lxc/storage_volume.go:282 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
 msgid   "Attach new storage volumes to profiles"
 msgstr  ""
 
@@ -807,16 +807,16 @@ msgstr  ""
 msgid   "Backing up instance: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:2708
+#: lxc/storage_volume.go:2719
 #, c-format
 msgid   "Backing up storage volume: %s"
 msgstr  ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2785
+#: lxc/export.go:192 lxc/storage_volume.go:2796
 msgid   "Backup exported successfully!"
 msgstr  ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1538
 msgid   "Backups:"
 msgstr  ""
 
@@ -835,7 +835,7 @@ msgstr  ""
 msgid   "Bad key=value pair: %q"
 msgstr  ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
 #, c-format
 msgid   "Bad key=value pair: %s"
 msgstr  ""
@@ -878,7 +878,7 @@ msgstr  ""
 msgid   "COMMON NAME"
 msgstr  ""
 
-#: lxc/storage_volume.go:1739
+#: lxc/storage_volume.go:1750
 msgid   "CONTENT-TYPE"
 msgstr  ""
 
@@ -963,7 +963,7 @@ msgstr  ""
 msgid   "Can't specify a different remote for rename"
 msgstr  ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
 msgid   "Can't specify column L when not clustered"
 msgstr  ""
 
@@ -971,7 +971,7 @@ msgstr  ""
 msgid   "Can't supply uid/gid/mode in recursive mode"
 msgstr  ""
 
-#: lxc/config.go:702 lxc/config.go:1097
+#: lxc/config.go:702 lxc/config.go:1098
 #, c-format
 msgid   "Can't unset key '%s', it's not currently set"
 msgstr  ""
@@ -980,11 +980,11 @@ msgstr  ""
 msgid   "Can't use an image with --empty"
 msgstr  ""
 
-#: lxc/storage_volume.go:492
+#: lxc/storage_volume.go:493
 msgid   "Cannot set --destination-target when destination server is not clustered"
 msgstr  ""
 
-#: lxc/storage_volume.go:446
+#: lxc/storage_volume.go:447
 msgid   "Cannot set --target when source server is not clustered"
 msgstr  ""
 
@@ -1059,7 +1059,7 @@ msgstr  ""
 msgid   "Cluster group %s renamed to %s"
 msgstr  ""
 
-#: lxc/cluster.go:1154
+#: lxc/cluster.go:1155
 #, c-format
 msgid   "Cluster join token for %s:%s deleted"
 msgstr  ""
@@ -1084,23 +1084,23 @@ msgstr  ""
 msgid   "Cluster member %s removed from group %s"
 msgstr  ""
 
-#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776 lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65 lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877 lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416 lxc/network_forward.go:182 lxc/network_forward.go:264 lxc/network_forward.go:497 lxc/network_forward.go:649 lxc/network_forward.go:803 lxc/network_forward.go:892 lxc/network_forward.go:974 lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484 lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774 lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938 lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125 lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748 lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91 lxc/storage_bucket.go:191 lxc/storage_bucket.go:254 lxc/storage_bucket.go:385 lxc/storage_bucket.go:542 lxc/storage_bucket.go:635 lxc/storage_bucket.go:701 lxc/storage_bucket.go:776 lxc/storage_bucket.go:862 lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027 lxc/storage_bucket.go:1163 lxc/storage_volume.go:394 lxc/storage_volume.go:618 lxc/storage_volume.go:723 lxc/storage_volume.go:1011 lxc/storage_volume.go:1237 lxc/storage_volume.go:1366 lxc/storage_volume.go:1854 lxc/storage_volume.go:1952 lxc/storage_volume.go:2091 lxc/storage_volume.go:2251 lxc/storage_volume.go:2367 lxc/storage_volume.go:2428 lxc/storage_volume.go:2555 lxc/storage_volume.go:2643 lxc/storage_volume.go:2807
+#: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776 lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65 lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877 lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353 lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264 lxc/network_forward.go:497 lxc/network_forward.go:649 lxc/network_forward.go:803 lxc/network_forward.go:892 lxc/network_forward.go:974 lxc/network_load_balancer.go:184 lxc/network_load_balancer.go:266 lxc/network_load_balancer.go:484 lxc/network_load_balancer.go:619 lxc/network_load_balancer.go:774 lxc/network_load_balancer.go:862 lxc/network_load_balancer.go:938 lxc/network_load_balancer.go:1051 lxc/network_load_balancer.go:1125 lxc/storage.go:105 lxc/storage.go:396 lxc/storage.go:479 lxc/storage.go:748 lxc/storage.go:850 lxc/storage.go:943 lxc/storage_bucket.go:91 lxc/storage_bucket.go:191 lxc/storage_bucket.go:254 lxc/storage_bucket.go:385 lxc/storage_bucket.go:542 lxc/storage_bucket.go:635 lxc/storage_bucket.go:701 lxc/storage_bucket.go:776 lxc/storage_bucket.go:862 lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027 lxc/storage_bucket.go:1163 lxc/storage_volume.go:395 lxc/storage_volume.go:619 lxc/storage_volume.go:724 lxc/storage_volume.go:1022 lxc/storage_volume.go:1248 lxc/storage_volume.go:1377 lxc/storage_volume.go:1865 lxc/storage_volume.go:1963 lxc/storage_volume.go:2102 lxc/storage_volume.go:2262 lxc/storage_volume.go:2378 lxc/storage_volume.go:2439 lxc/storage_volume.go:2566 lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
 msgid   "Cluster member name"
 msgstr  ""
 
-#: lxc/cluster.go:894
+#: lxc/cluster.go:895
 msgid   "Cluster member name (alternative to passing it as an argument)"
 msgstr  ""
 
-#: lxc/cluster.go:926
+#: lxc/cluster.go:927
 msgid   "Cluster member name was provided as both a flag and as an argument"
 msgstr  ""
 
-#: lxc/cluster.go:756
+#: lxc/cluster.go:757
 msgid   "Clustering enabled"
 msgstr  ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595 lxc/warning.go:93
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606 lxc/warning.go:93
 msgid   "Columns"
 msgstr  ""
 
@@ -1135,16 +1135,16 @@ msgstr  ""
 msgid   "Config key/value to apply to the target instance"
 msgstr  ""
 
-#: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281 lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156 lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759 lxc/network_acl.go:698 lxc/network_forward.go:767 lxc/network_load_balancer.go:738 lxc/network_peer.go:698 lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595 lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349 lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156 lxc/storage_volume.go:1188
+#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281 lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156 lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759 lxc/network_acl.go:698 lxc/network_forward.go:767 lxc/network_load_balancer.go:738 lxc/network_peer.go:698 lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595 lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349 lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167 lxc/storage_volume.go:1199
 #, c-format
 msgid   "Config parsing error: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:619
+#: lxc/storage_volume.go:620
 msgid   "Content type, block or filesystem"
 msgstr  ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid   "Content type: %s"
 msgstr  ""
@@ -1154,7 +1154,11 @@ msgstr  ""
 msgid   "Control: %s (%s)"
 msgstr  ""
 
-#: lxc/copy.go:60 lxc/move.go:65
+#: lxc/move.go:65
+msgid   "Copy a stateful instance as stateless"
+msgstr  ""
+
+#: lxc/copy.go:60
 msgid   "Copy a stateful instance stateless"
 msgstr  ""
 
@@ -1196,7 +1200,7 @@ msgstr  ""
 msgid   "Copy profiles"
 msgstr  ""
 
-#: lxc/storage_volume.go:389 lxc/storage_volume.go:390
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
 msgid   "Copy storage volumes"
 msgstr  ""
 
@@ -1204,11 +1208,11 @@ msgstr  ""
 msgid   "Copy the instance without its snapshots"
 msgstr  ""
 
-#: lxc/storage_volume.go:396
+#: lxc/storage_volume.go:397
 msgid   "Copy the volume without its snapshots"
 msgstr  ""
 
-#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273 lxc/storage_volume.go:397
+#: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273 lxc/storage_volume.go:398
 msgid   "Copy to a project different from the source"
 msgstr  ""
 
@@ -1221,7 +1225,7 @@ msgstr  ""
 msgid   "Copying the image: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:515
 #, c-format
 msgid   "Copying the storage volume: %s"
 msgstr  ""
@@ -1244,12 +1248,12 @@ msgstr  ""
 msgid   "Could not create server cert dir"
 msgstr  ""
 
-#: lxc/cluster.go:1235
+#: lxc/cluster.go:1236
 #, c-format
 msgid   "Could not find certificate file path: %s"
 msgstr  ""
 
-#: lxc/cluster.go:1239
+#: lxc/cluster.go:1240
 #, c-format
 msgid   "Could not find certificate key file path: %s"
 msgstr  ""
@@ -1264,17 +1268,17 @@ msgstr  ""
 msgid   "Could not parse identity: %s"
 msgstr  ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid   "Could not read certificate file: %s with error: %v"
 msgstr  ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid   "Could not read certificate key file: %s with error: %v"
 msgstr  ""
 
-#: lxc/cluster.go:1266
+#: lxc/cluster.go:1267
 #, c-format
 msgid   "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr  ""
@@ -1355,7 +1359,7 @@ msgstr  ""
 msgid   "Create new custom storage buckets"
 msgstr  ""
 
-#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
 msgid   "Create new custom storage volumes"
 msgstr  ""
 
@@ -1407,7 +1411,7 @@ msgstr  ""
 msgid   "Create the instance with no profiles applied"
 msgstr  ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
 #, c-format
 msgid   "Created: %s"
 msgstr  ""
@@ -1435,7 +1439,7 @@ msgstr  ""
 msgid   "DEFAULT TARGET ADDRESS"
 msgstr  ""
 
-#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504 lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086 lxc/network_acl.go:157 lxc/network_forward.go:157 lxc/network_load_balancer.go:160 lxc/network_peer.go:149 lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173 lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723 lxc/storage_bucket.go:513 lxc/storage_bucket.go:833 lxc/storage_volume.go:1738
+#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504 lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095 lxc/network_acl.go:157 lxc/network_forward.go:157 lxc/network_load_balancer.go:160 lxc/network_peer.go:149 lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173 lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723 lxc/storage_bucket.go:513 lxc/storage_bucket.go:833 lxc/storage_volume.go:1749
 msgid   "DESCRIPTION"
 msgstr  ""
 
@@ -1455,7 +1459,7 @@ msgstr  ""
 msgid   "Default VLAN ID"
 msgstr  ""
 
-#: lxc/storage_volume.go:2642
+#: lxc/storage_volume.go:2653
 msgid   "Define a compression algorithm: for backup or none"
 msgstr  ""
 
@@ -1551,7 +1555,7 @@ msgstr  ""
 msgid   "Delete storage pools"
 msgstr  ""
 
-#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
 msgid   "Delete storage volumes"
 msgstr  ""
 
@@ -1559,16 +1563,16 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104 lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398 lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581 lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985 lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292 lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464 lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781 lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060 lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087 lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329 lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170 lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956 lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173 lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409 lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634 lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28 lxc/config_metadata.go:56 lxc/config_metadata.go:189 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:119 lxc/config_template.go:173 lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689 lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602 lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106 lxc/network.go:1185 lxc/network.go:1245 lxc/network.go:1341 lxc/network.go:1413 lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53 lxc/network_forward.go:33 lxc/network_forward.go:90 lxc/network_forward.go:179 lxc/network_forward.go:256 lxc/network_forward.go:404 lxc/network_forward.go:489 lxc/network_forward.go:599 lxc/network_forward.go:646 lxc/network_forward.go:800 lxc/network_forward.go:874 lxc/network_forward.go:889 lxc/network_forward.go:970 lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121 lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:165 lxc/network_zone.go:228 lxc/network_zone.go:301 lxc/network_zone.go:396 lxc/network_zone.go:484 lxc/network_zone.go:527 lxc/network_zone.go:654 lxc/network_zone.go:710 lxc/network_zone.go:767 lxc/network_zone.go:845 lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083 lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349 lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483 lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749 lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018 lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250 lxc/storage_bucket.go:383 lxc/storage_bucket.go:459 lxc/storage_bucket.go:536 lxc/storage_bucket.go:630 lxc/storage_bucket.go:699 lxc/storage_bucket.go:733 lxc/storage_bucket.go:774 lxc/storage_bucket.go:853 lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158 lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:283 lxc/storage_volume.go:390 lxc/storage_volume.go:611 lxc/storage_volume.go:720 lxc/storage_volume.go:807 lxc/storage_volume.go:905 lxc/storage_volume.go:1002 lxc/storage_volume.go:1223 lxc/storage_volume.go:1354 lxc/storage_volume.go:1513 lxc/storage_volume.go:1597 lxc/storage_volume.go:1850 lxc/storage_volume.go:1949 lxc/storage_volume.go:2076 lxc/storage_volume.go:2234 lxc/storage_volume.go:2355 lxc/storage_volume.go:2417 lxc/storage_volume.go:2553 lxc/storage_volume.go:2636 lxc/storage_volume.go:2802 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104 lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398 lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581 lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985 lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292 lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464 lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781 lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060 lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088 lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330 lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170 lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957 lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174 lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409 lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634 lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28 lxc/config_metadata.go:56 lxc/config_metadata.go:189 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:119 lxc/config_template.go:173 lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689 lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602 lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194 lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422 lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53 lxc/network_forward.go:33 lxc/network_forward.go:90 lxc/network_forward.go:179 lxc/network_forward.go:256 lxc/network_forward.go:404 lxc/network_forward.go:489 lxc/network_forward.go:599 lxc/network_forward.go:646 lxc/network_forward.go:800 lxc/network_forward.go:874 lxc/network_forward.go:889 lxc/network_forward.go:970 lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121 lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:165 lxc/network_zone.go:228 lxc/network_zone.go:301 lxc/network_zone.go:396 lxc/network_zone.go:484 lxc/network_zone.go:527 lxc/network_zone.go:654 lxc/network_zone.go:710 lxc/network_zone.go:767 lxc/network_zone.go:845 lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083 lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349 lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483 lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749 lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018 lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250 lxc/storage_bucket.go:383 lxc/storage_bucket.go:459 lxc/storage_bucket.go:536 lxc/storage_bucket.go:630 lxc/storage_bucket.go:699 lxc/storage_bucket.go:733 lxc/storage_bucket.go:774 lxc/storage_bucket.go:853 lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158 lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:284 lxc/storage_volume.go:391 lxc/storage_volume.go:612 lxc/storage_volume.go:721 lxc/storage_volume.go:808 lxc/storage_volume.go:911 lxc/storage_volume.go:1013 lxc/storage_volume.go:1234 lxc/storage_volume.go:1365 lxc/storage_volume.go:1524 lxc/storage_volume.go:1608 lxc/storage_volume.go:1861 lxc/storage_volume.go:1960 lxc/storage_volume.go:2087 lxc/storage_volume.go:2245 lxc/storage_volume.go:2366 lxc/storage_volume.go:2428 lxc/storage_volume.go:2564 lxc/storage_volume.go:2647 lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid   "Description"
 msgstr  ""
 
-#: lxc/storage_volume.go:1454
+#: lxc/storage_volume.go:1465
 #, c-format
 msgid   "Description: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
 msgid   "Destination cluster member name"
 msgstr  ""
 
@@ -1580,11 +1584,11 @@ msgstr  ""
 msgid   "Detach network interfaces from profiles"
 msgstr  ""
 
-#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
 msgid   "Detach storage volumes from instances"
 msgstr  ""
 
-#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
+#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
 msgid   "Detach storage volumes from profiles"
 msgstr  ""
 
@@ -1707,7 +1711,7 @@ msgstr  ""
 msgid   "EPHEMERAL"
 msgstr  ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:516
+#: lxc/cluster.go:1072 lxc/config_trust.go:516
 msgid   "EXPIRES AT"
 msgstr  ""
 
@@ -1727,7 +1731,7 @@ msgstr  ""
 msgid   "Edit an identity as YAML"
 msgstr  ""
 
-#: lxc/cluster.go:769 lxc/cluster.go:770
+#: lxc/cluster.go:770 lxc/cluster.go:771
 msgid   "Edit cluster member configurations as YAML"
 msgstr  ""
 
@@ -1747,7 +1751,7 @@ msgstr  ""
 msgid   "Edit image properties"
 msgstr  ""
 
-#: lxc/config.go:1226 lxc/config.go:1227
+#: lxc/config.go:1227 lxc/config.go:1228
 msgid   "Edit instance UEFI variables"
 msgstr  ""
 
@@ -1811,7 +1815,7 @@ msgstr  ""
 msgid   "Edit storage pool configurations as YAML"
 msgstr  ""
 
-#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
 msgid   "Edit storage volume configurations as YAML"
 msgstr  ""
 
@@ -1819,7 +1823,7 @@ msgstr  ""
 msgid   "Edit trust configurations as YAML"
 msgstr  ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772 lxc/warning.go:236
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783 lxc/warning.go:236
 #, c-format
 msgid   "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr  ""
@@ -1834,9 +1838,10 @@ msgid   "Enable clustering on a single non-clustered LXD server\n"
         "  This command turns a non-clustered LXD server into the first member of a new\n"
         "  LXD cluster, which will have the given name.\n"
         "\n"
-        "  It's required that the LXD is already available on the network. You can check\n"
-        "  that by running 'lxc config get core.https_address', and possibly set a value\n"
-        "  for the address if not yet set."
+        "  It's required that LXD is already available on the network. You can check\n"
+        "  this by running 'lxc config get core.https_address'. If either an IP address\n"
+        "  and port is displayed, or both, LXD is already available on the network. If\n"
+        "  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr  ""
 
 #: lxc/network_zone.go:1427
@@ -1866,7 +1871,7 @@ msgstr  ""
 msgid   "Error retrieving aliases: %w"
 msgstr  ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319 lxc/network_acl.go:524 lxc/network_forward.go:572 lxc/network_load_balancer.go:559 lxc/network_peer.go:522 lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987 lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603 lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328 lxc/network_acl.go:524 lxc/network_forward.go:572 lxc/network_load_balancer.go:559 lxc/network_peer.go:522 lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987 lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603 lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
 #, c-format
 msgid   "Error setting properties: %v"
 msgstr  ""
@@ -1876,7 +1881,7 @@ msgstr  ""
 msgid   "Error unsetting properties: %v"
 msgstr  ""
 
-#: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518 lxc/network_forward.go:566 lxc/network_load_balancer.go:553 lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141 lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806 lxc/storage_bucket.go:597 lxc/storage_volume.go:2161 lxc/storage_volume.go:2199
+#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518 lxc/network_forward.go:566 lxc/network_load_balancer.go:553 lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141 lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806 lxc/storage_bucket.go:597 lxc/storage_volume.go:2172 lxc/storage_volume.go:2210
 #, c-format
 msgid   "Error unsetting property: %v"
 msgstr  ""
@@ -1886,11 +1891,11 @@ msgstr  ""
 msgid   "Error updating template file: %s"
 msgstr  ""
 
-#: lxc/cluster.go:1298 lxc/cluster.go:1299
+#: lxc/cluster.go:1299 lxc/cluster.go:1300
 msgid   "Evacuate cluster member"
 msgstr  ""
 
-#: lxc/cluster.go:1396
+#: lxc/cluster.go:1397
 #, c-format
 msgid   "Evacuating cluster member: %s"
 msgstr  ""
@@ -1916,7 +1921,7 @@ msgid   "Execute commands in instances\n"
         "Mode defaults to non-interactive, interactive mode is selected if both stdin AND stdout are terminals (stderr is ignored)."
 msgstr  ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514 lxc/storage_volume.go:1564
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525 lxc/storage_volume.go:1575
 msgid   "Expires at"
 msgstr  ""
 
@@ -1939,7 +1944,7 @@ msgid   "Export and download images\n"
         "The output target is optional and defaults to the working directory."
 msgstr  ""
 
-#: lxc/storage_volume.go:2635 lxc/storage_volume.go:2636
+#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
 msgid   "Export custom storage volume"
 msgstr  ""
 
@@ -1951,11 +1956,11 @@ msgstr  ""
 msgid   "Export instances as backup tarballs."
 msgstr  ""
 
-#: lxc/storage_volume.go:2639
+#: lxc/storage_volume.go:2650
 msgid   "Export the volume without its snapshots"
 msgstr  ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2768
+#: lxc/export.go:152 lxc/storage_volume.go:2779
 #, c-format
 msgid   "Exporting the backup: %s"
 msgstr  ""
@@ -2134,7 +2139,7 @@ msgstr  ""
 msgid   "Fast mode (same as --columns=nsacPt)"
 msgstr  ""
 
-#: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124 lxc/operation.go:137
+#: lxc/network.go:1046 lxc/network_acl.go:133 lxc/network_zone.go:124 lxc/operation.go:137
 msgid   "Filtering isn't supported yet"
 msgstr  ""
 
@@ -2143,7 +2148,7 @@ msgstr  ""
 msgid   "Fingerprint: %s"
 msgstr  ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1303
 msgid   "Force a particular evacuation action"
 msgstr  ""
 
@@ -2151,7 +2156,7 @@ msgstr  ""
 msgid   "Force creating files or directories"
 msgstr  ""
 
-#: lxc/cluster.go:1301
+#: lxc/cluster.go:1302
 msgid   "Force evacuation without user confirmation"
 msgstr  ""
 
@@ -2163,7 +2168,7 @@ msgstr  ""
 msgid   "Force removing a member, even if degraded"
 msgstr  ""
 
-#: lxc/cluster.go:1331
+#: lxc/cluster.go:1332
 msgid   "Force restoration without user confirmation"
 msgstr  ""
 
@@ -2198,7 +2203,7 @@ msgid   "Forcefully removing a server from the cluster should only be done as a 
         "Are you really sure you want to force removing %s? (yes/no): "
 msgstr  ""
 
-#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904 lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442 lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434 lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009 lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59 lxc/network_forward.go:93 lxc/network_load_balancer.go:97 lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770 lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474 lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657 lxc/storage_bucket.go:460 lxc/storage_bucket.go:775 lxc/storage_volume.go:1614 lxc/warning.go:94
+#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904 lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442 lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434 lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010 lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59 lxc/network_forward.go:93 lxc/network_load_balancer.go:97 lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770 lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474 lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657 lxc/storage_bucket.go:460 lxc/storage_bucket.go:775 lxc/storage_volume.go:1625 lxc/warning.go:94
 msgid   "Format (csv|json|table|yaml|compact)"
 msgstr  ""
 
@@ -2258,7 +2263,7 @@ msgstr  ""
 msgid   "Generating a client certificate. This may take a minute..."
 msgstr  ""
 
-#: lxc/config.go:995 lxc/config.go:996
+#: lxc/config.go:996 lxc/config.go:997
 msgid   "Get UEFI variables for instance"
 msgstr  ""
 
@@ -2322,7 +2327,7 @@ msgstr  ""
 msgid   "Get the key as a storage property"
 msgstr  ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1249
 msgid   "Get the key as a storage volume property"
 msgstr  ""
 
@@ -2386,11 +2391,11 @@ msgstr  ""
 msgid   "Get values for storage pool configuration keys"
 msgstr  ""
 
-#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
+#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
 msgid   "Get values for storage volume configuration keys"
 msgstr  ""
 
-#: lxc/storage_volume.go:475
+#: lxc/storage_volume.go:476
 #, c-format
 msgid   "Given target %q does not match source volume location %q"
 msgstr  ""
@@ -2418,7 +2423,7 @@ msgstr  ""
 msgid   "HARDWARE ADDRESS"
 msgstr  ""
 
-#: lxc/network.go:1161
+#: lxc/network.go:1170
 msgid   "HOSTNAME"
 msgstr  ""
 
@@ -2472,7 +2477,7 @@ msgstr  ""
 msgid   "IMAGES"
 msgstr  ""
 
-#: lxc/network.go:1163
+#: lxc/network.go:1172
 msgid   "IP ADDRESS"
 msgstr  ""
 
@@ -2484,11 +2489,11 @@ msgstr  ""
 msgid   "IP addresses:"
 msgstr  ""
 
-#: lxc/list.go:560 lxc/network.go:1084
+#: lxc/list.go:560 lxc/network.go:1093
 msgid   "IPV4"
 msgstr  ""
 
-#: lxc/list.go:561 lxc/network.go:1085
+#: lxc/list.go:561 lxc/network.go:1094
 msgid   "IPV6"
 msgstr  ""
 
@@ -2518,7 +2523,7 @@ msgstr  ""
 msgid   "If the image alias already exists, delete and create a new one"
 msgstr  ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2427
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
 msgid   "If the snapshot name already exists, delete and create a new one"
 msgstr  ""
 
@@ -2530,7 +2535,7 @@ msgstr  ""
 msgid   "Ignore any configured auto-expiry for the instance"
 msgstr  ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2437
 msgid   "Ignore any configured auto-expiry for the storage volume"
 msgstr  ""
 
@@ -2580,7 +2585,7 @@ msgstr  ""
 msgid   "Immediately attach to the console"
 msgstr  ""
 
-#: lxc/storage_volume.go:2802
+#: lxc/storage_volume.go:2813
 msgid   "Import backups of custom volumes including their snapshots."
 msgstr  ""
 
@@ -2588,7 +2593,7 @@ msgstr  ""
 msgid   "Import backups of instances including their snapshots."
 msgstr  ""
 
-#: lxc/storage_volume.go:2801
+#: lxc/storage_volume.go:2812
 msgid   "Import custom storage volumes"
 msgstr  ""
 
@@ -2608,11 +2613,11 @@ msgstr  ""
 msgid   "Import instance backups"
 msgstr  ""
 
-#: lxc/storage_volume.go:2809
+#: lxc/storage_volume.go:2820
 msgid   "Import type, backup or iso (default \"backup\")"
 msgstr  ""
 
-#: lxc/storage_volume.go:2883
+#: lxc/storage_volume.go:2894
 #, c-format
 msgid   "Importing custom volume: %s"
 msgstr  ""
@@ -2656,7 +2661,7 @@ msgstr  ""
 msgid   "Instance name is: %s"
 msgstr  ""
 
-#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
+#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
 msgid   "Instance name must be specified"
 msgstr  ""
 
@@ -2737,7 +2742,7 @@ msgstr  ""
 msgid   "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr  ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2012
+#: lxc/move.go:148 lxc/storage_volume.go:2023
 msgid   "Invalid new snapshot name"
 msgstr  ""
 
@@ -2745,7 +2750,7 @@ msgstr  ""
 msgid   "Invalid new snapshot name, parent must be the same as source"
 msgstr  ""
 
-#: lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2019
 msgid   "Invalid new snapshot name, parent volume must be the same as source"
 msgstr  ""
 
@@ -2763,7 +2768,7 @@ msgstr  ""
 msgid   "Invalid protocol: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287 lxc/storage_volume.go:1411 lxc/storage_volume.go:1997 lxc/storage_volume.go:2144 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298 lxc/storage_volume.go:1422 lxc/storage_volume.go:2008 lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
 msgid   "Invalid snapshot name"
 msgstr  ""
 
@@ -2807,7 +2812,7 @@ msgstr  ""
 msgid   "LISTEN ADDRESS"
 msgstr  ""
 
-#: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163 lxc/network_load_balancer.go:165 lxc/operation.go:178 lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
+#: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163 lxc/network_load_balancer.go:165 lxc/operation.go:178 lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
 msgid   "LOCATION"
 msgstr  ""
 
@@ -2819,7 +2824,7 @@ msgstr  ""
 msgid   "LXD automatically uses either spicy or remote-viewer when present."
 msgstr  ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1020 lxc/cluster.go:1123 lxc/cluster.go:1231 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124 lxc/cluster.go:1232 lxc/cluster_group.go:485
 msgid   "LXD server isn't part of a cluster"
 msgstr  ""
 
@@ -2856,7 +2861,7 @@ msgstr  ""
 msgid   "Link speed: %dMbit/s (%s duplex)"
 msgstr  ""
 
-#: lxc/network.go:1105 lxc/network.go:1106
+#: lxc/network.go:1114 lxc/network.go:1115
 msgid   "List DHCP leases"
 msgstr  ""
 
@@ -2868,7 +2873,7 @@ msgstr  ""
 msgid   "List all active certificate add tokens"
 msgstr  ""
 
-#: lxc/cluster.go:976 lxc/cluster.go:977
+#: lxc/cluster.go:977 lxc/cluster.go:978
 msgid   "List all active cluster member join tokens"
 msgstr  ""
 
@@ -2916,7 +2921,7 @@ msgstr  ""
 msgid   "List available network zoneS"
 msgstr  ""
 
-#: lxc/network.go:1004 lxc/network.go:1005
+#: lxc/network.go:1005 lxc/network.go:1006
 msgid   "List available networks"
 msgstr  ""
 
@@ -3000,7 +3005,7 @@ msgid   "List instances\n"
         "Default column layout: ns46tS\n"
         "Fast column layout: nsacPt\n"
         "\n"
-        "A single keyword like \"web\" which will list any instance with a name starting by \"web\".\n"
+        "A single keyword like \"web\" which will list any instance with a name starting with \"web\".\n"
         "A regular expression on the instance name. (e.g. .*web.*01$).\n"
         "A key/value pair referring to a configuration item. For those, the\n"
         "namespace can be abbreviated to the smallest unambiguous identifier.\n"
@@ -3053,7 +3058,7 @@ msgid   "List instances\n"
         "  P - Profiles\n"
         "  s - State\n"
         "  S - Number of snapshots\n"
-        "  t - Type (persistent or ephemeral)\n"
+        "  t - Type (container or virtual-machine, ephemeral indicated if applicable)\n"
         "  u - CPU usage (in seconds)\n"
         "  L - Location of the instance (e.g. its cluster member)\n"
         "  f - Base Image Fingerprint (short)\n"
@@ -3100,11 +3105,11 @@ msgstr  ""
 msgid   "List storage buckets"
 msgstr  ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1603
 msgid   "List storage volumes"
 msgstr  ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1608
 msgid   "List storage volumes\n"
         "\n"
         "The -c option takes a (optionally comma-separated) list of arguments\n"
@@ -3161,7 +3166,7 @@ msgstr  ""
 msgid   "List, show and delete background operations"
 msgstr  ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1470
+#: lxc/info.go:489 lxc/storage_volume.go:1481
 #, c-format
 msgid   "Location: %s"
 msgstr  ""
@@ -3182,7 +3187,7 @@ msgstr  ""
 msgid   "Lower devices"
 msgstr  ""
 
-#: lxc/network.go:1162
+#: lxc/network.go:1171
 msgid   "MAC ADDRESS"
 msgstr  ""
 
@@ -3200,7 +3205,7 @@ msgstr  ""
 msgid   "MAD: %s (%s)"
 msgstr  ""
 
-#: lxc/network.go:1083
+#: lxc/network.go:1092
 msgid   "MANAGED"
 msgstr  ""
 
@@ -3320,7 +3325,7 @@ msgid   "Manage images\n"
         "hash or alias name (if one is set)."
 msgstr  ""
 
-#: lxc/config.go:955 lxc/config.go:956
+#: lxc/config.go:956 lxc/config.go:957
 msgid   "Manage instance UEFI variables"
 msgstr  ""
 
@@ -3457,7 +3462,7 @@ msgstr  ""
 msgid   "Member %q does not have role %q"
 msgstr  ""
 
-#: lxc/cluster.go:957
+#: lxc/cluster.go:958
 #, c-format
 msgid   "Member %s join token:"
 msgstr  ""
@@ -3514,7 +3519,7 @@ msgstr  ""
 msgid   "Missing cluster group name"
 msgstr  ""
 
-#: lxc/cluster.go:811 lxc/cluster.go:1367 lxc/cluster_group.go:129 lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82 lxc/cluster_role.go:150
+#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129 lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82 lxc/cluster_role.go:150
 msgid   "Missing cluster member name"
 msgstr  ""
 
@@ -3554,7 +3559,7 @@ msgstr  ""
 msgid   "Missing network ACL name"
 msgstr  ""
 
-#: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499 lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908 lxc/network.go:1139 lxc/network.go:1217 lxc/network.go:1283 lxc/network.go:1375 lxc/network_forward.go:127 lxc/network_forward.go:215 lxc/network_forward.go:284 lxc/network_forward.go:445 lxc/network_forward.go:530 lxc/network_forward.go:705 lxc/network_forward.go:836 lxc/network_forward.go:929 lxc/network_forward.go:1011 lxc/network_load_balancer.go:131 lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286 lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517 lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807 lxc/network_load_balancer.go:895 lxc/network_load_balancer.go:971 lxc/network_load_balancer.go:1084 lxc/network_load_balancer.go:1158 lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266 lxc/network_peer.go:401 lxc/network_peer.go:485 lxc/network_peer.go:644 lxc/network_peer.go:765
+#: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499 lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908 lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292 lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215 lxc/network_forward.go:284 lxc/network_forward.go:445 lxc/network_forward.go:530 lxc/network_forward.go:705 lxc/network_forward.go:836 lxc/network_forward.go:929 lxc/network_forward.go:1011 lxc/network_load_balancer.go:131 lxc/network_load_balancer.go:217 lxc/network_load_balancer.go:286 lxc/network_load_balancer.go:432 lxc/network_load_balancer.go:517 lxc/network_load_balancer.go:675 lxc/network_load_balancer.go:807 lxc/network_load_balancer.go:895 lxc/network_load_balancer.go:971 lxc/network_load_balancer.go:1084 lxc/network_load_balancer.go:1158 lxc/network_peer.go:119 lxc/network_peer.go:201 lxc/network_peer.go:266 lxc/network_peer.go:401 lxc/network_peer.go:485 lxc/network_peer.go:644 lxc/network_peer.go:765
 msgid   "Missing network name"
 msgstr  ""
 
@@ -3570,7 +3575,7 @@ msgstr  ""
 msgid   "Missing peer name"
 msgstr  ""
 
-#: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509 lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113 lxc/storage_bucket.go:213 lxc/storage_bucket.go:289 lxc/storage_bucket.go:408 lxc/storage_bucket.go:483 lxc/storage_bucket.go:565 lxc/storage_bucket.go:657 lxc/storage_bucket.go:799 lxc/storage_bucket.go:886 lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062 lxc/storage_bucket.go:1185 lxc/storage_volume.go:209 lxc/storage_volume.go:323 lxc/storage_volume.go:649 lxc/storage_volume.go:756 lxc/storage_volume.go:847 lxc/storage_volume.go:945 lxc/storage_volume.go:1059 lxc/storage_volume.go:1276 lxc/storage_volume.go:1986 lxc/storage_volume.go:2127 lxc/storage_volume.go:2285 lxc/storage_volume.go:2476 lxc/storage_volume.go:2593
+#: lxc/storage.go:235 lxc/storage.go:313 lxc/storage.go:431 lxc/storage.go:509 lxc/storage.go:780 lxc/storage.go:886 lxc/storage_bucket.go:113 lxc/storage_bucket.go:213 lxc/storage_bucket.go:289 lxc/storage_bucket.go:408 lxc/storage_bucket.go:483 lxc/storage_bucket.go:565 lxc/storage_bucket.go:657 lxc/storage_bucket.go:799 lxc/storage_bucket.go:886 lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062 lxc/storage_bucket.go:1185 lxc/storage_volume.go:209 lxc/storage_volume.go:324 lxc/storage_volume.go:650 lxc/storage_volume.go:757 lxc/storage_volume.go:848 lxc/storage_volume.go:951 lxc/storage_volume.go:1070 lxc/storage_volume.go:1287 lxc/storage_volume.go:1997 lxc/storage_volume.go:2138 lxc/storage_volume.go:2296 lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
 msgid   "Missing pool name"
 msgstr  ""
 
@@ -3586,11 +3591,11 @@ msgstr  ""
 msgid   "Missing source profile name"
 msgstr  ""
 
-#: lxc/storage_volume.go:438 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
 msgid   "Missing source volume name"
 msgstr  ""
 
-#: lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1411
 msgid   "Missing storage pool name"
 msgstr  ""
 
@@ -3626,7 +3631,7 @@ msgid   "Monitor a local or remote LXD server\n"
         "By default the monitor will listen to all message types."
 msgstr  ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867 lxc/storage_volume.go:964
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873 lxc/storage_volume.go:975
 msgid   "More than one device matches, specify the device name"
 msgstr  ""
 
@@ -3658,7 +3663,7 @@ msgid   "Move instances within or in between LXD servers\n"
         "The pull transfer mode is the default as it is compatible with all LXD versions.\n"
 msgstr  ""
 
-#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
 msgid   "Move storage volumes between pools"
 msgstr  ""
 
@@ -3666,11 +3671,11 @@ msgstr  ""
 msgid   "Move the instance without its snapshots"
 msgstr  ""
 
-#: lxc/storage_volume.go:1856
+#: lxc/storage_volume.go:1867
 msgid   "Move to a project different from the source"
 msgstr  ""
 
-#: lxc/storage_volume.go:518
+#: lxc/storage_volume.go:519
 #, c-format
 msgid   "Moving the storage volume: %s"
 msgstr  ""
@@ -3691,7 +3696,7 @@ msgstr  ""
 msgid   "Must supply instance name for: "
 msgstr  ""
 
-#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192 lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081 lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147 lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567 lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512 lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
+#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192 lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090 lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147 lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567 lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512 lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
 msgid   "NAME"
 msgstr  ""
 
@@ -3719,7 +3724,7 @@ msgstr  ""
 msgid   "NICs:"
 msgstr  ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525 lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545 lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525 lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545 lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid   "NO"
 msgstr  ""
 
@@ -3741,7 +3746,7 @@ msgstr  ""
 msgid   "NVRM Version: %v"
 msgstr  ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512 lxc/storage_volume.go:1562
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523 lxc/storage_volume.go:1573
 msgid   "Name"
 msgstr  ""
 
@@ -3749,7 +3754,7 @@ msgstr  ""
 msgid   "Name of the project to use for this remote:"
 msgstr  ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
 #, c-format
 msgid   "Name: %s"
 msgstr  ""
@@ -3774,7 +3779,7 @@ msgstr  ""
 msgid   "Network %s pending on member %s"
 msgstr  ""
 
-#: lxc/network.go:1227
+#: lxc/network.go:1236
 #, c-format
 msgid   "Network %s renamed to %s"
 msgstr  ""
@@ -3883,7 +3888,7 @@ msgstr  ""
 msgid   "No certificate add token for member %s on remote: %s"
 msgstr  ""
 
-#: lxc/cluster.go:1161
+#: lxc/cluster.go:1162
 #, c-format
 msgid   "No cluster join token for member %s on remote: %s"
 msgstr  ""
@@ -3892,7 +3897,7 @@ msgstr  ""
 msgid   "No device found for this network"
 msgstr  ""
 
-#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
+#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
 msgid   "No device found for this storage volume"
 msgstr  ""
 
@@ -3912,11 +3917,11 @@ msgstr  ""
 msgid   "No need to specify a warning UUID when using --all"
 msgstr  ""
 
-#: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
 msgid   "No storage pool for source volume specified"
 msgstr  ""
 
-#: lxc/storage_volume.go:502 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
 msgid   "No storage pool for target volume specified"
 msgstr  ""
 
@@ -3930,7 +3935,7 @@ msgstr  ""
 msgid   "Node %d:\n"
 msgstr  ""
 
-#: lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2035
 msgid   "Not a snapshot name"
 msgstr  ""
 
@@ -3938,15 +3943,15 @@ msgstr  ""
 msgid   "OVN:"
 msgstr  ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:343
+#: lxc/storage_volume.go:214 lxc/storage_volume.go:344 lxc/storage_volume.go:865 lxc/storage_volume.go:967
 msgid   "Only \"custom\" volumes can be attached to instances"
 msgstr  ""
 
-#: lxc/storage_volume.go:2690
+#: lxc/storage_volume.go:2701
 msgid   "Only \"custom\" volumes can be exported"
 msgstr  ""
 
-#: lxc/storage_volume.go:2489
+#: lxc/storage_volume.go:2500
 msgid   "Only \"custom\" volumes can be snapshotted"
 msgstr  ""
 
@@ -3958,11 +3963,11 @@ msgstr  ""
 msgid   "Only https:// is supported for remote image import"
 msgstr  ""
 
-#: lxc/storage_volume.go:1418
+#: lxc/storage_volume.go:1429
 msgid   "Only instance or custom volumes are supported"
 msgstr  ""
 
-#: lxc/network.go:735 lxc/network.go:1298
+#: lxc/network.go:735 lxc/network.go:1307
 msgid   "Only managed networks can be modified"
 msgstr  ""
 
@@ -3971,7 +3976,7 @@ msgstr  ""
 msgid   "Operation %s deleted"
 msgstr  ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1577
 msgid   "Optimized Storage"
 msgstr  ""
 
@@ -4001,7 +4006,7 @@ msgstr  ""
 msgid   "PID: %d"
 msgstr  ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1767
 msgid   "POOL"
 msgstr  ""
 
@@ -4017,7 +4022,7 @@ msgstr  ""
 msgid   "PROFILES"
 msgstr  ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762 lxc/warning.go:213
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1773 lxc/warning.go:213
 msgid   "PROJECT"
 msgstr  ""
 
@@ -4062,7 +4067,7 @@ msgstr  ""
 msgid   "Please provide client name: "
 msgstr  ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid   "Please provide cluster member name: "
 msgstr  ""
 
@@ -4083,7 +4088,7 @@ msgstr  ""
 msgid   "Press ctrl+c to finish"
 msgstr  ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860 lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357 lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239 lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760 lxc/network_acl.go:699 lxc/network_forward.go:768 lxc/network_load_balancer.go:739 lxc/network_peer.go:699 lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596 lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350 lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157 lxc/storage_volume.go:1189
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861 lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357 lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239 lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760 lxc/network_acl.go:699 lxc/network_forward.go:768 lxc/network_load_balancer.go:739 lxc/network_peer.go:699 lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596 lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350 lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168 lxc/storage_volume.go:1200
 msgid   "Press enter to open the editor again or ctrl+c to abort change"
 msgstr  ""
 
@@ -4200,7 +4205,7 @@ msgstr  ""
 msgid   "Property not found"
 msgstr  ""
 
-#: lxc/storage_volume.go:1356
+#: lxc/storage_volume.go:1367
 msgid   "Provide the type of the storage volume if it is not custom.\n"
         "Supported types are custom, container and virtual-machine.\n"
         "\n"
@@ -4211,7 +4216,7 @@ msgid   "Provide the type of the storage volume if it is not custom.\n"
         "    Returns state information for a virtual machine \"data\" in pool \"default\"."
 msgstr  ""
 
-#: lxc/storage_volume.go:1225
+#: lxc/storage_volume.go:1236
 msgid   "Provide the type of the storage volume if it is not custom.\n"
         "Supported types are custom, image, container and virtual-machine.\n"
         "\n"
@@ -4224,7 +4229,7 @@ msgid   "Provide the type of the storage volume if it is not custom.\n"
         "    Returns the snapshot expiration period for a virtual machine \"data\" in pool \"default\"."
 msgstr  ""
 
-#: lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2247
 msgid   "Provide the type of the storage volume if it is not custom.\n"
         "Supported types are custom, image, container and virtual-machine.\n"
         "\n"
@@ -4240,7 +4245,7 @@ msgid   "Provide the type of the storage volume if it is not custom.\n"
         "    Will show the properties of snapshot \"snap0\" for a virtual machine called \"data\" in the \"default\" pool."
 msgstr  ""
 
-#: lxc/storage_volume.go:1004
+#: lxc/storage_volume.go:1015
 msgid   "Provide the type of the storage volume if it is not custom.\n"
         "Supported types are custom, image, container and virtual-machine.\n"
         "\n"
@@ -4248,7 +4253,7 @@ msgid   "Provide the type of the storage volume if it is not custom.\n"
         "    Update a storage volume using the content of pool.yaml."
 msgstr  ""
 
-#: lxc/storage_volume.go:2081
+#: lxc/storage_volume.go:2092
 msgid   "Provide the type of the storage volume if it is not custom.\n"
         "Supported types are custom, image, container and virtual-machine.\n"
         "\n"
@@ -4259,12 +4264,12 @@ msgid   "Provide the type of the storage volume if it is not custom.\n"
         "    Sets the snapshot expiration period for a virtual machine \"data\" in pool \"default\" to seven days."
 msgstr  ""
 
-#: lxc/storage_volume.go:2357
+#: lxc/storage_volume.go:2368
 msgid   "Provide the type of the storage volume if it is not custom.\n"
         "Supported types are custom, image, container and virtual-machine.\n"
         "\n"
         "lxc storage volume unset default data size\n"
-        "    Remotes the size/quota of a custom volume \"data\" in pool \"default\".\n"
+        "    Removes the size/quota of a custom volume \"data\" in pool \"default\".\n"
         "\n"
         "lxc storage volume unset default virtual-machine/data snapshots.expiry\n"
         "    Removes the snapshot expiration period for a virtual machine \"data\" in pool \"default\"."
@@ -4343,7 +4348,7 @@ msgstr  ""
 msgid   "Recursively transfer files"
 msgstr  ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid   "Refresh and update the existing storage volume copies"
 msgstr  ""
 
@@ -4524,7 +4529,7 @@ msgstr  ""
 msgid   "Rename network ACLs"
 msgstr  ""
 
-#: lxc/network.go:1184 lxc/network.go:1185
+#: lxc/network.go:1193 lxc/network.go:1194
 msgid   "Rename networks"
 msgstr  ""
 
@@ -4540,15 +4545,15 @@ msgstr  ""
 msgid   "Rename remotes"
 msgstr  ""
 
-#: lxc/storage_volume.go:1949
+#: lxc/storage_volume.go:1960
 msgid   "Rename storage volumes"
 msgstr  ""
 
-#: lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:1959
 msgid   "Rename storage volumes and storage volume snapshots"
 msgstr  ""
 
-#: lxc/storage_volume.go:2037 lxc/storage_volume.go:2057
+#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
 #, c-format
 msgid   "Renamed storage volume from \"%s\" to \"%s\""
 msgstr  ""
@@ -4558,11 +4563,11 @@ msgstr  ""
 msgid   "Render: %s (%s)"
 msgstr  ""
 
-#: lxc/cluster.go:892 lxc/cluster.go:893
+#: lxc/cluster.go:893 lxc/cluster.go:894
 msgid   "Request a join token for adding a cluster member"
 msgstr  ""
 
-#: lxc/config.go:1032
+#: lxc/config.go:1033
 msgid   "Requested UEFI variable does not exist"
 msgstr  ""
 
@@ -4584,7 +4589,7 @@ msgid   "Restart instances\n"
         "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr  ""
 
-#: lxc/cluster.go:1328 lxc/cluster.go:1329
+#: lxc/cluster.go:1329 lxc/cluster.go:1330
 msgid   "Restore cluster member"
 msgstr  ""
 
@@ -4598,11 +4603,11 @@ msgid   "Restore instances from snapshots\n"
         "If --stateful is passed, then the running state will be restored too."
 msgstr  ""
 
-#: lxc/storage_volume.go:2552 lxc/storage_volume.go:2553
+#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
 msgid   "Restore storage volume snapshots"
 msgstr  ""
 
-#: lxc/cluster.go:1394
+#: lxc/cluster.go:1395
 #, c-format
 msgid   "Restoring cluster member: %s"
 msgstr  ""
@@ -4624,7 +4629,7 @@ msgstr  ""
 msgid   "Revoke certificate add token"
 msgstr  ""
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1087
 msgid   "Revoke cluster member join token"
 msgstr  ""
 
@@ -4674,7 +4679,7 @@ msgstr  ""
 msgid   "SSH client disconnected %q"
 msgstr  ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1088 lxc/network_peer.go:151 lxc/storage.go:725
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1097 lxc/network_peer.go:151 lxc/storage.go:725
 msgid   "STATE"
 msgstr  ""
 
@@ -4736,7 +4741,7 @@ msgstr  ""
 msgid   "Server version: %s\n"
 msgstr  ""
 
-#: lxc/config.go:1050 lxc/config.go:1051
+#: lxc/config.go:1051 lxc/config.go:1052
 msgid   "Set UEFI variables for instance"
 msgstr  ""
 
@@ -4792,11 +4797,11 @@ msgid   "Set network ACL configuration keys\n"
         "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr  ""
 
-#: lxc/network.go:1244
+#: lxc/network.go:1253
 msgid   "Set network configuration keys"
 msgstr  ""
 
-#: lxc/network.go:1245
+#: lxc/network.go:1254
 msgid   "Set network configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
@@ -4895,11 +4900,11 @@ msgid   "Set storage pool configuration keys\n"
         "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr  ""
 
-#: lxc/storage_volume.go:2075
+#: lxc/storage_volume.go:2086
 msgid   "Set storage volume configuration keys"
 msgstr  ""
 
-#: lxc/storage_volume.go:2076
+#: lxc/storage_volume.go:2087
 msgid   "Set storage volume configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
@@ -4954,7 +4959,7 @@ msgstr  ""
 msgid   "Set the key as a network peer property"
 msgstr  ""
 
-#: lxc/network.go:1252
+#: lxc/network.go:1261
 msgid   "Set the key as a network property"
 msgstr  ""
 
@@ -4982,7 +4987,7 @@ msgstr  ""
 msgid   "Set the key as a storage property"
 msgstr  ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2103
 msgid   "Set the key as a storage volume property"
 msgstr  ""
 
@@ -5047,7 +5052,7 @@ msgstr  ""
 msgid   "Show image properties"
 msgstr  ""
 
-#: lxc/config.go:1172 lxc/config.go:1173
+#: lxc/config.go:1173 lxc/config.go:1174
 msgid   "Show instance UEFI variables"
 msgstr  ""
 
@@ -5079,7 +5084,7 @@ msgstr  ""
 msgid   "Show network ACL log"
 msgstr  ""
 
-#: lxc/network.go:1340 lxc/network.go:1341
+#: lxc/network.go:1349 lxc/network.go:1350
 msgid   "Show network configurations"
 msgstr  ""
 
@@ -5127,11 +5132,11 @@ msgstr  ""
 msgid   "Show storage pool configurations and resources"
 msgstr  ""
 
-#: lxc/storage_volume.go:2233 lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
 msgid   "Show storage volume configurations"
 msgstr  ""
 
-#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
 msgid   "Show storage volume state information"
 msgstr  ""
 
@@ -5152,7 +5157,7 @@ msgid   "Show the expanded configuration"
 msgstr  ""
 
 #: lxc/info.go:43
-msgid   "Show the instance's last 100 log lines?"
+msgid   "Show the instance's last 100 log lines"
 msgstr  ""
 
 #: lxc/info.go:44
@@ -5197,15 +5202,15 @@ msgstr  ""
 msgid   "Size: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2417
+#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
 msgid   "Snapshot storage volumes"
 msgstr  ""
 
-#: lxc/storage_volume.go:2179
+#: lxc/storage_volume.go:2190
 msgid   "Snapshots are read-only and can't have their configuration changed"
 msgstr  ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1502
 msgid   "Snapshots:"
 msgstr  ""
 
@@ -5310,21 +5315,21 @@ msgstr  ""
 msgid   "Storage pool name"
 msgstr  ""
 
-#: lxc/storage_volume.go:702
+#: lxc/storage_volume.go:703
 #, c-format
 msgid   "Storage volume %s created"
 msgstr  ""
 
-#: lxc/storage_volume.go:790
+#: lxc/storage_volume.go:791
 #, c-format
 msgid   "Storage volume %s deleted"
 msgstr  ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:516
 msgid   "Storage volume copied successfully!"
 msgstr  ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:520
 msgid   "Storage volume moved successfully!"
 msgstr  ""
 
@@ -5332,7 +5337,7 @@ msgstr  ""
 msgid   "Store the instance state"
 msgstr  ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid   "Successfully updated cluster certificates for remote %s"
 msgstr  ""
@@ -5381,15 +5386,15 @@ msgstr  ""
 msgid   "TLS identity %q created with fingerprint %q"
 msgstr  ""
 
-#: lxc/cluster.go:1070 lxc/config_trust.go:515
+#: lxc/cluster.go:1071 lxc/config_trust.go:515
 msgid   "TOKEN"
 msgstr  ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147 lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082 lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172 lxc/storage_volume.go:1736 lxc/warning.go:216
+#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147 lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091 lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172 lxc/storage_volume.go:1747 lxc/warning.go:216
 msgid   "TYPE"
 msgstr  ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
 msgid   "Taken at"
 msgstr  ""
 
@@ -5542,12 +5547,12 @@ msgstr  ""
 msgid   "The property %q does not exist on the storage pool %q: %v"
 msgstr  ""
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1340
 #, c-format
 msgid   "The property %q does not exist on the storage pool volume %q: %v"
 msgstr  ""
 
-#: lxc/storage_volume.go:1306
+#: lxc/storage_volume.go:1317
 #, c-format
 msgid   "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
 msgstr  ""
@@ -5564,7 +5569,7 @@ msgstr  ""
 msgid   "The source LXD server is not clustered"
 msgstr  ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881 lxc/storage_volume.go:978
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887 lxc/storage_volume.go:989
 msgid   "The specified device doesn't exist"
 msgstr  ""
 
@@ -5584,11 +5589,11 @@ msgstr  ""
 msgid   "There is no config key to set on an instance snapshot."
 msgstr  ""
 
-#: lxc/cluster.go:739
+#: lxc/cluster.go:740
 msgid   "This LXD server is already clustered"
 msgstr  ""
 
-#: lxc/cluster.go:729
+#: lxc/cluster.go:730
 msgid   "This LXD server is not available on the network"
 msgstr  ""
 
@@ -5633,7 +5638,7 @@ msgstr  ""
 msgid   "To use --target, the destination remote must be a cluster"
 msgstr  ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid   "Total: %s"
 msgstr  ""
@@ -5648,7 +5653,7 @@ msgstr  ""
 msgid   "Transceiver type: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:1853
+#: lxc/storage_volume.go:1864
 msgid   "Transfer mode, one of pull (default), push or relay"
 msgstr  ""
 
@@ -5656,7 +5661,7 @@ msgstr  ""
 msgid   "Transfer mode. One of pull (default), push or relay"
 msgstr  ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:394
 msgid   "Transfer mode. One of pull (default), push or relay."
 msgstr  ""
 
@@ -5712,7 +5717,7 @@ msgstr  ""
 msgid   "Type of connection to establish: 'console' for serial console, 'vga' for SPICE graphical output"
 msgstr  ""
 
-#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930 lxc/storage_volume.go:1461
+#: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930 lxc/storage_volume.go:1472
 #, c-format
 msgid   "Type: %s"
 msgstr  ""
@@ -5734,11 +5739,11 @@ msgstr  ""
 msgid   "URL"
 msgstr  ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:995 lxc/storage_volume.go:1752
 msgid   "USAGE"
 msgstr  ""
 
-#: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24 lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575 lxc/storage.go:724 lxc/storage_volume.go:1740
+#: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24 lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575 lxc/storage.go:724 lxc/storage_volume.go:1751
 msgid   "USED BY"
 msgstr  ""
 
@@ -5770,7 +5775,7 @@ msgstr  ""
 msgid   "Unknown channel type for client %q: %s"
 msgstr  ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778 lxc/warning.go:242
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789 lxc/warning.go:242
 #, c-format
 msgid   "Unknown column shorthand char '%c' in '%s'"
 msgstr  ""
@@ -5795,7 +5800,7 @@ msgstr  ""
 msgid   "Unknown output type %q"
 msgstr  ""
 
-#: lxc/config.go:1141 lxc/config.go:1142
+#: lxc/config.go:1142 lxc/config.go:1143
 msgid   "Unset UEFI variables for instance"
 msgstr  ""
 
@@ -5823,7 +5828,7 @@ msgstr  ""
 msgid   "Unset network ACL configuration keys"
 msgstr  ""
 
-#: lxc/network.go:1412 lxc/network.go:1413
+#: lxc/network.go:1421 lxc/network.go:1422
 msgid   "Unset network configuration keys"
 msgstr  ""
 
@@ -5875,7 +5880,7 @@ msgstr  ""
 msgid   "Unset storage pool configuration keys"
 msgstr  ""
 
-#: lxc/storage_volume.go:2354 lxc/storage_volume.go:2355
+#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
 msgid   "Unset storage volume configuration keys"
 msgstr  ""
 
@@ -5899,7 +5904,7 @@ msgstr  ""
 msgid   "Unset the key as a network peer property"
 msgstr  ""
 
-#: lxc/network.go:1417
+#: lxc/network.go:1426
 msgid   "Unset the key as a network property"
 msgstr  ""
 
@@ -5927,7 +5932,7 @@ msgstr  ""
 msgid   "Unset the key as a storage property"
 msgstr  ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2379
 msgid   "Unset the key as a storage volume property"
 msgstr  ""
 
@@ -5935,7 +5940,7 @@ msgstr  ""
 msgid   "Unset the key as an instance property"
 msgstr  ""
 
-#: lxc/storage_volume.go:247
+#: lxc/storage_volume.go:248
 msgid   "Unsupported content type for attaching to instances"
 msgstr  ""
 
@@ -5948,11 +5953,11 @@ msgstr  ""
 msgid   "Up delay"
 msgstr  ""
 
-#: lxc/cluster.go:1174
+#: lxc/cluster.go:1175
 msgid   "Update cluster certificate"
 msgstr  ""
 
-#: lxc/cluster.go:1176
+#: lxc/cluster.go:1177
 msgid   "Update cluster certificate with PEM certificate and key read from input files."
 msgstr  ""
 
@@ -5969,12 +5974,12 @@ msgstr  ""
 msgid   "Upper devices"
 msgstr  ""
 
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid   "Usage: %s"
 msgstr  ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2641
+#: lxc/export.go:42 lxc/storage_volume.go:2652
 msgid   "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr  ""
 
@@ -6039,7 +6044,7 @@ msgstr  ""
 msgid   "View the current identity"
 msgstr  ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1576
 msgid   "Volume Only"
 msgstr  ""
 
@@ -6068,7 +6073,7 @@ msgstr  ""
 msgid   "Wipe the instance root disk and re-initialize. The original image is used to re-initialize the instance if a different image or --empty is not specified."
 msgstr  ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527 lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527 lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547 lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid   "YES"
 msgstr  ""
 
@@ -6092,15 +6097,15 @@ msgstr  ""
 msgid   "You need to specify an image name or use --empty"
 msgstr  ""
 
-#: lxc/storage_volume.go:903
+#: lxc/storage_volume.go:909
 msgid   "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:281
+#: lxc/storage_volume.go:282
 msgid   "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr  ""
 
-#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897 lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437 lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32 lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83 lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469 lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
+#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897 lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437 lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32 lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83 lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469 lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid   "[<remote>:]"
 msgstr  ""
 
@@ -6108,7 +6113,7 @@ msgstr  ""
 msgid   "[<remote>:] <backup file> [<instance name>]"
 msgstr  ""
 
-#: lxc/cluster.go:1172
+#: lxc/cluster.go:1173
 msgid   "[<remote>:] <cert.crt> <cert.key>"
 msgstr  ""
 
@@ -6264,7 +6269,7 @@ msgstr  ""
 msgid   "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr  ""
 
-#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329 lxc/config_device.go:761 lxc/config_metadata.go:54 lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329 lxc/config_device.go:761 lxc/config_metadata.go:54 lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid   "[<remote>:]<instance>"
 msgstr  ""
 
@@ -6284,11 +6289,11 @@ msgstr  ""
 msgid   "[<remote>:]<instance> <device> [key=value...]"
 msgstr  ""
 
-#: lxc/config.go:994 lxc/config.go:1140
+#: lxc/config.go:995 lxc/config.go:1141
 msgid   "[<remote>:]<instance> <key>"
 msgstr  ""
 
-#: lxc/config.go:1049
+#: lxc/config.go:1050
 msgid   "[<remote>:]<instance> <key>=<value>..."
 msgstr  ""
 
@@ -6364,7 +6369,7 @@ msgstr  ""
 msgid   "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr  ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:768 lxc/cluster.go:1085 lxc/cluster.go:1297 lxc/cluster.go:1327
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769 lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
 msgid   "[<remote>:]<member>"
 msgstr  ""
 
@@ -6388,7 +6393,7 @@ msgstr  ""
 msgid   "[<remote>:]<member> <role[,role...]>"
 msgstr  ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1104 lxc/network.go:1339 lxc/network_forward.go:87 lxc/network_load_balancer.go:91 lxc/network_peer.go:79
+#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1113 lxc/network.go:1348 lxc/network_forward.go:87 lxc/network_load_balancer.go:91 lxc/network_peer.go:79
 msgid   "[<remote>:]<network>"
 msgstr  ""
 
@@ -6400,11 +6405,11 @@ msgstr  ""
 msgid   "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr  ""
 
-#: lxc/network.go:791 lxc/network.go:1411
+#: lxc/network.go:791 lxc/network.go:1420
 msgid   "[<remote>:]<network> <key>"
 msgstr  ""
 
-#: lxc/network.go:1243
+#: lxc/network.go:1252
 msgid   "[<remote>:]<network> <key>=<value>..."
 msgstr  ""
 
@@ -6440,7 +6445,7 @@ msgstr  ""
 msgid   "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr  ""
 
-#: lxc/network.go:1182
+#: lxc/network.go:1191
 msgid   "[<remote>:]<network> <new-name>"
 msgstr  ""
 
@@ -6488,7 +6493,7 @@ msgstr  ""
 msgid   "[<remote>:]<pool>"
 msgstr  ""
 
-#: lxc/storage_volume.go:2800
+#: lxc/storage_volume.go:2811
 msgid   "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr  ""
 
@@ -6520,11 +6525,11 @@ msgstr  ""
 msgid   "[<remote>:]<pool> <key> <value>"
 msgstr  ""
 
-#: lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:1958
 msgid   "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot name>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:806
 msgid   "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr  ""
 
@@ -6532,51 +6537,51 @@ msgstr  ""
 msgid   "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:2551
+#: lxc/storage_volume.go:2562
 msgid   "[<remote>:]<pool> <volume> <snapshot>"
 msgstr  ""
 
-#: lxc/storage_volume.go:2634
+#: lxc/storage_volume.go:2645
 msgid   "[<remote>:]<pool> <volume> [<path>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:2415
+#: lxc/storage_volume.go:2426
 msgid   "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:609
+#: lxc/storage_volume.go:610
 msgid   "[<remote>:]<pool> <volume> [key=value...]"
 msgstr  ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:718
 msgid   "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
 msgid   "[<remote>:]<pool> [<type>/]<volume>"
 msgstr  ""
 
-#: lxc/storage_volume.go:2353
+#: lxc/storage_volume.go:2364
 msgid   "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr  ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2085
 msgid   "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr  ""
 
-#: lxc/storage_volume.go:2232
+#: lxc/storage_volume.go:2243
 msgid   "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:1221
+#: lxc/storage_volume.go:1232
 msgid   "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr  ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1858
 msgid   "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr  ""
 
-#: lxc/storage_volume.go:387
+#: lxc/storage_volume.go:388
 msgid   "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr  ""
 
@@ -6680,7 +6685,7 @@ msgstr  ""
 msgid   "[<remote>:][<instance>] <key>=<value>..."
 msgstr  ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1601
 msgid   "[<remote>:][<pool>] [<filter>...]"
 msgstr  ""
 
@@ -6692,7 +6697,7 @@ msgstr  ""
 msgid   "[<remote>] <IP|FQDN|URL|token>"
 msgstr  ""
 
-#: lxc/cluster.go:891
+#: lxc/cluster.go:892
 msgid   "[[<remote>:]<member>]"
 msgstr  ""
 
@@ -6755,7 +6760,7 @@ msgid   "lxc auth identity-provider-group edit <identity_provider_group> < ident
         "   Update an identity provider group using the content of identity-provider-group.yaml"
 msgstr  ""
 
-#: lxc/cluster.go:772
+#: lxc/cluster.go:773
 msgid   "lxc cluster edit <cluster member> < member.yaml\n"
         "    Update a cluster member using the content of member.yaml"
 msgstr  ""
@@ -6796,12 +6801,12 @@ msgid   "lxc config set [<remote>:]<instance> limits.cpu=2\n"
         "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr  ""
 
-#: lxc/config.go:1229
+#: lxc/config.go:1230
 msgid   "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
         "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr  ""
 
-#: lxc/config.go:1053
+#: lxc/config.go:1054
 msgid   "lxc config uefi set [<remote>:]<instance> testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
         "    Set a UEFI variable with name \"testvar\", GUID 9073e4e0-60ec-4b6e-9903-4c223c260f3c and value \"aabb\" (HEX-encoded) for the instance."
 msgstr  ""
@@ -7078,19 +7083,19 @@ msgid   "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
         "    Update a storage pool using the content of pool.yaml."
 msgstr  ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:614
 msgid   "lxc storage volume create p1 v1\n"
         "\n"
         "lxc storage volume create p1 v1 < config.yaml\n"
         "	Create storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr  ""
 
-#: lxc/storage_volume.go:2804
+#: lxc/storage_volume.go:2815
 msgid   "lxc storage volume import default backup0.tar.gz\n"
         "		Create a new custom volume using backup0.tar.gz as the source."
 msgstr  ""
 
-#: lxc/storage_volume.go:2419
+#: lxc/storage_volume.go:2430
 msgid   "lxc storage volume snapshot create default v1 snap0\n"
         "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
         "\n"

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-09 03:18-0300\n"
+"POT-Creation-Date: 2024-12-18 08:40-0700\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1030
+#: lxc/storage_volume.go:1041
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1240
+#: lxc/config.go:1241
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -412,7 +412,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:790
+#: lxc/cluster.go:791
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -585,13 +585,13 @@ msgstr ""
 msgid "Acknowledge warning"
 msgstr ""
 
+#: lxc/query.go:43
+msgid "Action"
+msgstr ""
+
 #: lxc/query.go:76
 #, c-format
 msgid "Action %q isn't supported by this tool"
-msgstr ""
-
-#: lxc/query.go:43
-msgid "Action (defaults to GET)"
 msgstr ""
 
 #: lxc/cluster_group.go:725
@@ -738,7 +738,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1596
+#: lxc/storage_volume.go:1607
 msgid "All projects"
 msgstr ""
 
@@ -760,7 +760,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1371
+#: lxc/cluster.go:1372
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -797,7 +797,7 @@ msgstr ""
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:282 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -849,16 +849,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2708
+#: lxc/storage_volume.go:2719
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2785
+#: lxc/export.go:192 lxc/storage_volume.go:2796
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1538
 msgid "Backups:"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -922,7 +922,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1739
+#: lxc/storage_volume.go:1750
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1007,7 +1007,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1097
+#: lxc/config.go:702 lxc/config.go:1098
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1024,12 +1024,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:492
+#: lxc/storage_volume.go:493
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:446
+#: lxc/storage_volume.go:447
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1105,7 +1105,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1154
+#: lxc/cluster.go:1155
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1133,8 +1133,8 @@ msgstr ""
 #: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
 #: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
-#: lxc/network_forward.go:182 lxc/network_forward.go:264
+#: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
+#: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
 #: lxc/network_forward.go:497 lxc/network_forward.go:649
 #: lxc/network_forward.go:803 lxc/network_forward.go:892
 #: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
@@ -1149,30 +1149,30 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
-#: lxc/storage_volume.go:1952 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2251 lxc/storage_volume.go:2367
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2555
-#: lxc/storage_volume.go:2643 lxc/storage_volume.go:2807
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
+#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
+#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:894
+#: lxc/cluster.go:895
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:926
+#: lxc/cluster.go:927
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:756
+#: lxc/cluster.go:757
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1209,24 +1209,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
+#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
-#: lxc/storage_volume.go:1188
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
+#: lxc/storage_volume.go:1199
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:619
+#: lxc/storage_volume.go:620
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1236,7 +1236,11 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/move.go:65
+#: lxc/move.go:65
+msgid "Copy a stateful instance as stateless"
+msgstr ""
+
+#: lxc/copy.go:60
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1284,7 +1288,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:389 lxc/storage_volume.go:390
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1292,12 +1296,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:396
+#: lxc/storage_volume.go:397
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:398
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1310,7 +1314,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:515
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1333,12 +1337,12 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1235
+#: lxc/cluster.go:1236
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1239
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1353,17 +1357,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1266
+#: lxc/cluster.go:1267
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1445,7 +1449,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1497,7 +1501,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1526,13 +1530,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1738
+#: lxc/storage_volume.go:1749
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1552,7 +1556,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2642
+#: lxc/storage_volume.go:2653
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1648,7 +1652,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1669,16 +1673,16 @@ msgstr ""
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
-#: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
+#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
+#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
-#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
-#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
+#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
+#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1701,8 +1705,8 @@ msgstr ""
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
 #: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1005 lxc/network.go:1106 lxc/network.go:1185
-#: lxc/network.go:1245 lxc/network.go:1341 lxc/network.go:1413
+#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
+#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
 #: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
 #: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
 #: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
@@ -1753,27 +1757,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
-#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
-#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
-#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1949
-#: lxc/storage_volume.go:2076 lxc/storage_volume.go:2234
-#: lxc/storage_volume.go:2355 lxc/storage_volume.go:2417
-#: lxc/storage_volume.go:2553 lxc/storage_volume.go:2636
-#: lxc/storage_volume.go:2802 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1454
+#: lxc/storage_volume.go:1465
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1785,11 +1789,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
+#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1917,7 +1921,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:516
+#: lxc/cluster.go:1072 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1939,7 +1943,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:769 lxc/cluster.go:770
+#: lxc/cluster.go:770 lxc/cluster.go:771
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1959,7 +1963,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1226 lxc/config.go:1227
+#: lxc/config.go:1227 lxc/config.go:1228
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2023,7 +2027,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2031,7 +2035,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2049,11 +2053,12 @@ msgid ""
 "new\n"
 "  LXD cluster, which will have the given name.\n"
 "\n"
-"  It's required that the LXD is already available on the network. You can "
-"check\n"
-"  that by running 'lxc config get core.https_address', and possibly set a "
-"value\n"
-"  for the address if not yet set."
+"  It's required that LXD is already available on the network. You can check\n"
+"  this by running 'lxc config get core.https_address'. If either an IP "
+"address\n"
+"  and port is displayed, or both, LXD is already available on the network. "
+"If\n"
+"  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
 #: lxc/network_zone.go:1427
@@ -2083,12 +2088,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
+#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2098,12 +2103,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
+#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
-#: lxc/storage_volume.go:2199
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
+#: lxc/storage_volume.go:2210
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2113,11 +2118,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1298 lxc/cluster.go:1299
+#: lxc/cluster.go:1299 lxc/cluster.go:1300
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1396
+#: lxc/cluster.go:1397
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2145,8 +2150,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
-#: lxc/storage_volume.go:1564
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Expires at"
 msgstr ""
 
@@ -2170,7 +2175,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2635 lxc/storage_volume.go:2636
+#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2182,11 +2187,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2639
+#: lxc/storage_volume.go:2650
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2768
+#: lxc/export.go:152 lxc/storage_volume.go:2779
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2366,7 +2371,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
+#: lxc/network.go:1046 lxc/network_acl.go:133 lxc/network_zone.go:124
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2376,7 +2381,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1303
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2384,7 +2389,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1301
+#: lxc/cluster.go:1302
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2396,7 +2401,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1331
+#: lxc/cluster.go:1332
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2437,16 +2442,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
-#: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1614 lxc/warning.go:94
+#: lxc/storage_volume.go:1625 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2506,7 +2511,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:996
+#: lxc/config.go:996 lxc/config.go:997
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2570,7 +2575,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1249
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2634,11 +2639,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
+#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:475
+#: lxc/storage_volume.go:476
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2666,7 +2671,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1161
+#: lxc/network.go:1170
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2720,7 +2725,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1163
+#: lxc/network.go:1172
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2732,11 +2737,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1084
+#: lxc/list.go:560 lxc/network.go:1093
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1085
+#: lxc/list.go:561 lxc/network.go:1094
 msgid "IPV6"
 msgstr ""
 
@@ -2766,7 +2771,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2427
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2780,7 +2785,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2437
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2830,7 +2835,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2802
+#: lxc/storage_volume.go:2813
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2838,7 +2843,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2801
+#: lxc/storage_volume.go:2812
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2860,11 +2865,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2809
+#: lxc/storage_volume.go:2820
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2883
+#: lxc/storage_volume.go:2894
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2908,7 +2913,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
+#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2990,7 +2995,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2012
+#: lxc/move.go:148 lxc/storage_volume.go:2023
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2998,7 +3003,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2019
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3016,9 +3021,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
-#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2144 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
+#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3062,9 +3067,9 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
+#: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3076,8 +3081,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1020 lxc/cluster.go:1123
-#: lxc/cluster.go:1231 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
+#: lxc/cluster.go:1232 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3114,7 +3119,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1105 lxc/network.go:1106
+#: lxc/network.go:1114 lxc/network.go:1115
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3126,7 +3131,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:976 lxc/cluster.go:977
+#: lxc/cluster.go:977 lxc/cluster.go:978
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -3174,7 +3179,7 @@ msgstr ""
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1004 lxc/network.go:1005
+#: lxc/network.go:1005 lxc/network.go:1006
 msgid "List available networks"
 msgstr ""
 
@@ -3262,7 +3267,7 @@ msgid ""
 "Fast column layout: nsacPt\n"
 "\n"
 "A single keyword like \"web\" which will list any instance with a name "
-"starting by \"web\".\n"
+"starting with \"web\".\n"
 "A regular expression on the instance name. (e.g. .*web.*01$).\n"
 "A key/value pair referring to a configuration item. For those, the\n"
 "namespace can be abbreviated to the smallest unambiguous identifier.\n"
@@ -3319,7 +3324,8 @@ msgid ""
 "  P - Profiles\n"
 "  s - State\n"
 "  S - Number of snapshots\n"
-"  t - Type (persistent or ephemeral)\n"
+"  t - Type (container or virtual-machine, ephemeral indicated if "
+"applicable)\n"
 "  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
@@ -3368,11 +3374,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1603
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1608
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3431,7 +3437,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1470
+#: lxc/info.go:489 lxc/storage_volume.go:1481
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3452,7 +3458,7 @@ msgstr ""
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1162
+#: lxc/network.go:1171
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3470,7 +3476,7 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1083
+#: lxc/network.go:1092
 msgid "MANAGED"
 msgstr ""
 
@@ -3593,7 +3599,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:955 lxc/config.go:956
+#: lxc/config.go:956 lxc/config.go:957
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3732,7 +3738,7 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:957
+#: lxc/cluster.go:958
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
@@ -3796,7 +3802,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:811 lxc/cluster.go:1367 lxc/cluster_group.go:129
+#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -3859,8 +3865,8 @@ msgstr ""
 
 #: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1139 lxc/network.go:1217 lxc/network.go:1283
-#: lxc/network.go:1375 lxc/network_forward.go:127 lxc/network_forward.go:215
+#: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
+#: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
 #: lxc/network_forward.go:284 lxc/network_forward.go:445
 #: lxc/network_forward.go:530 lxc/network_forward.go:705
 #: lxc/network_forward.go:836 lxc/network_forward.go:929
@@ -3901,12 +3907,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
-#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
-#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1986
-#: lxc/storage_volume.go:2127 lxc/storage_volume.go:2285
-#: lxc/storage_volume.go:2476 lxc/storage_volume.go:2593
+#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
+#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
 msgid "Missing pool name"
 msgstr ""
 
@@ -3925,11 +3931,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:438 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1411
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3966,8 +3972,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
-#: lxc/storage_volume.go:964
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
+#: lxc/storage_volume.go:975
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4004,7 +4010,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4012,11 +4018,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1856
+#: lxc/storage_volume.go:1867
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:518
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4038,12 +4044,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
+#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
 msgid "NAME"
 msgstr ""
 
@@ -4071,7 +4077,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
 #: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4095,8 +4101,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
-#: lxc/storage_volume.go:1562
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1573
 msgid "Name"
 msgstr ""
 
@@ -4104,7 +4110,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4129,7 +4135,7 @@ msgstr ""
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1227
+#: lxc/network.go:1236
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4239,7 +4245,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1161
+#: lxc/cluster.go:1162
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4248,7 +4254,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
+#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4268,11 +4274,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:502 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4286,7 +4292,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2035
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4294,15 +4300,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:343
+#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
+#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2690
+#: lxc/storage_volume.go:2701
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2489
+#: lxc/storage_volume.go:2500
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4314,11 +4321,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1418
+#: lxc/storage_volume.go:1429
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1298
+#: lxc/network.go:735 lxc/network.go:1307
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4327,7 +4334,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1577
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4357,7 +4364,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1767
 msgid "POOL"
 msgstr ""
 
@@ -4373,7 +4380,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1773
 #: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4419,7 +4426,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -4440,16 +4447,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
-#: lxc/storage_volume.go:1189
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
+#: lxc/storage_volume.go:1200
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4566,7 +4573,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1356
+#: lxc/storage_volume.go:1367
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4580,7 +4587,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1225
+#: lxc/storage_volume.go:1236
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4596,7 +4603,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2247
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4617,7 +4624,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1004
+#: lxc/storage_volume.go:1015
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4626,7 +4633,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2081
+#: lxc/storage_volume.go:2092
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4639,13 +4646,13 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2357
+#: lxc/storage_volume.go:2368
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
 "\n"
 "lxc storage volume unset default data size\n"
-"    Remotes the size/quota of a custom volume \"data\" in pool \"default\".\n"
+"    Removes the size/quota of a custom volume \"data\" in pool \"default\".\n"
 "\n"
 "lxc storage volume unset default virtual-machine/data snapshots.expiry\n"
 "    Removes the snapshot expiration period for a virtual machine \"data\" in "
@@ -4725,7 +4732,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4908,7 +4915,7 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1184 lxc/network.go:1185
+#: lxc/network.go:1193 lxc/network.go:1194
 msgid "Rename networks"
 msgstr ""
 
@@ -4924,15 +4931,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1949
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:1959
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2037 lxc/storage_volume.go:2057
+#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4942,11 +4949,11 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:892 lxc/cluster.go:893
+#: lxc/cluster.go:893 lxc/cluster.go:894
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1032
+#: lxc/config.go:1033
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -4969,7 +4976,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1328 lxc/cluster.go:1329
+#: lxc/cluster.go:1329 lxc/cluster.go:1330
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4984,11 +4991,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2552 lxc/storage_volume.go:2553
+#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1394
+#: lxc/cluster.go:1395
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5010,7 +5017,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1087
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5060,7 +5067,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1088
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1097
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5123,7 +5130,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1050 lxc/config.go:1051
+#: lxc/config.go:1051 lxc/config.go:1052
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5187,11 +5194,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1244
+#: lxc/network.go:1253
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1245
+#: lxc/network.go:1254
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5308,11 +5315,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2075
+#: lxc/storage_volume.go:2086
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2076
+#: lxc/storage_volume.go:2087
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5369,7 +5376,7 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1252
+#: lxc/network.go:1261
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5397,7 +5404,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2103
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5466,7 +5473,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1173
+#: lxc/config.go:1173 lxc/config.go:1174
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5498,7 +5505,7 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1340 lxc/network.go:1341
+#: lxc/network.go:1349 lxc/network.go:1350
 msgid "Show network configurations"
 msgstr ""
 
@@ -5546,11 +5553,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2233 lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5573,7 +5580,7 @@ msgid "Show the expanded configuration"
 msgstr ""
 
 #: lxc/info.go:43
-msgid "Show the instance's last 100 log lines?"
+msgid "Show the instance's last 100 log lines"
 msgstr ""
 
 #: lxc/info.go:44
@@ -5618,15 +5625,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2417
+#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2179
+#: lxc/storage_volume.go:2190
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1502
 msgid "Snapshots:"
 msgstr ""
 
@@ -5731,21 +5738,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:702
+#: lxc/storage_volume.go:703
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:790
+#: lxc/storage_volume.go:791
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:516
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:520
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5753,7 +5760,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5802,18 +5809,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1070 lxc/config_trust.go:515
+#: lxc/cluster.go:1071 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1736 lxc/warning.go:216
+#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1747 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
 msgid "Taken at"
 msgstr ""
 
@@ -5970,12 +5977,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1340
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1306
+#: lxc/storage_volume.go:1317
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -5994,8 +6001,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
-#: lxc/storage_volume.go:978
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:989
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6015,11 +6022,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:739
+#: lxc/cluster.go:740
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:729
+#: lxc/cluster.go:730
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6070,7 +6077,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6085,7 +6092,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1853
+#: lxc/storage_volume.go:1864
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6093,7 +6100,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:394
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6152,7 +6159,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1472
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6174,13 +6181,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:995 lxc/storage_volume.go:1752
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
+#: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1740
+#: lxc/storage.go:724 lxc/storage_volume.go:1751
 msgid "USED BY"
 msgstr ""
 
@@ -6212,7 +6219,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6238,7 +6245,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1141 lxc/config.go:1142
+#: lxc/config.go:1142 lxc/config.go:1143
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6266,7 +6273,7 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1412 lxc/network.go:1413
+#: lxc/network.go:1421 lxc/network.go:1422
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -6318,7 +6325,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2354 lxc/storage_volume.go:2355
+#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6342,7 +6349,7 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1417
+#: lxc/network.go:1426
 msgid "Unset the key as a network property"
 msgstr ""
 
@@ -6370,7 +6377,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2379
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6378,7 +6385,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:247
+#: lxc/storage_volume.go:248
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6391,11 +6398,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1174
+#: lxc/cluster.go:1175
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1176
+#: lxc/cluster.go:1177
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6414,12 +6421,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2641
+#: lxc/export.go:42 lxc/storage_volume.go:2652
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6486,7 +6493,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1576
 msgid "Volume Only"
 msgstr ""
 
@@ -6519,7 +6526,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
 #: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6545,18 +6552,18 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:903
+#: lxc/storage_volume.go:909
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:281
+#: lxc/storage_volume.go:282
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
-#: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
+#: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
@@ -6566,7 +6573,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1172
+#: lxc/cluster.go:1173
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -6729,7 +6736,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6751,11 +6758,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:1140
+#: lxc/config.go:995 lxc/config.go:1141
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1049
+#: lxc/config.go:1050
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -6834,8 +6841,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:768
-#: lxc/cluster.go:1085 lxc/cluster.go:1297 lxc/cluster.go:1327
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
+#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -6859,8 +6866,8 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1104
-#: lxc/network.go:1339 lxc/network_forward.go:87
+#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1113
+#: lxc/network.go:1348 lxc/network_forward.go:87
 #: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -6873,11 +6880,11 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1411
+#: lxc/network.go:791 lxc/network.go:1420
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1243
+#: lxc/network.go:1252
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
@@ -6922,7 +6929,7 @@ msgstr ""
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1182
+#: lxc/network.go:1191
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -6973,7 +6980,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2800
+#: lxc/storage_volume.go:2811
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7008,13 +7015,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:1958
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:806
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7022,51 +7029,51 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2551
+#: lxc/storage_volume.go:2562
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2634
+#: lxc/storage_volume.go:2645
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2415
+#: lxc/storage_volume.go:2426
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:609
+#: lxc/storage_volume.go:610
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:718
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2353
+#: lxc/storage_volume.go:2364
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2085
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2232
+#: lxc/storage_volume.go:2243
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1221
+#: lxc/storage_volume.go:1232
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1858
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:387
+#: lxc/storage_volume.go:388
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7172,7 +7179,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1601
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7184,7 +7191,7 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:891
+#: lxc/cluster.go:892
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -7256,7 +7263,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:772
+#: lxc/cluster.go:773
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7305,13 +7312,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1229
+#: lxc/config.go:1230
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1053
+#: lxc/config.go:1054
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7648,7 +7655,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:614
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7656,13 +7663,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2804
+#: lxc/storage_volume.go:2815
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2419
+#: lxc/storage_volume.go:2430
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-09 03:18-0300\n"
+"POT-Creation-Date: 2024-12-18 08:40-0700\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1030
+#: lxc/storage_volume.go:1041
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1240
+#: lxc/config.go:1241
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -412,7 +412,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:790
+#: lxc/cluster.go:791
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -585,13 +585,13 @@ msgstr ""
 msgid "Acknowledge warning"
 msgstr ""
 
+#: lxc/query.go:43
+msgid "Action"
+msgstr ""
+
 #: lxc/query.go:76
 #, c-format
 msgid "Action %q isn't supported by this tool"
-msgstr ""
-
-#: lxc/query.go:43
-msgid "Action (defaults to GET)"
 msgstr ""
 
 #: lxc/cluster_group.go:725
@@ -738,7 +738,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1596
+#: lxc/storage_volume.go:1607
 msgid "All projects"
 msgstr ""
 
@@ -760,7 +760,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1371
+#: lxc/cluster.go:1372
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -797,7 +797,7 @@ msgstr ""
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:282 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -849,16 +849,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2708
+#: lxc/storage_volume.go:2719
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2785
+#: lxc/export.go:192 lxc/storage_volume.go:2796
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1538
 msgid "Backups:"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -922,7 +922,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1739
+#: lxc/storage_volume.go:1750
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1007,7 +1007,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1097
+#: lxc/config.go:702 lxc/config.go:1098
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1024,12 +1024,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:492
+#: lxc/storage_volume.go:493
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:446
+#: lxc/storage_volume.go:447
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1105,7 +1105,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1154
+#: lxc/cluster.go:1155
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1133,8 +1133,8 @@ msgstr ""
 #: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
 #: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
-#: lxc/network_forward.go:182 lxc/network_forward.go:264
+#: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
+#: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
 #: lxc/network_forward.go:497 lxc/network_forward.go:649
 #: lxc/network_forward.go:803 lxc/network_forward.go:892
 #: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
@@ -1149,30 +1149,30 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
-#: lxc/storage_volume.go:1952 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2251 lxc/storage_volume.go:2367
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2555
-#: lxc/storage_volume.go:2643 lxc/storage_volume.go:2807
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
+#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
+#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:894
+#: lxc/cluster.go:895
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:926
+#: lxc/cluster.go:927
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:756
+#: lxc/cluster.go:757
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1209,24 +1209,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
+#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
-#: lxc/storage_volume.go:1188
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
+#: lxc/storage_volume.go:1199
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:619
+#: lxc/storage_volume.go:620
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1236,7 +1236,11 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/move.go:65
+#: lxc/move.go:65
+msgid "Copy a stateful instance as stateless"
+msgstr ""
+
+#: lxc/copy.go:60
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1284,7 +1288,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:389 lxc/storage_volume.go:390
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1292,12 +1296,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:396
+#: lxc/storage_volume.go:397
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:398
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1310,7 +1314,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:515
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1333,12 +1337,12 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1235
+#: lxc/cluster.go:1236
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1239
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1353,17 +1357,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1266
+#: lxc/cluster.go:1267
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1445,7 +1449,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1497,7 +1501,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1526,13 +1530,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1738
+#: lxc/storage_volume.go:1749
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1552,7 +1556,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2642
+#: lxc/storage_volume.go:2653
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1648,7 +1652,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1669,16 +1673,16 @@ msgstr ""
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
-#: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
+#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
+#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
-#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
-#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
+#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
+#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1701,8 +1705,8 @@ msgstr ""
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
 #: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1005 lxc/network.go:1106 lxc/network.go:1185
-#: lxc/network.go:1245 lxc/network.go:1341 lxc/network.go:1413
+#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
+#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
 #: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
 #: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
 #: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
@@ -1753,27 +1757,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
-#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
-#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
-#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1949
-#: lxc/storage_volume.go:2076 lxc/storage_volume.go:2234
-#: lxc/storage_volume.go:2355 lxc/storage_volume.go:2417
-#: lxc/storage_volume.go:2553 lxc/storage_volume.go:2636
-#: lxc/storage_volume.go:2802 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1454
+#: lxc/storage_volume.go:1465
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1785,11 +1789,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
+#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1917,7 +1921,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:516
+#: lxc/cluster.go:1072 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1939,7 +1943,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:769 lxc/cluster.go:770
+#: lxc/cluster.go:770 lxc/cluster.go:771
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1959,7 +1963,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1226 lxc/config.go:1227
+#: lxc/config.go:1227 lxc/config.go:1228
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2023,7 +2027,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2031,7 +2035,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2049,11 +2053,12 @@ msgid ""
 "new\n"
 "  LXD cluster, which will have the given name.\n"
 "\n"
-"  It's required that the LXD is already available on the network. You can "
-"check\n"
-"  that by running 'lxc config get core.https_address', and possibly set a "
-"value\n"
-"  for the address if not yet set."
+"  It's required that LXD is already available on the network. You can check\n"
+"  this by running 'lxc config get core.https_address'. If either an IP "
+"address\n"
+"  and port is displayed, or both, LXD is already available on the network. "
+"If\n"
+"  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
 #: lxc/network_zone.go:1427
@@ -2083,12 +2088,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
+#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2098,12 +2103,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
+#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
-#: lxc/storage_volume.go:2199
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
+#: lxc/storage_volume.go:2210
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2113,11 +2118,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1298 lxc/cluster.go:1299
+#: lxc/cluster.go:1299 lxc/cluster.go:1300
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1396
+#: lxc/cluster.go:1397
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2145,8 +2150,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
-#: lxc/storage_volume.go:1564
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Expires at"
 msgstr ""
 
@@ -2170,7 +2175,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2635 lxc/storage_volume.go:2636
+#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2182,11 +2187,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2639
+#: lxc/storage_volume.go:2650
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2768
+#: lxc/export.go:152 lxc/storage_volume.go:2779
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2366,7 +2371,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
+#: lxc/network.go:1046 lxc/network_acl.go:133 lxc/network_zone.go:124
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2376,7 +2381,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1303
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2384,7 +2389,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1301
+#: lxc/cluster.go:1302
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2396,7 +2401,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1331
+#: lxc/cluster.go:1332
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2437,16 +2442,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
-#: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1614 lxc/warning.go:94
+#: lxc/storage_volume.go:1625 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2506,7 +2511,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:996
+#: lxc/config.go:996 lxc/config.go:997
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2570,7 +2575,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1249
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2634,11 +2639,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
+#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:475
+#: lxc/storage_volume.go:476
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2666,7 +2671,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1161
+#: lxc/network.go:1170
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2720,7 +2725,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1163
+#: lxc/network.go:1172
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2732,11 +2737,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1084
+#: lxc/list.go:560 lxc/network.go:1093
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1085
+#: lxc/list.go:561 lxc/network.go:1094
 msgid "IPV6"
 msgstr ""
 
@@ -2766,7 +2771,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2427
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2780,7 +2785,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2437
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2830,7 +2835,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2802
+#: lxc/storage_volume.go:2813
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2838,7 +2843,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2801
+#: lxc/storage_volume.go:2812
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2860,11 +2865,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2809
+#: lxc/storage_volume.go:2820
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2883
+#: lxc/storage_volume.go:2894
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2908,7 +2913,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
+#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2990,7 +2995,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2012
+#: lxc/move.go:148 lxc/storage_volume.go:2023
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2998,7 +3003,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2019
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3016,9 +3021,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
-#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2144 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
+#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3062,9 +3067,9 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
+#: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3076,8 +3081,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1020 lxc/cluster.go:1123
-#: lxc/cluster.go:1231 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
+#: lxc/cluster.go:1232 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3114,7 +3119,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1105 lxc/network.go:1106
+#: lxc/network.go:1114 lxc/network.go:1115
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3126,7 +3131,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:976 lxc/cluster.go:977
+#: lxc/cluster.go:977 lxc/cluster.go:978
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -3174,7 +3179,7 @@ msgstr ""
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1004 lxc/network.go:1005
+#: lxc/network.go:1005 lxc/network.go:1006
 msgid "List available networks"
 msgstr ""
 
@@ -3262,7 +3267,7 @@ msgid ""
 "Fast column layout: nsacPt\n"
 "\n"
 "A single keyword like \"web\" which will list any instance with a name "
-"starting by \"web\".\n"
+"starting with \"web\".\n"
 "A regular expression on the instance name. (e.g. .*web.*01$).\n"
 "A key/value pair referring to a configuration item. For those, the\n"
 "namespace can be abbreviated to the smallest unambiguous identifier.\n"
@@ -3319,7 +3324,8 @@ msgid ""
 "  P - Profiles\n"
 "  s - State\n"
 "  S - Number of snapshots\n"
-"  t - Type (persistent or ephemeral)\n"
+"  t - Type (container or virtual-machine, ephemeral indicated if "
+"applicable)\n"
 "  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
@@ -3368,11 +3374,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1603
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1608
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3431,7 +3437,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1470
+#: lxc/info.go:489 lxc/storage_volume.go:1481
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3452,7 +3458,7 @@ msgstr ""
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1162
+#: lxc/network.go:1171
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3470,7 +3476,7 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1083
+#: lxc/network.go:1092
 msgid "MANAGED"
 msgstr ""
 
@@ -3593,7 +3599,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:955 lxc/config.go:956
+#: lxc/config.go:956 lxc/config.go:957
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3732,7 +3738,7 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:957
+#: lxc/cluster.go:958
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
@@ -3796,7 +3802,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:811 lxc/cluster.go:1367 lxc/cluster_group.go:129
+#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -3859,8 +3865,8 @@ msgstr ""
 
 #: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1139 lxc/network.go:1217 lxc/network.go:1283
-#: lxc/network.go:1375 lxc/network_forward.go:127 lxc/network_forward.go:215
+#: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
+#: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
 #: lxc/network_forward.go:284 lxc/network_forward.go:445
 #: lxc/network_forward.go:530 lxc/network_forward.go:705
 #: lxc/network_forward.go:836 lxc/network_forward.go:929
@@ -3901,12 +3907,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
-#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
-#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1986
-#: lxc/storage_volume.go:2127 lxc/storage_volume.go:2285
-#: lxc/storage_volume.go:2476 lxc/storage_volume.go:2593
+#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
+#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
 msgid "Missing pool name"
 msgstr ""
 
@@ -3925,11 +3931,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:438 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1411
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3966,8 +3972,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
-#: lxc/storage_volume.go:964
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
+#: lxc/storage_volume.go:975
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4004,7 +4010,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4012,11 +4018,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1856
+#: lxc/storage_volume.go:1867
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:518
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4038,12 +4044,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
+#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
 msgid "NAME"
 msgstr ""
 
@@ -4071,7 +4077,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
 #: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4095,8 +4101,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
-#: lxc/storage_volume.go:1562
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1573
 msgid "Name"
 msgstr ""
 
@@ -4104,7 +4110,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4129,7 +4135,7 @@ msgstr ""
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1227
+#: lxc/network.go:1236
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4239,7 +4245,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1161
+#: lxc/cluster.go:1162
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4248,7 +4254,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
+#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4268,11 +4274,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:502 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4286,7 +4292,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2035
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4294,15 +4300,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:343
+#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
+#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2690
+#: lxc/storage_volume.go:2701
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2489
+#: lxc/storage_volume.go:2500
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4314,11 +4321,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1418
+#: lxc/storage_volume.go:1429
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1298
+#: lxc/network.go:735 lxc/network.go:1307
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4327,7 +4334,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1577
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4357,7 +4364,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1767
 msgid "POOL"
 msgstr ""
 
@@ -4373,7 +4380,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1773
 #: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4419,7 +4426,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -4440,16 +4447,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
-#: lxc/storage_volume.go:1189
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
+#: lxc/storage_volume.go:1200
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4566,7 +4573,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1356
+#: lxc/storage_volume.go:1367
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4580,7 +4587,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1225
+#: lxc/storage_volume.go:1236
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4596,7 +4603,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2247
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4617,7 +4624,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1004
+#: lxc/storage_volume.go:1015
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4626,7 +4633,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2081
+#: lxc/storage_volume.go:2092
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4639,13 +4646,13 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2357
+#: lxc/storage_volume.go:2368
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
 "\n"
 "lxc storage volume unset default data size\n"
-"    Remotes the size/quota of a custom volume \"data\" in pool \"default\".\n"
+"    Removes the size/quota of a custom volume \"data\" in pool \"default\".\n"
 "\n"
 "lxc storage volume unset default virtual-machine/data snapshots.expiry\n"
 "    Removes the snapshot expiration period for a virtual machine \"data\" in "
@@ -4725,7 +4732,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4908,7 +4915,7 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1184 lxc/network.go:1185
+#: lxc/network.go:1193 lxc/network.go:1194
 msgid "Rename networks"
 msgstr ""
 
@@ -4924,15 +4931,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1949
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:1959
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2037 lxc/storage_volume.go:2057
+#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4942,11 +4949,11 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:892 lxc/cluster.go:893
+#: lxc/cluster.go:893 lxc/cluster.go:894
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1032
+#: lxc/config.go:1033
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -4969,7 +4976,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1328 lxc/cluster.go:1329
+#: lxc/cluster.go:1329 lxc/cluster.go:1330
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4984,11 +4991,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2552 lxc/storage_volume.go:2553
+#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1394
+#: lxc/cluster.go:1395
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5010,7 +5017,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1087
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5060,7 +5067,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1088
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1097
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5123,7 +5130,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1050 lxc/config.go:1051
+#: lxc/config.go:1051 lxc/config.go:1052
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5187,11 +5194,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1244
+#: lxc/network.go:1253
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1245
+#: lxc/network.go:1254
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5308,11 +5315,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2075
+#: lxc/storage_volume.go:2086
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2076
+#: lxc/storage_volume.go:2087
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5369,7 +5376,7 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1252
+#: lxc/network.go:1261
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5397,7 +5404,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2103
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5466,7 +5473,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1173
+#: lxc/config.go:1173 lxc/config.go:1174
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5498,7 +5505,7 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1340 lxc/network.go:1341
+#: lxc/network.go:1349 lxc/network.go:1350
 msgid "Show network configurations"
 msgstr ""
 
@@ -5546,11 +5553,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2233 lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5573,7 +5580,7 @@ msgid "Show the expanded configuration"
 msgstr ""
 
 #: lxc/info.go:43
-msgid "Show the instance's last 100 log lines?"
+msgid "Show the instance's last 100 log lines"
 msgstr ""
 
 #: lxc/info.go:44
@@ -5618,15 +5625,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2417
+#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2179
+#: lxc/storage_volume.go:2190
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1502
 msgid "Snapshots:"
 msgstr ""
 
@@ -5731,21 +5738,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:702
+#: lxc/storage_volume.go:703
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:790
+#: lxc/storage_volume.go:791
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:516
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:520
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5753,7 +5760,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5802,18 +5809,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1070 lxc/config_trust.go:515
+#: lxc/cluster.go:1071 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1736 lxc/warning.go:216
+#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1747 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
 msgid "Taken at"
 msgstr ""
 
@@ -5970,12 +5977,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1340
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1306
+#: lxc/storage_volume.go:1317
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -5994,8 +6001,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
-#: lxc/storage_volume.go:978
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:989
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6015,11 +6022,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:739
+#: lxc/cluster.go:740
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:729
+#: lxc/cluster.go:730
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6070,7 +6077,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6085,7 +6092,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1853
+#: lxc/storage_volume.go:1864
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6093,7 +6100,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:394
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6152,7 +6159,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1472
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6174,13 +6181,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:995 lxc/storage_volume.go:1752
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
+#: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1740
+#: lxc/storage.go:724 lxc/storage_volume.go:1751
 msgid "USED BY"
 msgstr ""
 
@@ -6212,7 +6219,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6238,7 +6245,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1141 lxc/config.go:1142
+#: lxc/config.go:1142 lxc/config.go:1143
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6266,7 +6273,7 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1412 lxc/network.go:1413
+#: lxc/network.go:1421 lxc/network.go:1422
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -6318,7 +6325,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2354 lxc/storage_volume.go:2355
+#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6342,7 +6349,7 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1417
+#: lxc/network.go:1426
 msgid "Unset the key as a network property"
 msgstr ""
 
@@ -6370,7 +6377,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2379
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6378,7 +6385,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:247
+#: lxc/storage_volume.go:248
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6391,11 +6398,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1174
+#: lxc/cluster.go:1175
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1176
+#: lxc/cluster.go:1177
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6414,12 +6421,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2641
+#: lxc/export.go:42 lxc/storage_volume.go:2652
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6486,7 +6493,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1576
 msgid "Volume Only"
 msgstr ""
 
@@ -6519,7 +6526,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
 #: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6545,18 +6552,18 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:903
+#: lxc/storage_volume.go:909
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:281
+#: lxc/storage_volume.go:282
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
-#: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
+#: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
@@ -6566,7 +6573,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1172
+#: lxc/cluster.go:1173
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -6729,7 +6736,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6751,11 +6758,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:1140
+#: lxc/config.go:995 lxc/config.go:1141
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1049
+#: lxc/config.go:1050
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -6834,8 +6841,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:768
-#: lxc/cluster.go:1085 lxc/cluster.go:1297 lxc/cluster.go:1327
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
+#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -6859,8 +6866,8 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1104
-#: lxc/network.go:1339 lxc/network_forward.go:87
+#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1113
+#: lxc/network.go:1348 lxc/network_forward.go:87
 #: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -6873,11 +6880,11 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1411
+#: lxc/network.go:791 lxc/network.go:1420
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1243
+#: lxc/network.go:1252
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
@@ -6922,7 +6929,7 @@ msgstr ""
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1182
+#: lxc/network.go:1191
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -6973,7 +6980,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2800
+#: lxc/storage_volume.go:2811
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7008,13 +7015,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:1958
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:806
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7022,51 +7029,51 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2551
+#: lxc/storage_volume.go:2562
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2634
+#: lxc/storage_volume.go:2645
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2415
+#: lxc/storage_volume.go:2426
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:609
+#: lxc/storage_volume.go:610
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:718
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2353
+#: lxc/storage_volume.go:2364
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2085
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2232
+#: lxc/storage_volume.go:2243
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1221
+#: lxc/storage_volume.go:1232
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1858
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:387
+#: lxc/storage_volume.go:388
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7172,7 +7179,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1601
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7184,7 +7191,7 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:891
+#: lxc/cluster.go:892
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -7256,7 +7263,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:772
+#: lxc/cluster.go:773
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7305,13 +7312,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1229
+#: lxc/config.go:1230
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1053
+#: lxc/config.go:1054
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7648,7 +7655,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:614
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7656,13 +7663,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2804
+#: lxc/storage_volume.go:2815
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2419
+#: lxc/storage_volume.go:2430
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-09 03:18-0300\n"
+"POT-Creation-Date: 2024-12-18 08:40-0700\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -74,7 +74,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:1030
+#: lxc/storage_volume.go:1041
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -99,7 +99,7 @@ msgstr ""
 "### config:\n"
 "###  size: \"61203283968\""
 
-#: lxc/config.go:1240
+#: lxc/config.go:1241
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -636,7 +636,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/cluster.go:790
+#: lxc/cluster.go:791
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -809,13 +809,13 @@ msgstr ""
 msgid "Acknowledge warning"
 msgstr ""
 
+#: lxc/query.go:43
+msgid "Action"
+msgstr ""
+
 #: lxc/query.go:76
 #, c-format
 msgid "Action %q isn't supported by this tool"
-msgstr ""
-
-#: lxc/query.go:43
-msgid "Action (defaults to GET)"
 msgstr ""
 
 #: lxc/cluster_group.go:725
@@ -962,7 +962,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1596
+#: lxc/storage_volume.go:1607
 msgid "All projects"
 msgstr ""
 
@@ -984,7 +984,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1371
+#: lxc/cluster.go:1372
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -1021,7 +1021,7 @@ msgstr ""
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:282 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -1073,16 +1073,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2708
+#: lxc/storage_volume.go:2719
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2785
+#: lxc/export.go:192 lxc/storage_volume.go:2796
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1538
 msgid "Backups:"
 msgstr ""
 
@@ -1103,7 +1103,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1146,7 +1146,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1739
+#: lxc/storage_volume.go:1750
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1231,7 +1231,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1239,7 +1239,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1097
+#: lxc/config.go:702 lxc/config.go:1098
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1248,12 +1248,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:492
+#: lxc/storage_volume.go:493
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:446
+#: lxc/storage_volume.go:447
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1329,7 +1329,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1154
+#: lxc/cluster.go:1155
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1357,8 +1357,8 @@ msgstr ""
 #: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
 #: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
-#: lxc/network_forward.go:182 lxc/network_forward.go:264
+#: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
+#: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
 #: lxc/network_forward.go:497 lxc/network_forward.go:649
 #: lxc/network_forward.go:803 lxc/network_forward.go:892
 #: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
@@ -1373,30 +1373,30 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
-#: lxc/storage_volume.go:1952 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2251 lxc/storage_volume.go:2367
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2555
-#: lxc/storage_volume.go:2643 lxc/storage_volume.go:2807
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
+#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
+#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:894
+#: lxc/cluster.go:895
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:926
+#: lxc/cluster.go:927
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:756
+#: lxc/cluster.go:757
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1433,24 +1433,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
+#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
-#: lxc/storage_volume.go:1188
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
+#: lxc/storage_volume.go:1199
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:619
+#: lxc/storage_volume.go:620
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1460,7 +1460,11 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/move.go:65
+#: lxc/move.go:65
+msgid "Copy a stateful instance as stateless"
+msgstr ""
+
+#: lxc/copy.go:60
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1508,7 +1512,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:389 lxc/storage_volume.go:390
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1516,12 +1520,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:396
+#: lxc/storage_volume.go:397
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:398
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1534,7 +1538,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:515
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1557,12 +1561,12 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1235
+#: lxc/cluster.go:1236
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1239
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1577,17 +1581,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1266
+#: lxc/cluster.go:1267
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1669,7 +1673,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1721,7 +1725,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1750,13 +1754,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1738
+#: lxc/storage_volume.go:1749
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1776,7 +1780,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2642
+#: lxc/storage_volume.go:2653
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1872,7 +1876,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1893,16 +1897,16 @@ msgstr ""
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
-#: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
+#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
+#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
-#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
-#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
+#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
+#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1925,8 +1929,8 @@ msgstr ""
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
 #: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1005 lxc/network.go:1106 lxc/network.go:1185
-#: lxc/network.go:1245 lxc/network.go:1341 lxc/network.go:1413
+#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
+#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
 #: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
 #: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
 #: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
@@ -1977,27 +1981,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
-#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
-#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
-#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1949
-#: lxc/storage_volume.go:2076 lxc/storage_volume.go:2234
-#: lxc/storage_volume.go:2355 lxc/storage_volume.go:2417
-#: lxc/storage_volume.go:2553 lxc/storage_volume.go:2636
-#: lxc/storage_volume.go:2802 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1454
+#: lxc/storage_volume.go:1465
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -2009,11 +2013,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
+#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2141,7 +2145,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:516
+#: lxc/cluster.go:1072 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -2163,7 +2167,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:769 lxc/cluster.go:770
+#: lxc/cluster.go:770 lxc/cluster.go:771
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2183,7 +2187,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1226 lxc/config.go:1227
+#: lxc/config.go:1227 lxc/config.go:1228
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2247,7 +2251,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2255,7 +2259,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2273,11 +2277,12 @@ msgid ""
 "new\n"
 "  LXD cluster, which will have the given name.\n"
 "\n"
-"  It's required that the LXD is already available on the network. You can "
-"check\n"
-"  that by running 'lxc config get core.https_address', and possibly set a "
-"value\n"
-"  for the address if not yet set."
+"  It's required that LXD is already available on the network. You can check\n"
+"  this by running 'lxc config get core.https_address'. If either an IP "
+"address\n"
+"  and port is displayed, or both, LXD is already available on the network. "
+"If\n"
+"  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
 #: lxc/network_zone.go:1427
@@ -2307,12 +2312,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
+#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2322,12 +2327,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
+#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
-#: lxc/storage_volume.go:2199
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
+#: lxc/storage_volume.go:2210
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2337,11 +2342,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1298 lxc/cluster.go:1299
+#: lxc/cluster.go:1299 lxc/cluster.go:1300
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1396
+#: lxc/cluster.go:1397
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2369,8 +2374,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
-#: lxc/storage_volume.go:1564
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Expires at"
 msgstr ""
 
@@ -2394,7 +2399,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2635 lxc/storage_volume.go:2636
+#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2406,11 +2411,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2639
+#: lxc/storage_volume.go:2650
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2768
+#: lxc/export.go:152 lxc/storage_volume.go:2779
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2590,7 +2595,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
+#: lxc/network.go:1046 lxc/network_acl.go:133 lxc/network_zone.go:124
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2600,7 +2605,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1303
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2608,7 +2613,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1301
+#: lxc/cluster.go:1302
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2620,7 +2625,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1331
+#: lxc/cluster.go:1332
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2661,16 +2666,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
-#: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1614 lxc/warning.go:94
+#: lxc/storage_volume.go:1625 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2730,7 +2735,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:996
+#: lxc/config.go:996 lxc/config.go:997
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2794,7 +2799,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1249
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2858,11 +2863,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
+#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:475
+#: lxc/storage_volume.go:476
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2890,7 +2895,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1161
+#: lxc/network.go:1170
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2944,7 +2949,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1163
+#: lxc/network.go:1172
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2956,11 +2961,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1084
+#: lxc/list.go:560 lxc/network.go:1093
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1085
+#: lxc/list.go:561 lxc/network.go:1094
 msgid "IPV6"
 msgstr ""
 
@@ -2990,7 +2995,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2427
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3004,7 +3009,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2437
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3054,7 +3059,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2802
+#: lxc/storage_volume.go:2813
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3062,7 +3067,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2801
+#: lxc/storage_volume.go:2812
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -3084,11 +3089,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2809
+#: lxc/storage_volume.go:2820
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2883
+#: lxc/storage_volume.go:2894
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3132,7 +3137,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
+#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3214,7 +3219,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2012
+#: lxc/move.go:148 lxc/storage_volume.go:2023
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3222,7 +3227,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2019
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3240,9 +3245,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
-#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2144 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
+#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3286,9 +3291,9 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
+#: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3300,8 +3305,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1020 lxc/cluster.go:1123
-#: lxc/cluster.go:1231 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
+#: lxc/cluster.go:1232 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3338,7 +3343,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1105 lxc/network.go:1106
+#: lxc/network.go:1114 lxc/network.go:1115
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3350,7 +3355,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:976 lxc/cluster.go:977
+#: lxc/cluster.go:977 lxc/cluster.go:978
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -3398,7 +3403,7 @@ msgstr ""
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1004 lxc/network.go:1005
+#: lxc/network.go:1005 lxc/network.go:1006
 msgid "List available networks"
 msgstr ""
 
@@ -3486,7 +3491,7 @@ msgid ""
 "Fast column layout: nsacPt\n"
 "\n"
 "A single keyword like \"web\" which will list any instance with a name "
-"starting by \"web\".\n"
+"starting with \"web\".\n"
 "A regular expression on the instance name. (e.g. .*web.*01$).\n"
 "A key/value pair referring to a configuration item. For those, the\n"
 "namespace can be abbreviated to the smallest unambiguous identifier.\n"
@@ -3543,7 +3548,8 @@ msgid ""
 "  P - Profiles\n"
 "  s - State\n"
 "  S - Number of snapshots\n"
-"  t - Type (persistent or ephemeral)\n"
+"  t - Type (container or virtual-machine, ephemeral indicated if "
+"applicable)\n"
 "  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
@@ -3592,11 +3598,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1603
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1608
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3655,7 +3661,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1470
+#: lxc/info.go:489 lxc/storage_volume.go:1481
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3676,7 +3682,7 @@ msgstr ""
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1162
+#: lxc/network.go:1171
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3694,7 +3700,7 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1083
+#: lxc/network.go:1092
 msgid "MANAGED"
 msgstr ""
 
@@ -3817,7 +3823,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:955 lxc/config.go:956
+#: lxc/config.go:956 lxc/config.go:957
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3956,7 +3962,7 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:957
+#: lxc/cluster.go:958
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
@@ -4020,7 +4026,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:811 lxc/cluster.go:1367 lxc/cluster_group.go:129
+#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -4083,8 +4089,8 @@ msgstr ""
 
 #: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1139 lxc/network.go:1217 lxc/network.go:1283
-#: lxc/network.go:1375 lxc/network_forward.go:127 lxc/network_forward.go:215
+#: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
+#: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
 #: lxc/network_forward.go:284 lxc/network_forward.go:445
 #: lxc/network_forward.go:530 lxc/network_forward.go:705
 #: lxc/network_forward.go:836 lxc/network_forward.go:929
@@ -4125,12 +4131,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
-#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
-#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1986
-#: lxc/storage_volume.go:2127 lxc/storage_volume.go:2285
-#: lxc/storage_volume.go:2476 lxc/storage_volume.go:2593
+#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
+#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
 msgid "Missing pool name"
 msgstr ""
 
@@ -4149,11 +4155,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:438 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1411
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4190,8 +4196,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
-#: lxc/storage_volume.go:964
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
+#: lxc/storage_volume.go:975
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4228,7 +4234,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4236,11 +4242,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1856
+#: lxc/storage_volume.go:1867
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:518
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4262,12 +4268,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
+#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
 msgid "NAME"
 msgstr ""
 
@@ -4295,7 +4301,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
 #: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4319,8 +4325,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
-#: lxc/storage_volume.go:1562
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1573
 msgid "Name"
 msgstr ""
 
@@ -4328,7 +4334,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4353,7 +4359,7 @@ msgstr ""
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1227
+#: lxc/network.go:1236
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4463,7 +4469,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1161
+#: lxc/cluster.go:1162
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4472,7 +4478,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
+#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4492,11 +4498,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:502 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4510,7 +4516,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2035
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4518,15 +4524,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:343
+#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
+#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2690
+#: lxc/storage_volume.go:2701
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2489
+#: lxc/storage_volume.go:2500
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4538,11 +4545,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1418
+#: lxc/storage_volume.go:1429
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1298
+#: lxc/network.go:735 lxc/network.go:1307
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4551,7 +4558,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1577
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4581,7 +4588,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1767
 msgid "POOL"
 msgstr ""
 
@@ -4597,7 +4604,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1773
 #: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4643,7 +4650,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -4664,16 +4671,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
-#: lxc/storage_volume.go:1189
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
+#: lxc/storage_volume.go:1200
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4790,7 +4797,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1356
+#: lxc/storage_volume.go:1367
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4804,7 +4811,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1225
+#: lxc/storage_volume.go:1236
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4820,7 +4827,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2247
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4841,7 +4848,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1004
+#: lxc/storage_volume.go:1015
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4850,7 +4857,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2081
+#: lxc/storage_volume.go:2092
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4863,13 +4870,13 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2357
+#: lxc/storage_volume.go:2368
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
 "\n"
 "lxc storage volume unset default data size\n"
-"    Remotes the size/quota of a custom volume \"data\" in pool \"default\".\n"
+"    Removes the size/quota of a custom volume \"data\" in pool \"default\".\n"
 "\n"
 "lxc storage volume unset default virtual-machine/data snapshots.expiry\n"
 "    Removes the snapshot expiration period for a virtual machine \"data\" in "
@@ -4949,7 +4956,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -5132,7 +5139,7 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1184 lxc/network.go:1185
+#: lxc/network.go:1193 lxc/network.go:1194
 msgid "Rename networks"
 msgstr ""
 
@@ -5148,15 +5155,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1949
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:1959
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2037 lxc/storage_volume.go:2057
+#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5166,11 +5173,11 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:892 lxc/cluster.go:893
+#: lxc/cluster.go:893 lxc/cluster.go:894
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1032
+#: lxc/config.go:1033
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5193,7 +5200,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1328 lxc/cluster.go:1329
+#: lxc/cluster.go:1329 lxc/cluster.go:1330
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5208,11 +5215,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2552 lxc/storage_volume.go:2553
+#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1394
+#: lxc/cluster.go:1395
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5234,7 +5241,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1087
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5284,7 +5291,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1088
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1097
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5347,7 +5354,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1050 lxc/config.go:1051
+#: lxc/config.go:1051 lxc/config.go:1052
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5411,11 +5418,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1244
+#: lxc/network.go:1253
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1245
+#: lxc/network.go:1254
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5532,11 +5539,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2075
+#: lxc/storage_volume.go:2086
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2076
+#: lxc/storage_volume.go:2087
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5593,7 +5600,7 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1252
+#: lxc/network.go:1261
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5621,7 +5628,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2103
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5690,7 +5697,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1173
+#: lxc/config.go:1173 lxc/config.go:1174
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5722,7 +5729,7 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1340 lxc/network.go:1341
+#: lxc/network.go:1349 lxc/network.go:1350
 msgid "Show network configurations"
 msgstr ""
 
@@ -5770,11 +5777,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2233 lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5797,7 +5804,7 @@ msgid "Show the expanded configuration"
 msgstr ""
 
 #: lxc/info.go:43
-msgid "Show the instance's last 100 log lines?"
+msgid "Show the instance's last 100 log lines"
 msgstr ""
 
 #: lxc/info.go:44
@@ -5842,15 +5849,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2417
+#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2179
+#: lxc/storage_volume.go:2190
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1502
 msgid "Snapshots:"
 msgstr ""
 
@@ -5955,21 +5962,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:702
+#: lxc/storage_volume.go:703
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:790
+#: lxc/storage_volume.go:791
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:516
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:520
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5977,7 +5984,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -6026,18 +6033,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1070 lxc/config_trust.go:515
+#: lxc/cluster.go:1071 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1736 lxc/warning.go:216
+#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1747 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
 msgid "Taken at"
 msgstr ""
 
@@ -6194,12 +6201,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1340
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1306
+#: lxc/storage_volume.go:1317
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6218,8 +6225,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
-#: lxc/storage_volume.go:978
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:989
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6239,11 +6246,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:739
+#: lxc/cluster.go:740
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:729
+#: lxc/cluster.go:730
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6294,7 +6301,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6309,7 +6316,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1853
+#: lxc/storage_volume.go:1864
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6317,7 +6324,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:394
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6376,7 +6383,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1472
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6398,13 +6405,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:995 lxc/storage_volume.go:1752
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
+#: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1740
+#: lxc/storage.go:724 lxc/storage_volume.go:1751
 msgid "USED BY"
 msgstr ""
 
@@ -6436,7 +6443,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6462,7 +6469,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1141 lxc/config.go:1142
+#: lxc/config.go:1142 lxc/config.go:1143
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6490,7 +6497,7 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1412 lxc/network.go:1413
+#: lxc/network.go:1421 lxc/network.go:1422
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -6542,7 +6549,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2354 lxc/storage_volume.go:2355
+#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6566,7 +6573,7 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1417
+#: lxc/network.go:1426
 msgid "Unset the key as a network property"
 msgstr ""
 
@@ -6594,7 +6601,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2379
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6602,7 +6609,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:247
+#: lxc/storage_volume.go:248
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6615,11 +6622,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1174
+#: lxc/cluster.go:1175
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1176
+#: lxc/cluster.go:1177
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6638,12 +6645,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2641
+#: lxc/export.go:42 lxc/storage_volume.go:2652
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6710,7 +6717,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1576
 msgid "Volume Only"
 msgstr ""
 
@@ -6743,7 +6750,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
 #: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6769,18 +6776,18 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:903
+#: lxc/storage_volume.go:909
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:281
+#: lxc/storage_volume.go:282
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
-#: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
+#: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
@@ -6790,7 +6797,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1172
+#: lxc/cluster.go:1173
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -6953,7 +6960,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6975,11 +6982,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:1140
+#: lxc/config.go:995 lxc/config.go:1141
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1049
+#: lxc/config.go:1050
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7058,8 +7065,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:768
-#: lxc/cluster.go:1085 lxc/cluster.go:1297 lxc/cluster.go:1327
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
+#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -7083,8 +7090,8 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1104
-#: lxc/network.go:1339 lxc/network_forward.go:87
+#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1113
+#: lxc/network.go:1348 lxc/network_forward.go:87
 #: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -7097,11 +7104,11 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1411
+#: lxc/network.go:791 lxc/network.go:1420
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1243
+#: lxc/network.go:1252
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
@@ -7146,7 +7153,7 @@ msgstr ""
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1182
+#: lxc/network.go:1191
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7197,7 +7204,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2800
+#: lxc/storage_volume.go:2811
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7232,13 +7239,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:1958
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:806
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7246,51 +7253,51 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2551
+#: lxc/storage_volume.go:2562
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2634
+#: lxc/storage_volume.go:2645
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2415
+#: lxc/storage_volume.go:2426
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:609
+#: lxc/storage_volume.go:610
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:718
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2353
+#: lxc/storage_volume.go:2364
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2085
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2232
+#: lxc/storage_volume.go:2243
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1221
+#: lxc/storage_volume.go:1232
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1858
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:387
+#: lxc/storage_volume.go:388
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7396,7 +7403,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1601
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7408,7 +7415,7 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:891
+#: lxc/cluster.go:892
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -7480,7 +7487,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:772
+#: lxc/cluster.go:773
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7529,13 +7536,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1229
+#: lxc/config.go:1230
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1053
+#: lxc/config.go:1054
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7872,7 +7879,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:614
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7880,13 +7887,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2804
+#: lxc/storage_volume.go:2815
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2419
+#: lxc/storage_volume.go:2430
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-09 03:18-0300\n"
+"POT-Creation-Date: 2024-12-18 08:40-0700\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1030
+#: lxc/storage_volume.go:1041
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1240
+#: lxc/config.go:1241
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -412,7 +412,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:790
+#: lxc/cluster.go:791
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -585,13 +585,13 @@ msgstr ""
 msgid "Acknowledge warning"
 msgstr ""
 
+#: lxc/query.go:43
+msgid "Action"
+msgstr ""
+
 #: lxc/query.go:76
 #, c-format
 msgid "Action %q isn't supported by this tool"
-msgstr ""
-
-#: lxc/query.go:43
-msgid "Action (defaults to GET)"
 msgstr ""
 
 #: lxc/cluster_group.go:725
@@ -738,7 +738,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1596
+#: lxc/storage_volume.go:1607
 msgid "All projects"
 msgstr ""
 
@@ -760,7 +760,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1371
+#: lxc/cluster.go:1372
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -797,7 +797,7 @@ msgstr ""
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:282 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -849,16 +849,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2708
+#: lxc/storage_volume.go:2719
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2785
+#: lxc/export.go:192 lxc/storage_volume.go:2796
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1538
 msgid "Backups:"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -922,7 +922,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1739
+#: lxc/storage_volume.go:1750
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1007,7 +1007,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1097
+#: lxc/config.go:702 lxc/config.go:1098
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1024,12 +1024,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:492
+#: lxc/storage_volume.go:493
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:446
+#: lxc/storage_volume.go:447
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1105,7 +1105,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1154
+#: lxc/cluster.go:1155
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1133,8 +1133,8 @@ msgstr ""
 #: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
 #: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
-#: lxc/network_forward.go:182 lxc/network_forward.go:264
+#: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
+#: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
 #: lxc/network_forward.go:497 lxc/network_forward.go:649
 #: lxc/network_forward.go:803 lxc/network_forward.go:892
 #: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
@@ -1149,30 +1149,30 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
-#: lxc/storage_volume.go:1952 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2251 lxc/storage_volume.go:2367
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2555
-#: lxc/storage_volume.go:2643 lxc/storage_volume.go:2807
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
+#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
+#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:894
+#: lxc/cluster.go:895
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:926
+#: lxc/cluster.go:927
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:756
+#: lxc/cluster.go:757
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1209,24 +1209,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
+#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
-#: lxc/storage_volume.go:1188
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
+#: lxc/storage_volume.go:1199
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:619
+#: lxc/storage_volume.go:620
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1236,7 +1236,11 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/move.go:65
+#: lxc/move.go:65
+msgid "Copy a stateful instance as stateless"
+msgstr ""
+
+#: lxc/copy.go:60
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1284,7 +1288,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:389 lxc/storage_volume.go:390
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1292,12 +1296,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:396
+#: lxc/storage_volume.go:397
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:398
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1310,7 +1314,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:515
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1333,12 +1337,12 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1235
+#: lxc/cluster.go:1236
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1239
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1353,17 +1357,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1266
+#: lxc/cluster.go:1267
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1445,7 +1449,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1497,7 +1501,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1526,13 +1530,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1738
+#: lxc/storage_volume.go:1749
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1552,7 +1556,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2642
+#: lxc/storage_volume.go:2653
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1648,7 +1652,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1669,16 +1673,16 @@ msgstr ""
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
-#: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
+#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
+#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
-#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
-#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
+#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
+#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1701,8 +1705,8 @@ msgstr ""
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
 #: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1005 lxc/network.go:1106 lxc/network.go:1185
-#: lxc/network.go:1245 lxc/network.go:1341 lxc/network.go:1413
+#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
+#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
 #: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
 #: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
 #: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
@@ -1753,27 +1757,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
-#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
-#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
-#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1949
-#: lxc/storage_volume.go:2076 lxc/storage_volume.go:2234
-#: lxc/storage_volume.go:2355 lxc/storage_volume.go:2417
-#: lxc/storage_volume.go:2553 lxc/storage_volume.go:2636
-#: lxc/storage_volume.go:2802 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1454
+#: lxc/storage_volume.go:1465
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1785,11 +1789,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
+#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1917,7 +1921,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:516
+#: lxc/cluster.go:1072 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1939,7 +1943,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:769 lxc/cluster.go:770
+#: lxc/cluster.go:770 lxc/cluster.go:771
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1959,7 +1963,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1226 lxc/config.go:1227
+#: lxc/config.go:1227 lxc/config.go:1228
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2023,7 +2027,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2031,7 +2035,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2049,11 +2053,12 @@ msgid ""
 "new\n"
 "  LXD cluster, which will have the given name.\n"
 "\n"
-"  It's required that the LXD is already available on the network. You can "
-"check\n"
-"  that by running 'lxc config get core.https_address', and possibly set a "
-"value\n"
-"  for the address if not yet set."
+"  It's required that LXD is already available on the network. You can check\n"
+"  this by running 'lxc config get core.https_address'. If either an IP "
+"address\n"
+"  and port is displayed, or both, LXD is already available on the network. "
+"If\n"
+"  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
 #: lxc/network_zone.go:1427
@@ -2083,12 +2088,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
+#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2098,12 +2103,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
+#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
-#: lxc/storage_volume.go:2199
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
+#: lxc/storage_volume.go:2210
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2113,11 +2118,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1298 lxc/cluster.go:1299
+#: lxc/cluster.go:1299 lxc/cluster.go:1300
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1396
+#: lxc/cluster.go:1397
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2145,8 +2150,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
-#: lxc/storage_volume.go:1564
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Expires at"
 msgstr ""
 
@@ -2170,7 +2175,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2635 lxc/storage_volume.go:2636
+#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2182,11 +2187,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2639
+#: lxc/storage_volume.go:2650
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2768
+#: lxc/export.go:152 lxc/storage_volume.go:2779
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2366,7 +2371,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
+#: lxc/network.go:1046 lxc/network_acl.go:133 lxc/network_zone.go:124
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2376,7 +2381,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1303
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2384,7 +2389,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1301
+#: lxc/cluster.go:1302
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2396,7 +2401,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1331
+#: lxc/cluster.go:1332
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2437,16 +2442,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
-#: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1614 lxc/warning.go:94
+#: lxc/storage_volume.go:1625 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2506,7 +2511,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:996
+#: lxc/config.go:996 lxc/config.go:997
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2570,7 +2575,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1249
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2634,11 +2639,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
+#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:475
+#: lxc/storage_volume.go:476
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2666,7 +2671,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1161
+#: lxc/network.go:1170
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2720,7 +2725,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1163
+#: lxc/network.go:1172
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2732,11 +2737,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1084
+#: lxc/list.go:560 lxc/network.go:1093
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1085
+#: lxc/list.go:561 lxc/network.go:1094
 msgid "IPV6"
 msgstr ""
 
@@ -2766,7 +2771,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2427
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2780,7 +2785,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2437
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2830,7 +2835,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2802
+#: lxc/storage_volume.go:2813
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2838,7 +2843,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2801
+#: lxc/storage_volume.go:2812
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2860,11 +2865,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2809
+#: lxc/storage_volume.go:2820
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2883
+#: lxc/storage_volume.go:2894
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2908,7 +2913,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
+#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2990,7 +2995,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2012
+#: lxc/move.go:148 lxc/storage_volume.go:2023
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2998,7 +3003,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2019
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3016,9 +3021,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
-#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2144 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
+#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3062,9 +3067,9 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
+#: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3076,8 +3081,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1020 lxc/cluster.go:1123
-#: lxc/cluster.go:1231 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
+#: lxc/cluster.go:1232 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3114,7 +3119,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1105 lxc/network.go:1106
+#: lxc/network.go:1114 lxc/network.go:1115
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3126,7 +3131,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:976 lxc/cluster.go:977
+#: lxc/cluster.go:977 lxc/cluster.go:978
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -3174,7 +3179,7 @@ msgstr ""
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1004 lxc/network.go:1005
+#: lxc/network.go:1005 lxc/network.go:1006
 msgid "List available networks"
 msgstr ""
 
@@ -3262,7 +3267,7 @@ msgid ""
 "Fast column layout: nsacPt\n"
 "\n"
 "A single keyword like \"web\" which will list any instance with a name "
-"starting by \"web\".\n"
+"starting with \"web\".\n"
 "A regular expression on the instance name. (e.g. .*web.*01$).\n"
 "A key/value pair referring to a configuration item. For those, the\n"
 "namespace can be abbreviated to the smallest unambiguous identifier.\n"
@@ -3319,7 +3324,8 @@ msgid ""
 "  P - Profiles\n"
 "  s - State\n"
 "  S - Number of snapshots\n"
-"  t - Type (persistent or ephemeral)\n"
+"  t - Type (container or virtual-machine, ephemeral indicated if "
+"applicable)\n"
 "  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
@@ -3368,11 +3374,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1603
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1608
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3431,7 +3437,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1470
+#: lxc/info.go:489 lxc/storage_volume.go:1481
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3452,7 +3458,7 @@ msgstr ""
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1162
+#: lxc/network.go:1171
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3470,7 +3476,7 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1083
+#: lxc/network.go:1092
 msgid "MANAGED"
 msgstr ""
 
@@ -3593,7 +3599,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:955 lxc/config.go:956
+#: lxc/config.go:956 lxc/config.go:957
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3732,7 +3738,7 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:957
+#: lxc/cluster.go:958
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
@@ -3796,7 +3802,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:811 lxc/cluster.go:1367 lxc/cluster_group.go:129
+#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -3859,8 +3865,8 @@ msgstr ""
 
 #: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1139 lxc/network.go:1217 lxc/network.go:1283
-#: lxc/network.go:1375 lxc/network_forward.go:127 lxc/network_forward.go:215
+#: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
+#: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
 #: lxc/network_forward.go:284 lxc/network_forward.go:445
 #: lxc/network_forward.go:530 lxc/network_forward.go:705
 #: lxc/network_forward.go:836 lxc/network_forward.go:929
@@ -3901,12 +3907,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
-#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
-#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1986
-#: lxc/storage_volume.go:2127 lxc/storage_volume.go:2285
-#: lxc/storage_volume.go:2476 lxc/storage_volume.go:2593
+#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
+#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
 msgid "Missing pool name"
 msgstr ""
 
@@ -3925,11 +3931,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:438 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1411
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3966,8 +3972,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
-#: lxc/storage_volume.go:964
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
+#: lxc/storage_volume.go:975
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4004,7 +4010,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4012,11 +4018,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1856
+#: lxc/storage_volume.go:1867
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:518
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4038,12 +4044,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
+#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
 msgid "NAME"
 msgstr ""
 
@@ -4071,7 +4077,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
 #: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4095,8 +4101,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
-#: lxc/storage_volume.go:1562
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1573
 msgid "Name"
 msgstr ""
 
@@ -4104,7 +4110,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4129,7 +4135,7 @@ msgstr ""
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1227
+#: lxc/network.go:1236
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4239,7 +4245,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1161
+#: lxc/cluster.go:1162
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4248,7 +4254,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
+#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4268,11 +4274,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:502 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4286,7 +4292,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2035
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4294,15 +4300,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:343
+#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
+#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2690
+#: lxc/storage_volume.go:2701
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2489
+#: lxc/storage_volume.go:2500
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4314,11 +4321,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1418
+#: lxc/storage_volume.go:1429
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1298
+#: lxc/network.go:735 lxc/network.go:1307
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4327,7 +4334,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1577
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4357,7 +4364,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1767
 msgid "POOL"
 msgstr ""
 
@@ -4373,7 +4380,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1773
 #: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4419,7 +4426,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -4440,16 +4447,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
-#: lxc/storage_volume.go:1189
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
+#: lxc/storage_volume.go:1200
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4566,7 +4573,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1356
+#: lxc/storage_volume.go:1367
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4580,7 +4587,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1225
+#: lxc/storage_volume.go:1236
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4596,7 +4603,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2247
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4617,7 +4624,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1004
+#: lxc/storage_volume.go:1015
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4626,7 +4633,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2081
+#: lxc/storage_volume.go:2092
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4639,13 +4646,13 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2357
+#: lxc/storage_volume.go:2368
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
 "\n"
 "lxc storage volume unset default data size\n"
-"    Remotes the size/quota of a custom volume \"data\" in pool \"default\".\n"
+"    Removes the size/quota of a custom volume \"data\" in pool \"default\".\n"
 "\n"
 "lxc storage volume unset default virtual-machine/data snapshots.expiry\n"
 "    Removes the snapshot expiration period for a virtual machine \"data\" in "
@@ -4725,7 +4732,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4908,7 +4915,7 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1184 lxc/network.go:1185
+#: lxc/network.go:1193 lxc/network.go:1194
 msgid "Rename networks"
 msgstr ""
 
@@ -4924,15 +4931,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1949
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:1959
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2037 lxc/storage_volume.go:2057
+#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4942,11 +4949,11 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:892 lxc/cluster.go:893
+#: lxc/cluster.go:893 lxc/cluster.go:894
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1032
+#: lxc/config.go:1033
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -4969,7 +4976,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1328 lxc/cluster.go:1329
+#: lxc/cluster.go:1329 lxc/cluster.go:1330
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4984,11 +4991,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2552 lxc/storage_volume.go:2553
+#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1394
+#: lxc/cluster.go:1395
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5010,7 +5017,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1087
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5060,7 +5067,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1088
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1097
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5123,7 +5130,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1050 lxc/config.go:1051
+#: lxc/config.go:1051 lxc/config.go:1052
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5187,11 +5194,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1244
+#: lxc/network.go:1253
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1245
+#: lxc/network.go:1254
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5308,11 +5315,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2075
+#: lxc/storage_volume.go:2086
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2076
+#: lxc/storage_volume.go:2087
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5369,7 +5376,7 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1252
+#: lxc/network.go:1261
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5397,7 +5404,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2103
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5466,7 +5473,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1173
+#: lxc/config.go:1173 lxc/config.go:1174
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5498,7 +5505,7 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1340 lxc/network.go:1341
+#: lxc/network.go:1349 lxc/network.go:1350
 msgid "Show network configurations"
 msgstr ""
 
@@ -5546,11 +5553,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2233 lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5573,7 +5580,7 @@ msgid "Show the expanded configuration"
 msgstr ""
 
 #: lxc/info.go:43
-msgid "Show the instance's last 100 log lines?"
+msgid "Show the instance's last 100 log lines"
 msgstr ""
 
 #: lxc/info.go:44
@@ -5618,15 +5625,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2417
+#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2179
+#: lxc/storage_volume.go:2190
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1502
 msgid "Snapshots:"
 msgstr ""
 
@@ -5731,21 +5738,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:702
+#: lxc/storage_volume.go:703
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:790
+#: lxc/storage_volume.go:791
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:516
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:520
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5753,7 +5760,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5802,18 +5809,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1070 lxc/config_trust.go:515
+#: lxc/cluster.go:1071 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1736 lxc/warning.go:216
+#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1747 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
 msgid "Taken at"
 msgstr ""
 
@@ -5970,12 +5977,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1340
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1306
+#: lxc/storage_volume.go:1317
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -5994,8 +6001,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
-#: lxc/storage_volume.go:978
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:989
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6015,11 +6022,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:739
+#: lxc/cluster.go:740
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:729
+#: lxc/cluster.go:730
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6070,7 +6077,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6085,7 +6092,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1853
+#: lxc/storage_volume.go:1864
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6093,7 +6100,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:394
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6152,7 +6159,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1472
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6174,13 +6181,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:995 lxc/storage_volume.go:1752
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
+#: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1740
+#: lxc/storage.go:724 lxc/storage_volume.go:1751
 msgid "USED BY"
 msgstr ""
 
@@ -6212,7 +6219,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6238,7 +6245,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1141 lxc/config.go:1142
+#: lxc/config.go:1142 lxc/config.go:1143
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6266,7 +6273,7 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1412 lxc/network.go:1413
+#: lxc/network.go:1421 lxc/network.go:1422
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -6318,7 +6325,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2354 lxc/storage_volume.go:2355
+#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6342,7 +6349,7 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1417
+#: lxc/network.go:1426
 msgid "Unset the key as a network property"
 msgstr ""
 
@@ -6370,7 +6377,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2379
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6378,7 +6385,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:247
+#: lxc/storage_volume.go:248
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6391,11 +6398,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1174
+#: lxc/cluster.go:1175
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1176
+#: lxc/cluster.go:1177
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6414,12 +6421,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2641
+#: lxc/export.go:42 lxc/storage_volume.go:2652
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6486,7 +6493,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1576
 msgid "Volume Only"
 msgstr ""
 
@@ -6519,7 +6526,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
 #: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6545,18 +6552,18 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:903
+#: lxc/storage_volume.go:909
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:281
+#: lxc/storage_volume.go:282
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
-#: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
+#: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
@@ -6566,7 +6573,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1172
+#: lxc/cluster.go:1173
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -6729,7 +6736,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6751,11 +6758,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:1140
+#: lxc/config.go:995 lxc/config.go:1141
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1049
+#: lxc/config.go:1050
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -6834,8 +6841,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:768
-#: lxc/cluster.go:1085 lxc/cluster.go:1297 lxc/cluster.go:1327
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
+#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -6859,8 +6866,8 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1104
-#: lxc/network.go:1339 lxc/network_forward.go:87
+#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1113
+#: lxc/network.go:1348 lxc/network_forward.go:87
 #: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -6873,11 +6880,11 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1411
+#: lxc/network.go:791 lxc/network.go:1420
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1243
+#: lxc/network.go:1252
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
@@ -6922,7 +6929,7 @@ msgstr ""
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1182
+#: lxc/network.go:1191
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -6973,7 +6980,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2800
+#: lxc/storage_volume.go:2811
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7008,13 +7015,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:1958
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:806
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7022,51 +7029,51 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2551
+#: lxc/storage_volume.go:2562
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2634
+#: lxc/storage_volume.go:2645
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2415
+#: lxc/storage_volume.go:2426
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:609
+#: lxc/storage_volume.go:610
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:718
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2353
+#: lxc/storage_volume.go:2364
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2085
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2232
+#: lxc/storage_volume.go:2243
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1221
+#: lxc/storage_volume.go:1232
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1858
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:387
+#: lxc/storage_volume.go:388
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7172,7 +7179,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1601
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7184,7 +7191,7 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:891
+#: lxc/cluster.go:892
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -7256,7 +7263,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:772
+#: lxc/cluster.go:773
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7305,13 +7312,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1229
+#: lxc/config.go:1230
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1053
+#: lxc/config.go:1054
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7648,7 +7655,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:614
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7656,13 +7663,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2804
+#: lxc/storage_volume.go:2815
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2419
+#: lxc/storage_volume.go:2430
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-09 03:18-0300\n"
+"POT-Creation-Date: 2024-12-18 08:40-0700\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -72,7 +72,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/storage_volume.go:1030
+#: lxc/storage_volume.go:1041
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -97,7 +97,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/config.go:1240
+#: lxc/config.go:1241
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -674,7 +674,7 @@ msgstr ""
 "###\n"
 "### Nazwa jest widoczna, ale nie może zostać zmieniona"
 
-#: lxc/cluster.go:790
+#: lxc/cluster.go:791
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -847,13 +847,13 @@ msgstr ""
 msgid "Acknowledge warning"
 msgstr ""
 
+#: lxc/query.go:43
+msgid "Action"
+msgstr ""
+
 #: lxc/query.go:76
 #, c-format
 msgid "Action %q isn't supported by this tool"
-msgstr ""
-
-#: lxc/query.go:43
-msgid "Action (defaults to GET)"
 msgstr ""
 
 #: lxc/cluster_group.go:725
@@ -1000,7 +1000,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1596
+#: lxc/storage_volume.go:1607
 msgid "All projects"
 msgstr ""
 
@@ -1022,7 +1022,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1371
+#: lxc/cluster.go:1372
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -1059,7 +1059,7 @@ msgstr ""
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:282 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -1111,16 +1111,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2708
+#: lxc/storage_volume.go:2719
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2785
+#: lxc/export.go:192 lxc/storage_volume.go:2796
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1538
 msgid "Backups:"
 msgstr ""
 
@@ -1141,7 +1141,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1184,7 +1184,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1739
+#: lxc/storage_volume.go:1750
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1269,7 +1269,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1277,7 +1277,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1097
+#: lxc/config.go:702 lxc/config.go:1098
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1286,12 +1286,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:492
+#: lxc/storage_volume.go:493
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:446
+#: lxc/storage_volume.go:447
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1367,7 +1367,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1154
+#: lxc/cluster.go:1155
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1395,8 +1395,8 @@ msgstr ""
 #: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
 #: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
-#: lxc/network_forward.go:182 lxc/network_forward.go:264
+#: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
+#: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
 #: lxc/network_forward.go:497 lxc/network_forward.go:649
 #: lxc/network_forward.go:803 lxc/network_forward.go:892
 #: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
@@ -1411,30 +1411,30 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
-#: lxc/storage_volume.go:1952 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2251 lxc/storage_volume.go:2367
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2555
-#: lxc/storage_volume.go:2643 lxc/storage_volume.go:2807
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
+#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
+#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:894
+#: lxc/cluster.go:895
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:926
+#: lxc/cluster.go:927
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:756
+#: lxc/cluster.go:757
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1471,24 +1471,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
+#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
-#: lxc/storage_volume.go:1188
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
+#: lxc/storage_volume.go:1199
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:619
+#: lxc/storage_volume.go:620
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1498,7 +1498,11 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/move.go:65
+#: lxc/move.go:65
+msgid "Copy a stateful instance as stateless"
+msgstr ""
+
+#: lxc/copy.go:60
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1546,7 +1550,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:389 lxc/storage_volume.go:390
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1554,12 +1558,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:396
+#: lxc/storage_volume.go:397
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:398
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1572,7 +1576,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:515
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1595,12 +1599,12 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1235
+#: lxc/cluster.go:1236
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1239
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1615,17 +1619,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1266
+#: lxc/cluster.go:1267
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1707,7 +1711,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1759,7 +1763,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1788,13 +1792,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1738
+#: lxc/storage_volume.go:1749
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1814,7 +1818,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2642
+#: lxc/storage_volume.go:2653
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1910,7 +1914,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1931,16 +1935,16 @@ msgstr ""
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
-#: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
+#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
+#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
-#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
-#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
+#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
+#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1963,8 +1967,8 @@ msgstr ""
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
 #: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1005 lxc/network.go:1106 lxc/network.go:1185
-#: lxc/network.go:1245 lxc/network.go:1341 lxc/network.go:1413
+#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
+#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
 #: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
 #: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
 #: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
@@ -2015,27 +2019,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
-#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
-#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
-#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1949
-#: lxc/storage_volume.go:2076 lxc/storage_volume.go:2234
-#: lxc/storage_volume.go:2355 lxc/storage_volume.go:2417
-#: lxc/storage_volume.go:2553 lxc/storage_volume.go:2636
-#: lxc/storage_volume.go:2802 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1454
+#: lxc/storage_volume.go:1465
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -2047,11 +2051,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
+#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2179,7 +2183,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:516
+#: lxc/cluster.go:1072 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -2201,7 +2205,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:769 lxc/cluster.go:770
+#: lxc/cluster.go:770 lxc/cluster.go:771
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2221,7 +2225,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1226 lxc/config.go:1227
+#: lxc/config.go:1227 lxc/config.go:1228
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2285,7 +2289,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2293,7 +2297,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2311,11 +2315,12 @@ msgid ""
 "new\n"
 "  LXD cluster, which will have the given name.\n"
 "\n"
-"  It's required that the LXD is already available on the network. You can "
-"check\n"
-"  that by running 'lxc config get core.https_address', and possibly set a "
-"value\n"
-"  for the address if not yet set."
+"  It's required that LXD is already available on the network. You can check\n"
+"  this by running 'lxc config get core.https_address'. If either an IP "
+"address\n"
+"  and port is displayed, or both, LXD is already available on the network. "
+"If\n"
+"  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
 #: lxc/network_zone.go:1427
@@ -2345,12 +2350,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
+#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2360,12 +2365,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
+#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
-#: lxc/storage_volume.go:2199
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
+#: lxc/storage_volume.go:2210
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2375,11 +2380,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1298 lxc/cluster.go:1299
+#: lxc/cluster.go:1299 lxc/cluster.go:1300
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1396
+#: lxc/cluster.go:1397
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2407,8 +2412,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
-#: lxc/storage_volume.go:1564
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Expires at"
 msgstr ""
 
@@ -2432,7 +2437,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2635 lxc/storage_volume.go:2636
+#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2444,11 +2449,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2639
+#: lxc/storage_volume.go:2650
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2768
+#: lxc/export.go:152 lxc/storage_volume.go:2779
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2628,7 +2633,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
+#: lxc/network.go:1046 lxc/network_acl.go:133 lxc/network_zone.go:124
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2638,7 +2643,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1303
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2646,7 +2651,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1301
+#: lxc/cluster.go:1302
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2658,7 +2663,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1331
+#: lxc/cluster.go:1332
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2699,16 +2704,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
-#: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1614 lxc/warning.go:94
+#: lxc/storage_volume.go:1625 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2768,7 +2773,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:996
+#: lxc/config.go:996 lxc/config.go:997
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2832,7 +2837,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1249
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2896,11 +2901,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
+#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:475
+#: lxc/storage_volume.go:476
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2928,7 +2933,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1161
+#: lxc/network.go:1170
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2982,7 +2987,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1163
+#: lxc/network.go:1172
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2994,11 +2999,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1084
+#: lxc/list.go:560 lxc/network.go:1093
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1085
+#: lxc/list.go:561 lxc/network.go:1094
 msgid "IPV6"
 msgstr ""
 
@@ -3028,7 +3033,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2427
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3042,7 +3047,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2437
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3092,7 +3097,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2802
+#: lxc/storage_volume.go:2813
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3100,7 +3105,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2801
+#: lxc/storage_volume.go:2812
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -3122,11 +3127,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2809
+#: lxc/storage_volume.go:2820
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2883
+#: lxc/storage_volume.go:2894
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3170,7 +3175,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
+#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3252,7 +3257,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2012
+#: lxc/move.go:148 lxc/storage_volume.go:2023
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3260,7 +3265,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2019
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3278,9 +3283,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
-#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2144 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
+#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3324,9 +3329,9 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
+#: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3338,8 +3343,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1020 lxc/cluster.go:1123
-#: lxc/cluster.go:1231 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
+#: lxc/cluster.go:1232 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3376,7 +3381,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1105 lxc/network.go:1106
+#: lxc/network.go:1114 lxc/network.go:1115
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3388,7 +3393,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:976 lxc/cluster.go:977
+#: lxc/cluster.go:977 lxc/cluster.go:978
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -3436,7 +3441,7 @@ msgstr ""
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1004 lxc/network.go:1005
+#: lxc/network.go:1005 lxc/network.go:1006
 msgid "List available networks"
 msgstr ""
 
@@ -3524,7 +3529,7 @@ msgid ""
 "Fast column layout: nsacPt\n"
 "\n"
 "A single keyword like \"web\" which will list any instance with a name "
-"starting by \"web\".\n"
+"starting with \"web\".\n"
 "A regular expression on the instance name. (e.g. .*web.*01$).\n"
 "A key/value pair referring to a configuration item. For those, the\n"
 "namespace can be abbreviated to the smallest unambiguous identifier.\n"
@@ -3581,7 +3586,8 @@ msgid ""
 "  P - Profiles\n"
 "  s - State\n"
 "  S - Number of snapshots\n"
-"  t - Type (persistent or ephemeral)\n"
+"  t - Type (container or virtual-machine, ephemeral indicated if "
+"applicable)\n"
 "  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
@@ -3630,11 +3636,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1603
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1608
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3693,7 +3699,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1470
+#: lxc/info.go:489 lxc/storage_volume.go:1481
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3714,7 +3720,7 @@ msgstr ""
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1162
+#: lxc/network.go:1171
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3732,7 +3738,7 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1083
+#: lxc/network.go:1092
 msgid "MANAGED"
 msgstr ""
 
@@ -3855,7 +3861,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:955 lxc/config.go:956
+#: lxc/config.go:956 lxc/config.go:957
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3994,7 +4000,7 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:957
+#: lxc/cluster.go:958
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
@@ -4058,7 +4064,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:811 lxc/cluster.go:1367 lxc/cluster_group.go:129
+#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -4121,8 +4127,8 @@ msgstr ""
 
 #: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1139 lxc/network.go:1217 lxc/network.go:1283
-#: lxc/network.go:1375 lxc/network_forward.go:127 lxc/network_forward.go:215
+#: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
+#: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
 #: lxc/network_forward.go:284 lxc/network_forward.go:445
 #: lxc/network_forward.go:530 lxc/network_forward.go:705
 #: lxc/network_forward.go:836 lxc/network_forward.go:929
@@ -4163,12 +4169,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
-#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
-#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1986
-#: lxc/storage_volume.go:2127 lxc/storage_volume.go:2285
-#: lxc/storage_volume.go:2476 lxc/storage_volume.go:2593
+#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
+#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
 msgid "Missing pool name"
 msgstr ""
 
@@ -4187,11 +4193,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:438 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1411
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4228,8 +4234,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
-#: lxc/storage_volume.go:964
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
+#: lxc/storage_volume.go:975
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4266,7 +4272,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4274,11 +4280,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1856
+#: lxc/storage_volume.go:1867
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:518
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4300,12 +4306,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
+#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
 msgid "NAME"
 msgstr ""
 
@@ -4333,7 +4339,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
 #: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4357,8 +4363,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
-#: lxc/storage_volume.go:1562
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1573
 msgid "Name"
 msgstr ""
 
@@ -4366,7 +4372,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4391,7 +4397,7 @@ msgstr ""
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1227
+#: lxc/network.go:1236
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4501,7 +4507,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1161
+#: lxc/cluster.go:1162
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4510,7 +4516,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
+#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4530,11 +4536,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:502 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4548,7 +4554,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2035
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4556,15 +4562,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:343
+#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
+#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2690
+#: lxc/storage_volume.go:2701
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2489
+#: lxc/storage_volume.go:2500
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4576,11 +4583,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1418
+#: lxc/storage_volume.go:1429
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1298
+#: lxc/network.go:735 lxc/network.go:1307
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4589,7 +4596,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1577
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4619,7 +4626,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1767
 msgid "POOL"
 msgstr ""
 
@@ -4635,7 +4642,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1773
 #: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4681,7 +4688,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -4702,16 +4709,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
-#: lxc/storage_volume.go:1189
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
+#: lxc/storage_volume.go:1200
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4828,7 +4835,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1356
+#: lxc/storage_volume.go:1367
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4842,7 +4849,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1225
+#: lxc/storage_volume.go:1236
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4858,7 +4865,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2247
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4879,7 +4886,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1004
+#: lxc/storage_volume.go:1015
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4888,7 +4895,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2081
+#: lxc/storage_volume.go:2092
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4901,13 +4908,13 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2357
+#: lxc/storage_volume.go:2368
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
 "\n"
 "lxc storage volume unset default data size\n"
-"    Remotes the size/quota of a custom volume \"data\" in pool \"default\".\n"
+"    Removes the size/quota of a custom volume \"data\" in pool \"default\".\n"
 "\n"
 "lxc storage volume unset default virtual-machine/data snapshots.expiry\n"
 "    Removes the snapshot expiration period for a virtual machine \"data\" in "
@@ -4987,7 +4994,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -5170,7 +5177,7 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1184 lxc/network.go:1185
+#: lxc/network.go:1193 lxc/network.go:1194
 msgid "Rename networks"
 msgstr ""
 
@@ -5186,15 +5193,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1949
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:1959
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2037 lxc/storage_volume.go:2057
+#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5204,11 +5211,11 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:892 lxc/cluster.go:893
+#: lxc/cluster.go:893 lxc/cluster.go:894
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1032
+#: lxc/config.go:1033
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5231,7 +5238,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1328 lxc/cluster.go:1329
+#: lxc/cluster.go:1329 lxc/cluster.go:1330
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5246,11 +5253,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2552 lxc/storage_volume.go:2553
+#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1394
+#: lxc/cluster.go:1395
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5272,7 +5279,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1087
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5322,7 +5329,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1088
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1097
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5385,7 +5392,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1050 lxc/config.go:1051
+#: lxc/config.go:1051 lxc/config.go:1052
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5449,11 +5456,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1244
+#: lxc/network.go:1253
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1245
+#: lxc/network.go:1254
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5570,11 +5577,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2075
+#: lxc/storage_volume.go:2086
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2076
+#: lxc/storage_volume.go:2087
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5631,7 +5638,7 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1252
+#: lxc/network.go:1261
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5659,7 +5666,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2103
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5728,7 +5735,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1173
+#: lxc/config.go:1173 lxc/config.go:1174
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5760,7 +5767,7 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1340 lxc/network.go:1341
+#: lxc/network.go:1349 lxc/network.go:1350
 msgid "Show network configurations"
 msgstr ""
 
@@ -5808,11 +5815,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2233 lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5835,7 +5842,7 @@ msgid "Show the expanded configuration"
 msgstr ""
 
 #: lxc/info.go:43
-msgid "Show the instance's last 100 log lines?"
+msgid "Show the instance's last 100 log lines"
 msgstr ""
 
 #: lxc/info.go:44
@@ -5880,15 +5887,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2417
+#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2179
+#: lxc/storage_volume.go:2190
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1502
 msgid "Snapshots:"
 msgstr ""
 
@@ -5993,21 +6000,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:702
+#: lxc/storage_volume.go:703
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:790
+#: lxc/storage_volume.go:791
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:516
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:520
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -6015,7 +6022,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -6064,18 +6071,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1070 lxc/config_trust.go:515
+#: lxc/cluster.go:1071 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1736 lxc/warning.go:216
+#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1747 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
 msgid "Taken at"
 msgstr ""
 
@@ -6232,12 +6239,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1340
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1306
+#: lxc/storage_volume.go:1317
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6256,8 +6263,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
-#: lxc/storage_volume.go:978
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:989
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6277,11 +6284,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:739
+#: lxc/cluster.go:740
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:729
+#: lxc/cluster.go:730
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6332,7 +6339,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6347,7 +6354,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1853
+#: lxc/storage_volume.go:1864
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6355,7 +6362,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:394
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6414,7 +6421,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1472
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6436,13 +6443,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:995 lxc/storage_volume.go:1752
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
+#: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1740
+#: lxc/storage.go:724 lxc/storage_volume.go:1751
 msgid "USED BY"
 msgstr ""
 
@@ -6474,7 +6481,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6500,7 +6507,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1141 lxc/config.go:1142
+#: lxc/config.go:1142 lxc/config.go:1143
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6528,7 +6535,7 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1412 lxc/network.go:1413
+#: lxc/network.go:1421 lxc/network.go:1422
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -6580,7 +6587,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2354 lxc/storage_volume.go:2355
+#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6604,7 +6611,7 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1417
+#: lxc/network.go:1426
 msgid "Unset the key as a network property"
 msgstr ""
 
@@ -6632,7 +6639,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2379
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6640,7 +6647,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:247
+#: lxc/storage_volume.go:248
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6653,11 +6660,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1174
+#: lxc/cluster.go:1175
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1176
+#: lxc/cluster.go:1177
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6676,12 +6683,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2641
+#: lxc/export.go:42 lxc/storage_volume.go:2652
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6748,7 +6755,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1576
 msgid "Volume Only"
 msgstr ""
 
@@ -6781,7 +6788,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
 #: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6807,18 +6814,18 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:903
+#: lxc/storage_volume.go:909
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:281
+#: lxc/storage_volume.go:282
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
-#: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
+#: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
@@ -6828,7 +6835,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1172
+#: lxc/cluster.go:1173
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -6991,7 +6998,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -7013,11 +7020,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:1140
+#: lxc/config.go:995 lxc/config.go:1141
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1049
+#: lxc/config.go:1050
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -7096,8 +7103,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:768
-#: lxc/cluster.go:1085 lxc/cluster.go:1297 lxc/cluster.go:1327
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
+#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -7121,8 +7128,8 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1104
-#: lxc/network.go:1339 lxc/network_forward.go:87
+#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1113
+#: lxc/network.go:1348 lxc/network_forward.go:87
 #: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -7135,11 +7142,11 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1411
+#: lxc/network.go:791 lxc/network.go:1420
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1243
+#: lxc/network.go:1252
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
@@ -7184,7 +7191,7 @@ msgstr ""
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1182
+#: lxc/network.go:1191
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7235,7 +7242,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2800
+#: lxc/storage_volume.go:2811
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7270,13 +7277,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:1958
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:806
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7284,51 +7291,51 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2551
+#: lxc/storage_volume.go:2562
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2634
+#: lxc/storage_volume.go:2645
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2415
+#: lxc/storage_volume.go:2426
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:609
+#: lxc/storage_volume.go:610
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:718
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2353
+#: lxc/storage_volume.go:2364
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2085
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2232
+#: lxc/storage_volume.go:2243
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1221
+#: lxc/storage_volume.go:1232
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1858
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:387
+#: lxc/storage_volume.go:388
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7434,7 +7441,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1601
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7446,7 +7453,7 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:891
+#: lxc/cluster.go:892
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -7518,7 +7525,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:772
+#: lxc/cluster.go:773
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7567,13 +7574,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1229
+#: lxc/config.go:1230
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1053
+#: lxc/config.go:1054
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7910,7 +7917,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:614
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7918,13 +7925,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2804
+#: lxc/storage_volume.go:2815
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2419
+#: lxc/storage_volume.go:2430
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-09 03:18-0300\n"
+"POT-Creation-Date: 2024-12-18 08:40-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -46,7 +46,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1030
+#: lxc/storage_volume.go:1041
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -60,7 +60,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1240
+#: lxc/config.go:1241
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -409,7 +409,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:790
+#: lxc/cluster.go:791
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -582,13 +582,13 @@ msgstr ""
 msgid "Acknowledge warning"
 msgstr ""
 
+#: lxc/query.go:43
+msgid "Action"
+msgstr ""
+
 #: lxc/query.go:76
 #, c-format
 msgid "Action %q isn't supported by this tool"
-msgstr ""
-
-#: lxc/query.go:43
-msgid "Action (defaults to GET)"
 msgstr ""
 
 #: lxc/cluster_group.go:725
@@ -735,7 +735,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1596
+#: lxc/storage_volume.go:1607
 msgid "All projects"
 msgstr ""
 
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1371
+#: lxc/cluster.go:1372
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -794,7 +794,7 @@ msgstr ""
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:282 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -846,16 +846,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2708
+#: lxc/storage_volume.go:2719
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2785
+#: lxc/export.go:192 lxc/storage_volume.go:2796
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1538
 msgid "Backups:"
 msgstr ""
 
@@ -876,7 +876,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -919,7 +919,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1739
+#: lxc/storage_volume.go:1750
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1004,7 +1004,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1012,7 +1012,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1097
+#: lxc/config.go:702 lxc/config.go:1098
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1021,12 +1021,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:492
+#: lxc/storage_volume.go:493
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:446
+#: lxc/storage_volume.go:447
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1102,7 +1102,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1154
+#: lxc/cluster.go:1155
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1130,8 +1130,8 @@ msgstr ""
 #: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
 #: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
-#: lxc/network_forward.go:182 lxc/network_forward.go:264
+#: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
+#: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
 #: lxc/network_forward.go:497 lxc/network_forward.go:649
 #: lxc/network_forward.go:803 lxc/network_forward.go:892
 #: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
@@ -1146,30 +1146,30 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
-#: lxc/storage_volume.go:1952 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2251 lxc/storage_volume.go:2367
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2555
-#: lxc/storage_volume.go:2643 lxc/storage_volume.go:2807
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
+#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
+#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:894
+#: lxc/cluster.go:895
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:926
+#: lxc/cluster.go:927
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:756
+#: lxc/cluster.go:757
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1206,24 +1206,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
+#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
-#: lxc/storage_volume.go:1188
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
+#: lxc/storage_volume.go:1199
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:619
+#: lxc/storage_volume.go:620
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1233,7 +1233,11 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/move.go:65
+#: lxc/move.go:65
+msgid "Copy a stateful instance as stateless"
+msgstr ""
+
+#: lxc/copy.go:60
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1281,7 +1285,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:389 lxc/storage_volume.go:390
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1289,12 +1293,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:396
+#: lxc/storage_volume.go:397
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:398
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1307,7 +1311,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:515
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1330,12 +1334,12 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1235
+#: lxc/cluster.go:1236
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1239
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1350,17 +1354,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1266
+#: lxc/cluster.go:1267
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1442,7 +1446,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1494,7 +1498,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1523,13 +1527,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1738
+#: lxc/storage_volume.go:1749
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1549,7 +1553,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2642
+#: lxc/storage_volume.go:2653
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1645,7 +1649,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1666,16 +1670,16 @@ msgstr ""
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
-#: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
+#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
+#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
-#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
-#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
+#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
+#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1698,8 +1702,8 @@ msgstr ""
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
 #: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1005 lxc/network.go:1106 lxc/network.go:1185
-#: lxc/network.go:1245 lxc/network.go:1341 lxc/network.go:1413
+#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
+#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
 #: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
 #: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
 #: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
@@ -1750,27 +1754,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
-#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
-#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
-#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1949
-#: lxc/storage_volume.go:2076 lxc/storage_volume.go:2234
-#: lxc/storage_volume.go:2355 lxc/storage_volume.go:2417
-#: lxc/storage_volume.go:2553 lxc/storage_volume.go:2636
-#: lxc/storage_volume.go:2802 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1454
+#: lxc/storage_volume.go:1465
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1782,11 +1786,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
+#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1914,7 +1918,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:516
+#: lxc/cluster.go:1072 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1936,7 +1940,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:769 lxc/cluster.go:770
+#: lxc/cluster.go:770 lxc/cluster.go:771
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1956,7 +1960,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1226 lxc/config.go:1227
+#: lxc/config.go:1227 lxc/config.go:1228
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2020,7 +2024,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2028,7 +2032,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2046,11 +2050,12 @@ msgid ""
 "new\n"
 "  LXD cluster, which will have the given name.\n"
 "\n"
-"  It's required that the LXD is already available on the network. You can "
-"check\n"
-"  that by running 'lxc config get core.https_address', and possibly set a "
-"value\n"
-"  for the address if not yet set."
+"  It's required that LXD is already available on the network. You can check\n"
+"  this by running 'lxc config get core.https_address'. If either an IP "
+"address\n"
+"  and port is displayed, or both, LXD is already available on the network. "
+"If\n"
+"  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
 #: lxc/network_zone.go:1427
@@ -2080,12 +2085,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
+#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2095,12 +2100,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
+#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
-#: lxc/storage_volume.go:2199
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
+#: lxc/storage_volume.go:2210
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2110,11 +2115,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1298 lxc/cluster.go:1299
+#: lxc/cluster.go:1299 lxc/cluster.go:1300
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1396
+#: lxc/cluster.go:1397
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2142,8 +2147,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
-#: lxc/storage_volume.go:1564
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Expires at"
 msgstr ""
 
@@ -2167,7 +2172,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2635 lxc/storage_volume.go:2636
+#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2179,11 +2184,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2639
+#: lxc/storage_volume.go:2650
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2768
+#: lxc/export.go:152 lxc/storage_volume.go:2779
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2363,7 +2368,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
+#: lxc/network.go:1046 lxc/network_acl.go:133 lxc/network_zone.go:124
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2373,7 +2378,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1303
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2381,7 +2386,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1301
+#: lxc/cluster.go:1302
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2393,7 +2398,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1331
+#: lxc/cluster.go:1332
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2434,16 +2439,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
-#: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1614 lxc/warning.go:94
+#: lxc/storage_volume.go:1625 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2503,7 +2508,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:996
+#: lxc/config.go:996 lxc/config.go:997
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2567,7 +2572,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1249
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2631,11 +2636,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
+#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:475
+#: lxc/storage_volume.go:476
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2663,7 +2668,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1161
+#: lxc/network.go:1170
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2717,7 +2722,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1163
+#: lxc/network.go:1172
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2729,11 +2734,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1084
+#: lxc/list.go:560 lxc/network.go:1093
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1085
+#: lxc/list.go:561 lxc/network.go:1094
 msgid "IPV6"
 msgstr ""
 
@@ -2763,7 +2768,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2427
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2777,7 +2782,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2437
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2827,7 +2832,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2802
+#: lxc/storage_volume.go:2813
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2835,7 +2840,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2801
+#: lxc/storage_volume.go:2812
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2857,11 +2862,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2809
+#: lxc/storage_volume.go:2820
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2883
+#: lxc/storage_volume.go:2894
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2905,7 +2910,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
+#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2987,7 +2992,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2012
+#: lxc/move.go:148 lxc/storage_volume.go:2023
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2995,7 +3000,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2019
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3013,9 +3018,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
-#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2144 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
+#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3059,9 +3064,9 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
+#: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3073,8 +3078,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1020 lxc/cluster.go:1123
-#: lxc/cluster.go:1231 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
+#: lxc/cluster.go:1232 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3111,7 +3116,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1105 lxc/network.go:1106
+#: lxc/network.go:1114 lxc/network.go:1115
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3123,7 +3128,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:976 lxc/cluster.go:977
+#: lxc/cluster.go:977 lxc/cluster.go:978
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -3171,7 +3176,7 @@ msgstr ""
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1004 lxc/network.go:1005
+#: lxc/network.go:1005 lxc/network.go:1006
 msgid "List available networks"
 msgstr ""
 
@@ -3259,7 +3264,7 @@ msgid ""
 "Fast column layout: nsacPt\n"
 "\n"
 "A single keyword like \"web\" which will list any instance with a name "
-"starting by \"web\".\n"
+"starting with \"web\".\n"
 "A regular expression on the instance name. (e.g. .*web.*01$).\n"
 "A key/value pair referring to a configuration item. For those, the\n"
 "namespace can be abbreviated to the smallest unambiguous identifier.\n"
@@ -3316,7 +3321,8 @@ msgid ""
 "  P - Profiles\n"
 "  s - State\n"
 "  S - Number of snapshots\n"
-"  t - Type (persistent or ephemeral)\n"
+"  t - Type (container or virtual-machine, ephemeral indicated if "
+"applicable)\n"
 "  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
@@ -3365,11 +3371,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1603
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1608
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3428,7 +3434,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1470
+#: lxc/info.go:489 lxc/storage_volume.go:1481
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3449,7 +3455,7 @@ msgstr ""
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1162
+#: lxc/network.go:1171
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3467,7 +3473,7 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1083
+#: lxc/network.go:1092
 msgid "MANAGED"
 msgstr ""
 
@@ -3590,7 +3596,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:955 lxc/config.go:956
+#: lxc/config.go:956 lxc/config.go:957
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3729,7 +3735,7 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:957
+#: lxc/cluster.go:958
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
@@ -3793,7 +3799,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:811 lxc/cluster.go:1367 lxc/cluster_group.go:129
+#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -3856,8 +3862,8 @@ msgstr ""
 
 #: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1139 lxc/network.go:1217 lxc/network.go:1283
-#: lxc/network.go:1375 lxc/network_forward.go:127 lxc/network_forward.go:215
+#: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
+#: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
 #: lxc/network_forward.go:284 lxc/network_forward.go:445
 #: lxc/network_forward.go:530 lxc/network_forward.go:705
 #: lxc/network_forward.go:836 lxc/network_forward.go:929
@@ -3898,12 +3904,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
-#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
-#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1986
-#: lxc/storage_volume.go:2127 lxc/storage_volume.go:2285
-#: lxc/storage_volume.go:2476 lxc/storage_volume.go:2593
+#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
+#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
 msgid "Missing pool name"
 msgstr ""
 
@@ -3922,11 +3928,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:438 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1411
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3963,8 +3969,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
-#: lxc/storage_volume.go:964
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
+#: lxc/storage_volume.go:975
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4001,7 +4007,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4009,11 +4015,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1856
+#: lxc/storage_volume.go:1867
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:518
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4035,12 +4041,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
+#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
 msgid "NAME"
 msgstr ""
 
@@ -4068,7 +4074,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
 #: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4092,8 +4098,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
-#: lxc/storage_volume.go:1562
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1573
 msgid "Name"
 msgstr ""
 
@@ -4101,7 +4107,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4126,7 +4132,7 @@ msgstr ""
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1227
+#: lxc/network.go:1236
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4236,7 +4242,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1161
+#: lxc/cluster.go:1162
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4245,7 +4251,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
+#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4265,11 +4271,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:502 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4283,7 +4289,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2035
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4291,15 +4297,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:343
+#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
+#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2690
+#: lxc/storage_volume.go:2701
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2489
+#: lxc/storage_volume.go:2500
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4311,11 +4318,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1418
+#: lxc/storage_volume.go:1429
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1298
+#: lxc/network.go:735 lxc/network.go:1307
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4324,7 +4331,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1577
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4354,7 +4361,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1767
 msgid "POOL"
 msgstr ""
 
@@ -4370,7 +4377,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1773
 #: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4416,7 +4423,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -4437,16 +4444,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
-#: lxc/storage_volume.go:1189
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
+#: lxc/storage_volume.go:1200
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4563,7 +4570,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1356
+#: lxc/storage_volume.go:1367
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4577,7 +4584,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1225
+#: lxc/storage_volume.go:1236
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4593,7 +4600,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2247
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4614,7 +4621,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1004
+#: lxc/storage_volume.go:1015
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4623,7 +4630,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2081
+#: lxc/storage_volume.go:2092
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4636,13 +4643,13 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2357
+#: lxc/storage_volume.go:2368
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
 "\n"
 "lxc storage volume unset default data size\n"
-"    Remotes the size/quota of a custom volume \"data\" in pool \"default\".\n"
+"    Removes the size/quota of a custom volume \"data\" in pool \"default\".\n"
 "\n"
 "lxc storage volume unset default virtual-machine/data snapshots.expiry\n"
 "    Removes the snapshot expiration period for a virtual machine \"data\" in "
@@ -4722,7 +4729,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4905,7 +4912,7 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1184 lxc/network.go:1185
+#: lxc/network.go:1193 lxc/network.go:1194
 msgid "Rename networks"
 msgstr ""
 
@@ -4921,15 +4928,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1949
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:1959
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2037 lxc/storage_volume.go:2057
+#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4939,11 +4946,11 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:892 lxc/cluster.go:893
+#: lxc/cluster.go:893 lxc/cluster.go:894
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1032
+#: lxc/config.go:1033
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -4966,7 +4973,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1328 lxc/cluster.go:1329
+#: lxc/cluster.go:1329 lxc/cluster.go:1330
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4981,11 +4988,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2552 lxc/storage_volume.go:2553
+#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1394
+#: lxc/cluster.go:1395
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5007,7 +5014,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1087
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5057,7 +5064,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1088
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1097
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5120,7 +5127,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1050 lxc/config.go:1051
+#: lxc/config.go:1051 lxc/config.go:1052
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5184,11 +5191,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1244
+#: lxc/network.go:1253
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1245
+#: lxc/network.go:1254
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5305,11 +5312,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2075
+#: lxc/storage_volume.go:2086
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2076
+#: lxc/storage_volume.go:2087
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5366,7 +5373,7 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1252
+#: lxc/network.go:1261
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5394,7 +5401,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2103
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5463,7 +5470,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1173
+#: lxc/config.go:1173 lxc/config.go:1174
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5495,7 +5502,7 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1340 lxc/network.go:1341
+#: lxc/network.go:1349 lxc/network.go:1350
 msgid "Show network configurations"
 msgstr ""
 
@@ -5543,11 +5550,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2233 lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5570,7 +5577,7 @@ msgid "Show the expanded configuration"
 msgstr ""
 
 #: lxc/info.go:43
-msgid "Show the instance's last 100 log lines?"
+msgid "Show the instance's last 100 log lines"
 msgstr ""
 
 #: lxc/info.go:44
@@ -5615,15 +5622,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2417
+#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2179
+#: lxc/storage_volume.go:2190
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1502
 msgid "Snapshots:"
 msgstr ""
 
@@ -5728,21 +5735,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:702
+#: lxc/storage_volume.go:703
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:790
+#: lxc/storage_volume.go:791
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:516
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:520
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5750,7 +5757,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5799,18 +5806,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1070 lxc/config_trust.go:515
+#: lxc/cluster.go:1071 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1736 lxc/warning.go:216
+#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1747 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
 msgid "Taken at"
 msgstr ""
 
@@ -5967,12 +5974,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1340
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1306
+#: lxc/storage_volume.go:1317
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -5991,8 +5998,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
-#: lxc/storage_volume.go:978
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:989
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6012,11 +6019,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:739
+#: lxc/cluster.go:740
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:729
+#: lxc/cluster.go:730
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6067,7 +6074,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6082,7 +6089,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1853
+#: lxc/storage_volume.go:1864
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6090,7 +6097,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:394
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6149,7 +6156,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1472
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6171,13 +6178,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:995 lxc/storage_volume.go:1752
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
+#: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1740
+#: lxc/storage.go:724 lxc/storage_volume.go:1751
 msgid "USED BY"
 msgstr ""
 
@@ -6209,7 +6216,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6235,7 +6242,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1141 lxc/config.go:1142
+#: lxc/config.go:1142 lxc/config.go:1143
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6263,7 +6270,7 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1412 lxc/network.go:1413
+#: lxc/network.go:1421 lxc/network.go:1422
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -6315,7 +6322,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2354 lxc/storage_volume.go:2355
+#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6339,7 +6346,7 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1417
+#: lxc/network.go:1426
 msgid "Unset the key as a network property"
 msgstr ""
 
@@ -6367,7 +6374,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2379
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6375,7 +6382,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:247
+#: lxc/storage_volume.go:248
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6388,11 +6395,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1174
+#: lxc/cluster.go:1175
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1176
+#: lxc/cluster.go:1177
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6411,12 +6418,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2641
+#: lxc/export.go:42 lxc/storage_volume.go:2652
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6483,7 +6490,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1576
 msgid "Volume Only"
 msgstr ""
 
@@ -6516,7 +6523,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
 #: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6542,18 +6549,18 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:903
+#: lxc/storage_volume.go:909
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:281
+#: lxc/storage_volume.go:282
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
-#: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
+#: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
@@ -6563,7 +6570,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1172
+#: lxc/cluster.go:1173
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -6726,7 +6733,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6748,11 +6755,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:1140
+#: lxc/config.go:995 lxc/config.go:1141
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1049
+#: lxc/config.go:1050
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -6831,8 +6838,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:768
-#: lxc/cluster.go:1085 lxc/cluster.go:1297 lxc/cluster.go:1327
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
+#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -6856,8 +6863,8 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1104
-#: lxc/network.go:1339 lxc/network_forward.go:87
+#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1113
+#: lxc/network.go:1348 lxc/network_forward.go:87
 #: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -6870,11 +6877,11 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1411
+#: lxc/network.go:791 lxc/network.go:1420
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1243
+#: lxc/network.go:1252
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
@@ -6919,7 +6926,7 @@ msgstr ""
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1182
+#: lxc/network.go:1191
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -6970,7 +6977,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2800
+#: lxc/storage_volume.go:2811
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7005,13 +7012,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:1958
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:806
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7019,51 +7026,51 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2551
+#: lxc/storage_volume.go:2562
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2634
+#: lxc/storage_volume.go:2645
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2415
+#: lxc/storage_volume.go:2426
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:609
+#: lxc/storage_volume.go:610
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:718
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2353
+#: lxc/storage_volume.go:2364
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2085
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2232
+#: lxc/storage_volume.go:2243
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1221
+#: lxc/storage_volume.go:1232
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1858
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:387
+#: lxc/storage_volume.go:388
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7169,7 +7176,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1601
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7181,7 +7188,7 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:891
+#: lxc/cluster.go:892
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -7253,7 +7260,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:772
+#: lxc/cluster.go:773
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7302,13 +7309,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1229
+#: lxc/config.go:1230
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1053
+#: lxc/config.go:1054
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7645,7 +7652,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:614
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7653,13 +7660,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2804
+#: lxc/storage_volume.go:2815
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2419
+#: lxc/storage_volume.go:2430
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-09 03:18-0300\n"
+"POT-Creation-Date: 2024-12-18 08:40-0700\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -76,7 +76,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:1030
+#: lxc/storage_volume.go:1041
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -102,7 +102,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/config.go:1240
+#: lxc/config.go:1241
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -658,7 +658,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/cluster.go:790
+#: lxc/cluster.go:791
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -845,14 +845,14 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Acknowledge warning"
 msgstr ""
 
+#: lxc/query.go:43
+msgid "Action"
+msgstr ""
+
 #: lxc/query.go:76
 #, fuzzy, c-format
 msgid "Action %q isn't supported by this tool"
 msgstr "Tipo de autenticação '%s' não suportada pelo servidor"
-
-#: lxc/query.go:43
-msgid "Action (defaults to GET)"
-msgstr "Ação (padrão para o GET)"
 
 #: lxc/cluster_group.go:725
 #, fuzzy
@@ -1005,7 +1005,7 @@ msgstr "Alias %s já existe"
 msgid "Aliases:"
 msgstr "Aliases:"
 
-#: lxc/storage_volume.go:1596
+#: lxc/storage_volume.go:1607
 #, fuzzy
 msgid "All projects"
 msgstr "Criar projetos"
@@ -1029,7 +1029,7 @@ msgstr "Arquitetura: %s"
 msgid "Architecture: %v"
 msgstr "Arquitetura: %v"
 
-#: lxc/cluster.go:1371
+#: lxc/cluster.go:1372
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -1071,7 +1071,7 @@ msgstr "Anexar uma nova interface de rede aos containers"
 msgid "Attach new storage volumes to instances"
 msgstr "Desconectar volumes de armazenamento dos containers"
 
-#: lxc/storage_volume.go:282 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -1125,16 +1125,16 @@ msgstr "IMAGEM BASE"
 msgid "Backing up instance: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/storage_volume.go:2708
+#: lxc/storage_volume.go:2719
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/export.go:192 lxc/storage_volume.go:2785
+#: lxc/export.go:192 lxc/storage_volume.go:2796
 msgid "Backup exported successfully!"
 msgstr "Backup exportado com sucesso!"
 
-#: lxc/info.go:666 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1538
 msgid "Backups:"
 msgstr ""
 
@@ -1155,7 +1155,7 @@ msgstr "par de chave/valor inválido %s"
 msgid "Bad key=value pair: %q"
 msgstr "par de chave=valor inválido %s"
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr "par de chave=valor inválido %s"
@@ -1198,7 +1198,7 @@ msgstr "CANCELÁVEL"
 msgid "COMMON NAME"
 msgstr "NOME COMUM"
 
-#: lxc/storage_volume.go:1739
+#: lxc/storage_volume.go:1750
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1285,7 +1285,7 @@ msgstr "Não é possível especificar --fast com --columns"
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr "Não pode especificar a coluna L, quando não em cluster"
 
@@ -1293,7 +1293,7 @@ msgstr "Não pode especificar a coluna L, quando não em cluster"
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "Não é possível fornecer o uid/gid/modo no modo recursivo"
 
-#: lxc/config.go:702 lxc/config.go:1097
+#: lxc/config.go:702 lxc/config.go:1098
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr "Não é possível remover chave '%s', não está atualmente definido"
@@ -1302,12 +1302,12 @@ msgstr "Não é possível remover chave '%s', não está atualmente definido"
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:492
+#: lxc/storage_volume.go:493
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:446
+#: lxc/storage_volume.go:447
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1385,7 +1385,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1154
+#: lxc/cluster.go:1155
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1413,8 +1413,8 @@ msgstr "Dispositivo %s removido de %s"
 #: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
 #: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
-#: lxc/network_forward.go:182 lxc/network_forward.go:264
+#: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
+#: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
 #: lxc/network_forward.go:497 lxc/network_forward.go:649
 #: lxc/network_forward.go:803 lxc/network_forward.go:892
 #: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
@@ -1429,30 +1429,30 @@ msgstr "Dispositivo %s removido de %s"
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
-#: lxc/storage_volume.go:1952 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2251 lxc/storage_volume.go:2367
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2555
-#: lxc/storage_volume.go:2643 lxc/storage_volume.go:2807
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
+#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
+#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
 msgid "Cluster member name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/cluster.go:894
+#: lxc/cluster.go:895
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:926
+#: lxc/cluster.go:927
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:756
+#: lxc/cluster.go:757
 msgid "Clustering enabled"
 msgstr "Clustering ativado"
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr "Colunas"
@@ -1498,24 +1498,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
-#: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
+#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
-#: lxc/storage_volume.go:1188
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
+#: lxc/storage_volume.go:1199
 #, c-format
 msgid "Config parsing error: %s"
 msgstr "Erro de análise de configuração: %s"
 
-#: lxc/storage_volume.go:619
+#: lxc/storage_volume.go:620
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1525,7 +1525,12 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/move.go:65
+#: lxc/move.go:65
+#, fuzzy
+msgid "Copy a stateful instance as stateless"
+msgstr "Ignorar o estado do container"
+
+#: lxc/copy.go:60
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1574,7 +1579,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr "Copiar perfis"
 
-#: lxc/storage_volume.go:389 lxc/storage_volume.go:390
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1582,12 +1587,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:396
+#: lxc/storage_volume.go:397
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:398
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1601,7 +1606,7 @@ msgstr "Copiar a imagem: %s"
 msgid "Copying the image: %s"
 msgstr "Copiar a imagem: %s"
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:515
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1624,12 +1629,12 @@ msgstr "Impossível criar diretório para certificado do servidor"
 msgid "Could not create server cert dir"
 msgstr "Impossível criar diretório para certificado do servidor"
 
-#: lxc/cluster.go:1235
+#: lxc/cluster.go:1236
 #, fuzzy, c-format
 msgid "Could not find certificate file path: %s"
 msgstr "Certificado fingerprint: %s"
 
-#: lxc/cluster.go:1239
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1644,17 +1649,17 @@ msgstr "Erro de análise de configuração: %s"
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, fuzzy, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr "Certificado fingerprint: %s"
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, fuzzy, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr "Certificado fingerprint: %s"
 
-#: lxc/cluster.go:1266
+#: lxc/cluster.go:1267
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1748,7 +1753,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr "Criar novas redes"
 
-#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1807,7 +1812,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
 #, c-format
 msgid "Created: %s"
 msgstr "Criado: %s"
@@ -1837,13 +1842,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1738
+#: lxc/storage_volume.go:1749
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1863,7 +1868,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2642
+#: lxc/storage_volume.go:2653
 #, fuzzy
 msgid "Define a compression algorithm: for backup or none"
 msgstr "Definir um algoritmo de compressão: para imagem ou nenhum"
@@ -1973,7 +1978,7 @@ msgstr "Apagar projetos"
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1994,16 +1999,16 @@ msgstr ""
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
-#: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
+#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
+#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
-#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
-#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
+#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
+#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -2026,8 +2031,8 @@ msgstr ""
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
 #: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1005 lxc/network.go:1106 lxc/network.go:1185
-#: lxc/network.go:1245 lxc/network.go:1341 lxc/network.go:1413
+#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
+#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
 #: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
 #: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
 #: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
@@ -2078,27 +2083,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
-#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
-#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
-#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1949
-#: lxc/storage_volume.go:2076 lxc/storage_volume.go:2234
-#: lxc/storage_volume.go:2355 lxc/storage_volume.go:2417
-#: lxc/storage_volume.go:2553 lxc/storage_volume.go:2636
-#: lxc/storage_volume.go:2802 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr "Descrição"
 
-#: lxc/storage_volume.go:1454
+#: lxc/storage_volume.go:1465
 #, fuzzy, c-format
 msgid "Description: %s"
 msgstr "Descrição"
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Nome de membro do cluster"
@@ -2112,12 +2117,12 @@ msgstr "Desconectar interfaces de rede dos containers"
 msgid "Detach network interfaces from profiles"
 msgstr "Desconectar interfaces de rede dos perfis"
 
-#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
 #, fuzzy
 msgid "Detach storage volumes from instances"
 msgstr "Desconectar volumes de armazenamento dos containers"
 
-#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
+#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
 msgid "Detach storage volumes from profiles"
 msgstr "Desconectar volumes de armazenamento dos perfis"
 
@@ -2250,7 +2255,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr "EFÊMERO"
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:516
+#: lxc/cluster.go:1072 lxc/config_trust.go:516
 #, fuzzy
 msgid "EXPIRES AT"
 msgstr "DATA DE VALIDADE"
@@ -2274,7 +2279,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr "Editar configurações de rede como YAML"
 
-#: lxc/cluster.go:769 lxc/cluster.go:770
+#: lxc/cluster.go:770 lxc/cluster.go:771
 #, fuzzy
 msgid "Edit cluster member configurations as YAML"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -2298,7 +2303,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Edit image properties"
 msgstr "Editar propriedades da imagem"
 
-#: lxc/config.go:1226 lxc/config.go:1227
+#: lxc/config.go:1227 lxc/config.go:1228
 #, fuzzy
 msgid "Edit instance UEFI variables"
 msgstr "Editar arquivos de metadados do container"
@@ -2374,7 +2379,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2383,7 +2388,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2401,11 +2406,12 @@ msgid ""
 "new\n"
 "  LXD cluster, which will have the given name.\n"
 "\n"
-"  It's required that the LXD is already available on the network. You can "
-"check\n"
-"  that by running 'lxc config get core.https_address', and possibly set a "
-"value\n"
-"  for the address if not yet set."
+"  It's required that LXD is already available on the network. You can check\n"
+"  this by running 'lxc config get core.https_address'. If either an IP "
+"address\n"
+"  and port is displayed, or both, LXD is already available on the network. "
+"If\n"
+"  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
 #: lxc/network_zone.go:1427
@@ -2435,12 +2441,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
+#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Editar propriedades da imagem"
@@ -2450,12 +2456,12 @@ msgstr "Editar propriedades da imagem"
 msgid "Error unsetting properties: %v"
 msgstr "Editar propriedades da imagem"
 
-#: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
+#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
-#: lxc/storage_volume.go:2199
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
+#: lxc/storage_volume.go:2210
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2465,12 +2471,12 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1298 lxc/cluster.go:1299
+#: lxc/cluster.go:1299 lxc/cluster.go:1300
 #, fuzzy
 msgid "Evacuate cluster member"
 msgstr "Nome de membro do cluster"
 
-#: lxc/cluster.go:1396
+#: lxc/cluster.go:1397
 #, fuzzy, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "Nome de membro do cluster"
@@ -2498,8 +2504,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
-#: lxc/storage_volume.go:1564
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Expires at"
 msgstr ""
 
@@ -2523,7 +2529,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2635 lxc/storage_volume.go:2636
+#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2535,11 +2541,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2639
+#: lxc/storage_volume.go:2650
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2768
+#: lxc/export.go:152 lxc/storage_volume.go:2779
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2719,7 +2725,7 @@ msgstr "Aceitar certificado"
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
+#: lxc/network.go:1046 lxc/network_acl.go:133 lxc/network_zone.go:124
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2729,7 +2735,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1303
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2737,7 +2743,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1301
+#: lxc/cluster.go:1302
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2749,7 +2755,7 @@ msgstr "Forçar alocação de pseudo-terminal"
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1331
+#: lxc/cluster.go:1332
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2791,16 +2797,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
-#: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1614 lxc/warning.go:94
+#: lxc/storage_volume.go:1625 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2860,7 +2866,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:996
+#: lxc/config.go:996 lxc/config.go:997
 #, fuzzy
 msgid "Get UEFI variables for instance"
 msgstr "Adicionar perfis aos containers"
@@ -2932,7 +2938,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1249
 #, fuzzy
 msgid "Get the key as a storage volume property"
 msgstr "Desconectar volumes de armazenamento dos perfis"
@@ -3008,11 +3014,11 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
+#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:475
+#: lxc/storage_volume.go:476
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -3040,7 +3046,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1161
+#: lxc/network.go:1170
 msgid "HOSTNAME"
 msgstr "HOSTNAME"
 
@@ -3094,7 +3100,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1163
+#: lxc/network.go:1172
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -3106,11 +3112,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1084
+#: lxc/list.go:560 lxc/network.go:1093
 msgid "IPV4"
 msgstr "IPV4"
 
-#: lxc/list.go:561 lxc/network.go:1085
+#: lxc/list.go:561 lxc/network.go:1094
 msgid "IPV6"
 msgstr "IPV6"
 
@@ -3140,7 +3146,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2427
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3154,7 +3160,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2437
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3206,7 +3212,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr "Anexar interfaces de rede aos perfis"
 
-#: lxc/storage_volume.go:2802
+#: lxc/storage_volume.go:2813
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3214,7 +3220,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2801
+#: lxc/storage_volume.go:2812
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -3236,11 +3242,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2809
+#: lxc/storage_volume.go:2820
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2883
+#: lxc/storage_volume.go:2894
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Editar arquivos no container"
@@ -3284,7 +3290,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
+#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3366,7 +3372,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2012
+#: lxc/move.go:148 lxc/storage_volume.go:2023
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "Editar arquivos no container"
@@ -3375,7 +3381,7 @@ msgstr "Editar arquivos no container"
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2019
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3393,9 +3399,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
-#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2144 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
+#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Editar arquivos no container"
@@ -3440,9 +3446,9 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
+#: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3454,8 +3460,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1020 lxc/cluster.go:1123
-#: lxc/cluster.go:1231 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
+#: lxc/cluster.go:1232 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3493,7 +3499,7 @@ msgstr "Arquitetura: %v"
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1105 lxc/network.go:1106
+#: lxc/network.go:1114 lxc/network.go:1115
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3506,7 +3512,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr "Nome de membro do cluster"
 
-#: lxc/cluster.go:976 lxc/cluster.go:977
+#: lxc/cluster.go:977 lxc/cluster.go:978
 #, fuzzy
 msgid "List all active cluster member join tokens"
 msgstr "Nome de membro do cluster"
@@ -3558,7 +3564,7 @@ msgstr "Criar novas redes"
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1004 lxc/network.go:1005
+#: lxc/network.go:1005 lxc/network.go:1006
 msgid "List available networks"
 msgstr ""
 
@@ -3647,7 +3653,7 @@ msgid ""
 "Fast column layout: nsacPt\n"
 "\n"
 "A single keyword like \"web\" which will list any instance with a name "
-"starting by \"web\".\n"
+"starting with \"web\".\n"
 "A regular expression on the instance name. (e.g. .*web.*01$).\n"
 "A key/value pair referring to a configuration item. For those, the\n"
 "namespace can be abbreviated to the smallest unambiguous identifier.\n"
@@ -3704,7 +3710,8 @@ msgid ""
 "  P - Profiles\n"
 "  s - State\n"
 "  S - Number of snapshots\n"
-"  t - Type (persistent or ephemeral)\n"
+"  t - Type (container or virtual-machine, ephemeral indicated if "
+"applicable)\n"
 "  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
@@ -3755,11 +3762,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1603
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1608
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3818,7 +3825,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1470
+#: lxc/info.go:489 lxc/storage_volume.go:1481
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3841,7 +3848,7 @@ msgstr "Editar arquivos no container"
 msgid "Lower devices"
 msgstr "Editar arquivos no container"
 
-#: lxc/network.go:1162
+#: lxc/network.go:1171
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3859,7 +3866,7 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr "Em cache: %s"
 
-#: lxc/network.go:1083
+#: lxc/network.go:1092
 msgid "MANAGED"
 msgstr ""
 
@@ -3987,7 +3994,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:955 lxc/config.go:956
+#: lxc/config.go:956 lxc/config.go:957
 #, fuzzy
 msgid "Manage instance UEFI variables"
 msgstr "Editar arquivos de metadados do container"
@@ -4147,7 +4154,7 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:957
+#: lxc/cluster.go:958
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
@@ -4214,7 +4221,7 @@ msgstr "Certificado fingerprint: %s"
 msgid "Missing cluster group name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/cluster.go:811 lxc/cluster.go:1367 lxc/cluster_group.go:129
+#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 #, fuzzy
@@ -4285,8 +4292,8 @@ msgstr "Nome de membro do cluster"
 
 #: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1139 lxc/network.go:1217 lxc/network.go:1283
-#: lxc/network.go:1375 lxc/network_forward.go:127 lxc/network_forward.go:215
+#: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
+#: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
 #: lxc/network_forward.go:284 lxc/network_forward.go:445
 #: lxc/network_forward.go:530 lxc/network_forward.go:705
 #: lxc/network_forward.go:836 lxc/network_forward.go:929
@@ -4330,12 +4337,12 @@ msgstr "Nome de membro do cluster"
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
-#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
-#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1986
-#: lxc/storage_volume.go:2127 lxc/storage_volume.go:2285
-#: lxc/storage_volume.go:2476 lxc/storage_volume.go:2593
+#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
+#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
 msgid "Missing pool name"
 msgstr ""
 
@@ -4354,11 +4361,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:438 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1411
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Nome de membro do cluster"
@@ -4397,8 +4404,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
-#: lxc/storage_volume.go:964
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
+#: lxc/storage_volume.go:975
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4436,7 +4443,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4444,11 +4451,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1856
+#: lxc/storage_volume.go:1867
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:518
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4470,12 +4477,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
+#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
 msgid "NAME"
 msgstr ""
 
@@ -4503,7 +4510,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
 #: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4527,8 +4534,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
-#: lxc/storage_volume.go:1562
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1573
 msgid "Name"
 msgstr ""
 
@@ -4536,7 +4543,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4561,7 +4568,7 @@ msgstr ""
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1227
+#: lxc/network.go:1236
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4671,7 +4678,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1161
+#: lxc/cluster.go:1162
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4680,7 +4687,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
+#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4700,11 +4707,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:502 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4718,7 +4725,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2035
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4726,15 +4733,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:343
+#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
+#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2690
+#: lxc/storage_volume.go:2701
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2489
+#: lxc/storage_volume.go:2500
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4746,11 +4754,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1418
+#: lxc/storage_volume.go:1429
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1298
+#: lxc/network.go:735 lxc/network.go:1307
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4759,7 +4767,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1577
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4789,7 +4797,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1767
 msgid "POOL"
 msgstr ""
 
@@ -4805,7 +4813,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1773
 #: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4851,7 +4859,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 #, fuzzy
 msgid "Please provide cluster member name: "
 msgstr "Nome de membro do cluster"
@@ -4873,16 +4881,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
-#: lxc/storage_volume.go:1189
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
+#: lxc/storage_volume.go:1200
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -5004,7 +5012,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1356
+#: lxc/storage_volume.go:1367
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -5018,7 +5026,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1225
+#: lxc/storage_volume.go:1236
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5034,7 +5042,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2247
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5055,7 +5063,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1004
+#: lxc/storage_volume.go:1015
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5064,7 +5072,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2081
+#: lxc/storage_volume.go:2092
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5077,13 +5085,13 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2357
+#: lxc/storage_volume.go:2368
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
 "\n"
 "lxc storage volume unset default data size\n"
-"    Remotes the size/quota of a custom volume \"data\" in pool \"default\".\n"
+"    Removes the size/quota of a custom volume \"data\" in pool \"default\".\n"
 "\n"
 "lxc storage volume unset default virtual-machine/data snapshots.expiry\n"
 "    Removes the snapshot expiration period for a virtual machine \"data\" in "
@@ -5166,7 +5174,7 @@ msgstr "Editar arquivos no container"
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -5366,7 +5374,7 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr "Criar novas redes"
 
-#: lxc/network.go:1184 lxc/network.go:1185
+#: lxc/network.go:1193 lxc/network.go:1194
 msgid "Rename networks"
 msgstr ""
 
@@ -5382,15 +5390,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1949
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:1959
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2037 lxc/storage_volume.go:2057
+#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5400,11 +5408,11 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:892 lxc/cluster.go:893
+#: lxc/cluster.go:893 lxc/cluster.go:894
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1032
+#: lxc/config.go:1033
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5428,7 +5436,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1328 lxc/cluster.go:1329
+#: lxc/cluster.go:1329 lxc/cluster.go:1330
 #, fuzzy
 msgid "Restore cluster member"
 msgstr "Nome de membro do cluster"
@@ -5449,11 +5457,11 @@ msgstr ""
 "Quando --stateful é usado, o LXD tenta criar um checkpoint do estado atual \n"
 "do container, incluindo estado de memória dos processos, conexões TCP, ..."
 
-#: lxc/storage_volume.go:2552 lxc/storage_volume.go:2553
+#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1394
+#: lxc/cluster.go:1395
 #, fuzzy, c-format
 msgid "Restoring cluster member: %s"
 msgstr "Nome de membro do cluster"
@@ -5476,7 +5484,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr "Nome de membro do cluster"
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1087
 #, fuzzy
 msgid "Revoke cluster member join token"
 msgstr "Nome de membro do cluster"
@@ -5528,7 +5536,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1088
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1097
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5591,7 +5599,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1050 lxc/config.go:1051
+#: lxc/config.go:1051 lxc/config.go:1052
 #, fuzzy
 msgid "Set UEFI variables for instance"
 msgstr "Adicionar perfis aos containers"
@@ -5661,11 +5669,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1244
+#: lxc/network.go:1253
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1245
+#: lxc/network.go:1254
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5789,11 +5797,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2075
+#: lxc/storage_volume.go:2086
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2076
+#: lxc/storage_volume.go:2087
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5853,7 +5861,7 @@ msgstr "Criar novas redes"
 msgid "Set the key as a network peer property"
 msgstr "Criar novas redes"
 
-#: lxc/network.go:1252
+#: lxc/network.go:1261
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5884,7 +5892,7 @@ msgstr "Criar novas redes"
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2103
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "Desconectar volumes de armazenamento dos perfis"
@@ -5958,7 +5966,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1173
+#: lxc/config.go:1173 lxc/config.go:1174
 #, fuzzy
 msgid "Show instance UEFI variables"
 msgstr "Editar arquivos de metadados do container"
@@ -5996,7 +6004,7 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Show network ACL log"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/network.go:1340 lxc/network.go:1341
+#: lxc/network.go:1349 lxc/network.go:1350
 msgid "Show network configurations"
 msgstr ""
 
@@ -6052,11 +6060,11 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2233 lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
 #, fuzzy
 msgid "Show storage volume state information"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -6080,8 +6088,9 @@ msgid "Show the expanded configuration"
 msgstr ""
 
 #: lxc/info.go:43
-msgid "Show the instance's last 100 log lines?"
-msgstr ""
+#, fuzzy
+msgid "Show the instance's last 100 log lines"
+msgstr "Ignorar o estado do container"
 
 #: lxc/info.go:44
 msgid "Show the resources available to the server"
@@ -6127,15 +6136,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2417
+#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2179
+#: lxc/storage_volume.go:2190
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1502
 msgid "Snapshots:"
 msgstr ""
 
@@ -6240,21 +6249,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:702
+#: lxc/storage_volume.go:703
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:790
+#: lxc/storage_volume.go:791
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:516
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:520
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -6263,7 +6272,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr "Ignorar o estado do container"
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -6312,18 +6321,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr "Certificado fingerprint: %s"
 
-#: lxc/cluster.go:1070 lxc/config_trust.go:515
+#: lxc/cluster.go:1071 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1736 lxc/warning.go:216
+#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1747 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
 msgid "Taken at"
 msgstr ""
 
@@ -6484,12 +6493,12 @@ msgstr "Nome de membro do cluster"
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1340
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "Nome de membro do cluster"
 
-#: lxc/storage_volume.go:1306
+#: lxc/storage_volume.go:1317
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6508,8 +6517,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
-#: lxc/storage_volume.go:978
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:989
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6530,11 +6539,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr "Nome de membro do cluster"
 
-#: lxc/cluster.go:739
+#: lxc/cluster.go:740
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:729
+#: lxc/cluster.go:730
 #, fuzzy
 msgid "This LXD server is not available on the network"
 msgstr "A importação de diretório não está disponível nessa plataforma"
@@ -6586,7 +6595,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6601,7 +6610,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1853
+#: lxc/storage_volume.go:1864
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6609,7 +6618,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:394
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6670,7 +6679,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1472
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6692,13 +6701,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:995 lxc/storage_volume.go:1752
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
+#: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1740
+#: lxc/storage.go:724 lxc/storage_volume.go:1751
 msgid "USED BY"
 msgstr ""
 
@@ -6731,7 +6740,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6757,7 +6766,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1141 lxc/config.go:1142
+#: lxc/config.go:1142 lxc/config.go:1143
 #, fuzzy
 msgid "Unset UEFI variables for instance"
 msgstr "Não pode fornecer um nome para a imagem de destino"
@@ -6792,7 +6801,7 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Unset network ACL configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/network.go:1412 lxc/network.go:1413
+#: lxc/network.go:1421 lxc/network.go:1422
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -6854,7 +6863,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2354 lxc/storage_volume.go:2355
+#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6881,7 +6890,7 @@ msgstr "Criar novas redes"
 msgid "Unset the key as a network peer property"
 msgstr "Criar novas redes"
 
-#: lxc/network.go:1417
+#: lxc/network.go:1426
 #, fuzzy
 msgid "Unset the key as a network property"
 msgstr "Criar novas redes"
@@ -6913,7 +6922,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2379
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6921,7 +6930,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:247
+#: lxc/storage_volume.go:248
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6934,12 +6943,12 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1174
+#: lxc/cluster.go:1175
 #, fuzzy
 msgid "Update cluster certificate"
 msgstr "Aceitar certificado"
 
-#: lxc/cluster.go:1176
+#: lxc/cluster.go:1177
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6959,12 +6968,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr "Editar arquivos no container"
 
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1485
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Criado: %s"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2641
+#: lxc/export.go:42 lxc/storage_volume.go:2652
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -7031,7 +7040,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1576
 msgid "Volume Only"
 msgstr ""
 
@@ -7064,7 +7073,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
 #: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -7090,19 +7099,19 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:903
+#: lxc/storage_volume.go:909
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:281
+#: lxc/storage_volume.go:282
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "Criar perfis"
 
 #: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
-#: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
+#: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
@@ -7113,7 +7122,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr "Criar perfis"
 
-#: lxc/cluster.go:1172
+#: lxc/cluster.go:1173
 #, fuzzy
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr "Editar templates de arquivo do container"
@@ -7299,7 +7308,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -7321,12 +7330,12 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:1140
+#: lxc/config.go:995 lxc/config.go:1141
 #, fuzzy
 msgid "[<remote>:]<instance> <key>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/config.go:1049
+#: lxc/config.go:1050
 #, fuzzy
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr "Editar templates de arquivo do container"
@@ -7410,8 +7419,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:768
-#: lxc/cluster.go:1085 lxc/cluster.go:1297 lxc/cluster.go:1327
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
+#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -7439,8 +7448,8 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1104
-#: lxc/network.go:1339 lxc/network_forward.go:87
+#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1113
+#: lxc/network.go:1348 lxc/network_forward.go:87
 #: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -7453,11 +7462,11 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1411
+#: lxc/network.go:791 lxc/network.go:1420
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1243
+#: lxc/network.go:1252
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
@@ -7508,7 +7517,7 @@ msgstr ""
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1182
+#: lxc/network.go:1191
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7565,7 +7574,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2800
+#: lxc/storage_volume.go:2811
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "Criar perfis"
@@ -7605,13 +7614,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:1958
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:806
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7620,58 +7629,58 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:2551
+#: lxc/storage_volume.go:2562
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2634
+#: lxc/storage_volume.go:2645
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:2415
+#: lxc/storage_volume.go:2426
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:609
+#: lxc/storage_volume.go:610
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:718
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:2353
+#: lxc/storage_volume.go:2364
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2085
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:2232
+#: lxc/storage_volume.go:2243
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:1221
+#: lxc/storage_volume.go:1232
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1858
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:387
+#: lxc/storage_volume.go:388
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr "Criar perfis"
@@ -7789,7 +7798,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1601
 #, fuzzy
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr "Criar perfis"
@@ -7804,7 +7813,7 @@ msgstr "Criar perfis"
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr "Criar perfis"
 
-#: lxc/cluster.go:891
+#: lxc/cluster.go:892
 #, fuzzy
 msgid "[[<remote>:]<member>]"
 msgstr "Editar templates de arquivo do container"
@@ -7877,7 +7886,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:772
+#: lxc/cluster.go:773
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7926,13 +7935,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1229
+#: lxc/config.go:1230
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1053
+#: lxc/config.go:1054
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -8269,7 +8278,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:614
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -8277,13 +8286,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2804
+#: lxc/storage_volume.go:2815
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2419
+#: lxc/storage_volume.go:2430
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"
@@ -8350,6 +8359,9 @@ msgstr ""
 #: lxc/image.go:1206
 msgid "yes"
 msgstr "sim"
+
+#~ msgid "Action (defaults to GET)"
+#~ msgstr "Ação (padrão para o GET)"
 
 #, fuzzy, c-format
 #~ msgid "Failed to create certificate: %w"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-09 03:18-0300\n"
+"POT-Creation-Date: 2024-12-18 08:40-0700\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -78,7 +78,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:1030
+#: lxc/storage_volume.go:1041
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -106,7 +106,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/config.go:1240
+#: lxc/config.go:1241
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -669,7 +669,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что имя отображается, но не может быть изменено"
 
-#: lxc/cluster.go:790
+#: lxc/cluster.go:791
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -848,13 +848,13 @@ msgstr ""
 msgid "Acknowledge warning"
 msgstr ""
 
+#: lxc/query.go:43
+msgid "Action"
+msgstr ""
+
 #: lxc/query.go:76
 #, c-format
 msgid "Action %q isn't supported by this tool"
-msgstr ""
-
-#: lxc/query.go:43
-msgid "Action (defaults to GET)"
 msgstr ""
 
 #: lxc/cluster_group.go:725
@@ -1006,7 +1006,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr "Псевдонимы:"
 
-#: lxc/storage_volume.go:1596
+#: lxc/storage_volume.go:1607
 #, fuzzy
 msgid "All projects"
 msgstr "Доступные команды:"
@@ -1030,7 +1030,7 @@ msgstr "Архитектура: %s"
 msgid "Architecture: %v"
 msgstr "Архитектура: %v"
 
-#: lxc/cluster.go:1371
+#: lxc/cluster.go:1372
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -1069,7 +1069,7 @@ msgstr ""
 msgid "Attach new storage volumes to instances"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:282 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -1122,16 +1122,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/storage_volume.go:2708
+#: lxc/storage_volume.go:2719
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/export.go:192 lxc/storage_volume.go:2785
+#: lxc/export.go:192 lxc/storage_volume.go:2796
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1538
 msgid "Backups:"
 msgstr ""
 
@@ -1152,7 +1152,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr "Имя контейнера: %s"
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1195,7 +1195,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr "ОБЩЕЕ ИМЯ"
 
-#: lxc/storage_volume.go:1739
+#: lxc/storage_volume.go:1750
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1282,7 +1282,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1290,7 +1290,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1097
+#: lxc/config.go:702 lxc/config.go:1098
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1299,12 +1299,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:492
+#: lxc/storage_volume.go:493
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:446
+#: lxc/storage_volume.go:447
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1385,7 +1385,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1154
+#: lxc/cluster.go:1155
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1413,8 +1413,8 @@ msgstr ""
 #: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
 #: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
-#: lxc/network_forward.go:182 lxc/network_forward.go:264
+#: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
+#: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
 #: lxc/network_forward.go:497 lxc/network_forward.go:649
 #: lxc/network_forward.go:803 lxc/network_forward.go:892
 #: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
@@ -1429,30 +1429,30 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
-#: lxc/storage_volume.go:1952 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2251 lxc/storage_volume.go:2367
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2555
-#: lxc/storage_volume.go:2643 lxc/storage_volume.go:2807
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
+#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
+#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:894
+#: lxc/cluster.go:895
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:926
+#: lxc/cluster.go:927
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:756
+#: lxc/cluster.go:757
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr "Столбцы"
@@ -1489,24 +1489,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
+#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
-#: lxc/storage_volume.go:1188
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
+#: lxc/storage_volume.go:1199
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:619
+#: lxc/storage_volume.go:620
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1478
 #, fuzzy, c-format
 msgid "Content type: %s"
 msgstr "Авто-обновление: %s"
@@ -1516,7 +1516,12 @@ msgstr "Авто-обновление: %s"
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/move.go:65
+#: lxc/move.go:65
+#, fuzzy
+msgid "Copy a stateful instance as stateless"
+msgstr "Невозможно добавить имя контейнера в список"
+
+#: lxc/copy.go:60
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1564,7 +1569,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:389 lxc/storage_volume.go:390
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
 #, fuzzy
 msgid "Copy storage volumes"
 msgstr "Копирование образа: %s"
@@ -1573,12 +1578,12 @@ msgstr "Копирование образа: %s"
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:396
+#: lxc/storage_volume.go:397
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:398
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1592,7 +1597,7 @@ msgstr "Копирование образа: %s"
 msgid "Copying the image: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:515
 #, fuzzy, c-format
 msgid "Copying the storage volume: %s"
 msgstr "Копирование образа: %s"
@@ -1615,12 +1620,12 @@ msgstr "Не удалось создать каталог сертификата
 msgid "Could not create server cert dir"
 msgstr "Не удалось создать каталог сертификата сервера"
 
-#: lxc/cluster.go:1235
+#: lxc/cluster.go:1236
 #, fuzzy, c-format
 msgid "Could not find certificate file path: %s"
 msgstr "Не удалось очистить путь %s"
 
-#: lxc/cluster.go:1239
+#: lxc/cluster.go:1240
 #, fuzzy, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr "Не удалось очистить путь %s"
@@ -1635,17 +1640,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, fuzzy, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr "Не удалось очистить путь %s"
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, fuzzy, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr "Не удалось очистить путь %s"
 
-#: lxc/cluster.go:1266
+#: lxc/cluster.go:1267
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1737,7 +1742,7 @@ msgstr "Копирование образа: %s"
 msgid "Create new custom storage buckets"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
 #, fuzzy
 msgid "Create new custom storage volumes"
 msgstr "Копирование образа: %s"
@@ -1798,7 +1803,7 @@ msgstr "Копирование образа: %s"
 msgid "Create the instance with no profiles applied"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1828,13 +1833,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1738
+#: lxc/storage_volume.go:1749
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1854,7 +1859,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2642
+#: lxc/storage_volume.go:2653
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1959,7 +1964,7 @@ msgstr "Копирование образа: %s"
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
 #, fuzzy
 msgid "Delete storage volumes"
 msgstr "Копирование образа: %s"
@@ -1981,16 +1986,16 @@ msgstr ""
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
-#: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
+#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
+#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
-#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
-#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
+#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
+#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -2013,8 +2018,8 @@ msgstr ""
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
 #: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1005 lxc/network.go:1106 lxc/network.go:1185
-#: lxc/network.go:1245 lxc/network.go:1341 lxc/network.go:1413
+#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
+#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
 #: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
 #: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
 #: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
@@ -2065,27 +2070,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
-#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
-#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
-#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1949
-#: lxc/storage_volume.go:2076 lxc/storage_volume.go:2234
-#: lxc/storage_volume.go:2355 lxc/storage_volume.go:2417
-#: lxc/storage_volume.go:2553 lxc/storage_volume.go:2636
-#: lxc/storage_volume.go:2802 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1454
+#: lxc/storage_volume.go:1465
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Копирование образа: %s"
@@ -2098,12 +2103,12 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
 #, fuzzy
 msgid "Detach storage volumes from instances"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
+#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2237,7 +2242,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:516
+#: lxc/cluster.go:1072 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -2259,7 +2264,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:769 lxc/cluster.go:770
+#: lxc/cluster.go:770 lxc/cluster.go:771
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2280,7 +2285,7 @@ msgstr "Копирование образа: %s"
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1226 lxc/config.go:1227
+#: lxc/config.go:1227 lxc/config.go:1228
 #, fuzzy
 msgid "Edit instance UEFI variables"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -2352,7 +2357,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2360,7 +2365,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2378,11 +2383,12 @@ msgid ""
 "new\n"
 "  LXD cluster, which will have the given name.\n"
 "\n"
-"  It's required that the LXD is already available on the network. You can "
-"check\n"
-"  that by running 'lxc config get core.https_address', and possibly set a "
-"value\n"
-"  for the address if not yet set."
+"  It's required that LXD is already available on the network. You can check\n"
+"  this by running 'lxc config get core.https_address'. If either an IP "
+"address\n"
+"  and port is displayed, or both, LXD is already available on the network. "
+"If\n"
+"  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
 #: lxc/network_zone.go:1427
@@ -2412,12 +2418,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
+#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
 #, fuzzy, c-format
 msgid "Error setting properties: %v"
 msgstr "Копирование образа: %s"
@@ -2427,12 +2433,12 @@ msgstr "Копирование образа: %s"
 msgid "Error unsetting properties: %v"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
+#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
-#: lxc/storage_volume.go:2199
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
+#: lxc/storage_volume.go:2210
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2442,7 +2448,7 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:1298 lxc/cluster.go:1299
+#: lxc/cluster.go:1299 lxc/cluster.go:1300
 #, fuzzy
 msgid "Evacuate cluster member"
 msgstr ""
@@ -2450,7 +2456,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:1396
+#: lxc/cluster.go:1397
 #, fuzzy, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "Копирование образа: %s"
@@ -2478,8 +2484,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
-#: lxc/storage_volume.go:1564
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Expires at"
 msgstr ""
 
@@ -2504,7 +2510,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2635 lxc/storage_volume.go:2636
+#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
 #, fuzzy
 msgid "Export custom storage volume"
 msgstr "Копирование образа: %s"
@@ -2519,12 +2525,12 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Export instances as backup tarballs."
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/storage_volume.go:2639
+#: lxc/storage_volume.go:2650
 #, fuzzy
 msgid "Export the volume without its snapshots"
 msgstr "Копирование образа: %s"
 
-#: lxc/export.go:152 lxc/storage_volume.go:2768
+#: lxc/export.go:152 lxc/storage_volume.go:2779
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Копирование образа: %s"
@@ -2704,7 +2710,7 @@ msgstr "Принять сертификат"
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
+#: lxc/network.go:1046 lxc/network_acl.go:133 lxc/network_zone.go:124
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2714,7 +2720,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1303
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2722,7 +2728,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1301
+#: lxc/cluster.go:1302
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2734,7 +2740,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1331
+#: lxc/cluster.go:1332
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2776,16 +2782,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
-#: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1614 lxc/warning.go:94
+#: lxc/storage_volume.go:1625 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2845,7 +2851,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:996
+#: lxc/config.go:996 lxc/config.go:997
 #, fuzzy
 msgid "Get UEFI variables for instance"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -2917,7 +2923,7 @@ msgstr "Копирование образа: %s"
 msgid "Get the key as a storage property"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1249
 #, fuzzy
 msgid "Get the key as a storage volume property"
 msgstr "Копирование образа: %s"
@@ -2989,11 +2995,11 @@ msgstr "Копирование образа: %s"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
+#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:475
+#: lxc/storage_volume.go:476
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -3021,7 +3027,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1161
+#: lxc/network.go:1170
 msgid "HOSTNAME"
 msgstr ""
 
@@ -3076,7 +3082,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1163
+#: lxc/network.go:1172
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -3088,11 +3094,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1084
+#: lxc/list.go:560 lxc/network.go:1093
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1085
+#: lxc/list.go:561 lxc/network.go:1094
 msgid "IPV6"
 msgstr ""
 
@@ -3122,7 +3128,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2427
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -3136,7 +3142,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2437
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -3187,7 +3193,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2802
+#: lxc/storage_volume.go:2813
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -3195,7 +3201,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2801
+#: lxc/storage_volume.go:2812
 #, fuzzy
 msgid "Import custom storage volumes"
 msgstr "Копирование образа: %s"
@@ -3220,11 +3226,11 @@ msgstr "Копирование образа: %s"
 msgid "Import instance backups"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/storage_volume.go:2809
+#: lxc/storage_volume.go:2820
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2883
+#: lxc/storage_volume.go:2894
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -3270,7 +3276,7 @@ msgstr "Имя контейнера является обязательным"
 msgid "Instance name is: %s"
 msgstr "Имя контейнера: %s"
 
-#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
+#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
 #, fuzzy
 msgid "Instance name must be specified"
 msgstr "Имя контейнера: %s"
@@ -3353,7 +3359,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2012
+#: lxc/move.go:148 lxc/storage_volume.go:2023
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "Нельзя использовать '/' в имени снимка"
@@ -3362,7 +3368,7 @@ msgstr "Нельзя использовать '/' в имени снимка"
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2019
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3380,9 +3386,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
-#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2144 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
+#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Имя контейнера: %s"
@@ -3427,9 +3433,9 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
+#: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3441,8 +3447,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1020 lxc/cluster.go:1123
-#: lxc/cluster.go:1231 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
+#: lxc/cluster.go:1232 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3480,7 +3486,7 @@ msgstr "Архитектура: %s"
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1105 lxc/network.go:1106
+#: lxc/network.go:1114 lxc/network.go:1115
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3494,7 +3500,7 @@ msgstr "Псевдонимы:"
 msgid "List all active certificate add tokens"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:976 lxc/cluster.go:977
+#: lxc/cluster.go:977 lxc/cluster.go:978
 #, fuzzy
 msgid "List all active cluster member join tokens"
 msgstr "Копирование образа: %s"
@@ -3547,7 +3553,7 @@ msgstr "Копирование образа: %s"
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1004 lxc/network.go:1005
+#: lxc/network.go:1005 lxc/network.go:1006
 msgid "List available networks"
 msgstr ""
 
@@ -3639,7 +3645,7 @@ msgid ""
 "Fast column layout: nsacPt\n"
 "\n"
 "A single keyword like \"web\" which will list any instance with a name "
-"starting by \"web\".\n"
+"starting with \"web\".\n"
 "A regular expression on the instance name. (e.g. .*web.*01$).\n"
 "A key/value pair referring to a configuration item. For those, the\n"
 "namespace can be abbreviated to the smallest unambiguous identifier.\n"
@@ -3696,7 +3702,8 @@ msgid ""
 "  P - Profiles\n"
 "  s - State\n"
 "  S - Number of snapshots\n"
-"  t - Type (persistent or ephemeral)\n"
+"  t - Type (container or virtual-machine, ephemeral indicated if "
+"applicable)\n"
 "  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
@@ -3749,12 +3756,12 @@ msgstr "Копирование образа: %s"
 msgid "List storage buckets"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1603
 #, fuzzy
 msgid "List storage volumes"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1608
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3814,7 +3821,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1470
+#: lxc/info.go:489 lxc/storage_volume.go:1481
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3837,7 +3844,7 @@ msgstr "Копирование образа: %s"
 msgid "Lower devices"
 msgstr "Копирование образа: %s"
 
-#: lxc/network.go:1162
+#: lxc/network.go:1171
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3855,7 +3862,7 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1083
+#: lxc/network.go:1092
 msgid "MANAGED"
 msgstr ""
 
@@ -3983,7 +3990,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:955 lxc/config.go:956
+#: lxc/config.go:956 lxc/config.go:957
 #, fuzzy
 msgid "Manage instance UEFI variables"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -4144,7 +4151,7 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:957
+#: lxc/cluster.go:958
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
@@ -4212,7 +4219,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:811 lxc/cluster.go:1367 lxc/cluster_group.go:129
+#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 #, fuzzy
@@ -4284,8 +4291,8 @@ msgstr "Имя контейнера: %s"
 
 #: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1139 lxc/network.go:1217 lxc/network.go:1283
-#: lxc/network.go:1375 lxc/network_forward.go:127 lxc/network_forward.go:215
+#: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
+#: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
 #: lxc/network_forward.go:284 lxc/network_forward.go:445
 #: lxc/network_forward.go:530 lxc/network_forward.go:705
 #: lxc/network_forward.go:836 lxc/network_forward.go:929
@@ -4329,12 +4336,12 @@ msgstr "Имя контейнера: %s"
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
-#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
-#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1986
-#: lxc/storage_volume.go:2127 lxc/storage_volume.go:2285
-#: lxc/storage_volume.go:2476 lxc/storage_volume.go:2593
+#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
+#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
 msgid "Missing pool name"
 msgstr ""
 
@@ -4354,12 +4361,12 @@ msgstr "Имя контейнера: %s"
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:438 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
 #, fuzzy
 msgid "Missing source volume name"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1411
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Копирование образа: %s"
@@ -4398,8 +4405,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
-#: lxc/storage_volume.go:964
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
+#: lxc/storage_volume.go:975
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4437,7 +4444,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
 #, fuzzy
 msgid "Move storage volumes between pools"
 msgstr "Копирование образа: %s"
@@ -4446,11 +4453,11 @@ msgstr "Копирование образа: %s"
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1856
+#: lxc/storage_volume.go:1867
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:518
+#: lxc/storage_volume.go:519
 #, fuzzy, c-format
 msgid "Moving the storage volume: %s"
 msgstr "Копирование образа: %s"
@@ -4472,12 +4479,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
+#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
 msgid "NAME"
 msgstr ""
 
@@ -4505,7 +4512,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
 #: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4529,8 +4536,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
-#: lxc/storage_volume.go:1562
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1573
 msgid "Name"
 msgstr ""
 
@@ -4538,7 +4545,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4563,7 +4570,7 @@ msgstr ""
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1227
+#: lxc/network.go:1236
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4675,7 +4682,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1161
+#: lxc/cluster.go:1162
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4684,7 +4691,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
+#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
 #, fuzzy
 msgid "No device found for this storage volume"
 msgstr "Копирование образа: %s"
@@ -4705,11 +4712,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:502 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4723,7 +4730,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2035
 #, fuzzy
 msgid "Not a snapshot name"
 msgstr "Нельзя использовать '/' в имени снимка"
@@ -4732,15 +4739,16 @@ msgstr "Нельзя использовать '/' в имени снимка"
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:343
+#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
+#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2690
+#: lxc/storage_volume.go:2701
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2489
+#: lxc/storage_volume.go:2500
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4752,11 +4760,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1418
+#: lxc/storage_volume.go:1429
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1298
+#: lxc/network.go:735 lxc/network.go:1307
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4765,7 +4773,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1577
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4795,7 +4803,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1767
 msgid "POOL"
 msgstr ""
 
@@ -4811,7 +4819,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1773
 #: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4857,7 +4865,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 #, fuzzy
 msgid "Please provide cluster member name: "
 msgstr "Копирование образа: %s"
@@ -4879,16 +4887,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
-#: lxc/storage_volume.go:1189
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
+#: lxc/storage_volume.go:1200
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -5005,7 +5013,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1356
+#: lxc/storage_volume.go:1367
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -5019,7 +5027,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1225
+#: lxc/storage_volume.go:1236
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5035,7 +5043,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2247
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5056,7 +5064,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1004
+#: lxc/storage_volume.go:1015
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5065,7 +5073,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2081
+#: lxc/storage_volume.go:2092
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -5078,13 +5086,13 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2357
+#: lxc/storage_volume.go:2368
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
 "\n"
 "lxc storage volume unset default data size\n"
-"    Remotes the size/quota of a custom volume \"data\" in pool \"default\".\n"
+"    Removes the size/quota of a custom volume \"data\" in pool \"default\".\n"
 "\n"
 "lxc storage volume unset default virtual-machine/data snapshots.expiry\n"
 "    Removes the snapshot expiration period for a virtual machine \"data\" in "
@@ -5166,7 +5174,7 @@ msgstr "Псевдонимы:"
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 #, fuzzy
 msgid "Refresh and update the existing storage volume copies"
 msgstr "Копирование образа: %s"
@@ -5362,7 +5370,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1184 lxc/network.go:1185
+#: lxc/network.go:1193 lxc/network.go:1194
 msgid "Rename networks"
 msgstr ""
 
@@ -5378,17 +5386,17 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1949
+#: lxc/storage_volume.go:1960
 #, fuzzy
 msgid "Rename storage volumes"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:1959
 #, fuzzy
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:2037 lxc/storage_volume.go:2057
+#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5398,11 +5406,11 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:892 lxc/cluster.go:893
+#: lxc/cluster.go:893 lxc/cluster.go:894
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1032
+#: lxc/config.go:1033
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5426,7 +5434,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1328 lxc/cluster.go:1329
+#: lxc/cluster.go:1329 lxc/cluster.go:1330
 #, fuzzy
 msgid "Restore cluster member"
 msgstr "Копирование образа: %s"
@@ -5443,12 +5451,12 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2552 lxc/storage_volume.go:2553
+#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
 #, fuzzy
 msgid "Restore storage volume snapshots"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:1394
+#: lxc/cluster.go:1395
 #, fuzzy, c-format
 msgid "Restoring cluster member: %s"
 msgstr "Копирование образа: %s"
@@ -5471,7 +5479,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1087
 #, fuzzy
 msgid "Revoke cluster member join token"
 msgstr "Копирование образа: %s"
@@ -5523,7 +5531,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1088
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1097
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5586,7 +5594,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1050 lxc/config.go:1051
+#: lxc/config.go:1051 lxc/config.go:1052
 #, fuzzy
 msgid "Set UEFI variables for instance"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -5652,11 +5660,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1244
+#: lxc/network.go:1253
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1245
+#: lxc/network.go:1254
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5779,11 +5787,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2075
+#: lxc/storage_volume.go:2086
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2076
+#: lxc/storage_volume.go:2087
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5843,7 +5851,7 @@ msgstr "Копирование образа: %s"
 msgid "Set the key as a network peer property"
 msgstr "Копирование образа: %s"
 
-#: lxc/network.go:1252
+#: lxc/network.go:1261
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5875,7 +5883,7 @@ msgstr "Копирование образа: %s"
 msgid "Set the key as a storage property"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2103
 #, fuzzy
 msgid "Set the key as a storage volume property"
 msgstr "Копирование образа: %s"
@@ -5948,7 +5956,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1173
+#: lxc/config.go:1173 lxc/config.go:1174
 #, fuzzy
 msgid "Show instance UEFI variables"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -5983,7 +5991,7 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr "Копирование образа: %s"
 
-#: lxc/network.go:1340 lxc/network.go:1341
+#: lxc/network.go:1349 lxc/network.go:1350
 msgid "Show network configurations"
 msgstr ""
 
@@ -6039,11 +6047,11 @@ msgstr "Копирование образа: %s"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2233 lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
 #, fuzzy
 msgid "Show storage volume state information"
 msgstr "Копирование образа: %s"
@@ -6067,8 +6075,9 @@ msgid "Show the expanded configuration"
 msgstr ""
 
 #: lxc/info.go:43
-msgid "Show the instance's last 100 log lines?"
-msgstr ""
+#, fuzzy
+msgid "Show the instance's last 100 log lines"
+msgstr "Невозможно добавить имя контейнера в список"
 
 #: lxc/info.go:44
 msgid "Show the resources available to the server"
@@ -6114,16 +6123,16 @@ msgstr "Авто-обновление: %s"
 msgid "Size: %s"
 msgstr "Авто-обновление: %s"
 
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2417
+#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
 #, fuzzy
 msgid "Snapshot storage volumes"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:2179
+#: lxc/storage_volume.go:2190
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1502
 msgid "Snapshots:"
 msgstr ""
 
@@ -6231,21 +6240,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:702
+#: lxc/storage_volume.go:703
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:790
+#: lxc/storage_volume.go:791
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:516
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:520
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -6254,7 +6263,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -6303,18 +6312,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1070 lxc/config_trust.go:515
+#: lxc/cluster.go:1071 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1736 lxc/warning.go:216
+#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1747 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
 msgid "Taken at"
 msgstr ""
 
@@ -6471,12 +6480,12 @@ msgstr "Копирование образа: %s"
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1340
 #, fuzzy, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1306
+#: lxc/storage_volume.go:1317
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6495,8 +6504,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
-#: lxc/storage_volume.go:978
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:989
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6517,11 +6526,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:739
+#: lxc/cluster.go:740
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:729
+#: lxc/cluster.go:730
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6572,7 +6581,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1487
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Авто-обновление: %s"
@@ -6587,7 +6596,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1853
+#: lxc/storage_volume.go:1864
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6595,7 +6604,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:394
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6655,7 +6664,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1472
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6677,13 +6686,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:995 lxc/storage_volume.go:1752
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
+#: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1740
+#: lxc/storage.go:724 lxc/storage_volume.go:1751
 msgid "USED BY"
 msgstr ""
 
@@ -6715,7 +6724,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6741,7 +6750,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1141 lxc/config.go:1142
+#: lxc/config.go:1142 lxc/config.go:1143
 #, fuzzy
 msgid "Unset UEFI variables for instance"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -6771,7 +6780,7 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1412 lxc/network.go:1413
+#: lxc/network.go:1421 lxc/network.go:1422
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -6832,7 +6841,7 @@ msgstr "Копирование образа: %s"
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2354 lxc/storage_volume.go:2355
+#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6859,7 +6868,7 @@ msgstr "Копирование образа: %s"
 msgid "Unset the key as a network peer property"
 msgstr "Копирование образа: %s"
 
-#: lxc/network.go:1417
+#: lxc/network.go:1426
 #, fuzzy
 msgid "Unset the key as a network property"
 msgstr "Копирование образа: %s"
@@ -6892,7 +6901,7 @@ msgstr "Копирование образа: %s"
 msgid "Unset the key as a storage property"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2379
 #, fuzzy
 msgid "Unset the key as a storage volume property"
 msgstr "Копирование образа: %s"
@@ -6901,7 +6910,7 @@ msgstr "Копирование образа: %s"
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:247
+#: lxc/storage_volume.go:248
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6914,12 +6923,12 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1174
+#: lxc/cluster.go:1175
 #, fuzzy
 msgid "Update cluster certificate"
 msgstr "Принять сертификат"
 
-#: lxc/cluster.go:1176
+#: lxc/cluster.go:1177
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6939,12 +6948,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1485
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Авто-обновление: %s"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2641
+#: lxc/export.go:42 lxc/storage_volume.go:2652
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -7011,7 +7020,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1576
 msgid "Volume Only"
 msgstr ""
 
@@ -7044,7 +7053,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
 #: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -7070,7 +7079,7 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:903
+#: lxc/storage_volume.go:909
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
@@ -7078,7 +7087,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:281
+#: lxc/storage_volume.go:282
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
@@ -7087,9 +7096,9 @@ msgstr ""
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
 #: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
-#: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
+#: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 #, fuzzy
@@ -7107,7 +7116,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:1172
+#: lxc/cluster.go:1173
 #, fuzzy
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
@@ -7410,7 +7419,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 #, fuzzy
@@ -7452,7 +7461,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:994 lxc/config.go:1140
+#: lxc/config.go:995 lxc/config.go:1141
 #, fuzzy
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
@@ -7460,7 +7469,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:1049
+#: lxc/config.go:1050
 #, fuzzy
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
@@ -7615,8 +7624,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:768
-#: lxc/cluster.go:1085 lxc/cluster.go:1297 lxc/cluster.go:1327
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
+#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
 #, fuzzy
 msgid "[<remote>:]<member>"
 msgstr ""
@@ -7664,8 +7673,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1104
-#: lxc/network.go:1339 lxc/network_forward.go:87
+#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1113
+#: lxc/network.go:1348 lxc/network_forward.go:87
 #: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
 #, fuzzy
 msgid "[<remote>:]<network>"
@@ -7690,7 +7699,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:791 lxc/network.go:1411
+#: lxc/network.go:791 lxc/network.go:1420
 #, fuzzy
 msgid "[<remote>:]<network> <key>"
 msgstr ""
@@ -7698,7 +7707,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:1243
+#: lxc/network.go:1252
 #, fuzzy
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
@@ -7775,7 +7784,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:1182
+#: lxc/network.go:1191
 #, fuzzy
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
@@ -7874,7 +7883,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2800
+#: lxc/storage_volume.go:2811
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
@@ -7941,7 +7950,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:1958
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
@@ -7951,7 +7960,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:806
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
@@ -7967,7 +7976,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2551
+#: lxc/storage_volume.go:2562
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
@@ -7975,7 +7984,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2634
+#: lxc/storage_volume.go:2645
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
@@ -7983,7 +7992,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2415
+#: lxc/storage_volume.go:2426
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
@@ -7991,7 +8000,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:609
+#: lxc/storage_volume.go:610
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
@@ -7999,7 +8008,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:718
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
@@ -8007,7 +8016,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
@@ -8015,7 +8024,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2353
+#: lxc/storage_volume.go:2364
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
@@ -8023,7 +8032,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2085
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
@@ -8031,7 +8040,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2232
+#: lxc/storage_volume.go:2243
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
@@ -8039,7 +8048,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1221
+#: lxc/storage_volume.go:1232
 #, fuzzy
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
@@ -8047,7 +8056,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1858
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -8055,7 +8064,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:387
+#: lxc/storage_volume.go:388
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -8265,7 +8274,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1601
 #, fuzzy
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
@@ -8289,7 +8298,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:891
+#: lxc/cluster.go:892
 #, fuzzy
 msgid "[[<remote>:]<member>]"
 msgstr ""
@@ -8365,7 +8374,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:772
+#: lxc/cluster.go:773
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -8414,13 +8423,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1229
+#: lxc/config.go:1230
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1053
+#: lxc/config.go:1054
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -8757,7 +8766,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:614
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -8765,13 +8774,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2804
+#: lxc/storage_volume.go:2815
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2419
+#: lxc/storage_volume.go:2430
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-09 03:18-0300\n"
+"POT-Creation-Date: 2024-12-18 08:40-0700\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1030
+#: lxc/storage_volume.go:1041
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1240
+#: lxc/config.go:1241
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -412,7 +412,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:790
+#: lxc/cluster.go:791
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -585,13 +585,13 @@ msgstr ""
 msgid "Acknowledge warning"
 msgstr ""
 
+#: lxc/query.go:43
+msgid "Action"
+msgstr ""
+
 #: lxc/query.go:76
 #, c-format
 msgid "Action %q isn't supported by this tool"
-msgstr ""
-
-#: lxc/query.go:43
-msgid "Action (defaults to GET)"
 msgstr ""
 
 #: lxc/cluster_group.go:725
@@ -738,7 +738,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1596
+#: lxc/storage_volume.go:1607
 msgid "All projects"
 msgstr ""
 
@@ -760,7 +760,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1371
+#: lxc/cluster.go:1372
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -797,7 +797,7 @@ msgstr ""
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:282 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -849,16 +849,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2708
+#: lxc/storage_volume.go:2719
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2785
+#: lxc/export.go:192 lxc/storage_volume.go:2796
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1538
 msgid "Backups:"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -922,7 +922,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1739
+#: lxc/storage_volume.go:1750
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1007,7 +1007,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1097
+#: lxc/config.go:702 lxc/config.go:1098
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1024,12 +1024,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:492
+#: lxc/storage_volume.go:493
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:446
+#: lxc/storage_volume.go:447
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1105,7 +1105,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1154
+#: lxc/cluster.go:1155
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1133,8 +1133,8 @@ msgstr ""
 #: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
 #: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
-#: lxc/network_forward.go:182 lxc/network_forward.go:264
+#: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
+#: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
 #: lxc/network_forward.go:497 lxc/network_forward.go:649
 #: lxc/network_forward.go:803 lxc/network_forward.go:892
 #: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
@@ -1149,30 +1149,30 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
-#: lxc/storage_volume.go:1952 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2251 lxc/storage_volume.go:2367
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2555
-#: lxc/storage_volume.go:2643 lxc/storage_volume.go:2807
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
+#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
+#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:894
+#: lxc/cluster.go:895
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:926
+#: lxc/cluster.go:927
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:756
+#: lxc/cluster.go:757
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1209,24 +1209,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
+#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
-#: lxc/storage_volume.go:1188
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
+#: lxc/storage_volume.go:1199
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:619
+#: lxc/storage_volume.go:620
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1236,7 +1236,11 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/move.go:65
+#: lxc/move.go:65
+msgid "Copy a stateful instance as stateless"
+msgstr ""
+
+#: lxc/copy.go:60
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1284,7 +1288,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:389 lxc/storage_volume.go:390
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1292,12 +1296,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:396
+#: lxc/storage_volume.go:397
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:398
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1310,7 +1314,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:515
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1333,12 +1337,12 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1235
+#: lxc/cluster.go:1236
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1239
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1353,17 +1357,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1266
+#: lxc/cluster.go:1267
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1445,7 +1449,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1497,7 +1501,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1526,13 +1530,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1738
+#: lxc/storage_volume.go:1749
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1552,7 +1556,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2642
+#: lxc/storage_volume.go:2653
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1648,7 +1652,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1669,16 +1673,16 @@ msgstr ""
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
-#: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
+#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
+#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
-#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
-#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
+#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
+#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1701,8 +1705,8 @@ msgstr ""
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
 #: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1005 lxc/network.go:1106 lxc/network.go:1185
-#: lxc/network.go:1245 lxc/network.go:1341 lxc/network.go:1413
+#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
+#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
 #: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
 #: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
 #: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
@@ -1753,27 +1757,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
-#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
-#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
-#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1949
-#: lxc/storage_volume.go:2076 lxc/storage_volume.go:2234
-#: lxc/storage_volume.go:2355 lxc/storage_volume.go:2417
-#: lxc/storage_volume.go:2553 lxc/storage_volume.go:2636
-#: lxc/storage_volume.go:2802 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1454
+#: lxc/storage_volume.go:1465
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1785,11 +1789,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
+#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1917,7 +1921,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:516
+#: lxc/cluster.go:1072 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1939,7 +1943,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:769 lxc/cluster.go:770
+#: lxc/cluster.go:770 lxc/cluster.go:771
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1959,7 +1963,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1226 lxc/config.go:1227
+#: lxc/config.go:1227 lxc/config.go:1228
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2023,7 +2027,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2031,7 +2035,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2049,11 +2053,12 @@ msgid ""
 "new\n"
 "  LXD cluster, which will have the given name.\n"
 "\n"
-"  It's required that the LXD is already available on the network. You can "
-"check\n"
-"  that by running 'lxc config get core.https_address', and possibly set a "
-"value\n"
-"  for the address if not yet set."
+"  It's required that LXD is already available on the network. You can check\n"
+"  this by running 'lxc config get core.https_address'. If either an IP "
+"address\n"
+"  and port is displayed, or both, LXD is already available on the network. "
+"If\n"
+"  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
 #: lxc/network_zone.go:1427
@@ -2083,12 +2088,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
+#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2098,12 +2103,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
+#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
-#: lxc/storage_volume.go:2199
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
+#: lxc/storage_volume.go:2210
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2113,11 +2118,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1298 lxc/cluster.go:1299
+#: lxc/cluster.go:1299 lxc/cluster.go:1300
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1396
+#: lxc/cluster.go:1397
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2145,8 +2150,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
-#: lxc/storage_volume.go:1564
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Expires at"
 msgstr ""
 
@@ -2170,7 +2175,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2635 lxc/storage_volume.go:2636
+#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2182,11 +2187,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2639
+#: lxc/storage_volume.go:2650
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2768
+#: lxc/export.go:152 lxc/storage_volume.go:2779
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2366,7 +2371,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
+#: lxc/network.go:1046 lxc/network_acl.go:133 lxc/network_zone.go:124
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2376,7 +2381,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1303
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2384,7 +2389,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1301
+#: lxc/cluster.go:1302
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2396,7 +2401,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1331
+#: lxc/cluster.go:1332
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2437,16 +2442,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
-#: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1614 lxc/warning.go:94
+#: lxc/storage_volume.go:1625 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2506,7 +2511,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:996
+#: lxc/config.go:996 lxc/config.go:997
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2570,7 +2575,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1249
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2634,11 +2639,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
+#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:475
+#: lxc/storage_volume.go:476
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2666,7 +2671,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1161
+#: lxc/network.go:1170
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2720,7 +2725,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1163
+#: lxc/network.go:1172
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2732,11 +2737,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1084
+#: lxc/list.go:560 lxc/network.go:1093
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1085
+#: lxc/list.go:561 lxc/network.go:1094
 msgid "IPV6"
 msgstr ""
 
@@ -2766,7 +2771,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2427
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2780,7 +2785,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2437
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2830,7 +2835,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2802
+#: lxc/storage_volume.go:2813
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2838,7 +2843,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2801
+#: lxc/storage_volume.go:2812
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2860,11 +2865,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2809
+#: lxc/storage_volume.go:2820
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2883
+#: lxc/storage_volume.go:2894
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2908,7 +2913,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
+#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2990,7 +2995,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2012
+#: lxc/move.go:148 lxc/storage_volume.go:2023
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2998,7 +3003,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2019
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3016,9 +3021,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
-#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2144 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
+#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3062,9 +3067,9 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
+#: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3076,8 +3081,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1020 lxc/cluster.go:1123
-#: lxc/cluster.go:1231 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
+#: lxc/cluster.go:1232 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3114,7 +3119,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1105 lxc/network.go:1106
+#: lxc/network.go:1114 lxc/network.go:1115
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3126,7 +3131,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:976 lxc/cluster.go:977
+#: lxc/cluster.go:977 lxc/cluster.go:978
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -3174,7 +3179,7 @@ msgstr ""
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1004 lxc/network.go:1005
+#: lxc/network.go:1005 lxc/network.go:1006
 msgid "List available networks"
 msgstr ""
 
@@ -3262,7 +3267,7 @@ msgid ""
 "Fast column layout: nsacPt\n"
 "\n"
 "A single keyword like \"web\" which will list any instance with a name "
-"starting by \"web\".\n"
+"starting with \"web\".\n"
 "A regular expression on the instance name. (e.g. .*web.*01$).\n"
 "A key/value pair referring to a configuration item. For those, the\n"
 "namespace can be abbreviated to the smallest unambiguous identifier.\n"
@@ -3319,7 +3324,8 @@ msgid ""
 "  P - Profiles\n"
 "  s - State\n"
 "  S - Number of snapshots\n"
-"  t - Type (persistent or ephemeral)\n"
+"  t - Type (container or virtual-machine, ephemeral indicated if "
+"applicable)\n"
 "  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
@@ -3368,11 +3374,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1603
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1608
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3431,7 +3437,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1470
+#: lxc/info.go:489 lxc/storage_volume.go:1481
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3452,7 +3458,7 @@ msgstr ""
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1162
+#: lxc/network.go:1171
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3470,7 +3476,7 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1083
+#: lxc/network.go:1092
 msgid "MANAGED"
 msgstr ""
 
@@ -3593,7 +3599,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:955 lxc/config.go:956
+#: lxc/config.go:956 lxc/config.go:957
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3732,7 +3738,7 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:957
+#: lxc/cluster.go:958
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
@@ -3796,7 +3802,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:811 lxc/cluster.go:1367 lxc/cluster_group.go:129
+#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -3859,8 +3865,8 @@ msgstr ""
 
 #: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1139 lxc/network.go:1217 lxc/network.go:1283
-#: lxc/network.go:1375 lxc/network_forward.go:127 lxc/network_forward.go:215
+#: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
+#: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
 #: lxc/network_forward.go:284 lxc/network_forward.go:445
 #: lxc/network_forward.go:530 lxc/network_forward.go:705
 #: lxc/network_forward.go:836 lxc/network_forward.go:929
@@ -3901,12 +3907,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
-#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
-#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1986
-#: lxc/storage_volume.go:2127 lxc/storage_volume.go:2285
-#: lxc/storage_volume.go:2476 lxc/storage_volume.go:2593
+#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
+#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
 msgid "Missing pool name"
 msgstr ""
 
@@ -3925,11 +3931,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:438 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1411
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3966,8 +3972,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
-#: lxc/storage_volume.go:964
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
+#: lxc/storage_volume.go:975
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4004,7 +4010,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4012,11 +4018,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1856
+#: lxc/storage_volume.go:1867
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:518
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4038,12 +4044,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
+#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
 msgid "NAME"
 msgstr ""
 
@@ -4071,7 +4077,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
 #: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4095,8 +4101,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
-#: lxc/storage_volume.go:1562
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1573
 msgid "Name"
 msgstr ""
 
@@ -4104,7 +4110,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4129,7 +4135,7 @@ msgstr ""
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1227
+#: lxc/network.go:1236
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4239,7 +4245,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1161
+#: lxc/cluster.go:1162
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4248,7 +4254,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
+#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4268,11 +4274,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:502 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4286,7 +4292,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2035
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4294,15 +4300,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:343
+#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
+#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2690
+#: lxc/storage_volume.go:2701
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2489
+#: lxc/storage_volume.go:2500
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4314,11 +4321,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1418
+#: lxc/storage_volume.go:1429
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1298
+#: lxc/network.go:735 lxc/network.go:1307
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4327,7 +4334,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1577
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4357,7 +4364,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1767
 msgid "POOL"
 msgstr ""
 
@@ -4373,7 +4380,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1773
 #: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4419,7 +4426,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -4440,16 +4447,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
-#: lxc/storage_volume.go:1189
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
+#: lxc/storage_volume.go:1200
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4566,7 +4573,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1356
+#: lxc/storage_volume.go:1367
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4580,7 +4587,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1225
+#: lxc/storage_volume.go:1236
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4596,7 +4603,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2247
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4617,7 +4624,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1004
+#: lxc/storage_volume.go:1015
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4626,7 +4633,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2081
+#: lxc/storage_volume.go:2092
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4639,13 +4646,13 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2357
+#: lxc/storage_volume.go:2368
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
 "\n"
 "lxc storage volume unset default data size\n"
-"    Remotes the size/quota of a custom volume \"data\" in pool \"default\".\n"
+"    Removes the size/quota of a custom volume \"data\" in pool \"default\".\n"
 "\n"
 "lxc storage volume unset default virtual-machine/data snapshots.expiry\n"
 "    Removes the snapshot expiration period for a virtual machine \"data\" in "
@@ -4725,7 +4732,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4908,7 +4915,7 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1184 lxc/network.go:1185
+#: lxc/network.go:1193 lxc/network.go:1194
 msgid "Rename networks"
 msgstr ""
 
@@ -4924,15 +4931,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1949
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:1959
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2037 lxc/storage_volume.go:2057
+#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4942,11 +4949,11 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:892 lxc/cluster.go:893
+#: lxc/cluster.go:893 lxc/cluster.go:894
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1032
+#: lxc/config.go:1033
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -4969,7 +4976,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1328 lxc/cluster.go:1329
+#: lxc/cluster.go:1329 lxc/cluster.go:1330
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4984,11 +4991,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2552 lxc/storage_volume.go:2553
+#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1394
+#: lxc/cluster.go:1395
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5010,7 +5017,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1087
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5060,7 +5067,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1088
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1097
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5123,7 +5130,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1050 lxc/config.go:1051
+#: lxc/config.go:1051 lxc/config.go:1052
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5187,11 +5194,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1244
+#: lxc/network.go:1253
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1245
+#: lxc/network.go:1254
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5308,11 +5315,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2075
+#: lxc/storage_volume.go:2086
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2076
+#: lxc/storage_volume.go:2087
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5369,7 +5376,7 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1252
+#: lxc/network.go:1261
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5397,7 +5404,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2103
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5466,7 +5473,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1173
+#: lxc/config.go:1173 lxc/config.go:1174
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5498,7 +5505,7 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1340 lxc/network.go:1341
+#: lxc/network.go:1349 lxc/network.go:1350
 msgid "Show network configurations"
 msgstr ""
 
@@ -5546,11 +5553,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2233 lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5573,7 +5580,7 @@ msgid "Show the expanded configuration"
 msgstr ""
 
 #: lxc/info.go:43
-msgid "Show the instance's last 100 log lines?"
+msgid "Show the instance's last 100 log lines"
 msgstr ""
 
 #: lxc/info.go:44
@@ -5618,15 +5625,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2417
+#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2179
+#: lxc/storage_volume.go:2190
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1502
 msgid "Snapshots:"
 msgstr ""
 
@@ -5731,21 +5738,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:702
+#: lxc/storage_volume.go:703
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:790
+#: lxc/storage_volume.go:791
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:516
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:520
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5753,7 +5760,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5802,18 +5809,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1070 lxc/config_trust.go:515
+#: lxc/cluster.go:1071 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1736 lxc/warning.go:216
+#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1747 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
 msgid "Taken at"
 msgstr ""
 
@@ -5970,12 +5977,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1340
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1306
+#: lxc/storage_volume.go:1317
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -5994,8 +6001,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
-#: lxc/storage_volume.go:978
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:989
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6015,11 +6022,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:739
+#: lxc/cluster.go:740
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:729
+#: lxc/cluster.go:730
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6070,7 +6077,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6085,7 +6092,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1853
+#: lxc/storage_volume.go:1864
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6093,7 +6100,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:394
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6152,7 +6159,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1472
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6174,13 +6181,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:995 lxc/storage_volume.go:1752
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
+#: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1740
+#: lxc/storage.go:724 lxc/storage_volume.go:1751
 msgid "USED BY"
 msgstr ""
 
@@ -6212,7 +6219,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6238,7 +6245,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1141 lxc/config.go:1142
+#: lxc/config.go:1142 lxc/config.go:1143
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6266,7 +6273,7 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1412 lxc/network.go:1413
+#: lxc/network.go:1421 lxc/network.go:1422
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -6318,7 +6325,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2354 lxc/storage_volume.go:2355
+#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6342,7 +6349,7 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1417
+#: lxc/network.go:1426
 msgid "Unset the key as a network property"
 msgstr ""
 
@@ -6370,7 +6377,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2379
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6378,7 +6385,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:247
+#: lxc/storage_volume.go:248
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6391,11 +6398,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1174
+#: lxc/cluster.go:1175
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1176
+#: lxc/cluster.go:1177
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6414,12 +6421,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2641
+#: lxc/export.go:42 lxc/storage_volume.go:2652
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6486,7 +6493,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1576
 msgid "Volume Only"
 msgstr ""
 
@@ -6519,7 +6526,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
 #: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6545,18 +6552,18 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:903
+#: lxc/storage_volume.go:909
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:281
+#: lxc/storage_volume.go:282
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
-#: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
+#: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
@@ -6566,7 +6573,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1172
+#: lxc/cluster.go:1173
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -6729,7 +6736,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6751,11 +6758,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:1140
+#: lxc/config.go:995 lxc/config.go:1141
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1049
+#: lxc/config.go:1050
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -6834,8 +6841,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:768
-#: lxc/cluster.go:1085 lxc/cluster.go:1297 lxc/cluster.go:1327
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
+#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -6859,8 +6866,8 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1104
-#: lxc/network.go:1339 lxc/network_forward.go:87
+#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1113
+#: lxc/network.go:1348 lxc/network_forward.go:87
 #: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -6873,11 +6880,11 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1411
+#: lxc/network.go:791 lxc/network.go:1420
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1243
+#: lxc/network.go:1252
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
@@ -6922,7 +6929,7 @@ msgstr ""
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1182
+#: lxc/network.go:1191
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -6973,7 +6980,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2800
+#: lxc/storage_volume.go:2811
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7008,13 +7015,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:1958
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:806
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7022,51 +7029,51 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2551
+#: lxc/storage_volume.go:2562
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2634
+#: lxc/storage_volume.go:2645
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2415
+#: lxc/storage_volume.go:2426
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:609
+#: lxc/storage_volume.go:610
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:718
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2353
+#: lxc/storage_volume.go:2364
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2085
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2232
+#: lxc/storage_volume.go:2243
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1221
+#: lxc/storage_volume.go:1232
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1858
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:387
+#: lxc/storage_volume.go:388
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7172,7 +7179,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1601
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7184,7 +7191,7 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:891
+#: lxc/cluster.go:892
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -7256,7 +7263,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:772
+#: lxc/cluster.go:773
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7305,13 +7312,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1229
+#: lxc/config.go:1230
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1053
+#: lxc/config.go:1054
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7648,7 +7655,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:614
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7656,13 +7663,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2804
+#: lxc/storage_volume.go:2815
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2419
+#: lxc/storage_volume.go:2430
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-09 03:18-0300\n"
+"POT-Creation-Date: 2024-12-18 08:40-0700\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -50,7 +50,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1030
+#: lxc/storage_volume.go:1041
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -64,7 +64,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1240
+#: lxc/config.go:1241
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -413,7 +413,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:790
+#: lxc/cluster.go:791
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -586,13 +586,13 @@ msgstr ""
 msgid "Acknowledge warning"
 msgstr ""
 
+#: lxc/query.go:43
+msgid "Action"
+msgstr ""
+
 #: lxc/query.go:76
 #, c-format
 msgid "Action %q isn't supported by this tool"
-msgstr ""
-
-#: lxc/query.go:43
-msgid "Action (defaults to GET)"
 msgstr ""
 
 #: lxc/cluster_group.go:725
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1596
+#: lxc/storage_volume.go:1607
 msgid "All projects"
 msgstr ""
 
@@ -761,7 +761,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1371
+#: lxc/cluster.go:1372
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -798,7 +798,7 @@ msgstr ""
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:282 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -850,16 +850,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2708
+#: lxc/storage_volume.go:2719
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2785
+#: lxc/export.go:192 lxc/storage_volume.go:2796
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1538
 msgid "Backups:"
 msgstr ""
 
@@ -880,7 +880,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -923,7 +923,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1739
+#: lxc/storage_volume.go:1750
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1008,7 +1008,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1016,7 +1016,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1097
+#: lxc/config.go:702 lxc/config.go:1098
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1025,12 +1025,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:492
+#: lxc/storage_volume.go:493
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:446
+#: lxc/storage_volume.go:447
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1106,7 +1106,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1154
+#: lxc/cluster.go:1155
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1134,8 +1134,8 @@ msgstr ""
 #: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
 #: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
-#: lxc/network_forward.go:182 lxc/network_forward.go:264
+#: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
+#: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
 #: lxc/network_forward.go:497 lxc/network_forward.go:649
 #: lxc/network_forward.go:803 lxc/network_forward.go:892
 #: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
@@ -1150,30 +1150,30 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
-#: lxc/storage_volume.go:1952 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2251 lxc/storage_volume.go:2367
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2555
-#: lxc/storage_volume.go:2643 lxc/storage_volume.go:2807
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
+#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
+#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:894
+#: lxc/cluster.go:895
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:926
+#: lxc/cluster.go:927
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:756
+#: lxc/cluster.go:757
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1210,24 +1210,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
+#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
-#: lxc/storage_volume.go:1188
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
+#: lxc/storage_volume.go:1199
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:619
+#: lxc/storage_volume.go:620
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1237,7 +1237,11 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/move.go:65
+#: lxc/move.go:65
+msgid "Copy a stateful instance as stateless"
+msgstr ""
+
+#: lxc/copy.go:60
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1285,7 +1289,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:389 lxc/storage_volume.go:390
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1293,12 +1297,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:396
+#: lxc/storage_volume.go:397
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:398
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1311,7 +1315,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:515
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1334,12 +1338,12 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1235
+#: lxc/cluster.go:1236
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1239
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1354,17 +1358,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1266
+#: lxc/cluster.go:1267
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1446,7 +1450,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1498,7 +1502,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1527,13 +1531,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1738
+#: lxc/storage_volume.go:1749
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1553,7 +1557,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2642
+#: lxc/storage_volume.go:2653
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1649,7 +1653,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1670,16 +1674,16 @@ msgstr ""
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
-#: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
+#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
+#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
-#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
-#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
+#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
+#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1702,8 +1706,8 @@ msgstr ""
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
 #: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1005 lxc/network.go:1106 lxc/network.go:1185
-#: lxc/network.go:1245 lxc/network.go:1341 lxc/network.go:1413
+#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
+#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
 #: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
 #: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
 #: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
@@ -1754,27 +1758,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
-#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
-#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
-#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1949
-#: lxc/storage_volume.go:2076 lxc/storage_volume.go:2234
-#: lxc/storage_volume.go:2355 lxc/storage_volume.go:2417
-#: lxc/storage_volume.go:2553 lxc/storage_volume.go:2636
-#: lxc/storage_volume.go:2802 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1454
+#: lxc/storage_volume.go:1465
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1786,11 +1790,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
+#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1918,7 +1922,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:516
+#: lxc/cluster.go:1072 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1940,7 +1944,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:769 lxc/cluster.go:770
+#: lxc/cluster.go:770 lxc/cluster.go:771
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1960,7 +1964,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1226 lxc/config.go:1227
+#: lxc/config.go:1227 lxc/config.go:1228
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2024,7 +2028,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2032,7 +2036,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2050,11 +2054,12 @@ msgid ""
 "new\n"
 "  LXD cluster, which will have the given name.\n"
 "\n"
-"  It's required that the LXD is already available on the network. You can "
-"check\n"
-"  that by running 'lxc config get core.https_address', and possibly set a "
-"value\n"
-"  for the address if not yet set."
+"  It's required that LXD is already available on the network. You can check\n"
+"  this by running 'lxc config get core.https_address'. If either an IP "
+"address\n"
+"  and port is displayed, or both, LXD is already available on the network. "
+"If\n"
+"  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
 #: lxc/network_zone.go:1427
@@ -2084,12 +2089,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
+#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2099,12 +2104,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
+#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
-#: lxc/storage_volume.go:2199
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
+#: lxc/storage_volume.go:2210
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2114,11 +2119,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1298 lxc/cluster.go:1299
+#: lxc/cluster.go:1299 lxc/cluster.go:1300
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1396
+#: lxc/cluster.go:1397
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2146,8 +2151,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
-#: lxc/storage_volume.go:1564
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Expires at"
 msgstr ""
 
@@ -2171,7 +2176,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2635 lxc/storage_volume.go:2636
+#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2183,11 +2188,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2639
+#: lxc/storage_volume.go:2650
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2768
+#: lxc/export.go:152 lxc/storage_volume.go:2779
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2367,7 +2372,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
+#: lxc/network.go:1046 lxc/network_acl.go:133 lxc/network_zone.go:124
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2377,7 +2382,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1303
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2385,7 +2390,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1301
+#: lxc/cluster.go:1302
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2397,7 +2402,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1331
+#: lxc/cluster.go:1332
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2438,16 +2443,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
-#: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1614 lxc/warning.go:94
+#: lxc/storage_volume.go:1625 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2507,7 +2512,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:996
+#: lxc/config.go:996 lxc/config.go:997
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2571,7 +2576,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1249
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2635,11 +2640,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
+#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:475
+#: lxc/storage_volume.go:476
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2667,7 +2672,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1161
+#: lxc/network.go:1170
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2721,7 +2726,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1163
+#: lxc/network.go:1172
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2733,11 +2738,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1084
+#: lxc/list.go:560 lxc/network.go:1093
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1085
+#: lxc/list.go:561 lxc/network.go:1094
 msgid "IPV6"
 msgstr ""
 
@@ -2767,7 +2772,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2427
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2781,7 +2786,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2437
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2831,7 +2836,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2802
+#: lxc/storage_volume.go:2813
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2839,7 +2844,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2801
+#: lxc/storage_volume.go:2812
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2861,11 +2866,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2809
+#: lxc/storage_volume.go:2820
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2883
+#: lxc/storage_volume.go:2894
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2909,7 +2914,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
+#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2991,7 +2996,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2012
+#: lxc/move.go:148 lxc/storage_volume.go:2023
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2999,7 +3004,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2019
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3017,9 +3022,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
-#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2144 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
+#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3063,9 +3068,9 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
+#: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3077,8 +3082,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1020 lxc/cluster.go:1123
-#: lxc/cluster.go:1231 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
+#: lxc/cluster.go:1232 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3115,7 +3120,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1105 lxc/network.go:1106
+#: lxc/network.go:1114 lxc/network.go:1115
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3127,7 +3132,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:976 lxc/cluster.go:977
+#: lxc/cluster.go:977 lxc/cluster.go:978
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -3175,7 +3180,7 @@ msgstr ""
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1004 lxc/network.go:1005
+#: lxc/network.go:1005 lxc/network.go:1006
 msgid "List available networks"
 msgstr ""
 
@@ -3263,7 +3268,7 @@ msgid ""
 "Fast column layout: nsacPt\n"
 "\n"
 "A single keyword like \"web\" which will list any instance with a name "
-"starting by \"web\".\n"
+"starting with \"web\".\n"
 "A regular expression on the instance name. (e.g. .*web.*01$).\n"
 "A key/value pair referring to a configuration item. For those, the\n"
 "namespace can be abbreviated to the smallest unambiguous identifier.\n"
@@ -3320,7 +3325,8 @@ msgid ""
 "  P - Profiles\n"
 "  s - State\n"
 "  S - Number of snapshots\n"
-"  t - Type (persistent or ephemeral)\n"
+"  t - Type (container or virtual-machine, ephemeral indicated if "
+"applicable)\n"
 "  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
@@ -3369,11 +3375,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1603
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1608
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3432,7 +3438,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1470
+#: lxc/info.go:489 lxc/storage_volume.go:1481
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3453,7 +3459,7 @@ msgstr ""
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1162
+#: lxc/network.go:1171
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3471,7 +3477,7 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1083
+#: lxc/network.go:1092
 msgid "MANAGED"
 msgstr ""
 
@@ -3594,7 +3600,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:955 lxc/config.go:956
+#: lxc/config.go:956 lxc/config.go:957
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3733,7 +3739,7 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:957
+#: lxc/cluster.go:958
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
@@ -3797,7 +3803,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:811 lxc/cluster.go:1367 lxc/cluster_group.go:129
+#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -3860,8 +3866,8 @@ msgstr ""
 
 #: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1139 lxc/network.go:1217 lxc/network.go:1283
-#: lxc/network.go:1375 lxc/network_forward.go:127 lxc/network_forward.go:215
+#: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
+#: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
 #: lxc/network_forward.go:284 lxc/network_forward.go:445
 #: lxc/network_forward.go:530 lxc/network_forward.go:705
 #: lxc/network_forward.go:836 lxc/network_forward.go:929
@@ -3902,12 +3908,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
-#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
-#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1986
-#: lxc/storage_volume.go:2127 lxc/storage_volume.go:2285
-#: lxc/storage_volume.go:2476 lxc/storage_volume.go:2593
+#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
+#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
 msgid "Missing pool name"
 msgstr ""
 
@@ -3926,11 +3932,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:438 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1411
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3967,8 +3973,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
-#: lxc/storage_volume.go:964
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
+#: lxc/storage_volume.go:975
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4005,7 +4011,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4013,11 +4019,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1856
+#: lxc/storage_volume.go:1867
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:518
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4039,12 +4045,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
+#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
 msgid "NAME"
 msgstr ""
 
@@ -4072,7 +4078,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
 #: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4096,8 +4102,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
-#: lxc/storage_volume.go:1562
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1573
 msgid "Name"
 msgstr ""
 
@@ -4105,7 +4111,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4130,7 +4136,7 @@ msgstr ""
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1227
+#: lxc/network.go:1236
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4240,7 +4246,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1161
+#: lxc/cluster.go:1162
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4249,7 +4255,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
+#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4269,11 +4275,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:502 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4287,7 +4293,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2035
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4295,15 +4301,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:343
+#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
+#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2690
+#: lxc/storage_volume.go:2701
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2489
+#: lxc/storage_volume.go:2500
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4315,11 +4322,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1418
+#: lxc/storage_volume.go:1429
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1298
+#: lxc/network.go:735 lxc/network.go:1307
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4328,7 +4335,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1577
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4358,7 +4365,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1767
 msgid "POOL"
 msgstr ""
 
@@ -4374,7 +4381,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1773
 #: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4420,7 +4427,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -4441,16 +4448,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
-#: lxc/storage_volume.go:1189
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
+#: lxc/storage_volume.go:1200
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4567,7 +4574,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1356
+#: lxc/storage_volume.go:1367
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4581,7 +4588,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1225
+#: lxc/storage_volume.go:1236
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4597,7 +4604,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2247
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4618,7 +4625,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1004
+#: lxc/storage_volume.go:1015
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4627,7 +4634,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2081
+#: lxc/storage_volume.go:2092
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4640,13 +4647,13 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2357
+#: lxc/storage_volume.go:2368
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
 "\n"
 "lxc storage volume unset default data size\n"
-"    Remotes the size/quota of a custom volume \"data\" in pool \"default\".\n"
+"    Removes the size/quota of a custom volume \"data\" in pool \"default\".\n"
 "\n"
 "lxc storage volume unset default virtual-machine/data snapshots.expiry\n"
 "    Removes the snapshot expiration period for a virtual machine \"data\" in "
@@ -4726,7 +4733,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4909,7 +4916,7 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1184 lxc/network.go:1185
+#: lxc/network.go:1193 lxc/network.go:1194
 msgid "Rename networks"
 msgstr ""
 
@@ -4925,15 +4932,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1949
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:1959
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2037 lxc/storage_volume.go:2057
+#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4943,11 +4950,11 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:892 lxc/cluster.go:893
+#: lxc/cluster.go:893 lxc/cluster.go:894
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1032
+#: lxc/config.go:1033
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -4970,7 +4977,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1328 lxc/cluster.go:1329
+#: lxc/cluster.go:1329 lxc/cluster.go:1330
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4985,11 +4992,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2552 lxc/storage_volume.go:2553
+#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1394
+#: lxc/cluster.go:1395
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5011,7 +5018,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1087
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5061,7 +5068,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1088
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1097
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5124,7 +5131,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1050 lxc/config.go:1051
+#: lxc/config.go:1051 lxc/config.go:1052
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5188,11 +5195,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1244
+#: lxc/network.go:1253
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1245
+#: lxc/network.go:1254
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5309,11 +5316,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2075
+#: lxc/storage_volume.go:2086
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2076
+#: lxc/storage_volume.go:2087
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5370,7 +5377,7 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1252
+#: lxc/network.go:1261
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5398,7 +5405,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2103
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5467,7 +5474,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1173
+#: lxc/config.go:1173 lxc/config.go:1174
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5499,7 +5506,7 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1340 lxc/network.go:1341
+#: lxc/network.go:1349 lxc/network.go:1350
 msgid "Show network configurations"
 msgstr ""
 
@@ -5547,11 +5554,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2233 lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5574,7 +5581,7 @@ msgid "Show the expanded configuration"
 msgstr ""
 
 #: lxc/info.go:43
-msgid "Show the instance's last 100 log lines?"
+msgid "Show the instance's last 100 log lines"
 msgstr ""
 
 #: lxc/info.go:44
@@ -5619,15 +5626,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2417
+#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2179
+#: lxc/storage_volume.go:2190
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1502
 msgid "Snapshots:"
 msgstr ""
 
@@ -5732,21 +5739,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:702
+#: lxc/storage_volume.go:703
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:790
+#: lxc/storage_volume.go:791
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:516
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:520
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5754,7 +5761,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5803,18 +5810,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1070 lxc/config_trust.go:515
+#: lxc/cluster.go:1071 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1736 lxc/warning.go:216
+#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1747 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
 msgid "Taken at"
 msgstr ""
 
@@ -5971,12 +5978,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1340
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1306
+#: lxc/storage_volume.go:1317
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -5995,8 +6002,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
-#: lxc/storage_volume.go:978
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:989
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6016,11 +6023,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:739
+#: lxc/cluster.go:740
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:729
+#: lxc/cluster.go:730
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6071,7 +6078,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6086,7 +6093,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1853
+#: lxc/storage_volume.go:1864
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6094,7 +6101,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:394
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6153,7 +6160,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1472
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6175,13 +6182,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:995 lxc/storage_volume.go:1752
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
+#: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1740
+#: lxc/storage.go:724 lxc/storage_volume.go:1751
 msgid "USED BY"
 msgstr ""
 
@@ -6213,7 +6220,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6239,7 +6246,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1141 lxc/config.go:1142
+#: lxc/config.go:1142 lxc/config.go:1143
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6267,7 +6274,7 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1412 lxc/network.go:1413
+#: lxc/network.go:1421 lxc/network.go:1422
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -6319,7 +6326,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2354 lxc/storage_volume.go:2355
+#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6343,7 +6350,7 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1417
+#: lxc/network.go:1426
 msgid "Unset the key as a network property"
 msgstr ""
 
@@ -6371,7 +6378,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2379
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6379,7 +6386,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:247
+#: lxc/storage_volume.go:248
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6392,11 +6399,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1174
+#: lxc/cluster.go:1175
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1176
+#: lxc/cluster.go:1177
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6415,12 +6422,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2641
+#: lxc/export.go:42 lxc/storage_volume.go:2652
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6487,7 +6494,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1576
 msgid "Volume Only"
 msgstr ""
 
@@ -6520,7 +6527,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
 #: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6546,18 +6553,18 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:903
+#: lxc/storage_volume.go:909
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:281
+#: lxc/storage_volume.go:282
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
-#: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
+#: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
@@ -6567,7 +6574,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1172
+#: lxc/cluster.go:1173
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -6730,7 +6737,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6752,11 +6759,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:1140
+#: lxc/config.go:995 lxc/config.go:1141
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1049
+#: lxc/config.go:1050
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -6835,8 +6842,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:768
-#: lxc/cluster.go:1085 lxc/cluster.go:1297 lxc/cluster.go:1327
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
+#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -6860,8 +6867,8 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1104
-#: lxc/network.go:1339 lxc/network_forward.go:87
+#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1113
+#: lxc/network.go:1348 lxc/network_forward.go:87
 #: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -6874,11 +6881,11 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1411
+#: lxc/network.go:791 lxc/network.go:1420
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1243
+#: lxc/network.go:1252
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
@@ -6923,7 +6930,7 @@ msgstr ""
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1182
+#: lxc/network.go:1191
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -6974,7 +6981,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2800
+#: lxc/storage_volume.go:2811
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7009,13 +7016,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:1958
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:806
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7023,51 +7030,51 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2551
+#: lxc/storage_volume.go:2562
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2634
+#: lxc/storage_volume.go:2645
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2415
+#: lxc/storage_volume.go:2426
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:609
+#: lxc/storage_volume.go:610
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:718
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2353
+#: lxc/storage_volume.go:2364
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2085
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2232
+#: lxc/storage_volume.go:2243
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1221
+#: lxc/storage_volume.go:1232
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1858
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:387
+#: lxc/storage_volume.go:388
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7173,7 +7180,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1601
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7185,7 +7192,7 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:891
+#: lxc/cluster.go:892
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -7257,7 +7264,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:772
+#: lxc/cluster.go:773
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7306,13 +7313,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1229
+#: lxc/config.go:1230
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1053
+#: lxc/config.go:1054
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7649,7 +7656,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:614
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7657,13 +7664,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2804
+#: lxc/storage_volume.go:2815
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2419
+#: lxc/storage_volume.go:2430
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-09 03:18-0300\n"
+"POT-Creation-Date: 2024-12-18 08:40-0700\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -50,7 +50,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1030
+#: lxc/storage_volume.go:1041
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -64,7 +64,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1240
+#: lxc/config.go:1241
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -413,7 +413,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:790
+#: lxc/cluster.go:791
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -586,13 +586,13 @@ msgstr ""
 msgid "Acknowledge warning"
 msgstr ""
 
+#: lxc/query.go:43
+msgid "Action"
+msgstr ""
+
 #: lxc/query.go:76
 #, c-format
 msgid "Action %q isn't supported by this tool"
-msgstr ""
-
-#: lxc/query.go:43
-msgid "Action (defaults to GET)"
 msgstr ""
 
 #: lxc/cluster_group.go:725
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1596
+#: lxc/storage_volume.go:1607
 msgid "All projects"
 msgstr ""
 
@@ -761,7 +761,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1371
+#: lxc/cluster.go:1372
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -798,7 +798,7 @@ msgstr ""
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:282 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -850,16 +850,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2708
+#: lxc/storage_volume.go:2719
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2785
+#: lxc/export.go:192 lxc/storage_volume.go:2796
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1538
 msgid "Backups:"
 msgstr ""
 
@@ -880,7 +880,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -923,7 +923,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1739
+#: lxc/storage_volume.go:1750
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1008,7 +1008,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1016,7 +1016,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1097
+#: lxc/config.go:702 lxc/config.go:1098
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1025,12 +1025,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:492
+#: lxc/storage_volume.go:493
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:446
+#: lxc/storage_volume.go:447
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1106,7 +1106,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1154
+#: lxc/cluster.go:1155
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1134,8 +1134,8 @@ msgstr ""
 #: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
 #: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
-#: lxc/network_forward.go:182 lxc/network_forward.go:264
+#: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
+#: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
 #: lxc/network_forward.go:497 lxc/network_forward.go:649
 #: lxc/network_forward.go:803 lxc/network_forward.go:892
 #: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
@@ -1150,30 +1150,30 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
-#: lxc/storage_volume.go:1952 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2251 lxc/storage_volume.go:2367
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2555
-#: lxc/storage_volume.go:2643 lxc/storage_volume.go:2807
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
+#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
+#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:894
+#: lxc/cluster.go:895
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:926
+#: lxc/cluster.go:927
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:756
+#: lxc/cluster.go:757
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1210,24 +1210,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
+#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
-#: lxc/storage_volume.go:1188
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
+#: lxc/storage_volume.go:1199
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:619
+#: lxc/storage_volume.go:620
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1237,7 +1237,11 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/move.go:65
+#: lxc/move.go:65
+msgid "Copy a stateful instance as stateless"
+msgstr ""
+
+#: lxc/copy.go:60
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1285,7 +1289,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:389 lxc/storage_volume.go:390
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1293,12 +1297,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:396
+#: lxc/storage_volume.go:397
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:398
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1311,7 +1315,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:515
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1334,12 +1338,12 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1235
+#: lxc/cluster.go:1236
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1239
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1354,17 +1358,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1266
+#: lxc/cluster.go:1267
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1446,7 +1450,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1498,7 +1502,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1527,13 +1531,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1738
+#: lxc/storage_volume.go:1749
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1553,7 +1557,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2642
+#: lxc/storage_volume.go:2653
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1649,7 +1653,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1670,16 +1674,16 @@ msgstr ""
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
-#: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
+#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
+#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
-#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
-#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
+#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
+#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1702,8 +1706,8 @@ msgstr ""
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
 #: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1005 lxc/network.go:1106 lxc/network.go:1185
-#: lxc/network.go:1245 lxc/network.go:1341 lxc/network.go:1413
+#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
+#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
 #: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
 #: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
 #: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
@@ -1754,27 +1758,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
-#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
-#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
-#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1949
-#: lxc/storage_volume.go:2076 lxc/storage_volume.go:2234
-#: lxc/storage_volume.go:2355 lxc/storage_volume.go:2417
-#: lxc/storage_volume.go:2553 lxc/storage_volume.go:2636
-#: lxc/storage_volume.go:2802 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1454
+#: lxc/storage_volume.go:1465
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1786,11 +1790,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
+#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1918,7 +1922,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:516
+#: lxc/cluster.go:1072 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1940,7 +1944,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:769 lxc/cluster.go:770
+#: lxc/cluster.go:770 lxc/cluster.go:771
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1960,7 +1964,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1226 lxc/config.go:1227
+#: lxc/config.go:1227 lxc/config.go:1228
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2024,7 +2028,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2032,7 +2036,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2050,11 +2054,12 @@ msgid ""
 "new\n"
 "  LXD cluster, which will have the given name.\n"
 "\n"
-"  It's required that the LXD is already available on the network. You can "
-"check\n"
-"  that by running 'lxc config get core.https_address', and possibly set a "
-"value\n"
-"  for the address if not yet set."
+"  It's required that LXD is already available on the network. You can check\n"
+"  this by running 'lxc config get core.https_address'. If either an IP "
+"address\n"
+"  and port is displayed, or both, LXD is already available on the network. "
+"If\n"
+"  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
 #: lxc/network_zone.go:1427
@@ -2084,12 +2089,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
+#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2099,12 +2104,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
+#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
-#: lxc/storage_volume.go:2199
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
+#: lxc/storage_volume.go:2210
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2114,11 +2119,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1298 lxc/cluster.go:1299
+#: lxc/cluster.go:1299 lxc/cluster.go:1300
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1396
+#: lxc/cluster.go:1397
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2146,8 +2151,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
-#: lxc/storage_volume.go:1564
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Expires at"
 msgstr ""
 
@@ -2171,7 +2176,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2635 lxc/storage_volume.go:2636
+#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2183,11 +2188,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2639
+#: lxc/storage_volume.go:2650
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2768
+#: lxc/export.go:152 lxc/storage_volume.go:2779
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2367,7 +2372,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
+#: lxc/network.go:1046 lxc/network_acl.go:133 lxc/network_zone.go:124
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2377,7 +2382,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1303
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2385,7 +2390,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1301
+#: lxc/cluster.go:1302
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2397,7 +2402,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1331
+#: lxc/cluster.go:1332
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2438,16 +2443,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
-#: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1614 lxc/warning.go:94
+#: lxc/storage_volume.go:1625 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2507,7 +2512,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:996
+#: lxc/config.go:996 lxc/config.go:997
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2571,7 +2576,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1249
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2635,11 +2640,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
+#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:475
+#: lxc/storage_volume.go:476
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2667,7 +2672,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1161
+#: lxc/network.go:1170
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2721,7 +2726,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1163
+#: lxc/network.go:1172
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2733,11 +2738,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1084
+#: lxc/list.go:560 lxc/network.go:1093
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1085
+#: lxc/list.go:561 lxc/network.go:1094
 msgid "IPV6"
 msgstr ""
 
@@ -2767,7 +2772,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2427
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2781,7 +2786,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2437
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2831,7 +2836,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2802
+#: lxc/storage_volume.go:2813
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2839,7 +2844,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2801
+#: lxc/storage_volume.go:2812
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2861,11 +2866,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2809
+#: lxc/storage_volume.go:2820
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2883
+#: lxc/storage_volume.go:2894
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2909,7 +2914,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
+#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2991,7 +2996,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2012
+#: lxc/move.go:148 lxc/storage_volume.go:2023
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2999,7 +3004,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2019
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3017,9 +3022,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
-#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2144 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
+#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3063,9 +3068,9 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
+#: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3077,8 +3082,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1020 lxc/cluster.go:1123
-#: lxc/cluster.go:1231 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
+#: lxc/cluster.go:1232 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3115,7 +3120,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1105 lxc/network.go:1106
+#: lxc/network.go:1114 lxc/network.go:1115
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3127,7 +3132,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:976 lxc/cluster.go:977
+#: lxc/cluster.go:977 lxc/cluster.go:978
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -3175,7 +3180,7 @@ msgstr ""
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1004 lxc/network.go:1005
+#: lxc/network.go:1005 lxc/network.go:1006
 msgid "List available networks"
 msgstr ""
 
@@ -3263,7 +3268,7 @@ msgid ""
 "Fast column layout: nsacPt\n"
 "\n"
 "A single keyword like \"web\" which will list any instance with a name "
-"starting by \"web\".\n"
+"starting with \"web\".\n"
 "A regular expression on the instance name. (e.g. .*web.*01$).\n"
 "A key/value pair referring to a configuration item. For those, the\n"
 "namespace can be abbreviated to the smallest unambiguous identifier.\n"
@@ -3320,7 +3325,8 @@ msgid ""
 "  P - Profiles\n"
 "  s - State\n"
 "  S - Number of snapshots\n"
-"  t - Type (persistent or ephemeral)\n"
+"  t - Type (container or virtual-machine, ephemeral indicated if "
+"applicable)\n"
 "  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
@@ -3369,11 +3375,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1603
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1608
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3432,7 +3438,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1470
+#: lxc/info.go:489 lxc/storage_volume.go:1481
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3453,7 +3459,7 @@ msgstr ""
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1162
+#: lxc/network.go:1171
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3471,7 +3477,7 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1083
+#: lxc/network.go:1092
 msgid "MANAGED"
 msgstr ""
 
@@ -3594,7 +3600,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:955 lxc/config.go:956
+#: lxc/config.go:956 lxc/config.go:957
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3733,7 +3739,7 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:957
+#: lxc/cluster.go:958
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
@@ -3797,7 +3803,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:811 lxc/cluster.go:1367 lxc/cluster_group.go:129
+#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -3860,8 +3866,8 @@ msgstr ""
 
 #: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1139 lxc/network.go:1217 lxc/network.go:1283
-#: lxc/network.go:1375 lxc/network_forward.go:127 lxc/network_forward.go:215
+#: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
+#: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
 #: lxc/network_forward.go:284 lxc/network_forward.go:445
 #: lxc/network_forward.go:530 lxc/network_forward.go:705
 #: lxc/network_forward.go:836 lxc/network_forward.go:929
@@ -3902,12 +3908,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
-#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
-#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1986
-#: lxc/storage_volume.go:2127 lxc/storage_volume.go:2285
-#: lxc/storage_volume.go:2476 lxc/storage_volume.go:2593
+#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
+#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
 msgid "Missing pool name"
 msgstr ""
 
@@ -3926,11 +3932,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:438 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1411
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3967,8 +3973,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
-#: lxc/storage_volume.go:964
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
+#: lxc/storage_volume.go:975
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4005,7 +4011,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4013,11 +4019,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1856
+#: lxc/storage_volume.go:1867
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:518
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4039,12 +4045,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
+#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
 msgid "NAME"
 msgstr ""
 
@@ -4072,7 +4078,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
 #: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4096,8 +4102,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
-#: lxc/storage_volume.go:1562
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1573
 msgid "Name"
 msgstr ""
 
@@ -4105,7 +4111,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4130,7 +4136,7 @@ msgstr ""
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1227
+#: lxc/network.go:1236
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4240,7 +4246,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1161
+#: lxc/cluster.go:1162
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4249,7 +4255,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
+#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4269,11 +4275,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:502 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4287,7 +4293,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2035
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4295,15 +4301,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:343
+#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
+#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2690
+#: lxc/storage_volume.go:2701
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2489
+#: lxc/storage_volume.go:2500
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4315,11 +4322,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1418
+#: lxc/storage_volume.go:1429
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1298
+#: lxc/network.go:735 lxc/network.go:1307
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4328,7 +4335,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1577
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4358,7 +4365,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1767
 msgid "POOL"
 msgstr ""
 
@@ -4374,7 +4381,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1773
 #: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4420,7 +4427,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -4441,16 +4448,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
-#: lxc/storage_volume.go:1189
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
+#: lxc/storage_volume.go:1200
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4567,7 +4574,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1356
+#: lxc/storage_volume.go:1367
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4581,7 +4588,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1225
+#: lxc/storage_volume.go:1236
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4597,7 +4604,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2247
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4618,7 +4625,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1004
+#: lxc/storage_volume.go:1015
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4627,7 +4634,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2081
+#: lxc/storage_volume.go:2092
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4640,13 +4647,13 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2357
+#: lxc/storage_volume.go:2368
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
 "\n"
 "lxc storage volume unset default data size\n"
-"    Remotes the size/quota of a custom volume \"data\" in pool \"default\".\n"
+"    Removes the size/quota of a custom volume \"data\" in pool \"default\".\n"
 "\n"
 "lxc storage volume unset default virtual-machine/data snapshots.expiry\n"
 "    Removes the snapshot expiration period for a virtual machine \"data\" in "
@@ -4726,7 +4733,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4909,7 +4916,7 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1184 lxc/network.go:1185
+#: lxc/network.go:1193 lxc/network.go:1194
 msgid "Rename networks"
 msgstr ""
 
@@ -4925,15 +4932,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1949
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:1959
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2037 lxc/storage_volume.go:2057
+#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4943,11 +4950,11 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:892 lxc/cluster.go:893
+#: lxc/cluster.go:893 lxc/cluster.go:894
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1032
+#: lxc/config.go:1033
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -4970,7 +4977,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1328 lxc/cluster.go:1329
+#: lxc/cluster.go:1329 lxc/cluster.go:1330
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4985,11 +4992,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2552 lxc/storage_volume.go:2553
+#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1394
+#: lxc/cluster.go:1395
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5011,7 +5018,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1087
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5061,7 +5068,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1088
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1097
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5124,7 +5131,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1050 lxc/config.go:1051
+#: lxc/config.go:1051 lxc/config.go:1052
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5188,11 +5195,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1244
+#: lxc/network.go:1253
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1245
+#: lxc/network.go:1254
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5309,11 +5316,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2075
+#: lxc/storage_volume.go:2086
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2076
+#: lxc/storage_volume.go:2087
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5370,7 +5377,7 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1252
+#: lxc/network.go:1261
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5398,7 +5405,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2103
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5467,7 +5474,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1173
+#: lxc/config.go:1173 lxc/config.go:1174
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5499,7 +5506,7 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1340 lxc/network.go:1341
+#: lxc/network.go:1349 lxc/network.go:1350
 msgid "Show network configurations"
 msgstr ""
 
@@ -5547,11 +5554,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2233 lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5574,7 +5581,7 @@ msgid "Show the expanded configuration"
 msgstr ""
 
 #: lxc/info.go:43
-msgid "Show the instance's last 100 log lines?"
+msgid "Show the instance's last 100 log lines"
 msgstr ""
 
 #: lxc/info.go:44
@@ -5619,15 +5626,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2417
+#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2179
+#: lxc/storage_volume.go:2190
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1502
 msgid "Snapshots:"
 msgstr ""
 
@@ -5732,21 +5739,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:702
+#: lxc/storage_volume.go:703
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:790
+#: lxc/storage_volume.go:791
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:516
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:520
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5754,7 +5761,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5803,18 +5810,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1070 lxc/config_trust.go:515
+#: lxc/cluster.go:1071 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1736 lxc/warning.go:216
+#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1747 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
 msgid "Taken at"
 msgstr ""
 
@@ -5971,12 +5978,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1340
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1306
+#: lxc/storage_volume.go:1317
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -5995,8 +6002,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
-#: lxc/storage_volume.go:978
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:989
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6016,11 +6023,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:739
+#: lxc/cluster.go:740
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:729
+#: lxc/cluster.go:730
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6071,7 +6078,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6086,7 +6093,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1853
+#: lxc/storage_volume.go:1864
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6094,7 +6101,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:394
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6153,7 +6160,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1472
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6175,13 +6182,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:995 lxc/storage_volume.go:1752
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
+#: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1740
+#: lxc/storage.go:724 lxc/storage_volume.go:1751
 msgid "USED BY"
 msgstr ""
 
@@ -6213,7 +6220,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6239,7 +6246,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1141 lxc/config.go:1142
+#: lxc/config.go:1142 lxc/config.go:1143
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6267,7 +6274,7 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1412 lxc/network.go:1413
+#: lxc/network.go:1421 lxc/network.go:1422
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -6319,7 +6326,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2354 lxc/storage_volume.go:2355
+#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6343,7 +6350,7 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1417
+#: lxc/network.go:1426
 msgid "Unset the key as a network property"
 msgstr ""
 
@@ -6371,7 +6378,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2379
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6379,7 +6386,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:247
+#: lxc/storage_volume.go:248
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6392,11 +6399,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1174
+#: lxc/cluster.go:1175
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1176
+#: lxc/cluster.go:1177
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6415,12 +6422,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2641
+#: lxc/export.go:42 lxc/storage_volume.go:2652
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6487,7 +6494,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1576
 msgid "Volume Only"
 msgstr ""
 
@@ -6520,7 +6527,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
 #: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6546,18 +6553,18 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:903
+#: lxc/storage_volume.go:909
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:281
+#: lxc/storage_volume.go:282
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
-#: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
+#: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
@@ -6567,7 +6574,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1172
+#: lxc/cluster.go:1173
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -6730,7 +6737,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6752,11 +6759,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:1140
+#: lxc/config.go:995 lxc/config.go:1141
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1049
+#: lxc/config.go:1050
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -6835,8 +6842,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:768
-#: lxc/cluster.go:1085 lxc/cluster.go:1297 lxc/cluster.go:1327
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
+#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -6860,8 +6867,8 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1104
-#: lxc/network.go:1339 lxc/network_forward.go:87
+#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1113
+#: lxc/network.go:1348 lxc/network_forward.go:87
 #: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -6874,11 +6881,11 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1411
+#: lxc/network.go:791 lxc/network.go:1420
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1243
+#: lxc/network.go:1252
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
@@ -6923,7 +6930,7 @@ msgstr ""
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1182
+#: lxc/network.go:1191
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -6974,7 +6981,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2800
+#: lxc/storage_volume.go:2811
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7009,13 +7016,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:1958
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:806
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7023,51 +7030,51 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2551
+#: lxc/storage_volume.go:2562
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2634
+#: lxc/storage_volume.go:2645
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2415
+#: lxc/storage_volume.go:2426
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:609
+#: lxc/storage_volume.go:610
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:718
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2353
+#: lxc/storage_volume.go:2364
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2085
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2232
+#: lxc/storage_volume.go:2243
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1221
+#: lxc/storage_volume.go:1232
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1858
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:387
+#: lxc/storage_volume.go:388
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7173,7 +7180,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1601
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7185,7 +7192,7 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:891
+#: lxc/cluster.go:892
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -7257,7 +7264,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:772
+#: lxc/cluster.go:773
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7306,13 +7313,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1229
+#: lxc/config.go:1230
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1053
+#: lxc/config.go:1054
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7649,7 +7656,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:614
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7657,13 +7664,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2804
+#: lxc/storage_volume.go:2815
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2419
+#: lxc/storage_volume.go:2430
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-09 03:18-0300\n"
+"POT-Creation-Date: 2024-12-18 08:40-0700\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1030
+#: lxc/storage_volume.go:1041
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1240
+#: lxc/config.go:1241
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -412,7 +412,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:790
+#: lxc/cluster.go:791
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -585,13 +585,13 @@ msgstr ""
 msgid "Acknowledge warning"
 msgstr ""
 
+#: lxc/query.go:43
+msgid "Action"
+msgstr ""
+
 #: lxc/query.go:76
 #, c-format
 msgid "Action %q isn't supported by this tool"
-msgstr ""
-
-#: lxc/query.go:43
-msgid "Action (defaults to GET)"
 msgstr ""
 
 #: lxc/cluster_group.go:725
@@ -738,7 +738,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1596
+#: lxc/storage_volume.go:1607
 msgid "All projects"
 msgstr ""
 
@@ -760,7 +760,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1371
+#: lxc/cluster.go:1372
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -797,7 +797,7 @@ msgstr ""
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:282 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -849,16 +849,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2708
+#: lxc/storage_volume.go:2719
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2785
+#: lxc/export.go:192 lxc/storage_volume.go:2796
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1538
 msgid "Backups:"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -922,7 +922,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1739
+#: lxc/storage_volume.go:1750
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1007,7 +1007,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1097
+#: lxc/config.go:702 lxc/config.go:1098
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1024,12 +1024,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:492
+#: lxc/storage_volume.go:493
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:446
+#: lxc/storage_volume.go:447
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1105,7 +1105,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1154
+#: lxc/cluster.go:1155
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1133,8 +1133,8 @@ msgstr ""
 #: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
 #: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
-#: lxc/network_forward.go:182 lxc/network_forward.go:264
+#: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
+#: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
 #: lxc/network_forward.go:497 lxc/network_forward.go:649
 #: lxc/network_forward.go:803 lxc/network_forward.go:892
 #: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
@@ -1149,30 +1149,30 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
-#: lxc/storage_volume.go:1952 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2251 lxc/storage_volume.go:2367
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2555
-#: lxc/storage_volume.go:2643 lxc/storage_volume.go:2807
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
+#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
+#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:894
+#: lxc/cluster.go:895
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:926
+#: lxc/cluster.go:927
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:756
+#: lxc/cluster.go:757
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1209,24 +1209,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
+#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
-#: lxc/storage_volume.go:1188
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
+#: lxc/storage_volume.go:1199
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:619
+#: lxc/storage_volume.go:620
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1236,7 +1236,11 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/move.go:65
+#: lxc/move.go:65
+msgid "Copy a stateful instance as stateless"
+msgstr ""
+
+#: lxc/copy.go:60
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1284,7 +1288,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:389 lxc/storage_volume.go:390
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1292,12 +1296,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:396
+#: lxc/storage_volume.go:397
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:398
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1310,7 +1314,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:515
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1333,12 +1337,12 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1235
+#: lxc/cluster.go:1236
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1239
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1353,17 +1357,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1266
+#: lxc/cluster.go:1267
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1445,7 +1449,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1497,7 +1501,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1526,13 +1530,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1738
+#: lxc/storage_volume.go:1749
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1552,7 +1556,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2642
+#: lxc/storage_volume.go:2653
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1648,7 +1652,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1669,16 +1673,16 @@ msgstr ""
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
-#: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
+#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
+#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
-#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
-#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
+#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
+#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1701,8 +1705,8 @@ msgstr ""
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
 #: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1005 lxc/network.go:1106 lxc/network.go:1185
-#: lxc/network.go:1245 lxc/network.go:1341 lxc/network.go:1413
+#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
+#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
 #: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
 #: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
 #: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
@@ -1753,27 +1757,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
-#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
-#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
-#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1949
-#: lxc/storage_volume.go:2076 lxc/storage_volume.go:2234
-#: lxc/storage_volume.go:2355 lxc/storage_volume.go:2417
-#: lxc/storage_volume.go:2553 lxc/storage_volume.go:2636
-#: lxc/storage_volume.go:2802 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1454
+#: lxc/storage_volume.go:1465
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1785,11 +1789,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
+#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1917,7 +1921,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:516
+#: lxc/cluster.go:1072 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1939,7 +1943,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:769 lxc/cluster.go:770
+#: lxc/cluster.go:770 lxc/cluster.go:771
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1959,7 +1963,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1226 lxc/config.go:1227
+#: lxc/config.go:1227 lxc/config.go:1228
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2023,7 +2027,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2031,7 +2035,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2049,11 +2053,12 @@ msgid ""
 "new\n"
 "  LXD cluster, which will have the given name.\n"
 "\n"
-"  It's required that the LXD is already available on the network. You can "
-"check\n"
-"  that by running 'lxc config get core.https_address', and possibly set a "
-"value\n"
-"  for the address if not yet set."
+"  It's required that LXD is already available on the network. You can check\n"
+"  this by running 'lxc config get core.https_address'. If either an IP "
+"address\n"
+"  and port is displayed, or both, LXD is already available on the network. "
+"If\n"
+"  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
 #: lxc/network_zone.go:1427
@@ -2083,12 +2088,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
+#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2098,12 +2103,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
+#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
-#: lxc/storage_volume.go:2199
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
+#: lxc/storage_volume.go:2210
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2113,11 +2118,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1298 lxc/cluster.go:1299
+#: lxc/cluster.go:1299 lxc/cluster.go:1300
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1396
+#: lxc/cluster.go:1397
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2145,8 +2150,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
-#: lxc/storage_volume.go:1564
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Expires at"
 msgstr ""
 
@@ -2170,7 +2175,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2635 lxc/storage_volume.go:2636
+#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2182,11 +2187,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2639
+#: lxc/storage_volume.go:2650
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2768
+#: lxc/export.go:152 lxc/storage_volume.go:2779
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2366,7 +2371,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
+#: lxc/network.go:1046 lxc/network_acl.go:133 lxc/network_zone.go:124
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2376,7 +2381,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1303
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2384,7 +2389,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1301
+#: lxc/cluster.go:1302
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2396,7 +2401,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1331
+#: lxc/cluster.go:1332
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2437,16 +2442,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
-#: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1614 lxc/warning.go:94
+#: lxc/storage_volume.go:1625 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2506,7 +2511,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:996
+#: lxc/config.go:996 lxc/config.go:997
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2570,7 +2575,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1249
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2634,11 +2639,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
+#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:475
+#: lxc/storage_volume.go:476
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2666,7 +2671,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1161
+#: lxc/network.go:1170
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2720,7 +2725,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1163
+#: lxc/network.go:1172
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2732,11 +2737,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1084
+#: lxc/list.go:560 lxc/network.go:1093
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1085
+#: lxc/list.go:561 lxc/network.go:1094
 msgid "IPV6"
 msgstr ""
 
@@ -2766,7 +2771,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2427
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2780,7 +2785,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2437
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2830,7 +2835,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2802
+#: lxc/storage_volume.go:2813
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2838,7 +2843,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2801
+#: lxc/storage_volume.go:2812
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2860,11 +2865,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2809
+#: lxc/storage_volume.go:2820
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2883
+#: lxc/storage_volume.go:2894
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2908,7 +2913,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
+#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2990,7 +2995,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2012
+#: lxc/move.go:148 lxc/storage_volume.go:2023
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2998,7 +3003,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2019
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3016,9 +3021,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
-#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2144 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
+#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3062,9 +3067,9 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
+#: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3076,8 +3081,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1020 lxc/cluster.go:1123
-#: lxc/cluster.go:1231 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
+#: lxc/cluster.go:1232 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3114,7 +3119,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1105 lxc/network.go:1106
+#: lxc/network.go:1114 lxc/network.go:1115
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3126,7 +3131,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:976 lxc/cluster.go:977
+#: lxc/cluster.go:977 lxc/cluster.go:978
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -3174,7 +3179,7 @@ msgstr ""
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1004 lxc/network.go:1005
+#: lxc/network.go:1005 lxc/network.go:1006
 msgid "List available networks"
 msgstr ""
 
@@ -3262,7 +3267,7 @@ msgid ""
 "Fast column layout: nsacPt\n"
 "\n"
 "A single keyword like \"web\" which will list any instance with a name "
-"starting by \"web\".\n"
+"starting with \"web\".\n"
 "A regular expression on the instance name. (e.g. .*web.*01$).\n"
 "A key/value pair referring to a configuration item. For those, the\n"
 "namespace can be abbreviated to the smallest unambiguous identifier.\n"
@@ -3319,7 +3324,8 @@ msgid ""
 "  P - Profiles\n"
 "  s - State\n"
 "  S - Number of snapshots\n"
-"  t - Type (persistent or ephemeral)\n"
+"  t - Type (container or virtual-machine, ephemeral indicated if "
+"applicable)\n"
 "  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
@@ -3368,11 +3374,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1603
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1608
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3431,7 +3437,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1470
+#: lxc/info.go:489 lxc/storage_volume.go:1481
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3452,7 +3458,7 @@ msgstr ""
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1162
+#: lxc/network.go:1171
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3470,7 +3476,7 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1083
+#: lxc/network.go:1092
 msgid "MANAGED"
 msgstr ""
 
@@ -3593,7 +3599,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:955 lxc/config.go:956
+#: lxc/config.go:956 lxc/config.go:957
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3732,7 +3738,7 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:957
+#: lxc/cluster.go:958
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
@@ -3796,7 +3802,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:811 lxc/cluster.go:1367 lxc/cluster_group.go:129
+#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -3859,8 +3865,8 @@ msgstr ""
 
 #: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1139 lxc/network.go:1217 lxc/network.go:1283
-#: lxc/network.go:1375 lxc/network_forward.go:127 lxc/network_forward.go:215
+#: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
+#: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
 #: lxc/network_forward.go:284 lxc/network_forward.go:445
 #: lxc/network_forward.go:530 lxc/network_forward.go:705
 #: lxc/network_forward.go:836 lxc/network_forward.go:929
@@ -3901,12 +3907,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
-#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
-#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1986
-#: lxc/storage_volume.go:2127 lxc/storage_volume.go:2285
-#: lxc/storage_volume.go:2476 lxc/storage_volume.go:2593
+#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
+#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
 msgid "Missing pool name"
 msgstr ""
 
@@ -3925,11 +3931,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:438 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1411
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3966,8 +3972,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
-#: lxc/storage_volume.go:964
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
+#: lxc/storage_volume.go:975
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4004,7 +4010,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4012,11 +4018,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1856
+#: lxc/storage_volume.go:1867
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:518
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4038,12 +4044,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
+#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
 msgid "NAME"
 msgstr ""
 
@@ -4071,7 +4077,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
 #: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4095,8 +4101,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
-#: lxc/storage_volume.go:1562
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1573
 msgid "Name"
 msgstr ""
 
@@ -4104,7 +4110,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4129,7 +4135,7 @@ msgstr ""
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1227
+#: lxc/network.go:1236
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4239,7 +4245,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1161
+#: lxc/cluster.go:1162
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4248,7 +4254,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
+#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4268,11 +4274,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:502 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4286,7 +4292,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2035
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4294,15 +4300,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:343
+#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
+#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2690
+#: lxc/storage_volume.go:2701
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2489
+#: lxc/storage_volume.go:2500
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4314,11 +4321,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1418
+#: lxc/storage_volume.go:1429
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1298
+#: lxc/network.go:735 lxc/network.go:1307
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4327,7 +4334,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1577
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4357,7 +4364,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1767
 msgid "POOL"
 msgstr ""
 
@@ -4373,7 +4380,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1773
 #: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4419,7 +4426,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -4440,16 +4447,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
-#: lxc/storage_volume.go:1189
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
+#: lxc/storage_volume.go:1200
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4566,7 +4573,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1356
+#: lxc/storage_volume.go:1367
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4580,7 +4587,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1225
+#: lxc/storage_volume.go:1236
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4596,7 +4603,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2247
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4617,7 +4624,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1004
+#: lxc/storage_volume.go:1015
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4626,7 +4633,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2081
+#: lxc/storage_volume.go:2092
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4639,13 +4646,13 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2357
+#: lxc/storage_volume.go:2368
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
 "\n"
 "lxc storage volume unset default data size\n"
-"    Remotes the size/quota of a custom volume \"data\" in pool \"default\".\n"
+"    Removes the size/quota of a custom volume \"data\" in pool \"default\".\n"
 "\n"
 "lxc storage volume unset default virtual-machine/data snapshots.expiry\n"
 "    Removes the snapshot expiration period for a virtual machine \"data\" in "
@@ -4725,7 +4732,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4908,7 +4915,7 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1184 lxc/network.go:1185
+#: lxc/network.go:1193 lxc/network.go:1194
 msgid "Rename networks"
 msgstr ""
 
@@ -4924,15 +4931,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1949
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:1959
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2037 lxc/storage_volume.go:2057
+#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4942,11 +4949,11 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:892 lxc/cluster.go:893
+#: lxc/cluster.go:893 lxc/cluster.go:894
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1032
+#: lxc/config.go:1033
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -4969,7 +4976,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1328 lxc/cluster.go:1329
+#: lxc/cluster.go:1329 lxc/cluster.go:1330
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4984,11 +4991,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2552 lxc/storage_volume.go:2553
+#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1394
+#: lxc/cluster.go:1395
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5010,7 +5017,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1087
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5060,7 +5067,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1088
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1097
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5123,7 +5130,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1050 lxc/config.go:1051
+#: lxc/config.go:1051 lxc/config.go:1052
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5187,11 +5194,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1244
+#: lxc/network.go:1253
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1245
+#: lxc/network.go:1254
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5308,11 +5315,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2075
+#: lxc/storage_volume.go:2086
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2076
+#: lxc/storage_volume.go:2087
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5369,7 +5376,7 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1252
+#: lxc/network.go:1261
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5397,7 +5404,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2103
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5466,7 +5473,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1173
+#: lxc/config.go:1173 lxc/config.go:1174
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5498,7 +5505,7 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1340 lxc/network.go:1341
+#: lxc/network.go:1349 lxc/network.go:1350
 msgid "Show network configurations"
 msgstr ""
 
@@ -5546,11 +5553,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2233 lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5573,7 +5580,7 @@ msgid "Show the expanded configuration"
 msgstr ""
 
 #: lxc/info.go:43
-msgid "Show the instance's last 100 log lines?"
+msgid "Show the instance's last 100 log lines"
 msgstr ""
 
 #: lxc/info.go:44
@@ -5618,15 +5625,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2417
+#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2179
+#: lxc/storage_volume.go:2190
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1502
 msgid "Snapshots:"
 msgstr ""
 
@@ -5731,21 +5738,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:702
+#: lxc/storage_volume.go:703
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:790
+#: lxc/storage_volume.go:791
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:516
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:520
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5753,7 +5760,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5802,18 +5809,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1070 lxc/config_trust.go:515
+#: lxc/cluster.go:1071 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1736 lxc/warning.go:216
+#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1747 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
 msgid "Taken at"
 msgstr ""
 
@@ -5970,12 +5977,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1340
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1306
+#: lxc/storage_volume.go:1317
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -5994,8 +6001,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
-#: lxc/storage_volume.go:978
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:989
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6015,11 +6022,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:739
+#: lxc/cluster.go:740
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:729
+#: lxc/cluster.go:730
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6070,7 +6077,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6085,7 +6092,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1853
+#: lxc/storage_volume.go:1864
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6093,7 +6100,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:394
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6152,7 +6159,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1472
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6174,13 +6181,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:995 lxc/storage_volume.go:1752
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
+#: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1740
+#: lxc/storage.go:724 lxc/storage_volume.go:1751
 msgid "USED BY"
 msgstr ""
 
@@ -6212,7 +6219,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6238,7 +6245,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1141 lxc/config.go:1142
+#: lxc/config.go:1142 lxc/config.go:1143
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6266,7 +6273,7 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1412 lxc/network.go:1413
+#: lxc/network.go:1421 lxc/network.go:1422
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -6318,7 +6325,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2354 lxc/storage_volume.go:2355
+#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6342,7 +6349,7 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1417
+#: lxc/network.go:1426
 msgid "Unset the key as a network property"
 msgstr ""
 
@@ -6370,7 +6377,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2379
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6378,7 +6385,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:247
+#: lxc/storage_volume.go:248
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6391,11 +6398,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1174
+#: lxc/cluster.go:1175
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1176
+#: lxc/cluster.go:1177
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6414,12 +6421,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2641
+#: lxc/export.go:42 lxc/storage_volume.go:2652
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6486,7 +6493,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1576
 msgid "Volume Only"
 msgstr ""
 
@@ -6519,7 +6526,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
 #: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6545,18 +6552,18 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:903
+#: lxc/storage_volume.go:909
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:281
+#: lxc/storage_volume.go:282
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
-#: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
+#: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
@@ -6566,7 +6573,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1172
+#: lxc/cluster.go:1173
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -6729,7 +6736,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6751,11 +6758,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:1140
+#: lxc/config.go:995 lxc/config.go:1141
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1049
+#: lxc/config.go:1050
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -6834,8 +6841,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:768
-#: lxc/cluster.go:1085 lxc/cluster.go:1297 lxc/cluster.go:1327
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
+#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -6859,8 +6866,8 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1104
-#: lxc/network.go:1339 lxc/network_forward.go:87
+#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1113
+#: lxc/network.go:1348 lxc/network_forward.go:87
 #: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -6873,11 +6880,11 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1411
+#: lxc/network.go:791 lxc/network.go:1420
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1243
+#: lxc/network.go:1252
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
@@ -6922,7 +6929,7 @@ msgstr ""
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1182
+#: lxc/network.go:1191
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -6973,7 +6980,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2800
+#: lxc/storage_volume.go:2811
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7008,13 +7015,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:1958
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:806
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7022,51 +7029,51 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2551
+#: lxc/storage_volume.go:2562
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2634
+#: lxc/storage_volume.go:2645
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2415
+#: lxc/storage_volume.go:2426
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:609
+#: lxc/storage_volume.go:610
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:718
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2353
+#: lxc/storage_volume.go:2364
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2085
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2232
+#: lxc/storage_volume.go:2243
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1221
+#: lxc/storage_volume.go:1232
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1858
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:387
+#: lxc/storage_volume.go:388
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7172,7 +7179,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1601
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7184,7 +7191,7 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:891
+#: lxc/cluster.go:892
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -7256,7 +7263,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:772
+#: lxc/cluster.go:773
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7305,13 +7312,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1229
+#: lxc/config.go:1230
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1053
+#: lxc/config.go:1054
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7648,7 +7655,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:614
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7656,13 +7663,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2804
+#: lxc/storage_volume.go:2815
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2419
+#: lxc/storage_volume.go:2430
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-09 03:18-0300\n"
+"POT-Creation-Date: 2024-12-18 08:40-0700\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1030
+#: lxc/storage_volume.go:1041
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1240
+#: lxc/config.go:1241
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -412,7 +412,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:790
+#: lxc/cluster.go:791
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -585,13 +585,13 @@ msgstr ""
 msgid "Acknowledge warning"
 msgstr ""
 
+#: lxc/query.go:43
+msgid "Action"
+msgstr ""
+
 #: lxc/query.go:76
 #, c-format
 msgid "Action %q isn't supported by this tool"
-msgstr ""
-
-#: lxc/query.go:43
-msgid "Action (defaults to GET)"
 msgstr ""
 
 #: lxc/cluster_group.go:725
@@ -738,7 +738,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1596
+#: lxc/storage_volume.go:1607
 msgid "All projects"
 msgstr ""
 
@@ -760,7 +760,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1371
+#: lxc/cluster.go:1372
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -797,7 +797,7 @@ msgstr ""
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:282 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -849,16 +849,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2708
+#: lxc/storage_volume.go:2719
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2785
+#: lxc/export.go:192 lxc/storage_volume.go:2796
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1538
 msgid "Backups:"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -922,7 +922,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1739
+#: lxc/storage_volume.go:1750
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1007,7 +1007,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1097
+#: lxc/config.go:702 lxc/config.go:1098
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1024,12 +1024,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:492
+#: lxc/storage_volume.go:493
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:446
+#: lxc/storage_volume.go:447
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1105,7 +1105,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1154
+#: lxc/cluster.go:1155
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1133,8 +1133,8 @@ msgstr ""
 #: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
 #: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
-#: lxc/network_forward.go:182 lxc/network_forward.go:264
+#: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
+#: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
 #: lxc/network_forward.go:497 lxc/network_forward.go:649
 #: lxc/network_forward.go:803 lxc/network_forward.go:892
 #: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
@@ -1149,30 +1149,30 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
-#: lxc/storage_volume.go:1952 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2251 lxc/storage_volume.go:2367
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2555
-#: lxc/storage_volume.go:2643 lxc/storage_volume.go:2807
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
+#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
+#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:894
+#: lxc/cluster.go:895
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:926
+#: lxc/cluster.go:927
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:756
+#: lxc/cluster.go:757
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1209,24 +1209,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
+#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
-#: lxc/storage_volume.go:1188
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
+#: lxc/storage_volume.go:1199
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:619
+#: lxc/storage_volume.go:620
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1236,7 +1236,11 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/move.go:65
+#: lxc/move.go:65
+msgid "Copy a stateful instance as stateless"
+msgstr ""
+
+#: lxc/copy.go:60
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1284,7 +1288,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:389 lxc/storage_volume.go:390
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1292,12 +1296,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:396
+#: lxc/storage_volume.go:397
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:398
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1310,7 +1314,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:515
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1333,12 +1337,12 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1235
+#: lxc/cluster.go:1236
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1239
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1353,17 +1357,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1266
+#: lxc/cluster.go:1267
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1445,7 +1449,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1497,7 +1501,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1526,13 +1530,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1738
+#: lxc/storage_volume.go:1749
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1552,7 +1556,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2642
+#: lxc/storage_volume.go:2653
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1648,7 +1652,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1669,16 +1673,16 @@ msgstr ""
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
-#: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
+#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
+#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
-#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
-#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
+#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
+#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1701,8 +1705,8 @@ msgstr ""
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
 #: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1005 lxc/network.go:1106 lxc/network.go:1185
-#: lxc/network.go:1245 lxc/network.go:1341 lxc/network.go:1413
+#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
+#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
 #: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
 #: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
 #: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
@@ -1753,27 +1757,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
-#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
-#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
-#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1949
-#: lxc/storage_volume.go:2076 lxc/storage_volume.go:2234
-#: lxc/storage_volume.go:2355 lxc/storage_volume.go:2417
-#: lxc/storage_volume.go:2553 lxc/storage_volume.go:2636
-#: lxc/storage_volume.go:2802 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1454
+#: lxc/storage_volume.go:1465
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1785,11 +1789,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
+#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1917,7 +1921,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:516
+#: lxc/cluster.go:1072 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1939,7 +1943,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:769 lxc/cluster.go:770
+#: lxc/cluster.go:770 lxc/cluster.go:771
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1959,7 +1963,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1226 lxc/config.go:1227
+#: lxc/config.go:1227 lxc/config.go:1228
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2023,7 +2027,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2031,7 +2035,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2049,11 +2053,12 @@ msgid ""
 "new\n"
 "  LXD cluster, which will have the given name.\n"
 "\n"
-"  It's required that the LXD is already available on the network. You can "
-"check\n"
-"  that by running 'lxc config get core.https_address', and possibly set a "
-"value\n"
-"  for the address if not yet set."
+"  It's required that LXD is already available on the network. You can check\n"
+"  this by running 'lxc config get core.https_address'. If either an IP "
+"address\n"
+"  and port is displayed, or both, LXD is already available on the network. "
+"If\n"
+"  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
 #: lxc/network_zone.go:1427
@@ -2083,12 +2088,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
+#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2098,12 +2103,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
+#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
-#: lxc/storage_volume.go:2199
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
+#: lxc/storage_volume.go:2210
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2113,11 +2118,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1298 lxc/cluster.go:1299
+#: lxc/cluster.go:1299 lxc/cluster.go:1300
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1396
+#: lxc/cluster.go:1397
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2145,8 +2150,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
-#: lxc/storage_volume.go:1564
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Expires at"
 msgstr ""
 
@@ -2170,7 +2175,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2635 lxc/storage_volume.go:2636
+#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2182,11 +2187,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2639
+#: lxc/storage_volume.go:2650
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2768
+#: lxc/export.go:152 lxc/storage_volume.go:2779
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2366,7 +2371,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
+#: lxc/network.go:1046 lxc/network_acl.go:133 lxc/network_zone.go:124
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2376,7 +2381,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1303
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2384,7 +2389,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1301
+#: lxc/cluster.go:1302
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2396,7 +2401,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1331
+#: lxc/cluster.go:1332
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2437,16 +2442,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
-#: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1614 lxc/warning.go:94
+#: lxc/storage_volume.go:1625 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2506,7 +2511,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:996
+#: lxc/config.go:996 lxc/config.go:997
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2570,7 +2575,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1249
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2634,11 +2639,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
+#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:475
+#: lxc/storage_volume.go:476
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2666,7 +2671,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1161
+#: lxc/network.go:1170
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2720,7 +2725,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1163
+#: lxc/network.go:1172
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2732,11 +2737,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1084
+#: lxc/list.go:560 lxc/network.go:1093
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1085
+#: lxc/list.go:561 lxc/network.go:1094
 msgid "IPV6"
 msgstr ""
 
@@ -2766,7 +2771,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2427
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2780,7 +2785,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2437
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2830,7 +2835,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2802
+#: lxc/storage_volume.go:2813
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2838,7 +2843,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2801
+#: lxc/storage_volume.go:2812
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2860,11 +2865,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2809
+#: lxc/storage_volume.go:2820
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2883
+#: lxc/storage_volume.go:2894
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2908,7 +2913,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
+#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2990,7 +2995,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2012
+#: lxc/move.go:148 lxc/storage_volume.go:2023
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2998,7 +3003,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2019
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3016,9 +3021,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
-#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2144 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
+#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3062,9 +3067,9 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
+#: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3076,8 +3081,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1020 lxc/cluster.go:1123
-#: lxc/cluster.go:1231 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
+#: lxc/cluster.go:1232 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3114,7 +3119,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1105 lxc/network.go:1106
+#: lxc/network.go:1114 lxc/network.go:1115
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3126,7 +3131,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:976 lxc/cluster.go:977
+#: lxc/cluster.go:977 lxc/cluster.go:978
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -3174,7 +3179,7 @@ msgstr ""
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1004 lxc/network.go:1005
+#: lxc/network.go:1005 lxc/network.go:1006
 msgid "List available networks"
 msgstr ""
 
@@ -3262,7 +3267,7 @@ msgid ""
 "Fast column layout: nsacPt\n"
 "\n"
 "A single keyword like \"web\" which will list any instance with a name "
-"starting by \"web\".\n"
+"starting with \"web\".\n"
 "A regular expression on the instance name. (e.g. .*web.*01$).\n"
 "A key/value pair referring to a configuration item. For those, the\n"
 "namespace can be abbreviated to the smallest unambiguous identifier.\n"
@@ -3319,7 +3324,8 @@ msgid ""
 "  P - Profiles\n"
 "  s - State\n"
 "  S - Number of snapshots\n"
-"  t - Type (persistent or ephemeral)\n"
+"  t - Type (container or virtual-machine, ephemeral indicated if "
+"applicable)\n"
 "  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
@@ -3368,11 +3374,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1603
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1608
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3431,7 +3437,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1470
+#: lxc/info.go:489 lxc/storage_volume.go:1481
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3452,7 +3458,7 @@ msgstr ""
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1162
+#: lxc/network.go:1171
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3470,7 +3476,7 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1083
+#: lxc/network.go:1092
 msgid "MANAGED"
 msgstr ""
 
@@ -3593,7 +3599,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:955 lxc/config.go:956
+#: lxc/config.go:956 lxc/config.go:957
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3732,7 +3738,7 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:957
+#: lxc/cluster.go:958
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
@@ -3796,7 +3802,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:811 lxc/cluster.go:1367 lxc/cluster_group.go:129
+#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -3859,8 +3865,8 @@ msgstr ""
 
 #: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1139 lxc/network.go:1217 lxc/network.go:1283
-#: lxc/network.go:1375 lxc/network_forward.go:127 lxc/network_forward.go:215
+#: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
+#: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
 #: lxc/network_forward.go:284 lxc/network_forward.go:445
 #: lxc/network_forward.go:530 lxc/network_forward.go:705
 #: lxc/network_forward.go:836 lxc/network_forward.go:929
@@ -3901,12 +3907,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
-#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
-#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1986
-#: lxc/storage_volume.go:2127 lxc/storage_volume.go:2285
-#: lxc/storage_volume.go:2476 lxc/storage_volume.go:2593
+#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
+#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
 msgid "Missing pool name"
 msgstr ""
 
@@ -3925,11 +3931,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:438 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1411
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3966,8 +3972,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
-#: lxc/storage_volume.go:964
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
+#: lxc/storage_volume.go:975
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4004,7 +4010,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4012,11 +4018,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1856
+#: lxc/storage_volume.go:1867
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:518
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4038,12 +4044,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
+#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
 msgid "NAME"
 msgstr ""
 
@@ -4071,7 +4077,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
 #: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4095,8 +4101,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
-#: lxc/storage_volume.go:1562
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1573
 msgid "Name"
 msgstr ""
 
@@ -4104,7 +4110,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4129,7 +4135,7 @@ msgstr ""
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1227
+#: lxc/network.go:1236
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4239,7 +4245,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1161
+#: lxc/cluster.go:1162
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4248,7 +4254,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
+#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4268,11 +4274,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:502 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4286,7 +4292,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2035
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4294,15 +4300,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:343
+#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
+#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2690
+#: lxc/storage_volume.go:2701
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2489
+#: lxc/storage_volume.go:2500
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4314,11 +4321,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1418
+#: lxc/storage_volume.go:1429
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1298
+#: lxc/network.go:735 lxc/network.go:1307
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4327,7 +4334,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1577
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4357,7 +4364,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1767
 msgid "POOL"
 msgstr ""
 
@@ -4373,7 +4380,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1773
 #: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4419,7 +4426,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -4440,16 +4447,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
-#: lxc/storage_volume.go:1189
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
+#: lxc/storage_volume.go:1200
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4566,7 +4573,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1356
+#: lxc/storage_volume.go:1367
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4580,7 +4587,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1225
+#: lxc/storage_volume.go:1236
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4596,7 +4603,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2247
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4617,7 +4624,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1004
+#: lxc/storage_volume.go:1015
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4626,7 +4633,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2081
+#: lxc/storage_volume.go:2092
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4639,13 +4646,13 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2357
+#: lxc/storage_volume.go:2368
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
 "\n"
 "lxc storage volume unset default data size\n"
-"    Remotes the size/quota of a custom volume \"data\" in pool \"default\".\n"
+"    Removes the size/quota of a custom volume \"data\" in pool \"default\".\n"
 "\n"
 "lxc storage volume unset default virtual-machine/data snapshots.expiry\n"
 "    Removes the snapshot expiration period for a virtual machine \"data\" in "
@@ -4725,7 +4732,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4908,7 +4915,7 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1184 lxc/network.go:1185
+#: lxc/network.go:1193 lxc/network.go:1194
 msgid "Rename networks"
 msgstr ""
 
@@ -4924,15 +4931,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1949
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:1959
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2037 lxc/storage_volume.go:2057
+#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4942,11 +4949,11 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:892 lxc/cluster.go:893
+#: lxc/cluster.go:893 lxc/cluster.go:894
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1032
+#: lxc/config.go:1033
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -4969,7 +4976,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1328 lxc/cluster.go:1329
+#: lxc/cluster.go:1329 lxc/cluster.go:1330
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4984,11 +4991,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2552 lxc/storage_volume.go:2553
+#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1394
+#: lxc/cluster.go:1395
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5010,7 +5017,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1087
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5060,7 +5067,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1088
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1097
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5123,7 +5130,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1050 lxc/config.go:1051
+#: lxc/config.go:1051 lxc/config.go:1052
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5187,11 +5194,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1244
+#: lxc/network.go:1253
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1245
+#: lxc/network.go:1254
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5308,11 +5315,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2075
+#: lxc/storage_volume.go:2086
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2076
+#: lxc/storage_volume.go:2087
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5369,7 +5376,7 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1252
+#: lxc/network.go:1261
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5397,7 +5404,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2103
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5466,7 +5473,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1173
+#: lxc/config.go:1173 lxc/config.go:1174
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5498,7 +5505,7 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1340 lxc/network.go:1341
+#: lxc/network.go:1349 lxc/network.go:1350
 msgid "Show network configurations"
 msgstr ""
 
@@ -5546,11 +5553,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2233 lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5573,7 +5580,7 @@ msgid "Show the expanded configuration"
 msgstr ""
 
 #: lxc/info.go:43
-msgid "Show the instance's last 100 log lines?"
+msgid "Show the instance's last 100 log lines"
 msgstr ""
 
 #: lxc/info.go:44
@@ -5618,15 +5625,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2417
+#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2179
+#: lxc/storage_volume.go:2190
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1502
 msgid "Snapshots:"
 msgstr ""
 
@@ -5731,21 +5738,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:702
+#: lxc/storage_volume.go:703
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:790
+#: lxc/storage_volume.go:791
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:516
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:520
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5753,7 +5760,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5802,18 +5809,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1070 lxc/config_trust.go:515
+#: lxc/cluster.go:1071 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1736 lxc/warning.go:216
+#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1747 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
 msgid "Taken at"
 msgstr ""
 
@@ -5970,12 +5977,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1340
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1306
+#: lxc/storage_volume.go:1317
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -5994,8 +6001,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
-#: lxc/storage_volume.go:978
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:989
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6015,11 +6022,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:739
+#: lxc/cluster.go:740
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:729
+#: lxc/cluster.go:730
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6070,7 +6077,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6085,7 +6092,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1853
+#: lxc/storage_volume.go:1864
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6093,7 +6100,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:394
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6152,7 +6159,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1472
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6174,13 +6181,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:995 lxc/storage_volume.go:1752
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
+#: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1740
+#: lxc/storage.go:724 lxc/storage_volume.go:1751
 msgid "USED BY"
 msgstr ""
 
@@ -6212,7 +6219,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6238,7 +6245,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1141 lxc/config.go:1142
+#: lxc/config.go:1142 lxc/config.go:1143
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6266,7 +6273,7 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1412 lxc/network.go:1413
+#: lxc/network.go:1421 lxc/network.go:1422
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -6318,7 +6325,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2354 lxc/storage_volume.go:2355
+#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6342,7 +6349,7 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1417
+#: lxc/network.go:1426
 msgid "Unset the key as a network property"
 msgstr ""
 
@@ -6370,7 +6377,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2379
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6378,7 +6385,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:247
+#: lxc/storage_volume.go:248
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6391,11 +6398,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1174
+#: lxc/cluster.go:1175
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1176
+#: lxc/cluster.go:1177
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6414,12 +6421,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2641
+#: lxc/export.go:42 lxc/storage_volume.go:2652
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6486,7 +6493,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1576
 msgid "Volume Only"
 msgstr ""
 
@@ -6519,7 +6526,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
 #: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6545,18 +6552,18 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:903
+#: lxc/storage_volume.go:909
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:281
+#: lxc/storage_volume.go:282
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
-#: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
+#: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
@@ -6566,7 +6573,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1172
+#: lxc/cluster.go:1173
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -6729,7 +6736,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6751,11 +6758,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:1140
+#: lxc/config.go:995 lxc/config.go:1141
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1049
+#: lxc/config.go:1050
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -6834,8 +6841,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:768
-#: lxc/cluster.go:1085 lxc/cluster.go:1297 lxc/cluster.go:1327
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
+#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -6859,8 +6866,8 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1104
-#: lxc/network.go:1339 lxc/network_forward.go:87
+#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1113
+#: lxc/network.go:1348 lxc/network_forward.go:87
 #: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -6873,11 +6880,11 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1411
+#: lxc/network.go:791 lxc/network.go:1420
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1243
+#: lxc/network.go:1252
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
@@ -6922,7 +6929,7 @@ msgstr ""
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1182
+#: lxc/network.go:1191
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -6973,7 +6980,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2800
+#: lxc/storage_volume.go:2811
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7008,13 +7015,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:1958
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:806
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7022,51 +7029,51 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2551
+#: lxc/storage_volume.go:2562
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2634
+#: lxc/storage_volume.go:2645
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2415
+#: lxc/storage_volume.go:2426
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:609
+#: lxc/storage_volume.go:610
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:718
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2353
+#: lxc/storage_volume.go:2364
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2085
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2232
+#: lxc/storage_volume.go:2243
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1221
+#: lxc/storage_volume.go:1232
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1858
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:387
+#: lxc/storage_volume.go:388
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7172,7 +7179,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1601
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7184,7 +7191,7 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:891
+#: lxc/cluster.go:892
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -7256,7 +7263,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:772
+#: lxc/cluster.go:773
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7305,13 +7312,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1229
+#: lxc/config.go:1230
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1053
+#: lxc/config.go:1054
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7648,7 +7655,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:614
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7656,13 +7663,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2804
+#: lxc/storage_volume.go:2815
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2419
+#: lxc/storage_volume.go:2430
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/th.po
+++ b/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-09 03:18-0300\n"
+"POT-Creation-Date: 2024-12-18 08:40-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -46,7 +46,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1030
+#: lxc/storage_volume.go:1041
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -60,7 +60,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1240
+#: lxc/config.go:1241
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -409,7 +409,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:790
+#: lxc/cluster.go:791
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -582,13 +582,13 @@ msgstr ""
 msgid "Acknowledge warning"
 msgstr ""
 
+#: lxc/query.go:43
+msgid "Action"
+msgstr ""
+
 #: lxc/query.go:76
 #, c-format
 msgid "Action %q isn't supported by this tool"
-msgstr ""
-
-#: lxc/query.go:43
-msgid "Action (defaults to GET)"
 msgstr ""
 
 #: lxc/cluster_group.go:725
@@ -735,7 +735,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1596
+#: lxc/storage_volume.go:1607
 msgid "All projects"
 msgstr ""
 
@@ -757,7 +757,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1371
+#: lxc/cluster.go:1372
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -794,7 +794,7 @@ msgstr ""
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:282 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -846,16 +846,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2708
+#: lxc/storage_volume.go:2719
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2785
+#: lxc/export.go:192 lxc/storage_volume.go:2796
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1538
 msgid "Backups:"
 msgstr ""
 
@@ -876,7 +876,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -919,7 +919,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1739
+#: lxc/storage_volume.go:1750
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1004,7 +1004,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1012,7 +1012,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1097
+#: lxc/config.go:702 lxc/config.go:1098
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1021,12 +1021,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:492
+#: lxc/storage_volume.go:493
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:446
+#: lxc/storage_volume.go:447
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1102,7 +1102,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1154
+#: lxc/cluster.go:1155
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1130,8 +1130,8 @@ msgstr ""
 #: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
 #: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
-#: lxc/network_forward.go:182 lxc/network_forward.go:264
+#: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
+#: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
 #: lxc/network_forward.go:497 lxc/network_forward.go:649
 #: lxc/network_forward.go:803 lxc/network_forward.go:892
 #: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
@@ -1146,30 +1146,30 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
-#: lxc/storage_volume.go:1952 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2251 lxc/storage_volume.go:2367
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2555
-#: lxc/storage_volume.go:2643 lxc/storage_volume.go:2807
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
+#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
+#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:894
+#: lxc/cluster.go:895
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:926
+#: lxc/cluster.go:927
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:756
+#: lxc/cluster.go:757
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1206,24 +1206,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
+#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
-#: lxc/storage_volume.go:1188
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
+#: lxc/storage_volume.go:1199
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:619
+#: lxc/storage_volume.go:620
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1233,7 +1233,11 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/move.go:65
+#: lxc/move.go:65
+msgid "Copy a stateful instance as stateless"
+msgstr ""
+
+#: lxc/copy.go:60
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1281,7 +1285,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:389 lxc/storage_volume.go:390
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1289,12 +1293,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:396
+#: lxc/storage_volume.go:397
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:398
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1307,7 +1311,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:515
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1330,12 +1334,12 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1235
+#: lxc/cluster.go:1236
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1239
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1350,17 +1354,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1266
+#: lxc/cluster.go:1267
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1442,7 +1446,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1494,7 +1498,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1523,13 +1527,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1738
+#: lxc/storage_volume.go:1749
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1549,7 +1553,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2642
+#: lxc/storage_volume.go:2653
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1645,7 +1649,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1666,16 +1670,16 @@ msgstr ""
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
-#: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
+#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
+#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
-#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
-#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
+#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
+#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1698,8 +1702,8 @@ msgstr ""
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
 #: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1005 lxc/network.go:1106 lxc/network.go:1185
-#: lxc/network.go:1245 lxc/network.go:1341 lxc/network.go:1413
+#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
+#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
 #: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
 #: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
 #: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
@@ -1750,27 +1754,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
-#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
-#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
-#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1949
-#: lxc/storage_volume.go:2076 lxc/storage_volume.go:2234
-#: lxc/storage_volume.go:2355 lxc/storage_volume.go:2417
-#: lxc/storage_volume.go:2553 lxc/storage_volume.go:2636
-#: lxc/storage_volume.go:2802 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1454
+#: lxc/storage_volume.go:1465
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1782,11 +1786,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
+#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1914,7 +1918,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:516
+#: lxc/cluster.go:1072 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1936,7 +1940,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:769 lxc/cluster.go:770
+#: lxc/cluster.go:770 lxc/cluster.go:771
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1956,7 +1960,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1226 lxc/config.go:1227
+#: lxc/config.go:1227 lxc/config.go:1228
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2020,7 +2024,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2028,7 +2032,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2046,11 +2050,12 @@ msgid ""
 "new\n"
 "  LXD cluster, which will have the given name.\n"
 "\n"
-"  It's required that the LXD is already available on the network. You can "
-"check\n"
-"  that by running 'lxc config get core.https_address', and possibly set a "
-"value\n"
-"  for the address if not yet set."
+"  It's required that LXD is already available on the network. You can check\n"
+"  this by running 'lxc config get core.https_address'. If either an IP "
+"address\n"
+"  and port is displayed, or both, LXD is already available on the network. "
+"If\n"
+"  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
 #: lxc/network_zone.go:1427
@@ -2080,12 +2085,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
+#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2095,12 +2100,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
+#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
-#: lxc/storage_volume.go:2199
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
+#: lxc/storage_volume.go:2210
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2110,11 +2115,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1298 lxc/cluster.go:1299
+#: lxc/cluster.go:1299 lxc/cluster.go:1300
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1396
+#: lxc/cluster.go:1397
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2142,8 +2147,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
-#: lxc/storage_volume.go:1564
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Expires at"
 msgstr ""
 
@@ -2167,7 +2172,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2635 lxc/storage_volume.go:2636
+#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2179,11 +2184,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2639
+#: lxc/storage_volume.go:2650
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2768
+#: lxc/export.go:152 lxc/storage_volume.go:2779
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2363,7 +2368,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
+#: lxc/network.go:1046 lxc/network_acl.go:133 lxc/network_zone.go:124
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2373,7 +2378,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1303
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2381,7 +2386,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1301
+#: lxc/cluster.go:1302
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2393,7 +2398,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1331
+#: lxc/cluster.go:1332
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2434,16 +2439,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
-#: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1614 lxc/warning.go:94
+#: lxc/storage_volume.go:1625 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2503,7 +2508,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:996
+#: lxc/config.go:996 lxc/config.go:997
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2567,7 +2572,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1249
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2631,11 +2636,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
+#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:475
+#: lxc/storage_volume.go:476
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2663,7 +2668,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1161
+#: lxc/network.go:1170
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2717,7 +2722,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1163
+#: lxc/network.go:1172
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2729,11 +2734,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1084
+#: lxc/list.go:560 lxc/network.go:1093
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1085
+#: lxc/list.go:561 lxc/network.go:1094
 msgid "IPV6"
 msgstr ""
 
@@ -2763,7 +2768,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2427
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2777,7 +2782,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2437
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2827,7 +2832,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2802
+#: lxc/storage_volume.go:2813
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2835,7 +2840,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2801
+#: lxc/storage_volume.go:2812
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2857,11 +2862,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2809
+#: lxc/storage_volume.go:2820
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2883
+#: lxc/storage_volume.go:2894
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2905,7 +2910,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
+#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2987,7 +2992,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2012
+#: lxc/move.go:148 lxc/storage_volume.go:2023
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2995,7 +3000,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2019
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3013,9 +3018,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
-#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2144 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
+#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3059,9 +3064,9 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
+#: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3073,8 +3078,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1020 lxc/cluster.go:1123
-#: lxc/cluster.go:1231 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
+#: lxc/cluster.go:1232 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3111,7 +3116,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1105 lxc/network.go:1106
+#: lxc/network.go:1114 lxc/network.go:1115
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3123,7 +3128,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:976 lxc/cluster.go:977
+#: lxc/cluster.go:977 lxc/cluster.go:978
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -3171,7 +3176,7 @@ msgstr ""
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1004 lxc/network.go:1005
+#: lxc/network.go:1005 lxc/network.go:1006
 msgid "List available networks"
 msgstr ""
 
@@ -3259,7 +3264,7 @@ msgid ""
 "Fast column layout: nsacPt\n"
 "\n"
 "A single keyword like \"web\" which will list any instance with a name "
-"starting by \"web\".\n"
+"starting with \"web\".\n"
 "A regular expression on the instance name. (e.g. .*web.*01$).\n"
 "A key/value pair referring to a configuration item. For those, the\n"
 "namespace can be abbreviated to the smallest unambiguous identifier.\n"
@@ -3316,7 +3321,8 @@ msgid ""
 "  P - Profiles\n"
 "  s - State\n"
 "  S - Number of snapshots\n"
-"  t - Type (persistent or ephemeral)\n"
+"  t - Type (container or virtual-machine, ephemeral indicated if "
+"applicable)\n"
 "  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
@@ -3365,11 +3371,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1603
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1608
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3428,7 +3434,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1470
+#: lxc/info.go:489 lxc/storage_volume.go:1481
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3449,7 +3455,7 @@ msgstr ""
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1162
+#: lxc/network.go:1171
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3467,7 +3473,7 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1083
+#: lxc/network.go:1092
 msgid "MANAGED"
 msgstr ""
 
@@ -3590,7 +3596,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:955 lxc/config.go:956
+#: lxc/config.go:956 lxc/config.go:957
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3729,7 +3735,7 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:957
+#: lxc/cluster.go:958
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
@@ -3793,7 +3799,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:811 lxc/cluster.go:1367 lxc/cluster_group.go:129
+#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -3856,8 +3862,8 @@ msgstr ""
 
 #: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1139 lxc/network.go:1217 lxc/network.go:1283
-#: lxc/network.go:1375 lxc/network_forward.go:127 lxc/network_forward.go:215
+#: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
+#: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
 #: lxc/network_forward.go:284 lxc/network_forward.go:445
 #: lxc/network_forward.go:530 lxc/network_forward.go:705
 #: lxc/network_forward.go:836 lxc/network_forward.go:929
@@ -3898,12 +3904,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
-#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
-#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1986
-#: lxc/storage_volume.go:2127 lxc/storage_volume.go:2285
-#: lxc/storage_volume.go:2476 lxc/storage_volume.go:2593
+#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
+#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
 msgid "Missing pool name"
 msgstr ""
 
@@ -3922,11 +3928,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:438 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1411
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3963,8 +3969,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
-#: lxc/storage_volume.go:964
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
+#: lxc/storage_volume.go:975
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4001,7 +4007,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4009,11 +4015,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1856
+#: lxc/storage_volume.go:1867
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:518
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4035,12 +4041,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
+#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
 msgid "NAME"
 msgstr ""
 
@@ -4068,7 +4074,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
 #: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4092,8 +4098,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
-#: lxc/storage_volume.go:1562
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1573
 msgid "Name"
 msgstr ""
 
@@ -4101,7 +4107,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4126,7 +4132,7 @@ msgstr ""
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1227
+#: lxc/network.go:1236
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4236,7 +4242,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1161
+#: lxc/cluster.go:1162
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4245,7 +4251,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
+#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4265,11 +4271,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:502 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4283,7 +4289,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2035
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4291,15 +4297,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:343
+#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
+#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2690
+#: lxc/storage_volume.go:2701
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2489
+#: lxc/storage_volume.go:2500
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4311,11 +4318,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1418
+#: lxc/storage_volume.go:1429
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1298
+#: lxc/network.go:735 lxc/network.go:1307
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4324,7 +4331,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1577
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4354,7 +4361,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1767
 msgid "POOL"
 msgstr ""
 
@@ -4370,7 +4377,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1773
 #: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4416,7 +4423,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -4437,16 +4444,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
-#: lxc/storage_volume.go:1189
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
+#: lxc/storage_volume.go:1200
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4563,7 +4570,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1356
+#: lxc/storage_volume.go:1367
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4577,7 +4584,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1225
+#: lxc/storage_volume.go:1236
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4593,7 +4600,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2247
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4614,7 +4621,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1004
+#: lxc/storage_volume.go:1015
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4623,7 +4630,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2081
+#: lxc/storage_volume.go:2092
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4636,13 +4643,13 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2357
+#: lxc/storage_volume.go:2368
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
 "\n"
 "lxc storage volume unset default data size\n"
-"    Remotes the size/quota of a custom volume \"data\" in pool \"default\".\n"
+"    Removes the size/quota of a custom volume \"data\" in pool \"default\".\n"
 "\n"
 "lxc storage volume unset default virtual-machine/data snapshots.expiry\n"
 "    Removes the snapshot expiration period for a virtual machine \"data\" in "
@@ -4722,7 +4729,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4905,7 +4912,7 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1184 lxc/network.go:1185
+#: lxc/network.go:1193 lxc/network.go:1194
 msgid "Rename networks"
 msgstr ""
 
@@ -4921,15 +4928,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1949
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:1959
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2037 lxc/storage_volume.go:2057
+#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4939,11 +4946,11 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:892 lxc/cluster.go:893
+#: lxc/cluster.go:893 lxc/cluster.go:894
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1032
+#: lxc/config.go:1033
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -4966,7 +4973,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1328 lxc/cluster.go:1329
+#: lxc/cluster.go:1329 lxc/cluster.go:1330
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4981,11 +4988,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2552 lxc/storage_volume.go:2553
+#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1394
+#: lxc/cluster.go:1395
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5007,7 +5014,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1087
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5057,7 +5064,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1088
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1097
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5120,7 +5127,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1050 lxc/config.go:1051
+#: lxc/config.go:1051 lxc/config.go:1052
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5184,11 +5191,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1244
+#: lxc/network.go:1253
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1245
+#: lxc/network.go:1254
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5305,11 +5312,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2075
+#: lxc/storage_volume.go:2086
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2076
+#: lxc/storage_volume.go:2087
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5366,7 +5373,7 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1252
+#: lxc/network.go:1261
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5394,7 +5401,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2103
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5463,7 +5470,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1173
+#: lxc/config.go:1173 lxc/config.go:1174
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5495,7 +5502,7 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1340 lxc/network.go:1341
+#: lxc/network.go:1349 lxc/network.go:1350
 msgid "Show network configurations"
 msgstr ""
 
@@ -5543,11 +5550,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2233 lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5570,7 +5577,7 @@ msgid "Show the expanded configuration"
 msgstr ""
 
 #: lxc/info.go:43
-msgid "Show the instance's last 100 log lines?"
+msgid "Show the instance's last 100 log lines"
 msgstr ""
 
 #: lxc/info.go:44
@@ -5615,15 +5622,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2417
+#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2179
+#: lxc/storage_volume.go:2190
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1502
 msgid "Snapshots:"
 msgstr ""
 
@@ -5728,21 +5735,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:702
+#: lxc/storage_volume.go:703
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:790
+#: lxc/storage_volume.go:791
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:516
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:520
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5750,7 +5757,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5799,18 +5806,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1070 lxc/config_trust.go:515
+#: lxc/cluster.go:1071 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1736 lxc/warning.go:216
+#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1747 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
 msgid "Taken at"
 msgstr ""
 
@@ -5967,12 +5974,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1340
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1306
+#: lxc/storage_volume.go:1317
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -5991,8 +5998,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
-#: lxc/storage_volume.go:978
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:989
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6012,11 +6019,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:739
+#: lxc/cluster.go:740
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:729
+#: lxc/cluster.go:730
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6067,7 +6074,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6082,7 +6089,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1853
+#: lxc/storage_volume.go:1864
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6090,7 +6097,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:394
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6149,7 +6156,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1472
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6171,13 +6178,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:995 lxc/storage_volume.go:1752
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
+#: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1740
+#: lxc/storage.go:724 lxc/storage_volume.go:1751
 msgid "USED BY"
 msgstr ""
 
@@ -6209,7 +6216,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6235,7 +6242,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1141 lxc/config.go:1142
+#: lxc/config.go:1142 lxc/config.go:1143
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6263,7 +6270,7 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1412 lxc/network.go:1413
+#: lxc/network.go:1421 lxc/network.go:1422
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -6315,7 +6322,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2354 lxc/storage_volume.go:2355
+#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6339,7 +6346,7 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1417
+#: lxc/network.go:1426
 msgid "Unset the key as a network property"
 msgstr ""
 
@@ -6367,7 +6374,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2379
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6375,7 +6382,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:247
+#: lxc/storage_volume.go:248
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6388,11 +6395,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1174
+#: lxc/cluster.go:1175
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1176
+#: lxc/cluster.go:1177
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6411,12 +6418,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2641
+#: lxc/export.go:42 lxc/storage_volume.go:2652
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6483,7 +6490,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1576
 msgid "Volume Only"
 msgstr ""
 
@@ -6516,7 +6523,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
 #: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6542,18 +6549,18 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:903
+#: lxc/storage_volume.go:909
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:281
+#: lxc/storage_volume.go:282
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
-#: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
+#: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
@@ -6563,7 +6570,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1172
+#: lxc/cluster.go:1173
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -6726,7 +6733,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6748,11 +6755,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:1140
+#: lxc/config.go:995 lxc/config.go:1141
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1049
+#: lxc/config.go:1050
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -6831,8 +6838,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:768
-#: lxc/cluster.go:1085 lxc/cluster.go:1297 lxc/cluster.go:1327
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
+#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -6856,8 +6863,8 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1104
-#: lxc/network.go:1339 lxc/network_forward.go:87
+#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1113
+#: lxc/network.go:1348 lxc/network_forward.go:87
 #: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -6870,11 +6877,11 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1411
+#: lxc/network.go:791 lxc/network.go:1420
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1243
+#: lxc/network.go:1252
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
@@ -6919,7 +6926,7 @@ msgstr ""
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1182
+#: lxc/network.go:1191
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -6970,7 +6977,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2800
+#: lxc/storage_volume.go:2811
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7005,13 +7012,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:1958
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:806
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7019,51 +7026,51 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2551
+#: lxc/storage_volume.go:2562
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2634
+#: lxc/storage_volume.go:2645
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2415
+#: lxc/storage_volume.go:2426
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:609
+#: lxc/storage_volume.go:610
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:718
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2353
+#: lxc/storage_volume.go:2364
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2085
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2232
+#: lxc/storage_volume.go:2243
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1221
+#: lxc/storage_volume.go:1232
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1858
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:387
+#: lxc/storage_volume.go:388
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7169,7 +7176,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1601
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7181,7 +7188,7 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:891
+#: lxc/cluster.go:892
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -7253,7 +7260,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:772
+#: lxc/cluster.go:773
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7302,13 +7309,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1229
+#: lxc/config.go:1230
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1053
+#: lxc/config.go:1054
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7645,7 +7652,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:614
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7653,13 +7660,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2804
+#: lxc/storage_volume.go:2815
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2419
+#: lxc/storage_volume.go:2430
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-09 03:18-0300\n"
+"POT-Creation-Date: 2024-12-18 08:40-0700\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1030
+#: lxc/storage_volume.go:1041
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1240
+#: lxc/config.go:1241
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -412,7 +412,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:790
+#: lxc/cluster.go:791
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -585,13 +585,13 @@ msgstr ""
 msgid "Acknowledge warning"
 msgstr ""
 
+#: lxc/query.go:43
+msgid "Action"
+msgstr ""
+
 #: lxc/query.go:76
 #, c-format
 msgid "Action %q isn't supported by this tool"
-msgstr ""
-
-#: lxc/query.go:43
-msgid "Action (defaults to GET)"
 msgstr ""
 
 #: lxc/cluster_group.go:725
@@ -738,7 +738,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1596
+#: lxc/storage_volume.go:1607
 msgid "All projects"
 msgstr ""
 
@@ -760,7 +760,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1371
+#: lxc/cluster.go:1372
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -797,7 +797,7 @@ msgstr ""
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:282 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -849,16 +849,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2708
+#: lxc/storage_volume.go:2719
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2785
+#: lxc/export.go:192 lxc/storage_volume.go:2796
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1538
 msgid "Backups:"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -922,7 +922,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1739
+#: lxc/storage_volume.go:1750
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1007,7 +1007,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1097
+#: lxc/config.go:702 lxc/config.go:1098
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1024,12 +1024,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:492
+#: lxc/storage_volume.go:493
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:446
+#: lxc/storage_volume.go:447
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1105,7 +1105,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1154
+#: lxc/cluster.go:1155
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1133,8 +1133,8 @@ msgstr ""
 #: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
 #: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
-#: lxc/network_forward.go:182 lxc/network_forward.go:264
+#: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
+#: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
 #: lxc/network_forward.go:497 lxc/network_forward.go:649
 #: lxc/network_forward.go:803 lxc/network_forward.go:892
 #: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
@@ -1149,30 +1149,30 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
-#: lxc/storage_volume.go:1952 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2251 lxc/storage_volume.go:2367
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2555
-#: lxc/storage_volume.go:2643 lxc/storage_volume.go:2807
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
+#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
+#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:894
+#: lxc/cluster.go:895
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:926
+#: lxc/cluster.go:927
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:756
+#: lxc/cluster.go:757
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1209,24 +1209,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
+#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
-#: lxc/storage_volume.go:1188
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
+#: lxc/storage_volume.go:1199
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:619
+#: lxc/storage_volume.go:620
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1236,7 +1236,11 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/move.go:65
+#: lxc/move.go:65
+msgid "Copy a stateful instance as stateless"
+msgstr ""
+
+#: lxc/copy.go:60
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1284,7 +1288,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:389 lxc/storage_volume.go:390
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1292,12 +1296,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:396
+#: lxc/storage_volume.go:397
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:398
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1310,7 +1314,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:515
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1333,12 +1337,12 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1235
+#: lxc/cluster.go:1236
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1239
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1353,17 +1357,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1266
+#: lxc/cluster.go:1267
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1445,7 +1449,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1497,7 +1501,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1526,13 +1530,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1738
+#: lxc/storage_volume.go:1749
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1552,7 +1556,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2642
+#: lxc/storage_volume.go:2653
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1648,7 +1652,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1669,16 +1673,16 @@ msgstr ""
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
-#: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
+#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
+#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
-#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
-#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
+#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
+#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1701,8 +1705,8 @@ msgstr ""
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
 #: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1005 lxc/network.go:1106 lxc/network.go:1185
-#: lxc/network.go:1245 lxc/network.go:1341 lxc/network.go:1413
+#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
+#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
 #: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
 #: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
 #: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
@@ -1753,27 +1757,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
-#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
-#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
-#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1949
-#: lxc/storage_volume.go:2076 lxc/storage_volume.go:2234
-#: lxc/storage_volume.go:2355 lxc/storage_volume.go:2417
-#: lxc/storage_volume.go:2553 lxc/storage_volume.go:2636
-#: lxc/storage_volume.go:2802 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1454
+#: lxc/storage_volume.go:1465
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1785,11 +1789,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
+#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1917,7 +1921,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:516
+#: lxc/cluster.go:1072 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1939,7 +1943,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:769 lxc/cluster.go:770
+#: lxc/cluster.go:770 lxc/cluster.go:771
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1959,7 +1963,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1226 lxc/config.go:1227
+#: lxc/config.go:1227 lxc/config.go:1228
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2023,7 +2027,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2031,7 +2035,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2049,11 +2053,12 @@ msgid ""
 "new\n"
 "  LXD cluster, which will have the given name.\n"
 "\n"
-"  It's required that the LXD is already available on the network. You can "
-"check\n"
-"  that by running 'lxc config get core.https_address', and possibly set a "
-"value\n"
-"  for the address if not yet set."
+"  It's required that LXD is already available on the network. You can check\n"
+"  this by running 'lxc config get core.https_address'. If either an IP "
+"address\n"
+"  and port is displayed, or both, LXD is already available on the network. "
+"If\n"
+"  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
 #: lxc/network_zone.go:1427
@@ -2083,12 +2088,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
+#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2098,12 +2103,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
+#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
-#: lxc/storage_volume.go:2199
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
+#: lxc/storage_volume.go:2210
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2113,11 +2118,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1298 lxc/cluster.go:1299
+#: lxc/cluster.go:1299 lxc/cluster.go:1300
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1396
+#: lxc/cluster.go:1397
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2145,8 +2150,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
-#: lxc/storage_volume.go:1564
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Expires at"
 msgstr ""
 
@@ -2170,7 +2175,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2635 lxc/storage_volume.go:2636
+#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2182,11 +2187,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2639
+#: lxc/storage_volume.go:2650
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2768
+#: lxc/export.go:152 lxc/storage_volume.go:2779
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2366,7 +2371,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
+#: lxc/network.go:1046 lxc/network_acl.go:133 lxc/network_zone.go:124
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2376,7 +2381,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1303
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2384,7 +2389,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1301
+#: lxc/cluster.go:1302
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2396,7 +2401,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1331
+#: lxc/cluster.go:1332
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2437,16 +2442,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
-#: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1614 lxc/warning.go:94
+#: lxc/storage_volume.go:1625 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2506,7 +2511,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:996
+#: lxc/config.go:996 lxc/config.go:997
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2570,7 +2575,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1249
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2634,11 +2639,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
+#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:475
+#: lxc/storage_volume.go:476
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2666,7 +2671,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1161
+#: lxc/network.go:1170
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2720,7 +2725,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1163
+#: lxc/network.go:1172
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2732,11 +2737,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1084
+#: lxc/list.go:560 lxc/network.go:1093
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1085
+#: lxc/list.go:561 lxc/network.go:1094
 msgid "IPV6"
 msgstr ""
 
@@ -2766,7 +2771,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2427
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2780,7 +2785,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2437
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2830,7 +2835,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2802
+#: lxc/storage_volume.go:2813
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2838,7 +2843,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2801
+#: lxc/storage_volume.go:2812
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2860,11 +2865,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2809
+#: lxc/storage_volume.go:2820
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2883
+#: lxc/storage_volume.go:2894
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2908,7 +2913,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
+#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2990,7 +2995,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2012
+#: lxc/move.go:148 lxc/storage_volume.go:2023
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2998,7 +3003,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2019
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3016,9 +3021,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
-#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2144 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
+#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3062,9 +3067,9 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
+#: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3076,8 +3081,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1020 lxc/cluster.go:1123
-#: lxc/cluster.go:1231 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
+#: lxc/cluster.go:1232 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3114,7 +3119,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1105 lxc/network.go:1106
+#: lxc/network.go:1114 lxc/network.go:1115
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3126,7 +3131,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:976 lxc/cluster.go:977
+#: lxc/cluster.go:977 lxc/cluster.go:978
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -3174,7 +3179,7 @@ msgstr ""
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1004 lxc/network.go:1005
+#: lxc/network.go:1005 lxc/network.go:1006
 msgid "List available networks"
 msgstr ""
 
@@ -3262,7 +3267,7 @@ msgid ""
 "Fast column layout: nsacPt\n"
 "\n"
 "A single keyword like \"web\" which will list any instance with a name "
-"starting by \"web\".\n"
+"starting with \"web\".\n"
 "A regular expression on the instance name. (e.g. .*web.*01$).\n"
 "A key/value pair referring to a configuration item. For those, the\n"
 "namespace can be abbreviated to the smallest unambiguous identifier.\n"
@@ -3319,7 +3324,8 @@ msgid ""
 "  P - Profiles\n"
 "  s - State\n"
 "  S - Number of snapshots\n"
-"  t - Type (persistent or ephemeral)\n"
+"  t - Type (container or virtual-machine, ephemeral indicated if "
+"applicable)\n"
 "  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
@@ -3368,11 +3374,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1603
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1608
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3431,7 +3437,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1470
+#: lxc/info.go:489 lxc/storage_volume.go:1481
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3452,7 +3458,7 @@ msgstr ""
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1162
+#: lxc/network.go:1171
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3470,7 +3476,7 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1083
+#: lxc/network.go:1092
 msgid "MANAGED"
 msgstr ""
 
@@ -3593,7 +3599,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:955 lxc/config.go:956
+#: lxc/config.go:956 lxc/config.go:957
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3732,7 +3738,7 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:957
+#: lxc/cluster.go:958
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
@@ -3796,7 +3802,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:811 lxc/cluster.go:1367 lxc/cluster_group.go:129
+#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -3859,8 +3865,8 @@ msgstr ""
 
 #: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1139 lxc/network.go:1217 lxc/network.go:1283
-#: lxc/network.go:1375 lxc/network_forward.go:127 lxc/network_forward.go:215
+#: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
+#: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
 #: lxc/network_forward.go:284 lxc/network_forward.go:445
 #: lxc/network_forward.go:530 lxc/network_forward.go:705
 #: lxc/network_forward.go:836 lxc/network_forward.go:929
@@ -3901,12 +3907,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
-#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
-#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1986
-#: lxc/storage_volume.go:2127 lxc/storage_volume.go:2285
-#: lxc/storage_volume.go:2476 lxc/storage_volume.go:2593
+#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
+#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
 msgid "Missing pool name"
 msgstr ""
 
@@ -3925,11 +3931,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:438 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1411
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3966,8 +3972,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
-#: lxc/storage_volume.go:964
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
+#: lxc/storage_volume.go:975
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4004,7 +4010,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4012,11 +4018,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1856
+#: lxc/storage_volume.go:1867
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:518
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4038,12 +4044,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
+#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
 msgid "NAME"
 msgstr ""
 
@@ -4071,7 +4077,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
 #: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4095,8 +4101,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
-#: lxc/storage_volume.go:1562
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1573
 msgid "Name"
 msgstr ""
 
@@ -4104,7 +4110,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4129,7 +4135,7 @@ msgstr ""
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1227
+#: lxc/network.go:1236
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4239,7 +4245,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1161
+#: lxc/cluster.go:1162
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4248,7 +4254,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
+#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4268,11 +4274,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:502 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4286,7 +4292,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2035
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4294,15 +4300,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:343
+#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
+#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2690
+#: lxc/storage_volume.go:2701
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2489
+#: lxc/storage_volume.go:2500
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4314,11 +4321,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1418
+#: lxc/storage_volume.go:1429
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1298
+#: lxc/network.go:735 lxc/network.go:1307
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4327,7 +4334,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1577
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4357,7 +4364,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1767
 msgid "POOL"
 msgstr ""
 
@@ -4373,7 +4380,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1773
 #: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4419,7 +4426,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -4440,16 +4447,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
-#: lxc/storage_volume.go:1189
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
+#: lxc/storage_volume.go:1200
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4566,7 +4573,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1356
+#: lxc/storage_volume.go:1367
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4580,7 +4587,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1225
+#: lxc/storage_volume.go:1236
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4596,7 +4603,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2247
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4617,7 +4624,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1004
+#: lxc/storage_volume.go:1015
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4626,7 +4633,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2081
+#: lxc/storage_volume.go:2092
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4639,13 +4646,13 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2357
+#: lxc/storage_volume.go:2368
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
 "\n"
 "lxc storage volume unset default data size\n"
-"    Remotes the size/quota of a custom volume \"data\" in pool \"default\".\n"
+"    Removes the size/quota of a custom volume \"data\" in pool \"default\".\n"
 "\n"
 "lxc storage volume unset default virtual-machine/data snapshots.expiry\n"
 "    Removes the snapshot expiration period for a virtual machine \"data\" in "
@@ -4725,7 +4732,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4908,7 +4915,7 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1184 lxc/network.go:1185
+#: lxc/network.go:1193 lxc/network.go:1194
 msgid "Rename networks"
 msgstr ""
 
@@ -4924,15 +4931,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1949
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:1959
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2037 lxc/storage_volume.go:2057
+#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4942,11 +4949,11 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:892 lxc/cluster.go:893
+#: lxc/cluster.go:893 lxc/cluster.go:894
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1032
+#: lxc/config.go:1033
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -4969,7 +4976,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1328 lxc/cluster.go:1329
+#: lxc/cluster.go:1329 lxc/cluster.go:1330
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4984,11 +4991,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2552 lxc/storage_volume.go:2553
+#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1394
+#: lxc/cluster.go:1395
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5010,7 +5017,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1087
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5060,7 +5067,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1088
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1097
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5123,7 +5130,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1050 lxc/config.go:1051
+#: lxc/config.go:1051 lxc/config.go:1052
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5187,11 +5194,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1244
+#: lxc/network.go:1253
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1245
+#: lxc/network.go:1254
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5308,11 +5315,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2075
+#: lxc/storage_volume.go:2086
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2076
+#: lxc/storage_volume.go:2087
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5369,7 +5376,7 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1252
+#: lxc/network.go:1261
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5397,7 +5404,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2103
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5466,7 +5473,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1173
+#: lxc/config.go:1173 lxc/config.go:1174
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5498,7 +5505,7 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1340 lxc/network.go:1341
+#: lxc/network.go:1349 lxc/network.go:1350
 msgid "Show network configurations"
 msgstr ""
 
@@ -5546,11 +5553,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2233 lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5573,7 +5580,7 @@ msgid "Show the expanded configuration"
 msgstr ""
 
 #: lxc/info.go:43
-msgid "Show the instance's last 100 log lines?"
+msgid "Show the instance's last 100 log lines"
 msgstr ""
 
 #: lxc/info.go:44
@@ -5618,15 +5625,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2417
+#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2179
+#: lxc/storage_volume.go:2190
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1502
 msgid "Snapshots:"
 msgstr ""
 
@@ -5731,21 +5738,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:702
+#: lxc/storage_volume.go:703
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:790
+#: lxc/storage_volume.go:791
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:516
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:520
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5753,7 +5760,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5802,18 +5809,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1070 lxc/config_trust.go:515
+#: lxc/cluster.go:1071 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1736 lxc/warning.go:216
+#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1747 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
 msgid "Taken at"
 msgstr ""
 
@@ -5970,12 +5977,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1340
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1306
+#: lxc/storage_volume.go:1317
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -5994,8 +6001,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
-#: lxc/storage_volume.go:978
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:989
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6015,11 +6022,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:739
+#: lxc/cluster.go:740
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:729
+#: lxc/cluster.go:730
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6070,7 +6077,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6085,7 +6092,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1853
+#: lxc/storage_volume.go:1864
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6093,7 +6100,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:394
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6152,7 +6159,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1472
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6174,13 +6181,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:995 lxc/storage_volume.go:1752
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
+#: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1740
+#: lxc/storage.go:724 lxc/storage_volume.go:1751
 msgid "USED BY"
 msgstr ""
 
@@ -6212,7 +6219,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6238,7 +6245,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1141 lxc/config.go:1142
+#: lxc/config.go:1142 lxc/config.go:1143
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6266,7 +6273,7 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1412 lxc/network.go:1413
+#: lxc/network.go:1421 lxc/network.go:1422
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -6318,7 +6325,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2354 lxc/storage_volume.go:2355
+#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6342,7 +6349,7 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1417
+#: lxc/network.go:1426
 msgid "Unset the key as a network property"
 msgstr ""
 
@@ -6370,7 +6377,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2379
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6378,7 +6385,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:247
+#: lxc/storage_volume.go:248
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6391,11 +6398,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1174
+#: lxc/cluster.go:1175
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1176
+#: lxc/cluster.go:1177
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6414,12 +6421,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2641
+#: lxc/export.go:42 lxc/storage_volume.go:2652
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6486,7 +6493,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1576
 msgid "Volume Only"
 msgstr ""
 
@@ -6519,7 +6526,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
 #: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6545,18 +6552,18 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:903
+#: lxc/storage_volume.go:909
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:281
+#: lxc/storage_volume.go:282
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
-#: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
+#: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
@@ -6566,7 +6573,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1172
+#: lxc/cluster.go:1173
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -6729,7 +6736,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6751,11 +6758,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:1140
+#: lxc/config.go:995 lxc/config.go:1141
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1049
+#: lxc/config.go:1050
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -6834,8 +6841,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:768
-#: lxc/cluster.go:1085 lxc/cluster.go:1297 lxc/cluster.go:1327
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
+#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -6859,8 +6866,8 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1104
-#: lxc/network.go:1339 lxc/network_forward.go:87
+#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1113
+#: lxc/network.go:1348 lxc/network_forward.go:87
 #: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -6873,11 +6880,11 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1411
+#: lxc/network.go:791 lxc/network.go:1420
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1243
+#: lxc/network.go:1252
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
@@ -6922,7 +6929,7 @@ msgstr ""
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1182
+#: lxc/network.go:1191
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -6973,7 +6980,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2800
+#: lxc/storage_volume.go:2811
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7008,13 +7015,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:1958
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:806
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7022,51 +7029,51 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2551
+#: lxc/storage_volume.go:2562
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2634
+#: lxc/storage_volume.go:2645
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2415
+#: lxc/storage_volume.go:2426
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:609
+#: lxc/storage_volume.go:610
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:718
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2353
+#: lxc/storage_volume.go:2364
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2085
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2232
+#: lxc/storage_volume.go:2243
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1221
+#: lxc/storage_volume.go:1232
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1858
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:387
+#: lxc/storage_volume.go:388
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7172,7 +7179,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1601
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7184,7 +7191,7 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:891
+#: lxc/cluster.go:892
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -7256,7 +7263,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:772
+#: lxc/cluster.go:773
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7305,13 +7312,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1229
+#: lxc/config.go:1230
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1053
+#: lxc/config.go:1054
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7648,7 +7655,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:614
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7656,13 +7663,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2804
+#: lxc/storage_volume.go:2815
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2419
+#: lxc/storage_volume.go:2430
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-09 03:18-0300\n"
+"POT-Creation-Date: 2024-12-18 08:40-0700\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1030
+#: lxc/storage_volume.go:1041
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1240
+#: lxc/config.go:1241
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -412,7 +412,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:790
+#: lxc/cluster.go:791
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -585,13 +585,13 @@ msgstr ""
 msgid "Acknowledge warning"
 msgstr ""
 
+#: lxc/query.go:43
+msgid "Action"
+msgstr ""
+
 #: lxc/query.go:76
 #, c-format
 msgid "Action %q isn't supported by this tool"
-msgstr ""
-
-#: lxc/query.go:43
-msgid "Action (defaults to GET)"
 msgstr ""
 
 #: lxc/cluster_group.go:725
@@ -738,7 +738,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1596
+#: lxc/storage_volume.go:1607
 msgid "All projects"
 msgstr ""
 
@@ -760,7 +760,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1371
+#: lxc/cluster.go:1372
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -797,7 +797,7 @@ msgstr ""
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:282 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -849,16 +849,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2708
+#: lxc/storage_volume.go:2719
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2785
+#: lxc/export.go:192 lxc/storage_volume.go:2796
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1538
 msgid "Backups:"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -922,7 +922,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1739
+#: lxc/storage_volume.go:1750
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1007,7 +1007,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1097
+#: lxc/config.go:702 lxc/config.go:1098
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1024,12 +1024,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:492
+#: lxc/storage_volume.go:493
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:446
+#: lxc/storage_volume.go:447
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1105,7 +1105,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1154
+#: lxc/cluster.go:1155
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1133,8 +1133,8 @@ msgstr ""
 #: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
 #: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
-#: lxc/network_forward.go:182 lxc/network_forward.go:264
+#: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
+#: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
 #: lxc/network_forward.go:497 lxc/network_forward.go:649
 #: lxc/network_forward.go:803 lxc/network_forward.go:892
 #: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
@@ -1149,30 +1149,30 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
-#: lxc/storage_volume.go:1952 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2251 lxc/storage_volume.go:2367
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2555
-#: lxc/storage_volume.go:2643 lxc/storage_volume.go:2807
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
+#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
+#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:894
+#: lxc/cluster.go:895
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:926
+#: lxc/cluster.go:927
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:756
+#: lxc/cluster.go:757
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1209,24 +1209,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
+#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
-#: lxc/storage_volume.go:1188
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
+#: lxc/storage_volume.go:1199
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:619
+#: lxc/storage_volume.go:620
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1236,7 +1236,11 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/move.go:65
+#: lxc/move.go:65
+msgid "Copy a stateful instance as stateless"
+msgstr ""
+
+#: lxc/copy.go:60
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1284,7 +1288,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:389 lxc/storage_volume.go:390
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1292,12 +1296,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:396
+#: lxc/storage_volume.go:397
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:398
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1310,7 +1314,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:515
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1333,12 +1337,12 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1235
+#: lxc/cluster.go:1236
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1239
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1353,17 +1357,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1266
+#: lxc/cluster.go:1267
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1445,7 +1449,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1497,7 +1501,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1526,13 +1530,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1738
+#: lxc/storage_volume.go:1749
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1552,7 +1556,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2642
+#: lxc/storage_volume.go:2653
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1648,7 +1652,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1669,16 +1673,16 @@ msgstr ""
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
-#: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
+#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
+#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
-#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
-#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
+#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
+#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1701,8 +1705,8 @@ msgstr ""
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
 #: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1005 lxc/network.go:1106 lxc/network.go:1185
-#: lxc/network.go:1245 lxc/network.go:1341 lxc/network.go:1413
+#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
+#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
 #: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
 #: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
 #: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
@@ -1753,27 +1757,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
-#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
-#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
-#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1949
-#: lxc/storage_volume.go:2076 lxc/storage_volume.go:2234
-#: lxc/storage_volume.go:2355 lxc/storage_volume.go:2417
-#: lxc/storage_volume.go:2553 lxc/storage_volume.go:2636
-#: lxc/storage_volume.go:2802 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1454
+#: lxc/storage_volume.go:1465
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1785,11 +1789,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
+#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1917,7 +1921,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:516
+#: lxc/cluster.go:1072 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1939,7 +1943,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:769 lxc/cluster.go:770
+#: lxc/cluster.go:770 lxc/cluster.go:771
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1959,7 +1963,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1226 lxc/config.go:1227
+#: lxc/config.go:1227 lxc/config.go:1228
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2023,7 +2027,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2031,7 +2035,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2049,11 +2053,12 @@ msgid ""
 "new\n"
 "  LXD cluster, which will have the given name.\n"
 "\n"
-"  It's required that the LXD is already available on the network. You can "
-"check\n"
-"  that by running 'lxc config get core.https_address', and possibly set a "
-"value\n"
-"  for the address if not yet set."
+"  It's required that LXD is already available on the network. You can check\n"
+"  this by running 'lxc config get core.https_address'. If either an IP "
+"address\n"
+"  and port is displayed, or both, LXD is already available on the network. "
+"If\n"
+"  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
 #: lxc/network_zone.go:1427
@@ -2083,12 +2088,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
+#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2098,12 +2103,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
+#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
-#: lxc/storage_volume.go:2199
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
+#: lxc/storage_volume.go:2210
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2113,11 +2118,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1298 lxc/cluster.go:1299
+#: lxc/cluster.go:1299 lxc/cluster.go:1300
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1396
+#: lxc/cluster.go:1397
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2145,8 +2150,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
-#: lxc/storage_volume.go:1564
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Expires at"
 msgstr ""
 
@@ -2170,7 +2175,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2635 lxc/storage_volume.go:2636
+#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2182,11 +2187,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2639
+#: lxc/storage_volume.go:2650
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2768
+#: lxc/export.go:152 lxc/storage_volume.go:2779
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2366,7 +2371,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
+#: lxc/network.go:1046 lxc/network_acl.go:133 lxc/network_zone.go:124
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2376,7 +2381,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1303
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2384,7 +2389,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1301
+#: lxc/cluster.go:1302
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2396,7 +2401,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1331
+#: lxc/cluster.go:1332
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2437,16 +2442,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
-#: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1614 lxc/warning.go:94
+#: lxc/storage_volume.go:1625 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2506,7 +2511,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:996
+#: lxc/config.go:996 lxc/config.go:997
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2570,7 +2575,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1249
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2634,11 +2639,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
+#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:475
+#: lxc/storage_volume.go:476
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2666,7 +2671,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1161
+#: lxc/network.go:1170
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2720,7 +2725,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1163
+#: lxc/network.go:1172
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2732,11 +2737,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1084
+#: lxc/list.go:560 lxc/network.go:1093
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1085
+#: lxc/list.go:561 lxc/network.go:1094
 msgid "IPV6"
 msgstr ""
 
@@ -2766,7 +2771,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2427
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2780,7 +2785,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2437
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2830,7 +2835,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2802
+#: lxc/storage_volume.go:2813
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2838,7 +2843,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2801
+#: lxc/storage_volume.go:2812
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2860,11 +2865,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2809
+#: lxc/storage_volume.go:2820
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2883
+#: lxc/storage_volume.go:2894
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2908,7 +2913,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
+#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2990,7 +2995,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2012
+#: lxc/move.go:148 lxc/storage_volume.go:2023
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2998,7 +3003,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2019
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3016,9 +3021,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
-#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2144 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
+#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3062,9 +3067,9 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
+#: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3076,8 +3081,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1020 lxc/cluster.go:1123
-#: lxc/cluster.go:1231 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
+#: lxc/cluster.go:1232 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3114,7 +3119,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1105 lxc/network.go:1106
+#: lxc/network.go:1114 lxc/network.go:1115
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3126,7 +3131,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:976 lxc/cluster.go:977
+#: lxc/cluster.go:977 lxc/cluster.go:978
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -3174,7 +3179,7 @@ msgstr ""
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1004 lxc/network.go:1005
+#: lxc/network.go:1005 lxc/network.go:1006
 msgid "List available networks"
 msgstr ""
 
@@ -3262,7 +3267,7 @@ msgid ""
 "Fast column layout: nsacPt\n"
 "\n"
 "A single keyword like \"web\" which will list any instance with a name "
-"starting by \"web\".\n"
+"starting with \"web\".\n"
 "A regular expression on the instance name. (e.g. .*web.*01$).\n"
 "A key/value pair referring to a configuration item. For those, the\n"
 "namespace can be abbreviated to the smallest unambiguous identifier.\n"
@@ -3319,7 +3324,8 @@ msgid ""
 "  P - Profiles\n"
 "  s - State\n"
 "  S - Number of snapshots\n"
-"  t - Type (persistent or ephemeral)\n"
+"  t - Type (container or virtual-machine, ephemeral indicated if "
+"applicable)\n"
 "  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
@@ -3368,11 +3374,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1603
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1608
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3431,7 +3437,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1470
+#: lxc/info.go:489 lxc/storage_volume.go:1481
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3452,7 +3458,7 @@ msgstr ""
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1162
+#: lxc/network.go:1171
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3470,7 +3476,7 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1083
+#: lxc/network.go:1092
 msgid "MANAGED"
 msgstr ""
 
@@ -3593,7 +3599,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:955 lxc/config.go:956
+#: lxc/config.go:956 lxc/config.go:957
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3732,7 +3738,7 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:957
+#: lxc/cluster.go:958
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
@@ -3796,7 +3802,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:811 lxc/cluster.go:1367 lxc/cluster_group.go:129
+#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -3859,8 +3865,8 @@ msgstr ""
 
 #: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1139 lxc/network.go:1217 lxc/network.go:1283
-#: lxc/network.go:1375 lxc/network_forward.go:127 lxc/network_forward.go:215
+#: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
+#: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
 #: lxc/network_forward.go:284 lxc/network_forward.go:445
 #: lxc/network_forward.go:530 lxc/network_forward.go:705
 #: lxc/network_forward.go:836 lxc/network_forward.go:929
@@ -3901,12 +3907,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
-#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
-#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1986
-#: lxc/storage_volume.go:2127 lxc/storage_volume.go:2285
-#: lxc/storage_volume.go:2476 lxc/storage_volume.go:2593
+#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
+#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
 msgid "Missing pool name"
 msgstr ""
 
@@ -3925,11 +3931,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:438 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1411
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3966,8 +3972,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
-#: lxc/storage_volume.go:964
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
+#: lxc/storage_volume.go:975
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4004,7 +4010,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4012,11 +4018,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1856
+#: lxc/storage_volume.go:1867
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:518
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4038,12 +4044,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
+#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
 msgid "NAME"
 msgstr ""
 
@@ -4071,7 +4077,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
 #: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4095,8 +4101,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
-#: lxc/storage_volume.go:1562
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1573
 msgid "Name"
 msgstr ""
 
@@ -4104,7 +4110,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4129,7 +4135,7 @@ msgstr ""
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1227
+#: lxc/network.go:1236
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4239,7 +4245,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1161
+#: lxc/cluster.go:1162
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4248,7 +4254,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
+#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4268,11 +4274,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:502 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4286,7 +4292,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2035
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4294,15 +4300,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:343
+#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
+#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2690
+#: lxc/storage_volume.go:2701
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2489
+#: lxc/storage_volume.go:2500
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4314,11 +4321,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1418
+#: lxc/storage_volume.go:1429
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1298
+#: lxc/network.go:735 lxc/network.go:1307
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4327,7 +4334,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1577
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4357,7 +4364,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1767
 msgid "POOL"
 msgstr ""
 
@@ -4373,7 +4380,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1773
 #: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4419,7 +4426,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -4440,16 +4447,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
-#: lxc/storage_volume.go:1189
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
+#: lxc/storage_volume.go:1200
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4566,7 +4573,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1356
+#: lxc/storage_volume.go:1367
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4580,7 +4587,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1225
+#: lxc/storage_volume.go:1236
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4596,7 +4603,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2247
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4617,7 +4624,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1004
+#: lxc/storage_volume.go:1015
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4626,7 +4633,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2081
+#: lxc/storage_volume.go:2092
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4639,13 +4646,13 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2357
+#: lxc/storage_volume.go:2368
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
 "\n"
 "lxc storage volume unset default data size\n"
-"    Remotes the size/quota of a custom volume \"data\" in pool \"default\".\n"
+"    Removes the size/quota of a custom volume \"data\" in pool \"default\".\n"
 "\n"
 "lxc storage volume unset default virtual-machine/data snapshots.expiry\n"
 "    Removes the snapshot expiration period for a virtual machine \"data\" in "
@@ -4725,7 +4732,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4908,7 +4915,7 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1184 lxc/network.go:1185
+#: lxc/network.go:1193 lxc/network.go:1194
 msgid "Rename networks"
 msgstr ""
 
@@ -4924,15 +4931,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1949
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:1959
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2037 lxc/storage_volume.go:2057
+#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4942,11 +4949,11 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:892 lxc/cluster.go:893
+#: lxc/cluster.go:893 lxc/cluster.go:894
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1032
+#: lxc/config.go:1033
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -4969,7 +4976,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1328 lxc/cluster.go:1329
+#: lxc/cluster.go:1329 lxc/cluster.go:1330
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4984,11 +4991,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2552 lxc/storage_volume.go:2553
+#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1394
+#: lxc/cluster.go:1395
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5010,7 +5017,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1087
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5060,7 +5067,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1088
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1097
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5123,7 +5130,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1050 lxc/config.go:1051
+#: lxc/config.go:1051 lxc/config.go:1052
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5187,11 +5194,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1244
+#: lxc/network.go:1253
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1245
+#: lxc/network.go:1254
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5308,11 +5315,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2075
+#: lxc/storage_volume.go:2086
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2076
+#: lxc/storage_volume.go:2087
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5369,7 +5376,7 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1252
+#: lxc/network.go:1261
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5397,7 +5404,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2103
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5466,7 +5473,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1173
+#: lxc/config.go:1173 lxc/config.go:1174
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5498,7 +5505,7 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1340 lxc/network.go:1341
+#: lxc/network.go:1349 lxc/network.go:1350
 msgid "Show network configurations"
 msgstr ""
 
@@ -5546,11 +5553,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2233 lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5573,7 +5580,7 @@ msgid "Show the expanded configuration"
 msgstr ""
 
 #: lxc/info.go:43
-msgid "Show the instance's last 100 log lines?"
+msgid "Show the instance's last 100 log lines"
 msgstr ""
 
 #: lxc/info.go:44
@@ -5618,15 +5625,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2417
+#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2179
+#: lxc/storage_volume.go:2190
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1502
 msgid "Snapshots:"
 msgstr ""
 
@@ -5731,21 +5738,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:702
+#: lxc/storage_volume.go:703
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:790
+#: lxc/storage_volume.go:791
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:516
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:520
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5753,7 +5760,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5802,18 +5809,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1070 lxc/config_trust.go:515
+#: lxc/cluster.go:1071 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1736 lxc/warning.go:216
+#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1747 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
 msgid "Taken at"
 msgstr ""
 
@@ -5970,12 +5977,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1340
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1306
+#: lxc/storage_volume.go:1317
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -5994,8 +6001,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
-#: lxc/storage_volume.go:978
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:989
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6015,11 +6022,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:739
+#: lxc/cluster.go:740
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:729
+#: lxc/cluster.go:730
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6070,7 +6077,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6085,7 +6092,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1853
+#: lxc/storage_volume.go:1864
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6093,7 +6100,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:394
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6152,7 +6159,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1472
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6174,13 +6181,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:995 lxc/storage_volume.go:1752
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
+#: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1740
+#: lxc/storage.go:724 lxc/storage_volume.go:1751
 msgid "USED BY"
 msgstr ""
 
@@ -6212,7 +6219,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6238,7 +6245,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1141 lxc/config.go:1142
+#: lxc/config.go:1142 lxc/config.go:1143
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6266,7 +6273,7 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1412 lxc/network.go:1413
+#: lxc/network.go:1421 lxc/network.go:1422
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -6318,7 +6325,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2354 lxc/storage_volume.go:2355
+#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6342,7 +6349,7 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1417
+#: lxc/network.go:1426
 msgid "Unset the key as a network property"
 msgstr ""
 
@@ -6370,7 +6377,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2379
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6378,7 +6385,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:247
+#: lxc/storage_volume.go:248
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6391,11 +6398,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1174
+#: lxc/cluster.go:1175
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1176
+#: lxc/cluster.go:1177
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6414,12 +6421,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2641
+#: lxc/export.go:42 lxc/storage_volume.go:2652
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6486,7 +6493,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1576
 msgid "Volume Only"
 msgstr ""
 
@@ -6519,7 +6526,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
 #: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6545,18 +6552,18 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:903
+#: lxc/storage_volume.go:909
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:281
+#: lxc/storage_volume.go:282
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
-#: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
+#: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
@@ -6566,7 +6573,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1172
+#: lxc/cluster.go:1173
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -6729,7 +6736,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6751,11 +6758,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:1140
+#: lxc/config.go:995 lxc/config.go:1141
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1049
+#: lxc/config.go:1050
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -6834,8 +6841,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:768
-#: lxc/cluster.go:1085 lxc/cluster.go:1297 lxc/cluster.go:1327
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
+#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -6859,8 +6866,8 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1104
-#: lxc/network.go:1339 lxc/network_forward.go:87
+#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1113
+#: lxc/network.go:1348 lxc/network_forward.go:87
 #: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -6873,11 +6880,11 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1411
+#: lxc/network.go:791 lxc/network.go:1420
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1243
+#: lxc/network.go:1252
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
@@ -6922,7 +6929,7 @@ msgstr ""
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1182
+#: lxc/network.go:1191
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -6973,7 +6980,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2800
+#: lxc/storage_volume.go:2811
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7008,13 +7015,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:1958
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:806
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7022,51 +7029,51 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2551
+#: lxc/storage_volume.go:2562
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2634
+#: lxc/storage_volume.go:2645
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2415
+#: lxc/storage_volume.go:2426
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:609
+#: lxc/storage_volume.go:610
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:718
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2353
+#: lxc/storage_volume.go:2364
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2085
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2232
+#: lxc/storage_volume.go:2243
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1221
+#: lxc/storage_volume.go:1232
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1858
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:387
+#: lxc/storage_volume.go:388
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7172,7 +7179,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1601
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7184,7 +7191,7 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:891
+#: lxc/cluster.go:892
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -7256,7 +7263,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:772
+#: lxc/cluster.go:773
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7305,13 +7312,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1229
+#: lxc/config.go:1230
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1053
+#: lxc/config.go:1054
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7648,7 +7655,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:614
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7656,13 +7663,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2804
+#: lxc/storage_volume.go:2815
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2419
+#: lxc/storage_volume.go:2430
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-09 03:18-0300\n"
+"POT-Creation-Date: 2024-12-18 08:40-0700\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1030
+#: lxc/storage_volume.go:1041
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1240
+#: lxc/config.go:1241
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -412,7 +412,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:790
+#: lxc/cluster.go:791
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -585,13 +585,13 @@ msgstr ""
 msgid "Acknowledge warning"
 msgstr ""
 
+#: lxc/query.go:43
+msgid "Action"
+msgstr ""
+
 #: lxc/query.go:76
 #, c-format
 msgid "Action %q isn't supported by this tool"
-msgstr ""
-
-#: lxc/query.go:43
-msgid "Action (defaults to GET)"
 msgstr ""
 
 #: lxc/cluster_group.go:725
@@ -738,7 +738,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1596
+#: lxc/storage_volume.go:1607
 msgid "All projects"
 msgstr ""
 
@@ -760,7 +760,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1371
+#: lxc/cluster.go:1372
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -797,7 +797,7 @@ msgstr ""
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:282 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -849,16 +849,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2708
+#: lxc/storage_volume.go:2719
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2785
+#: lxc/export.go:192 lxc/storage_volume.go:2796
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1538
 msgid "Backups:"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -922,7 +922,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1739
+#: lxc/storage_volume.go:1750
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1007,7 +1007,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1097
+#: lxc/config.go:702 lxc/config.go:1098
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1024,12 +1024,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:492
+#: lxc/storage_volume.go:493
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:446
+#: lxc/storage_volume.go:447
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1105,7 +1105,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1154
+#: lxc/cluster.go:1155
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1133,8 +1133,8 @@ msgstr ""
 #: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
 #: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
-#: lxc/network_forward.go:182 lxc/network_forward.go:264
+#: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
+#: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
 #: lxc/network_forward.go:497 lxc/network_forward.go:649
 #: lxc/network_forward.go:803 lxc/network_forward.go:892
 #: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
@@ -1149,30 +1149,30 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
-#: lxc/storage_volume.go:1952 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2251 lxc/storage_volume.go:2367
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2555
-#: lxc/storage_volume.go:2643 lxc/storage_volume.go:2807
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
+#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
+#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:894
+#: lxc/cluster.go:895
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:926
+#: lxc/cluster.go:927
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:756
+#: lxc/cluster.go:757
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1209,24 +1209,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
+#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
-#: lxc/storage_volume.go:1188
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
+#: lxc/storage_volume.go:1199
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:619
+#: lxc/storage_volume.go:620
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1236,7 +1236,11 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/move.go:65
+#: lxc/move.go:65
+msgid "Copy a stateful instance as stateless"
+msgstr ""
+
+#: lxc/copy.go:60
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1284,7 +1288,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:389 lxc/storage_volume.go:390
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1292,12 +1296,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:396
+#: lxc/storage_volume.go:397
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:398
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1310,7 +1314,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:515
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1333,12 +1337,12 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1235
+#: lxc/cluster.go:1236
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1239
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1353,17 +1357,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1266
+#: lxc/cluster.go:1267
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1445,7 +1449,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1497,7 +1501,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1526,13 +1530,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1738
+#: lxc/storage_volume.go:1749
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1552,7 +1556,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2642
+#: lxc/storage_volume.go:2653
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1648,7 +1652,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1669,16 +1673,16 @@ msgstr ""
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
-#: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
+#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
+#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
-#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
-#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
+#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
+#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1701,8 +1705,8 @@ msgstr ""
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
 #: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1005 lxc/network.go:1106 lxc/network.go:1185
-#: lxc/network.go:1245 lxc/network.go:1341 lxc/network.go:1413
+#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
+#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
 #: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
 #: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
 #: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
@@ -1753,27 +1757,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
-#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
-#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
-#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1949
-#: lxc/storage_volume.go:2076 lxc/storage_volume.go:2234
-#: lxc/storage_volume.go:2355 lxc/storage_volume.go:2417
-#: lxc/storage_volume.go:2553 lxc/storage_volume.go:2636
-#: lxc/storage_volume.go:2802 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1454
+#: lxc/storage_volume.go:1465
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1785,11 +1789,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
+#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1917,7 +1921,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:516
+#: lxc/cluster.go:1072 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1939,7 +1943,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:769 lxc/cluster.go:770
+#: lxc/cluster.go:770 lxc/cluster.go:771
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1959,7 +1963,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1226 lxc/config.go:1227
+#: lxc/config.go:1227 lxc/config.go:1228
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2023,7 +2027,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2031,7 +2035,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2049,11 +2053,12 @@ msgid ""
 "new\n"
 "  LXD cluster, which will have the given name.\n"
 "\n"
-"  It's required that the LXD is already available on the network. You can "
-"check\n"
-"  that by running 'lxc config get core.https_address', and possibly set a "
-"value\n"
-"  for the address if not yet set."
+"  It's required that LXD is already available on the network. You can check\n"
+"  this by running 'lxc config get core.https_address'. If either an IP "
+"address\n"
+"  and port is displayed, or both, LXD is already available on the network. "
+"If\n"
+"  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
 #: lxc/network_zone.go:1427
@@ -2083,12 +2088,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
+#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2098,12 +2103,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
+#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
-#: lxc/storage_volume.go:2199
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
+#: lxc/storage_volume.go:2210
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2113,11 +2118,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1298 lxc/cluster.go:1299
+#: lxc/cluster.go:1299 lxc/cluster.go:1300
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1396
+#: lxc/cluster.go:1397
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2145,8 +2150,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
-#: lxc/storage_volume.go:1564
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Expires at"
 msgstr ""
 
@@ -2170,7 +2175,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2635 lxc/storage_volume.go:2636
+#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2182,11 +2187,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2639
+#: lxc/storage_volume.go:2650
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2768
+#: lxc/export.go:152 lxc/storage_volume.go:2779
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2366,7 +2371,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
+#: lxc/network.go:1046 lxc/network_acl.go:133 lxc/network_zone.go:124
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2376,7 +2381,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1303
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2384,7 +2389,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1301
+#: lxc/cluster.go:1302
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2396,7 +2401,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1331
+#: lxc/cluster.go:1332
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2437,16 +2442,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
-#: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1614 lxc/warning.go:94
+#: lxc/storage_volume.go:1625 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2506,7 +2511,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:996
+#: lxc/config.go:996 lxc/config.go:997
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2570,7 +2575,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1249
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2634,11 +2639,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
+#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:475
+#: lxc/storage_volume.go:476
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2666,7 +2671,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1161
+#: lxc/network.go:1170
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2720,7 +2725,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1163
+#: lxc/network.go:1172
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2732,11 +2737,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1084
+#: lxc/list.go:560 lxc/network.go:1093
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1085
+#: lxc/list.go:561 lxc/network.go:1094
 msgid "IPV6"
 msgstr ""
 
@@ -2766,7 +2771,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2427
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2780,7 +2785,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2437
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2830,7 +2835,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2802
+#: lxc/storage_volume.go:2813
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2838,7 +2843,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2801
+#: lxc/storage_volume.go:2812
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2860,11 +2865,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2809
+#: lxc/storage_volume.go:2820
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2883
+#: lxc/storage_volume.go:2894
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2908,7 +2913,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
+#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2990,7 +2995,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2012
+#: lxc/move.go:148 lxc/storage_volume.go:2023
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2998,7 +3003,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2019
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3016,9 +3021,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
-#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2144 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
+#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3062,9 +3067,9 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
+#: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3076,8 +3081,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1020 lxc/cluster.go:1123
-#: lxc/cluster.go:1231 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
+#: lxc/cluster.go:1232 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3114,7 +3119,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1105 lxc/network.go:1106
+#: lxc/network.go:1114 lxc/network.go:1115
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3126,7 +3131,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:976 lxc/cluster.go:977
+#: lxc/cluster.go:977 lxc/cluster.go:978
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -3174,7 +3179,7 @@ msgstr ""
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1004 lxc/network.go:1005
+#: lxc/network.go:1005 lxc/network.go:1006
 msgid "List available networks"
 msgstr ""
 
@@ -3262,7 +3267,7 @@ msgid ""
 "Fast column layout: nsacPt\n"
 "\n"
 "A single keyword like \"web\" which will list any instance with a name "
-"starting by \"web\".\n"
+"starting with \"web\".\n"
 "A regular expression on the instance name. (e.g. .*web.*01$).\n"
 "A key/value pair referring to a configuration item. For those, the\n"
 "namespace can be abbreviated to the smallest unambiguous identifier.\n"
@@ -3319,7 +3324,8 @@ msgid ""
 "  P - Profiles\n"
 "  s - State\n"
 "  S - Number of snapshots\n"
-"  t - Type (persistent or ephemeral)\n"
+"  t - Type (container or virtual-machine, ephemeral indicated if "
+"applicable)\n"
 "  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
@@ -3368,11 +3374,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1603
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1608
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3431,7 +3437,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1470
+#: lxc/info.go:489 lxc/storage_volume.go:1481
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3452,7 +3458,7 @@ msgstr ""
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1162
+#: lxc/network.go:1171
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3470,7 +3476,7 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1083
+#: lxc/network.go:1092
 msgid "MANAGED"
 msgstr ""
 
@@ -3593,7 +3599,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:955 lxc/config.go:956
+#: lxc/config.go:956 lxc/config.go:957
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3732,7 +3738,7 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:957
+#: lxc/cluster.go:958
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
@@ -3796,7 +3802,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:811 lxc/cluster.go:1367 lxc/cluster_group.go:129
+#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -3859,8 +3865,8 @@ msgstr ""
 
 #: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1139 lxc/network.go:1217 lxc/network.go:1283
-#: lxc/network.go:1375 lxc/network_forward.go:127 lxc/network_forward.go:215
+#: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
+#: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
 #: lxc/network_forward.go:284 lxc/network_forward.go:445
 #: lxc/network_forward.go:530 lxc/network_forward.go:705
 #: lxc/network_forward.go:836 lxc/network_forward.go:929
@@ -3901,12 +3907,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
-#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
-#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1986
-#: lxc/storage_volume.go:2127 lxc/storage_volume.go:2285
-#: lxc/storage_volume.go:2476 lxc/storage_volume.go:2593
+#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
+#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
 msgid "Missing pool name"
 msgstr ""
 
@@ -3925,11 +3931,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:438 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1411
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3966,8 +3972,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
-#: lxc/storage_volume.go:964
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
+#: lxc/storage_volume.go:975
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4004,7 +4010,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4012,11 +4018,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1856
+#: lxc/storage_volume.go:1867
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:518
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4038,12 +4044,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
+#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
 msgid "NAME"
 msgstr ""
 
@@ -4071,7 +4077,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
 #: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4095,8 +4101,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
-#: lxc/storage_volume.go:1562
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1573
 msgid "Name"
 msgstr ""
 
@@ -4104,7 +4110,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4129,7 +4135,7 @@ msgstr ""
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1227
+#: lxc/network.go:1236
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4239,7 +4245,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1161
+#: lxc/cluster.go:1162
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4248,7 +4254,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
+#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4268,11 +4274,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:502 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4286,7 +4292,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2035
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4294,15 +4300,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:343
+#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
+#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2690
+#: lxc/storage_volume.go:2701
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2489
+#: lxc/storage_volume.go:2500
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4314,11 +4321,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1418
+#: lxc/storage_volume.go:1429
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1298
+#: lxc/network.go:735 lxc/network.go:1307
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4327,7 +4334,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1577
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4357,7 +4364,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1767
 msgid "POOL"
 msgstr ""
 
@@ -4373,7 +4380,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1773
 #: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4419,7 +4426,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -4440,16 +4447,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
-#: lxc/storage_volume.go:1189
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
+#: lxc/storage_volume.go:1200
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4566,7 +4573,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1356
+#: lxc/storage_volume.go:1367
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4580,7 +4587,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1225
+#: lxc/storage_volume.go:1236
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4596,7 +4603,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2247
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4617,7 +4624,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1004
+#: lxc/storage_volume.go:1015
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4626,7 +4633,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2081
+#: lxc/storage_volume.go:2092
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4639,13 +4646,13 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2357
+#: lxc/storage_volume.go:2368
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
 "\n"
 "lxc storage volume unset default data size\n"
-"    Remotes the size/quota of a custom volume \"data\" in pool \"default\".\n"
+"    Removes the size/quota of a custom volume \"data\" in pool \"default\".\n"
 "\n"
 "lxc storage volume unset default virtual-machine/data snapshots.expiry\n"
 "    Removes the snapshot expiration period for a virtual machine \"data\" in "
@@ -4725,7 +4732,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4908,7 +4915,7 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1184 lxc/network.go:1185
+#: lxc/network.go:1193 lxc/network.go:1194
 msgid "Rename networks"
 msgstr ""
 
@@ -4924,15 +4931,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1949
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:1959
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2037 lxc/storage_volume.go:2057
+#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4942,11 +4949,11 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:892 lxc/cluster.go:893
+#: lxc/cluster.go:893 lxc/cluster.go:894
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1032
+#: lxc/config.go:1033
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -4969,7 +4976,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1328 lxc/cluster.go:1329
+#: lxc/cluster.go:1329 lxc/cluster.go:1330
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4984,11 +4991,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2552 lxc/storage_volume.go:2553
+#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1394
+#: lxc/cluster.go:1395
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5010,7 +5017,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1087
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5060,7 +5067,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1088
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1097
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5123,7 +5130,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1050 lxc/config.go:1051
+#: lxc/config.go:1051 lxc/config.go:1052
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5187,11 +5194,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1244
+#: lxc/network.go:1253
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1245
+#: lxc/network.go:1254
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5308,11 +5315,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2075
+#: lxc/storage_volume.go:2086
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2076
+#: lxc/storage_volume.go:2087
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5369,7 +5376,7 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1252
+#: lxc/network.go:1261
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5397,7 +5404,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2103
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5466,7 +5473,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1173
+#: lxc/config.go:1173 lxc/config.go:1174
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5498,7 +5505,7 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1340 lxc/network.go:1341
+#: lxc/network.go:1349 lxc/network.go:1350
 msgid "Show network configurations"
 msgstr ""
 
@@ -5546,11 +5553,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2233 lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5573,7 +5580,7 @@ msgid "Show the expanded configuration"
 msgstr ""
 
 #: lxc/info.go:43
-msgid "Show the instance's last 100 log lines?"
+msgid "Show the instance's last 100 log lines"
 msgstr ""
 
 #: lxc/info.go:44
@@ -5618,15 +5625,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2417
+#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2179
+#: lxc/storage_volume.go:2190
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1502
 msgid "Snapshots:"
 msgstr ""
 
@@ -5731,21 +5738,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:702
+#: lxc/storage_volume.go:703
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:790
+#: lxc/storage_volume.go:791
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:516
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:520
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5753,7 +5760,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5802,18 +5809,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1070 lxc/config_trust.go:515
+#: lxc/cluster.go:1071 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1736 lxc/warning.go:216
+#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1747 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
 msgid "Taken at"
 msgstr ""
 
@@ -5970,12 +5977,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1340
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1306
+#: lxc/storage_volume.go:1317
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -5994,8 +6001,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
-#: lxc/storage_volume.go:978
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:989
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6015,11 +6022,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:739
+#: lxc/cluster.go:740
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:729
+#: lxc/cluster.go:730
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6070,7 +6077,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6085,7 +6092,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1853
+#: lxc/storage_volume.go:1864
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6093,7 +6100,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:394
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6152,7 +6159,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1472
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6174,13 +6181,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:995 lxc/storage_volume.go:1752
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
+#: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1740
+#: lxc/storage.go:724 lxc/storage_volume.go:1751
 msgid "USED BY"
 msgstr ""
 
@@ -6212,7 +6219,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6238,7 +6245,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1141 lxc/config.go:1142
+#: lxc/config.go:1142 lxc/config.go:1143
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6266,7 +6273,7 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1412 lxc/network.go:1413
+#: lxc/network.go:1421 lxc/network.go:1422
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -6318,7 +6325,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2354 lxc/storage_volume.go:2355
+#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6342,7 +6349,7 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1417
+#: lxc/network.go:1426
 msgid "Unset the key as a network property"
 msgstr ""
 
@@ -6370,7 +6377,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2379
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6378,7 +6385,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:247
+#: lxc/storage_volume.go:248
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6391,11 +6398,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1174
+#: lxc/cluster.go:1175
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1176
+#: lxc/cluster.go:1177
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6414,12 +6421,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2641
+#: lxc/export.go:42 lxc/storage_volume.go:2652
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6486,7 +6493,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1576
 msgid "Volume Only"
 msgstr ""
 
@@ -6519,7 +6526,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
 #: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6545,18 +6552,18 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:903
+#: lxc/storage_volume.go:909
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:281
+#: lxc/storage_volume.go:282
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
-#: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
+#: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
@@ -6566,7 +6573,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1172
+#: lxc/cluster.go:1173
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -6729,7 +6736,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6751,11 +6758,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:1140
+#: lxc/config.go:995 lxc/config.go:1141
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1049
+#: lxc/config.go:1050
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -6834,8 +6841,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:768
-#: lxc/cluster.go:1085 lxc/cluster.go:1297 lxc/cluster.go:1327
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
+#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -6859,8 +6866,8 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1104
-#: lxc/network.go:1339 lxc/network_forward.go:87
+#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1113
+#: lxc/network.go:1348 lxc/network_forward.go:87
 #: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -6873,11 +6880,11 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1411
+#: lxc/network.go:791 lxc/network.go:1420
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1243
+#: lxc/network.go:1252
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
@@ -6922,7 +6929,7 @@ msgstr ""
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1182
+#: lxc/network.go:1191
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -6973,7 +6980,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2800
+#: lxc/storage_volume.go:2811
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7008,13 +7015,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:1958
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:806
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7022,51 +7029,51 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2551
+#: lxc/storage_volume.go:2562
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2634
+#: lxc/storage_volume.go:2645
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2415
+#: lxc/storage_volume.go:2426
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:609
+#: lxc/storage_volume.go:610
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:718
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2353
+#: lxc/storage_volume.go:2364
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2085
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2232
+#: lxc/storage_volume.go:2243
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1221
+#: lxc/storage_volume.go:1232
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1858
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:387
+#: lxc/storage_volume.go:388
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7172,7 +7179,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1601
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7184,7 +7191,7 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:891
+#: lxc/cluster.go:892
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -7256,7 +7263,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:772
+#: lxc/cluster.go:773
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7305,13 +7312,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1229
+#: lxc/config.go:1230
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1053
+#: lxc/config.go:1054
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7648,7 +7655,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:614
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7656,13 +7663,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2804
+#: lxc/storage_volume.go:2815
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2419
+#: lxc/storage_volume.go:2430
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-09 03:18-0300\n"
+"POT-Creation-Date: 2024-12-18 08:40-0700\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -50,7 +50,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1030
+#: lxc/storage_volume.go:1041
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -64,7 +64,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1240
+#: lxc/config.go:1241
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -413,7 +413,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:790
+#: lxc/cluster.go:791
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -586,13 +586,13 @@ msgstr ""
 msgid "Acknowledge warning"
 msgstr ""
 
+#: lxc/query.go:43
+msgid "Action"
+msgstr ""
+
 #: lxc/query.go:76
 #, c-format
 msgid "Action %q isn't supported by this tool"
-msgstr ""
-
-#: lxc/query.go:43
-msgid "Action (defaults to GET)"
 msgstr ""
 
 #: lxc/cluster_group.go:725
@@ -739,7 +739,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1596
+#: lxc/storage_volume.go:1607
 msgid "All projects"
 msgstr ""
 
@@ -761,7 +761,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1371
+#: lxc/cluster.go:1372
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -798,7 +798,7 @@ msgstr ""
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:282 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -850,16 +850,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2708
+#: lxc/storage_volume.go:2719
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2785
+#: lxc/export.go:192 lxc/storage_volume.go:2796
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1538
 msgid "Backups:"
 msgstr ""
 
@@ -880,7 +880,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -923,7 +923,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1739
+#: lxc/storage_volume.go:1750
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1008,7 +1008,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1016,7 +1016,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1097
+#: lxc/config.go:702 lxc/config.go:1098
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1025,12 +1025,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:492
+#: lxc/storage_volume.go:493
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:446
+#: lxc/storage_volume.go:447
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1106,7 +1106,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1154
+#: lxc/cluster.go:1155
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1134,8 +1134,8 @@ msgstr ""
 #: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
 #: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
-#: lxc/network_forward.go:182 lxc/network_forward.go:264
+#: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
+#: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
 #: lxc/network_forward.go:497 lxc/network_forward.go:649
 #: lxc/network_forward.go:803 lxc/network_forward.go:892
 #: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
@@ -1150,30 +1150,30 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
-#: lxc/storage_volume.go:1952 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2251 lxc/storage_volume.go:2367
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2555
-#: lxc/storage_volume.go:2643 lxc/storage_volume.go:2807
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
+#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
+#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:894
+#: lxc/cluster.go:895
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:926
+#: lxc/cluster.go:927
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:756
+#: lxc/cluster.go:757
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1210,24 +1210,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
+#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
-#: lxc/storage_volume.go:1188
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
+#: lxc/storage_volume.go:1199
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:619
+#: lxc/storage_volume.go:620
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1237,7 +1237,11 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/move.go:65
+#: lxc/move.go:65
+msgid "Copy a stateful instance as stateless"
+msgstr ""
+
+#: lxc/copy.go:60
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1285,7 +1289,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:389 lxc/storage_volume.go:390
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1293,12 +1297,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:396
+#: lxc/storage_volume.go:397
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:398
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1311,7 +1315,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:515
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1334,12 +1338,12 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1235
+#: lxc/cluster.go:1236
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1239
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1354,17 +1358,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1266
+#: lxc/cluster.go:1267
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1446,7 +1450,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1498,7 +1502,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1527,13 +1531,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1738
+#: lxc/storage_volume.go:1749
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1553,7 +1557,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2642
+#: lxc/storage_volume.go:2653
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1649,7 +1653,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1670,16 +1674,16 @@ msgstr ""
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
-#: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
+#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
+#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
-#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
-#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
+#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
+#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1702,8 +1706,8 @@ msgstr ""
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
 #: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1005 lxc/network.go:1106 lxc/network.go:1185
-#: lxc/network.go:1245 lxc/network.go:1341 lxc/network.go:1413
+#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
+#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
 #: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
 #: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
 #: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
@@ -1754,27 +1758,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
-#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
-#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
-#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1949
-#: lxc/storage_volume.go:2076 lxc/storage_volume.go:2234
-#: lxc/storage_volume.go:2355 lxc/storage_volume.go:2417
-#: lxc/storage_volume.go:2553 lxc/storage_volume.go:2636
-#: lxc/storage_volume.go:2802 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1454
+#: lxc/storage_volume.go:1465
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1786,11 +1790,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
+#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1918,7 +1922,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:516
+#: lxc/cluster.go:1072 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1940,7 +1944,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:769 lxc/cluster.go:770
+#: lxc/cluster.go:770 lxc/cluster.go:771
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1960,7 +1964,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1226 lxc/config.go:1227
+#: lxc/config.go:1227 lxc/config.go:1228
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2024,7 +2028,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2032,7 +2036,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2050,11 +2054,12 @@ msgid ""
 "new\n"
 "  LXD cluster, which will have the given name.\n"
 "\n"
-"  It's required that the LXD is already available on the network. You can "
-"check\n"
-"  that by running 'lxc config get core.https_address', and possibly set a "
-"value\n"
-"  for the address if not yet set."
+"  It's required that LXD is already available on the network. You can check\n"
+"  this by running 'lxc config get core.https_address'. If either an IP "
+"address\n"
+"  and port is displayed, or both, LXD is already available on the network. "
+"If\n"
+"  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
 #: lxc/network_zone.go:1427
@@ -2084,12 +2089,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
+#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2099,12 +2104,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
+#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
-#: lxc/storage_volume.go:2199
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
+#: lxc/storage_volume.go:2210
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2114,11 +2119,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1298 lxc/cluster.go:1299
+#: lxc/cluster.go:1299 lxc/cluster.go:1300
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1396
+#: lxc/cluster.go:1397
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2146,8 +2151,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
-#: lxc/storage_volume.go:1564
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Expires at"
 msgstr ""
 
@@ -2171,7 +2176,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2635 lxc/storage_volume.go:2636
+#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2183,11 +2188,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2639
+#: lxc/storage_volume.go:2650
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2768
+#: lxc/export.go:152 lxc/storage_volume.go:2779
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2367,7 +2372,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
+#: lxc/network.go:1046 lxc/network_acl.go:133 lxc/network_zone.go:124
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2377,7 +2382,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1303
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2385,7 +2390,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1301
+#: lxc/cluster.go:1302
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2397,7 +2402,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1331
+#: lxc/cluster.go:1332
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2438,16 +2443,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
-#: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1614 lxc/warning.go:94
+#: lxc/storage_volume.go:1625 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2507,7 +2512,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:996
+#: lxc/config.go:996 lxc/config.go:997
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2571,7 +2576,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1249
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2635,11 +2640,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
+#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:475
+#: lxc/storage_volume.go:476
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2667,7 +2672,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1161
+#: lxc/network.go:1170
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2721,7 +2726,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1163
+#: lxc/network.go:1172
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2733,11 +2738,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1084
+#: lxc/list.go:560 lxc/network.go:1093
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1085
+#: lxc/list.go:561 lxc/network.go:1094
 msgid "IPV6"
 msgstr ""
 
@@ -2767,7 +2772,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2427
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2781,7 +2786,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2437
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2831,7 +2836,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2802
+#: lxc/storage_volume.go:2813
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2839,7 +2844,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2801
+#: lxc/storage_volume.go:2812
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2861,11 +2866,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2809
+#: lxc/storage_volume.go:2820
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2883
+#: lxc/storage_volume.go:2894
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2909,7 +2914,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
+#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2991,7 +2996,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2012
+#: lxc/move.go:148 lxc/storage_volume.go:2023
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2999,7 +3004,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2019
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3017,9 +3022,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
-#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2144 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
+#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3063,9 +3068,9 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
+#: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3077,8 +3082,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1020 lxc/cluster.go:1123
-#: lxc/cluster.go:1231 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
+#: lxc/cluster.go:1232 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3115,7 +3120,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1105 lxc/network.go:1106
+#: lxc/network.go:1114 lxc/network.go:1115
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3127,7 +3132,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:976 lxc/cluster.go:977
+#: lxc/cluster.go:977 lxc/cluster.go:978
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -3175,7 +3180,7 @@ msgstr ""
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1004 lxc/network.go:1005
+#: lxc/network.go:1005 lxc/network.go:1006
 msgid "List available networks"
 msgstr ""
 
@@ -3263,7 +3268,7 @@ msgid ""
 "Fast column layout: nsacPt\n"
 "\n"
 "A single keyword like \"web\" which will list any instance with a name "
-"starting by \"web\".\n"
+"starting with \"web\".\n"
 "A regular expression on the instance name. (e.g. .*web.*01$).\n"
 "A key/value pair referring to a configuration item. For those, the\n"
 "namespace can be abbreviated to the smallest unambiguous identifier.\n"
@@ -3320,7 +3325,8 @@ msgid ""
 "  P - Profiles\n"
 "  s - State\n"
 "  S - Number of snapshots\n"
-"  t - Type (persistent or ephemeral)\n"
+"  t - Type (container or virtual-machine, ephemeral indicated if "
+"applicable)\n"
 "  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
@@ -3369,11 +3375,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1603
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1608
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3432,7 +3438,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1470
+#: lxc/info.go:489 lxc/storage_volume.go:1481
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3453,7 +3459,7 @@ msgstr ""
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1162
+#: lxc/network.go:1171
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3471,7 +3477,7 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1083
+#: lxc/network.go:1092
 msgid "MANAGED"
 msgstr ""
 
@@ -3594,7 +3600,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:955 lxc/config.go:956
+#: lxc/config.go:956 lxc/config.go:957
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3733,7 +3739,7 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:957
+#: lxc/cluster.go:958
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
@@ -3797,7 +3803,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:811 lxc/cluster.go:1367 lxc/cluster_group.go:129
+#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -3860,8 +3866,8 @@ msgstr ""
 
 #: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1139 lxc/network.go:1217 lxc/network.go:1283
-#: lxc/network.go:1375 lxc/network_forward.go:127 lxc/network_forward.go:215
+#: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
+#: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
 #: lxc/network_forward.go:284 lxc/network_forward.go:445
 #: lxc/network_forward.go:530 lxc/network_forward.go:705
 #: lxc/network_forward.go:836 lxc/network_forward.go:929
@@ -3902,12 +3908,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
-#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
-#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1986
-#: lxc/storage_volume.go:2127 lxc/storage_volume.go:2285
-#: lxc/storage_volume.go:2476 lxc/storage_volume.go:2593
+#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
+#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
 msgid "Missing pool name"
 msgstr ""
 
@@ -3926,11 +3932,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:438 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1411
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3967,8 +3973,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
-#: lxc/storage_volume.go:964
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
+#: lxc/storage_volume.go:975
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4005,7 +4011,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4013,11 +4019,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1856
+#: lxc/storage_volume.go:1867
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:518
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4039,12 +4045,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
+#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
 msgid "NAME"
 msgstr ""
 
@@ -4072,7 +4078,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
 #: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4096,8 +4102,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
-#: lxc/storage_volume.go:1562
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1573
 msgid "Name"
 msgstr ""
 
@@ -4105,7 +4111,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4130,7 +4136,7 @@ msgstr ""
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1227
+#: lxc/network.go:1236
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4240,7 +4246,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1161
+#: lxc/cluster.go:1162
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4249,7 +4255,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
+#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4269,11 +4275,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:502 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4287,7 +4293,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2035
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4295,15 +4301,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:343
+#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
+#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2690
+#: lxc/storage_volume.go:2701
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2489
+#: lxc/storage_volume.go:2500
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4315,11 +4322,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1418
+#: lxc/storage_volume.go:1429
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1298
+#: lxc/network.go:735 lxc/network.go:1307
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4328,7 +4335,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1577
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4358,7 +4365,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1767
 msgid "POOL"
 msgstr ""
 
@@ -4374,7 +4381,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1773
 #: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4420,7 +4427,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -4441,16 +4448,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
-#: lxc/storage_volume.go:1189
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
+#: lxc/storage_volume.go:1200
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4567,7 +4574,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1356
+#: lxc/storage_volume.go:1367
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4581,7 +4588,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1225
+#: lxc/storage_volume.go:1236
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4597,7 +4604,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2247
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4618,7 +4625,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1004
+#: lxc/storage_volume.go:1015
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4627,7 +4634,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2081
+#: lxc/storage_volume.go:2092
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4640,13 +4647,13 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2357
+#: lxc/storage_volume.go:2368
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
 "\n"
 "lxc storage volume unset default data size\n"
-"    Remotes the size/quota of a custom volume \"data\" in pool \"default\".\n"
+"    Removes the size/quota of a custom volume \"data\" in pool \"default\".\n"
 "\n"
 "lxc storage volume unset default virtual-machine/data snapshots.expiry\n"
 "    Removes the snapshot expiration period for a virtual machine \"data\" in "
@@ -4726,7 +4733,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4909,7 +4916,7 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1184 lxc/network.go:1185
+#: lxc/network.go:1193 lxc/network.go:1194
 msgid "Rename networks"
 msgstr ""
 
@@ -4925,15 +4932,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1949
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:1959
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2037 lxc/storage_volume.go:2057
+#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4943,11 +4950,11 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:892 lxc/cluster.go:893
+#: lxc/cluster.go:893 lxc/cluster.go:894
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1032
+#: lxc/config.go:1033
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -4970,7 +4977,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1328 lxc/cluster.go:1329
+#: lxc/cluster.go:1329 lxc/cluster.go:1330
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4985,11 +4992,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2552 lxc/storage_volume.go:2553
+#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1394
+#: lxc/cluster.go:1395
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5011,7 +5018,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1087
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5061,7 +5068,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1088
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1097
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5124,7 +5131,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1050 lxc/config.go:1051
+#: lxc/config.go:1051 lxc/config.go:1052
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5188,11 +5195,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1244
+#: lxc/network.go:1253
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1245
+#: lxc/network.go:1254
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5309,11 +5316,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2075
+#: lxc/storage_volume.go:2086
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2076
+#: lxc/storage_volume.go:2087
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5370,7 +5377,7 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1252
+#: lxc/network.go:1261
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5398,7 +5405,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2103
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5467,7 +5474,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1173
+#: lxc/config.go:1173 lxc/config.go:1174
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5499,7 +5506,7 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1340 lxc/network.go:1341
+#: lxc/network.go:1349 lxc/network.go:1350
 msgid "Show network configurations"
 msgstr ""
 
@@ -5547,11 +5554,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2233 lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5574,7 +5581,7 @@ msgid "Show the expanded configuration"
 msgstr ""
 
 #: lxc/info.go:43
-msgid "Show the instance's last 100 log lines?"
+msgid "Show the instance's last 100 log lines"
 msgstr ""
 
 #: lxc/info.go:44
@@ -5619,15 +5626,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2417
+#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2179
+#: lxc/storage_volume.go:2190
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1502
 msgid "Snapshots:"
 msgstr ""
 
@@ -5732,21 +5739,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:702
+#: lxc/storage_volume.go:703
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:790
+#: lxc/storage_volume.go:791
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:516
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:520
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5754,7 +5761,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5803,18 +5810,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1070 lxc/config_trust.go:515
+#: lxc/cluster.go:1071 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1736 lxc/warning.go:216
+#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1747 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
 msgid "Taken at"
 msgstr ""
 
@@ -5971,12 +5978,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1340
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1306
+#: lxc/storage_volume.go:1317
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -5995,8 +6002,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
-#: lxc/storage_volume.go:978
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:989
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6016,11 +6023,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:739
+#: lxc/cluster.go:740
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:729
+#: lxc/cluster.go:730
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6071,7 +6078,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6086,7 +6093,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1853
+#: lxc/storage_volume.go:1864
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6094,7 +6101,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:394
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6153,7 +6160,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1472
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6175,13 +6182,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:995 lxc/storage_volume.go:1752
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
+#: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1740
+#: lxc/storage.go:724 lxc/storage_volume.go:1751
 msgid "USED BY"
 msgstr ""
 
@@ -6213,7 +6220,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6239,7 +6246,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1141 lxc/config.go:1142
+#: lxc/config.go:1142 lxc/config.go:1143
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6267,7 +6274,7 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1412 lxc/network.go:1413
+#: lxc/network.go:1421 lxc/network.go:1422
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -6319,7 +6326,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2354 lxc/storage_volume.go:2355
+#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6343,7 +6350,7 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1417
+#: lxc/network.go:1426
 msgid "Unset the key as a network property"
 msgstr ""
 
@@ -6371,7 +6378,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2379
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6379,7 +6386,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:247
+#: lxc/storage_volume.go:248
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6392,11 +6399,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1174
+#: lxc/cluster.go:1175
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1176
+#: lxc/cluster.go:1177
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6415,12 +6422,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2641
+#: lxc/export.go:42 lxc/storage_volume.go:2652
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6487,7 +6494,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1576
 msgid "Volume Only"
 msgstr ""
 
@@ -6520,7 +6527,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
 #: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6546,18 +6553,18 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:903
+#: lxc/storage_volume.go:909
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:281
+#: lxc/storage_volume.go:282
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
-#: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
+#: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
@@ -6567,7 +6574,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1172
+#: lxc/cluster.go:1173
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -6730,7 +6737,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6752,11 +6759,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:1140
+#: lxc/config.go:995 lxc/config.go:1141
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1049
+#: lxc/config.go:1050
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -6835,8 +6842,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:768
-#: lxc/cluster.go:1085 lxc/cluster.go:1297 lxc/cluster.go:1327
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
+#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -6860,8 +6867,8 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1104
-#: lxc/network.go:1339 lxc/network_forward.go:87
+#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1113
+#: lxc/network.go:1348 lxc/network_forward.go:87
 #: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -6874,11 +6881,11 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1411
+#: lxc/network.go:791 lxc/network.go:1420
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1243
+#: lxc/network.go:1252
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
@@ -6923,7 +6930,7 @@ msgstr ""
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1182
+#: lxc/network.go:1191
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -6974,7 +6981,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2800
+#: lxc/storage_volume.go:2811
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7009,13 +7016,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:1958
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:806
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7023,51 +7030,51 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2551
+#: lxc/storage_volume.go:2562
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2634
+#: lxc/storage_volume.go:2645
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2415
+#: lxc/storage_volume.go:2426
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:609
+#: lxc/storage_volume.go:610
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:718
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2353
+#: lxc/storage_volume.go:2364
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2085
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2232
+#: lxc/storage_volume.go:2243
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1221
+#: lxc/storage_volume.go:1232
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1858
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:387
+#: lxc/storage_volume.go:388
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7173,7 +7180,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1601
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7185,7 +7192,7 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:891
+#: lxc/cluster.go:892
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -7257,7 +7264,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:772
+#: lxc/cluster.go:773
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7306,13 +7313,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1229
+#: lxc/config.go:1230
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1053
+#: lxc/config.go:1054
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7649,7 +7656,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:614
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7657,13 +7664,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2804
+#: lxc/storage_volume.go:2815
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2419
+#: lxc/storage_volume.go:2430
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-09 03:18-0300\n"
+"POT-Creation-Date: 2024-12-18 08:40-0700\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -73,7 +73,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:1030
+#: lxc/storage_volume.go:1041
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -97,7 +97,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/config.go:1240
+#: lxc/config.go:1241
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -573,7 +573,7 @@ msgstr ""
 "###\n"
 "### Note that the name is shown but cannot be changed"
 
-#: lxc/cluster.go:790
+#: lxc/cluster.go:791
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -746,13 +746,13 @@ msgstr ""
 msgid "Acknowledge warning"
 msgstr ""
 
+#: lxc/query.go:43
+msgid "Action"
+msgstr ""
+
 #: lxc/query.go:76
 #, c-format
 msgid "Action %q isn't supported by this tool"
-msgstr ""
-
-#: lxc/query.go:43
-msgid "Action (defaults to GET)"
 msgstr ""
 
 #: lxc/cluster_group.go:725
@@ -899,7 +899,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1596
+#: lxc/storage_volume.go:1607
 msgid "All projects"
 msgstr ""
 
@@ -921,7 +921,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1371
+#: lxc/cluster.go:1372
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -958,7 +958,7 @@ msgstr ""
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:282 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -1010,16 +1010,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2708
+#: lxc/storage_volume.go:2719
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2785
+#: lxc/export.go:192 lxc/storage_volume.go:2796
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1538
 msgid "Backups:"
 msgstr ""
 
@@ -1040,7 +1040,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1083,7 +1083,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1739
+#: lxc/storage_volume.go:1750
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1168,7 +1168,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1176,7 +1176,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1097
+#: lxc/config.go:702 lxc/config.go:1098
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1185,12 +1185,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:492
+#: lxc/storage_volume.go:493
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:446
+#: lxc/storage_volume.go:447
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1266,7 +1266,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1154
+#: lxc/cluster.go:1155
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1294,8 +1294,8 @@ msgstr ""
 #: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
 #: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
-#: lxc/network_forward.go:182 lxc/network_forward.go:264
+#: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
+#: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
 #: lxc/network_forward.go:497 lxc/network_forward.go:649
 #: lxc/network_forward.go:803 lxc/network_forward.go:892
 #: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
@@ -1310,30 +1310,30 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
-#: lxc/storage_volume.go:1952 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2251 lxc/storage_volume.go:2367
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2555
-#: lxc/storage_volume.go:2643 lxc/storage_volume.go:2807
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
+#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
+#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:894
+#: lxc/cluster.go:895
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:926
+#: lxc/cluster.go:927
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:756
+#: lxc/cluster.go:757
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1370,24 +1370,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
+#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
-#: lxc/storage_volume.go:1188
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
+#: lxc/storage_volume.go:1199
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:619
+#: lxc/storage_volume.go:620
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1397,7 +1397,11 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/move.go:65
+#: lxc/move.go:65
+msgid "Copy a stateful instance as stateless"
+msgstr ""
+
+#: lxc/copy.go:60
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1445,7 +1449,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:389 lxc/storage_volume.go:390
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1453,12 +1457,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:396
+#: lxc/storage_volume.go:397
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:398
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1471,7 +1475,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:515
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1494,12 +1498,12 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1235
+#: lxc/cluster.go:1236
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1239
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1514,17 +1518,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1266
+#: lxc/cluster.go:1267
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1606,7 +1610,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1658,7 +1662,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1687,13 +1691,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1738
+#: lxc/storage_volume.go:1749
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1713,7 +1717,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2642
+#: lxc/storage_volume.go:2653
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1809,7 +1813,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1830,16 +1834,16 @@ msgstr ""
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
-#: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
+#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
+#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
-#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
-#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
+#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
+#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1862,8 +1866,8 @@ msgstr ""
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
 #: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1005 lxc/network.go:1106 lxc/network.go:1185
-#: lxc/network.go:1245 lxc/network.go:1341 lxc/network.go:1413
+#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
+#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
 #: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
 #: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
 #: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
@@ -1914,27 +1918,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
-#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
-#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
-#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1949
-#: lxc/storage_volume.go:2076 lxc/storage_volume.go:2234
-#: lxc/storage_volume.go:2355 lxc/storage_volume.go:2417
-#: lxc/storage_volume.go:2553 lxc/storage_volume.go:2636
-#: lxc/storage_volume.go:2802 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1454
+#: lxc/storage_volume.go:1465
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1946,11 +1950,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
+#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2078,7 +2082,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:516
+#: lxc/cluster.go:1072 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -2100,7 +2104,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:769 lxc/cluster.go:770
+#: lxc/cluster.go:770 lxc/cluster.go:771
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2120,7 +2124,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1226 lxc/config.go:1227
+#: lxc/config.go:1227 lxc/config.go:1228
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2184,7 +2188,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2192,7 +2196,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2210,11 +2214,12 @@ msgid ""
 "new\n"
 "  LXD cluster, which will have the given name.\n"
 "\n"
-"  It's required that the LXD is already available on the network. You can "
-"check\n"
-"  that by running 'lxc config get core.https_address', and possibly set a "
-"value\n"
-"  for the address if not yet set."
+"  It's required that LXD is already available on the network. You can check\n"
+"  this by running 'lxc config get core.https_address'. If either an IP "
+"address\n"
+"  and port is displayed, or both, LXD is already available on the network. "
+"If\n"
+"  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
 #: lxc/network_zone.go:1427
@@ -2244,12 +2249,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
+#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2259,12 +2264,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
+#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
-#: lxc/storage_volume.go:2199
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
+#: lxc/storage_volume.go:2210
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2274,11 +2279,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1298 lxc/cluster.go:1299
+#: lxc/cluster.go:1299 lxc/cluster.go:1300
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1396
+#: lxc/cluster.go:1397
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2306,8 +2311,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
-#: lxc/storage_volume.go:1564
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Expires at"
 msgstr ""
 
@@ -2331,7 +2336,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2635 lxc/storage_volume.go:2636
+#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2343,11 +2348,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2639
+#: lxc/storage_volume.go:2650
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2768
+#: lxc/export.go:152 lxc/storage_volume.go:2779
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2527,7 +2532,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
+#: lxc/network.go:1046 lxc/network_acl.go:133 lxc/network_zone.go:124
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2537,7 +2542,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1303
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2545,7 +2550,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1301
+#: lxc/cluster.go:1302
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2557,7 +2562,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1331
+#: lxc/cluster.go:1332
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2598,16 +2603,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
-#: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1614 lxc/warning.go:94
+#: lxc/storage_volume.go:1625 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2667,7 +2672,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:996
+#: lxc/config.go:996 lxc/config.go:997
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2731,7 +2736,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1249
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2795,11 +2800,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
+#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:475
+#: lxc/storage_volume.go:476
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2827,7 +2832,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1161
+#: lxc/network.go:1170
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2881,7 +2886,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1163
+#: lxc/network.go:1172
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2893,11 +2898,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1084
+#: lxc/list.go:560 lxc/network.go:1093
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1085
+#: lxc/list.go:561 lxc/network.go:1094
 msgid "IPV6"
 msgstr ""
 
@@ -2927,7 +2932,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2427
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2941,7 +2946,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2437
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2991,7 +2996,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2802
+#: lxc/storage_volume.go:2813
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2999,7 +3004,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2801
+#: lxc/storage_volume.go:2812
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -3021,11 +3026,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2809
+#: lxc/storage_volume.go:2820
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2883
+#: lxc/storage_volume.go:2894
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -3069,7 +3074,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
+#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -3151,7 +3156,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2012
+#: lxc/move.go:148 lxc/storage_volume.go:2023
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -3159,7 +3164,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2019
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3177,9 +3182,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
-#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2144 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
+#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3223,9 +3228,9 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
+#: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3237,8 +3242,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1020 lxc/cluster.go:1123
-#: lxc/cluster.go:1231 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
+#: lxc/cluster.go:1232 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3275,7 +3280,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1105 lxc/network.go:1106
+#: lxc/network.go:1114 lxc/network.go:1115
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3287,7 +3292,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:976 lxc/cluster.go:977
+#: lxc/cluster.go:977 lxc/cluster.go:978
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -3335,7 +3340,7 @@ msgstr ""
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1004 lxc/network.go:1005
+#: lxc/network.go:1005 lxc/network.go:1006
 msgid "List available networks"
 msgstr ""
 
@@ -3423,7 +3428,7 @@ msgid ""
 "Fast column layout: nsacPt\n"
 "\n"
 "A single keyword like \"web\" which will list any instance with a name "
-"starting by \"web\".\n"
+"starting with \"web\".\n"
 "A regular expression on the instance name. (e.g. .*web.*01$).\n"
 "A key/value pair referring to a configuration item. For those, the\n"
 "namespace can be abbreviated to the smallest unambiguous identifier.\n"
@@ -3480,7 +3485,8 @@ msgid ""
 "  P - Profiles\n"
 "  s - State\n"
 "  S - Number of snapshots\n"
-"  t - Type (persistent or ephemeral)\n"
+"  t - Type (container or virtual-machine, ephemeral indicated if "
+"applicable)\n"
 "  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
@@ -3529,11 +3535,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1603
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1608
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3592,7 +3598,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1470
+#: lxc/info.go:489 lxc/storage_volume.go:1481
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3613,7 +3619,7 @@ msgstr ""
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1162
+#: lxc/network.go:1171
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3631,7 +3637,7 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1083
+#: lxc/network.go:1092
 msgid "MANAGED"
 msgstr ""
 
@@ -3754,7 +3760,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:955 lxc/config.go:956
+#: lxc/config.go:956 lxc/config.go:957
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3893,7 +3899,7 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:957
+#: lxc/cluster.go:958
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
@@ -3957,7 +3963,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:811 lxc/cluster.go:1367 lxc/cluster_group.go:129
+#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -4020,8 +4026,8 @@ msgstr ""
 
 #: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1139 lxc/network.go:1217 lxc/network.go:1283
-#: lxc/network.go:1375 lxc/network_forward.go:127 lxc/network_forward.go:215
+#: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
+#: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
 #: lxc/network_forward.go:284 lxc/network_forward.go:445
 #: lxc/network_forward.go:530 lxc/network_forward.go:705
 #: lxc/network_forward.go:836 lxc/network_forward.go:929
@@ -4062,12 +4068,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
-#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
-#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1986
-#: lxc/storage_volume.go:2127 lxc/storage_volume.go:2285
-#: lxc/storage_volume.go:2476 lxc/storage_volume.go:2593
+#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
+#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
 msgid "Missing pool name"
 msgstr ""
 
@@ -4086,11 +4092,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:438 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1411
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -4127,8 +4133,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
-#: lxc/storage_volume.go:964
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
+#: lxc/storage_volume.go:975
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4165,7 +4171,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4173,11 +4179,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1856
+#: lxc/storage_volume.go:1867
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:518
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4199,12 +4205,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
+#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
 msgid "NAME"
 msgstr ""
 
@@ -4232,7 +4238,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
 #: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4256,8 +4262,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
-#: lxc/storage_volume.go:1562
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1573
 msgid "Name"
 msgstr ""
 
@@ -4265,7 +4271,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4290,7 +4296,7 @@ msgstr ""
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1227
+#: lxc/network.go:1236
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4400,7 +4406,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1161
+#: lxc/cluster.go:1162
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4409,7 +4415,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
+#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4429,11 +4435,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:502 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4447,7 +4453,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2035
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4455,15 +4461,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:343
+#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
+#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2690
+#: lxc/storage_volume.go:2701
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2489
+#: lxc/storage_volume.go:2500
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4475,11 +4482,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1418
+#: lxc/storage_volume.go:1429
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1298
+#: lxc/network.go:735 lxc/network.go:1307
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4488,7 +4495,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1577
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4518,7 +4525,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1767
 msgid "POOL"
 msgstr ""
 
@@ -4534,7 +4541,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1773
 #: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4580,7 +4587,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -4601,16 +4608,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
-#: lxc/storage_volume.go:1189
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
+#: lxc/storage_volume.go:1200
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4727,7 +4734,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1356
+#: lxc/storage_volume.go:1367
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4741,7 +4748,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1225
+#: lxc/storage_volume.go:1236
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4757,7 +4764,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2247
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4778,7 +4785,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1004
+#: lxc/storage_volume.go:1015
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4787,7 +4794,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2081
+#: lxc/storage_volume.go:2092
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4800,13 +4807,13 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2357
+#: lxc/storage_volume.go:2368
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
 "\n"
 "lxc storage volume unset default data size\n"
-"    Remotes the size/quota of a custom volume \"data\" in pool \"default\".\n"
+"    Removes the size/quota of a custom volume \"data\" in pool \"default\".\n"
 "\n"
 "lxc storage volume unset default virtual-machine/data snapshots.expiry\n"
 "    Removes the snapshot expiration period for a virtual machine \"data\" in "
@@ -4886,7 +4893,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -5069,7 +5076,7 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1184 lxc/network.go:1185
+#: lxc/network.go:1193 lxc/network.go:1194
 msgid "Rename networks"
 msgstr ""
 
@@ -5085,15 +5092,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1949
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:1959
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2037 lxc/storage_volume.go:2057
+#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -5103,11 +5110,11 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:892 lxc/cluster.go:893
+#: lxc/cluster.go:893 lxc/cluster.go:894
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1032
+#: lxc/config.go:1033
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -5130,7 +5137,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1328 lxc/cluster.go:1329
+#: lxc/cluster.go:1329 lxc/cluster.go:1330
 msgid "Restore cluster member"
 msgstr ""
 
@@ -5145,11 +5152,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2552 lxc/storage_volume.go:2553
+#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1394
+#: lxc/cluster.go:1395
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5171,7 +5178,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1087
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5221,7 +5228,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1088
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1097
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5284,7 +5291,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1050 lxc/config.go:1051
+#: lxc/config.go:1051 lxc/config.go:1052
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5348,11 +5355,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1244
+#: lxc/network.go:1253
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1245
+#: lxc/network.go:1254
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5469,11 +5476,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2075
+#: lxc/storage_volume.go:2086
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2076
+#: lxc/storage_volume.go:2087
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5530,7 +5537,7 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1252
+#: lxc/network.go:1261
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5558,7 +5565,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2103
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5627,7 +5634,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1173
+#: lxc/config.go:1173 lxc/config.go:1174
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5659,7 +5666,7 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1340 lxc/network.go:1341
+#: lxc/network.go:1349 lxc/network.go:1350
 msgid "Show network configurations"
 msgstr ""
 
@@ -5707,11 +5714,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2233 lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5734,7 +5741,7 @@ msgid "Show the expanded configuration"
 msgstr ""
 
 #: lxc/info.go:43
-msgid "Show the instance's last 100 log lines?"
+msgid "Show the instance's last 100 log lines"
 msgstr ""
 
 #: lxc/info.go:44
@@ -5779,15 +5786,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2417
+#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2179
+#: lxc/storage_volume.go:2190
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1502
 msgid "Snapshots:"
 msgstr ""
 
@@ -5892,21 +5899,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:702
+#: lxc/storage_volume.go:703
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:790
+#: lxc/storage_volume.go:791
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:516
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:520
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5914,7 +5921,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5963,18 +5970,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1070 lxc/config_trust.go:515
+#: lxc/cluster.go:1071 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1736 lxc/warning.go:216
+#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1747 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
 msgid "Taken at"
 msgstr ""
 
@@ -6131,12 +6138,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1340
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1306
+#: lxc/storage_volume.go:1317
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -6155,8 +6162,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
-#: lxc/storage_volume.go:978
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:989
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6176,11 +6183,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:739
+#: lxc/cluster.go:740
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:729
+#: lxc/cluster.go:730
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6231,7 +6238,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6246,7 +6253,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1853
+#: lxc/storage_volume.go:1864
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6254,7 +6261,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:394
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6313,7 +6320,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1472
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6335,13 +6342,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:995 lxc/storage_volume.go:1752
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
+#: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1740
+#: lxc/storage.go:724 lxc/storage_volume.go:1751
 msgid "USED BY"
 msgstr ""
 
@@ -6373,7 +6380,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6399,7 +6406,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1141 lxc/config.go:1142
+#: lxc/config.go:1142 lxc/config.go:1143
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6427,7 +6434,7 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1412 lxc/network.go:1413
+#: lxc/network.go:1421 lxc/network.go:1422
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -6479,7 +6486,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2354 lxc/storage_volume.go:2355
+#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6503,7 +6510,7 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1417
+#: lxc/network.go:1426
 msgid "Unset the key as a network property"
 msgstr ""
 
@@ -6531,7 +6538,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2379
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6539,7 +6546,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:247
+#: lxc/storage_volume.go:248
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6552,11 +6559,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1174
+#: lxc/cluster.go:1175
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1176
+#: lxc/cluster.go:1177
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6575,12 +6582,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2641
+#: lxc/export.go:42 lxc/storage_volume.go:2652
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6647,7 +6654,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1576
 msgid "Volume Only"
 msgstr ""
 
@@ -6680,7 +6687,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
 #: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6706,18 +6713,18 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:903
+#: lxc/storage_volume.go:909
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:281
+#: lxc/storage_volume.go:282
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
-#: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
+#: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
@@ -6727,7 +6734,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1172
+#: lxc/cluster.go:1173
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -6890,7 +6897,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6912,11 +6919,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:1140
+#: lxc/config.go:995 lxc/config.go:1141
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1049
+#: lxc/config.go:1050
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -6995,8 +7002,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:768
-#: lxc/cluster.go:1085 lxc/cluster.go:1297 lxc/cluster.go:1327
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
+#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -7020,8 +7027,8 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1104
-#: lxc/network.go:1339 lxc/network_forward.go:87
+#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1113
+#: lxc/network.go:1348 lxc/network_forward.go:87
 #: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -7034,11 +7041,11 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1411
+#: lxc/network.go:791 lxc/network.go:1420
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1243
+#: lxc/network.go:1252
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
@@ -7083,7 +7090,7 @@ msgstr ""
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1182
+#: lxc/network.go:1191
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -7134,7 +7141,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2800
+#: lxc/storage_volume.go:2811
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7169,13 +7176,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:1958
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:806
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7183,51 +7190,51 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2551
+#: lxc/storage_volume.go:2562
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2634
+#: lxc/storage_volume.go:2645
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2415
+#: lxc/storage_volume.go:2426
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:609
+#: lxc/storage_volume.go:610
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:718
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2353
+#: lxc/storage_volume.go:2364
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2085
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2232
+#: lxc/storage_volume.go:2243
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1221
+#: lxc/storage_volume.go:1232
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1858
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:387
+#: lxc/storage_volume.go:388
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7333,7 +7340,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1601
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7345,7 +7352,7 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:891
+#: lxc/cluster.go:892
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -7417,7 +7424,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:772
+#: lxc/cluster.go:773
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7466,13 +7473,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1229
+#: lxc/config.go:1230
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1053
+#: lxc/config.go:1054
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7809,7 +7816,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:614
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7817,13 +7824,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2804
+#: lxc/storage_volume.go:2815
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2419
+#: lxc/storage_volume.go:2430
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-09 03:18-0300\n"
+"POT-Creation-Date: 2024-12-18 08:40-0700\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:1030
+#: lxc/storage_volume.go:1041
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -63,7 +63,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:1240
+#: lxc/config.go:1241
 msgid ""
 "### This is a YAML representation of the UEFI variables configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -412,7 +412,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:790
+#: lxc/cluster.go:791
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -585,13 +585,13 @@ msgstr ""
 msgid "Acknowledge warning"
 msgstr ""
 
+#: lxc/query.go:43
+msgid "Action"
+msgstr ""
+
 #: lxc/query.go:76
 #, c-format
 msgid "Action %q isn't supported by this tool"
-msgstr ""
-
-#: lxc/query.go:43
-msgid "Action (defaults to GET)"
 msgstr ""
 
 #: lxc/cluster_group.go:725
@@ -738,7 +738,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1596
+#: lxc/storage_volume.go:1607
 msgid "All projects"
 msgstr ""
 
@@ -760,7 +760,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1371
+#: lxc/cluster.go:1372
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -797,7 +797,7 @@ msgstr ""
 msgid "Attach new storage volumes to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:282 lxc/storage_volume.go:283
+#: lxc/storage_volume.go:283 lxc/storage_volume.go:284
 msgid "Attach new storage volumes to profiles"
 msgstr ""
 
@@ -849,16 +849,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2708
+#: lxc/storage_volume.go:2719
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:192 lxc/storage_volume.go:2785
+#: lxc/export.go:192 lxc/storage_volume.go:2796
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:666 lxc/storage_volume.go:1527
+#: lxc/info.go:666 lxc/storage_volume.go:1538
 msgid "Backups:"
 msgstr ""
 
@@ -879,7 +879,7 @@ msgstr ""
 msgid "Bad key=value pair: %q"
 msgstr ""
 
-#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:685
+#: lxc/publish.go:193 lxc/storage.go:162 lxc/storage_volume.go:686
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -922,7 +922,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1739
+#: lxc/storage_volume.go:1750
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1007,7 +1007,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:610 lxc/storage_volume.go:1749 lxc/warning.go:225
+#: lxc/list.go:610 lxc/storage_volume.go:1760 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1015,7 +1015,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:702 lxc/config.go:1097
+#: lxc/config.go:702 lxc/config.go:1098
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -1024,12 +1024,12 @@ msgstr ""
 msgid "Can't use an image with --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:492
+#: lxc/storage_volume.go:493
 msgid ""
 "Cannot set --destination-target when destination server is not clustered"
 msgstr ""
 
-#: lxc/storage_volume.go:446
+#: lxc/storage_volume.go:447
 msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
@@ -1105,7 +1105,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:1154
+#: lxc/cluster.go:1155
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1133,8 +1133,8 @@ msgstr ""
 #: lxc/config.go:106 lxc/config.go:398 lxc/config.go:554 lxc/config.go:776
 #: lxc/config.go:907 lxc/copy.go:62 lxc/info.go:45 lxc/init.go:65
 #: lxc/move.go:67 lxc/network.go:325 lxc/network.go:796 lxc/network.go:877
-#: lxc/network.go:1251 lxc/network.go:1344 lxc/network.go:1416
-#: lxc/network_forward.go:182 lxc/network_forward.go:264
+#: lxc/network.go:1011 lxc/network.go:1260 lxc/network.go:1353
+#: lxc/network.go:1425 lxc/network_forward.go:182 lxc/network_forward.go:264
 #: lxc/network_forward.go:497 lxc/network_forward.go:649
 #: lxc/network_forward.go:803 lxc/network_forward.go:892
 #: lxc/network_forward.go:974 lxc/network_load_balancer.go:184
@@ -1149,30 +1149,30 @@ msgstr ""
 #: lxc/storage_bucket.go:635 lxc/storage_bucket.go:701
 #: lxc/storage_bucket.go:776 lxc/storage_bucket.go:862
 #: lxc/storage_bucket.go:962 lxc/storage_bucket.go:1027
-#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:394
-#: lxc/storage_volume.go:618 lxc/storage_volume.go:723
-#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1237
-#: lxc/storage_volume.go:1366 lxc/storage_volume.go:1854
-#: lxc/storage_volume.go:1952 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2251 lxc/storage_volume.go:2367
-#: lxc/storage_volume.go:2428 lxc/storage_volume.go:2555
-#: lxc/storage_volume.go:2643 lxc/storage_volume.go:2807
+#: lxc/storage_bucket.go:1163 lxc/storage_volume.go:395
+#: lxc/storage_volume.go:619 lxc/storage_volume.go:724
+#: lxc/storage_volume.go:1022 lxc/storage_volume.go:1248
+#: lxc/storage_volume.go:1377 lxc/storage_volume.go:1865
+#: lxc/storage_volume.go:1963 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2262 lxc/storage_volume.go:2378
+#: lxc/storage_volume.go:2439 lxc/storage_volume.go:2566
+#: lxc/storage_volume.go:2654 lxc/storage_volume.go:2818
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:894
+#: lxc/cluster.go:895
 msgid "Cluster member name (alternative to passing it as an argument)"
 msgstr ""
 
-#: lxc/cluster.go:926
+#: lxc/cluster.go:927
 msgid "Cluster member name was provided as both a flag and as an argument"
 msgstr ""
 
-#: lxc/cluster.go:756
+#: lxc/cluster.go:757
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1595
+#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1606
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1209,24 +1209,24 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:859 lxc/cluster_group.go:397 lxc/config.go:281
-#: lxc/config.go:356 lxc/config.go:1340 lxc/config_metadata.go:156
+#: lxc/cluster.go:860 lxc/cluster_group.go:397 lxc/config.go:281
+#: lxc/config.go:356 lxc/config.go:1341 lxc/config_metadata.go:156
 #: lxc/config_trust.go:314 lxc/image.go:491 lxc/network.go:759
 #: lxc/network_acl.go:698 lxc/network_forward.go:767
 #: lxc/network_load_balancer.go:738 lxc/network_peer.go:698
 #: lxc/network_zone.go:621 lxc/network_zone.go:1316 lxc/profile.go:595
 #: lxc/project.go:364 lxc/storage.go:359 lxc/storage_bucket.go:349
-#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1156
-#: lxc/storage_volume.go:1188
+#: lxc/storage_bucket.go:1126 lxc/storage_volume.go:1167
+#: lxc/storage_volume.go:1199
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:619
+#: lxc/storage_volume.go:620
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1467
+#: lxc/storage_volume.go:1478
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1236,7 +1236,11 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:60 lxc/move.go:65
+#: lxc/move.go:65
+msgid "Copy a stateful instance as stateless"
+msgstr ""
+
+#: lxc/copy.go:60
 msgid "Copy a stateful instance stateless"
 msgstr ""
 
@@ -1284,7 +1288,7 @@ msgstr ""
 msgid "Copy profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:389 lxc/storage_volume.go:390
+#: lxc/storage_volume.go:390 lxc/storage_volume.go:391
 msgid "Copy storage volumes"
 msgstr ""
 
@@ -1292,12 +1296,12 @@ msgstr ""
 msgid "Copy the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:396
+#: lxc/storage_volume.go:397
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
 #: lxc/copy.go:63 lxc/image.go:171 lxc/move.go:68 lxc/profile.go:273
-#: lxc/storage_volume.go:397
+#: lxc/storage_volume.go:398
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -1310,7 +1314,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:514
+#: lxc/storage_volume.go:515
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1333,12 +1337,12 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1235
+#: lxc/cluster.go:1236
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1239
+#: lxc/cluster.go:1240
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
@@ -1353,17 +1357,17 @@ msgstr ""
 msgid "Could not parse identity: %s"
 msgstr ""
 
-#: lxc/cluster.go:1244
+#: lxc/cluster.go:1245
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1249
+#: lxc/cluster.go:1250
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1266
+#: lxc/cluster.go:1267
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1445,7 +1449,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:610 lxc/storage_volume.go:611
+#: lxc/storage_volume.go:611 lxc/storage_volume.go:612
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1497,7 +1501,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1481
+#: lxc/image.go:1023 lxc/info.go:497 lxc/storage_volume.go:1492
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1526,13 +1530,13 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
 #: lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723
 #: lxc/storage_bucket.go:513 lxc/storage_bucket.go:833
-#: lxc/storage_volume.go:1738
+#: lxc/storage_volume.go:1749
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1552,7 +1556,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2642
+#: lxc/storage_volume.go:2653
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1648,7 +1652,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:719 lxc/storage_volume.go:720
+#: lxc/storage_volume.go:720 lxc/storage_volume.go:721
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1669,16 +1673,16 @@ msgstr ""
 #: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
-#: lxc/cluster.go:770 lxc/cluster.go:893 lxc/cluster.go:977 lxc/cluster.go:1087
-#: lxc/cluster.go:1175 lxc/cluster.go:1299 lxc/cluster.go:1329
+#: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
+#: lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330
 #: lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170
 #: lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440
 #: lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663
 #: lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51
 #: lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393
-#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:956
-#: lxc/config.go:996 lxc/config.go:1051 lxc/config.go:1142 lxc/config.go:1173
-#: lxc/config.go:1227 lxc/config_device.go:25 lxc/config_device.go:79
+#: lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957
+#: lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174
+#: lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79
 #: lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409
 #: lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634
 #: lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28
@@ -1701,8 +1705,8 @@ msgstr ""
 #: lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136
 #: lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463
 #: lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874
-#: lxc/network.go:1005 lxc/network.go:1106 lxc/network.go:1185
-#: lxc/network.go:1245 lxc/network.go:1341 lxc/network.go:1413
+#: lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194
+#: lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422
 #: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174
 #: lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364
 #: lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592
@@ -1753,27 +1757,27 @@ msgstr ""
 #: lxc/storage_bucket.go:774 lxc/storage_bucket.go:853
 #: lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023
 #: lxc/storage_bucket.go:1158 lxc/storage_volume.go:58
-#: lxc/storage_volume.go:169 lxc/storage_volume.go:283
-#: lxc/storage_volume.go:390 lxc/storage_volume.go:611
-#: lxc/storage_volume.go:720 lxc/storage_volume.go:807
-#: lxc/storage_volume.go:905 lxc/storage_volume.go:1002
-#: lxc/storage_volume.go:1223 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1513 lxc/storage_volume.go:1597
-#: lxc/storage_volume.go:1850 lxc/storage_volume.go:1949
-#: lxc/storage_volume.go:2076 lxc/storage_volume.go:2234
-#: lxc/storage_volume.go:2355 lxc/storage_volume.go:2417
-#: lxc/storage_volume.go:2553 lxc/storage_volume.go:2636
-#: lxc/storage_volume.go:2802 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:169 lxc/storage_volume.go:284
+#: lxc/storage_volume.go:391 lxc/storage_volume.go:612
+#: lxc/storage_volume.go:721 lxc/storage_volume.go:808
+#: lxc/storage_volume.go:911 lxc/storage_volume.go:1013
+#: lxc/storage_volume.go:1234 lxc/storage_volume.go:1365
+#: lxc/storage_volume.go:1524 lxc/storage_volume.go:1608
+#: lxc/storage_volume.go:1861 lxc/storage_volume.go:1960
+#: lxc/storage_volume.go:2087 lxc/storage_volume.go:2245
+#: lxc/storage_volume.go:2366 lxc/storage_volume.go:2428
+#: lxc/storage_volume.go:2564 lxc/storage_volume.go:2647
+#: lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1454
+#: lxc/storage_volume.go:1465
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:395 lxc/storage_volume.go:1855
+#: lxc/storage_volume.go:396 lxc/storage_volume.go:1866
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1785,11 +1789,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:806 lxc/storage_volume.go:807
+#: lxc/storage_volume.go:807 lxc/storage_volume.go:808
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:904 lxc/storage_volume.go:905
+#: lxc/storage_volume.go:910 lxc/storage_volume.go:911
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1917,7 +1921,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/config_trust.go:516
+#: lxc/cluster.go:1072 lxc/config_trust.go:516
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1939,7 +1943,7 @@ msgstr ""
 msgid "Edit an identity as YAML"
 msgstr ""
 
-#: lxc/cluster.go:769 lxc/cluster.go:770
+#: lxc/cluster.go:770 lxc/cluster.go:771
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1959,7 +1963,7 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/config.go:1226 lxc/config.go:1227
+#: lxc/config.go:1227 lxc/config.go:1228
 msgid "Edit instance UEFI variables"
 msgstr ""
 
@@ -2023,7 +2027,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:1001 lxc/storage_volume.go:1002
+#: lxc/storage_volume.go:1012 lxc/storage_volume.go:1013
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2031,7 +2035,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1772
+#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1783
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2049,11 +2053,12 @@ msgid ""
 "new\n"
 "  LXD cluster, which will have the given name.\n"
 "\n"
-"  It's required that the LXD is already available on the network. You can "
-"check\n"
-"  that by running 'lxc config get core.https_address', and possibly set a "
-"value\n"
-"  for the address if not yet set."
+"  It's required that LXD is already available on the network. You can check\n"
+"  this by running 'lxc config get core.https_address'. If either an IP "
+"address\n"
+"  and port is displayed, or both, LXD is already available on the network. "
+"If\n"
+"  no value is set, use 'lxc config set core.https_address' to set it."
 msgstr ""
 
 #: lxc/network_zone.go:1427
@@ -2083,12 +2088,12 @@ msgstr ""
 msgid "Error retrieving aliases: %w"
 msgstr ""
 
-#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1319
+#: lxc/cluster.go:459 lxc/config.go:662 lxc/config.go:694 lxc/network.go:1328
 #: lxc/network_acl.go:524 lxc/network_forward.go:572
 #: lxc/network_load_balancer.go:559 lxc/network_peer.go:522
 #: lxc/network_zone.go:459 lxc/network_zone.go:1147 lxc/profile.go:987
 #: lxc/project.go:720 lxc/storage.go:812 lxc/storage_bucket.go:603
-#: lxc/storage_volume.go:2167 lxc/storage_volume.go:2205
+#: lxc/storage_volume.go:2178 lxc/storage_volume.go:2216
 #, c-format
 msgid "Error setting properties: %v"
 msgstr ""
@@ -2098,12 +2103,12 @@ msgstr ""
 msgid "Error unsetting properties: %v"
 msgstr ""
 
-#: lxc/cluster.go:453 lxc/network.go:1313 lxc/network_acl.go:518
+#: lxc/cluster.go:453 lxc/network.go:1322 lxc/network_acl.go:518
 #: lxc/network_forward.go:566 lxc/network_load_balancer.go:553
 #: lxc/network_peer.go:516 lxc/network_zone.go:453 lxc/network_zone.go:1141
 #: lxc/profile.go:981 lxc/project.go:714 lxc/storage.go:806
-#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2161
-#: lxc/storage_volume.go:2199
+#: lxc/storage_bucket.go:597 lxc/storage_volume.go:2172
+#: lxc/storage_volume.go:2210
 #, c-format
 msgid "Error unsetting property: %v"
 msgstr ""
@@ -2113,11 +2118,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1298 lxc/cluster.go:1299
+#: lxc/cluster.go:1299 lxc/cluster.go:1300
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1396
+#: lxc/cluster.go:1397
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2145,8 +2150,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1514
-#: lxc/storage_volume.go:1564
+#: lxc/info.go:652 lxc/info.go:703 lxc/storage_volume.go:1525
+#: lxc/storage_volume.go:1575
 msgid "Expires at"
 msgstr ""
 
@@ -2170,7 +2175,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2635 lxc/storage_volume.go:2636
+#: lxc/storage_volume.go:2646 lxc/storage_volume.go:2647
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2182,11 +2187,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2639
+#: lxc/storage_volume.go:2650
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:152 lxc/storage_volume.go:2768
+#: lxc/export.go:152 lxc/storage_volume.go:2779
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2366,7 +2371,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:1044 lxc/network_acl.go:133 lxc/network_zone.go:124
+#: lxc/network.go:1046 lxc/network_acl.go:133 lxc/network_zone.go:124
 #: lxc/operation.go:137
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -2376,7 +2381,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1302
+#: lxc/cluster.go:1303
 msgid "Force a particular evacuation action"
 msgstr ""
 
@@ -2384,7 +2389,7 @@ msgstr ""
 msgid "Force creating files or directories"
 msgstr ""
 
-#: lxc/cluster.go:1301
+#: lxc/cluster.go:1302
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2396,7 +2401,7 @@ msgstr ""
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
-#: lxc/cluster.go:1331
+#: lxc/cluster.go:1332
 msgid "Force restoration without user confirmation"
 msgstr ""
 
@@ -2437,16 +2442,16 @@ msgid ""
 msgstr ""
 
 #: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
-#: lxc/cluster.go:125 lxc/cluster.go:978 lxc/cluster_group.go:442
+#: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
-#: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
+#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
+#: lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
 #: lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474
 #: lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657
 #: lxc/storage_bucket.go:460 lxc/storage_bucket.go:775
-#: lxc/storage_volume.go:1614 lxc/warning.go:94
+#: lxc/storage_volume.go:1625 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2506,7 +2511,7 @@ msgstr ""
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/config.go:995 lxc/config.go:996
+#: lxc/config.go:996 lxc/config.go:997
 msgid "Get UEFI variables for instance"
 msgstr ""
 
@@ -2570,7 +2575,7 @@ msgstr ""
 msgid "Get the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:1238
+#: lxc/storage_volume.go:1249
 msgid "Get the key as a storage volume property"
 msgstr ""
 
@@ -2634,11 +2639,11 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1222 lxc/storage_volume.go:1223
+#: lxc/storage_volume.go:1233 lxc/storage_volume.go:1234
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:475
+#: lxc/storage_volume.go:476
 #, c-format
 msgid "Given target %q does not match source volume location %q"
 msgstr ""
@@ -2666,7 +2671,7 @@ msgstr ""
 msgid "HARDWARE ADDRESS"
 msgstr ""
 
-#: lxc/network.go:1161
+#: lxc/network.go:1170
 msgid "HOSTNAME"
 msgstr ""
 
@@ -2720,7 +2725,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:1163
+#: lxc/network.go:1172
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -2732,11 +2737,11 @@ msgstr ""
 msgid "IP addresses:"
 msgstr ""
 
-#: lxc/list.go:560 lxc/network.go:1084
+#: lxc/list.go:560 lxc/network.go:1093
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:561 lxc/network.go:1085
+#: lxc/list.go:561 lxc/network.go:1094
 msgid "IPV6"
 msgstr ""
 
@@ -2766,7 +2771,7 @@ msgstr ""
 msgid "If the image alias already exists, delete and create a new one"
 msgstr ""
 
-#: lxc/snapshot.go:46 lxc/storage_volume.go:2427
+#: lxc/snapshot.go:46 lxc/storage_volume.go:2438
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2780,7 +2785,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:2426
+#: lxc/storage_volume.go:2437
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2830,7 +2835,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2802
+#: lxc/storage_volume.go:2813
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2838,7 +2843,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2801
+#: lxc/storage_volume.go:2812
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2860,11 +2865,11 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2809
+#: lxc/storage_volume.go:2820
 msgid "Import type, backup or iso (default \"backup\")"
 msgstr ""
 
-#: lxc/storage_volume.go:2883
+#: lxc/storage_volume.go:2894
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2908,7 +2913,7 @@ msgstr ""
 msgid "Instance name is: %s"
 msgstr ""
 
-#: lxc/config.go:1021 lxc/config.go:1079 lxc/config.go:1198 lxc/config.go:1290
+#: lxc/config.go:1022 lxc/config.go:1080 lxc/config.go:1199 lxc/config.go:1291
 msgid "Instance name must be specified"
 msgstr ""
 
@@ -2990,7 +2995,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:148 lxc/storage_volume.go:2012
+#: lxc/move.go:148 lxc/storage_volume.go:2023
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2998,7 +3003,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2019
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3016,9 +3021,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1070 lxc/storage_volume.go:1287
-#: lxc/storage_volume.go:1411 lxc/storage_volume.go:1997
-#: lxc/storage_volume.go:2144 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:1081 lxc/storage_volume.go:1298
+#: lxc/storage_volume.go:1422 lxc/storage_volume.go:2008
+#: lxc/storage_volume.go:2155 lxc/storage_volume.go:2307
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -3062,9 +3067,9 @@ msgstr ""
 msgid "LISTEN ADDRESS"
 msgstr ""
 
-#: lxc/list.go:606 lxc/network.go:1168 lxc/network_forward.go:163
+#: lxc/list.go:606 lxc/network.go:1177 lxc/network_forward.go:163
 #: lxc/network_load_balancer.go:165 lxc/operation.go:178
-#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1745 lxc/warning.go:221
+#: lxc/storage_bucket.go:517 lxc/storage_volume.go:1756 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3076,8 +3081,8 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:167 lxc/cluster.go:1020 lxc/cluster.go:1123
-#: lxc/cluster.go:1231 lxc/cluster_group.go:485
+#: lxc/cluster.go:167 lxc/cluster.go:1021 lxc/cluster.go:1124
+#: lxc/cluster.go:1232 lxc/cluster_group.go:485
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -3114,7 +3119,7 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:1105 lxc/network.go:1106
+#: lxc/network.go:1114 lxc/network.go:1115
 msgid "List DHCP leases"
 msgstr ""
 
@@ -3126,7 +3131,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:976 lxc/cluster.go:977
+#: lxc/cluster.go:977 lxc/cluster.go:978
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -3174,7 +3179,7 @@ msgstr ""
 msgid "List available network zoneS"
 msgstr ""
 
-#: lxc/network.go:1004 lxc/network.go:1005
+#: lxc/network.go:1005 lxc/network.go:1006
 msgid "List available networks"
 msgstr ""
 
@@ -3262,7 +3267,7 @@ msgid ""
 "Fast column layout: nsacPt\n"
 "\n"
 "A single keyword like \"web\" which will list any instance with a name "
-"starting by \"web\".\n"
+"starting with \"web\".\n"
 "A regular expression on the instance name. (e.g. .*web.*01$).\n"
 "A key/value pair referring to a configuration item. For those, the\n"
 "namespace can be abbreviated to the smallest unambiguous identifier.\n"
@@ -3319,7 +3324,8 @@ msgid ""
 "  P - Profiles\n"
 "  s - State\n"
 "  S - Number of snapshots\n"
-"  t - Type (persistent or ephemeral)\n"
+"  t - Type (container or virtual-machine, ephemeral indicated if "
+"applicable)\n"
 "  u - CPU usage (in seconds)\n"
 "  L - Location of the instance (e.g. its cluster member)\n"
 "  f - Base Image Fingerprint (short)\n"
@@ -3368,11 +3374,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1603
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1608
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3431,7 +3437,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:489 lxc/storage_volume.go:1470
+#: lxc/info.go:489 lxc/storage_volume.go:1481
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3452,7 +3458,7 @@ msgstr ""
 msgid "Lower devices"
 msgstr ""
 
-#: lxc/network.go:1162
+#: lxc/network.go:1171
 msgid "MAC ADDRESS"
 msgstr ""
 
@@ -3470,7 +3476,7 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:1083
+#: lxc/network.go:1092
 msgid "MANAGED"
 msgstr ""
 
@@ -3593,7 +3599,7 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/config.go:955 lxc/config.go:956
+#: lxc/config.go:956 lxc/config.go:957
 msgid "Manage instance UEFI variables"
 msgstr ""
 
@@ -3732,7 +3738,7 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:957
+#: lxc/cluster.go:958
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
@@ -3796,7 +3802,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:811 lxc/cluster.go:1367 lxc/cluster_group.go:129
+#: lxc/cluster.go:812 lxc/cluster.go:1368 lxc/cluster_group.go:129
 #: lxc/cluster_group.go:559 lxc/cluster_group.go:761 lxc/cluster_role.go:82
 #: lxc/cluster_role.go:150
 msgid "Missing cluster member name"
@@ -3859,8 +3865,8 @@ msgstr ""
 
 #: lxc/network.go:172 lxc/network.go:269 lxc/network.go:437 lxc/network.go:499
 #: lxc/network.go:596 lxc/network.go:709 lxc/network.go:832 lxc/network.go:908
-#: lxc/network.go:1139 lxc/network.go:1217 lxc/network.go:1283
-#: lxc/network.go:1375 lxc/network_forward.go:127 lxc/network_forward.go:215
+#: lxc/network.go:1148 lxc/network.go:1226 lxc/network.go:1292
+#: lxc/network.go:1384 lxc/network_forward.go:127 lxc/network_forward.go:215
 #: lxc/network_forward.go:284 lxc/network_forward.go:445
 #: lxc/network_forward.go:530 lxc/network_forward.go:705
 #: lxc/network_forward.go:836 lxc/network_forward.go:929
@@ -3901,12 +3907,12 @@ msgstr ""
 #: lxc/storage_bucket.go:799 lxc/storage_bucket.go:886
 #: lxc/storage_bucket.go:983 lxc/storage_bucket.go:1062
 #: lxc/storage_bucket.go:1185 lxc/storage_volume.go:209
-#: lxc/storage_volume.go:323 lxc/storage_volume.go:649
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:847
-#: lxc/storage_volume.go:945 lxc/storage_volume.go:1059
-#: lxc/storage_volume.go:1276 lxc/storage_volume.go:1986
-#: lxc/storage_volume.go:2127 lxc/storage_volume.go:2285
-#: lxc/storage_volume.go:2476 lxc/storage_volume.go:2593
+#: lxc/storage_volume.go:324 lxc/storage_volume.go:650
+#: lxc/storage_volume.go:757 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:951 lxc/storage_volume.go:1070
+#: lxc/storage_volume.go:1287 lxc/storage_volume.go:1997
+#: lxc/storage_volume.go:2138 lxc/storage_volume.go:2296
+#: lxc/storage_volume.go:2487 lxc/storage_volume.go:2604
 msgid "Missing pool name"
 msgstr ""
 
@@ -3925,11 +3931,11 @@ msgstr ""
 msgid "Missing source profile name"
 msgstr ""
 
-#: lxc/storage_volume.go:438 lxc/storage_volume.go:1896
+#: lxc/storage_volume.go:439 lxc/storage_volume.go:1907
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1400
+#: lxc/storage_volume.go:1411
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3966,8 +3972,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:867
-#: lxc/storage_volume.go:964
+#: lxc/network.go:519 lxc/network.go:616 lxc/storage_volume.go:873
+#: lxc/storage_volume.go:975
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -4004,7 +4010,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1849 lxc/storage_volume.go:1850
+#: lxc/storage_volume.go:1860 lxc/storage_volume.go:1861
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -4012,11 +4018,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1856
+#: lxc/storage_volume.go:1867
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:518
+#: lxc/storage_volume.go:519
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -4038,12 +4044,12 @@ msgid "Must supply instance name for: "
 msgstr ""
 
 #: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
-#: lxc/cluster.go:1069 lxc/cluster_group.go:503 lxc/config_trust.go:409
-#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1081
+#: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
+#: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
 #: lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567
 #: lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512
-#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1737
+#: lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
 msgid "NAME"
 msgstr ""
 
@@ -4071,7 +4077,7 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:1058 lxc/operation.go:155 lxc/project.go:525
+#: lxc/network.go:1067 lxc/operation.go:155 lxc/project.go:525
 #: lxc/project.go:530 lxc/project.go:535 lxc/project.go:540 lxc/project.go:545
 #: lxc/project.go:550 lxc/remote.go:809 lxc/remote.go:814 lxc/remote.go:819
 msgid "NO"
@@ -4095,8 +4101,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1512
-#: lxc/storage_volume.go:1562
+#: lxc/info.go:650 lxc/info.go:701 lxc/storage_volume.go:1523
+#: lxc/storage_volume.go:1573
 msgid "Name"
 msgstr ""
 
@@ -4104,7 +4110,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1452
+#: lxc/info.go:472 lxc/network.go:926 lxc/storage_volume.go:1463
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4129,7 +4135,7 @@ msgstr ""
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1227
+#: lxc/network.go:1236
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -4239,7 +4245,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:1161
+#: lxc/cluster.go:1162
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4248,7 +4254,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:876 lxc/storage_volume.go:973
+#: lxc/storage_volume.go:882 lxc/storage_volume.go:984
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4268,11 +4274,11 @@ msgstr ""
 msgid "No need to specify a warning UUID when using --all"
 msgstr ""
 
-#: lxc/storage_volume.go:452 lxc/storage_volume.go:1905
+#: lxc/storage_volume.go:453 lxc/storage_volume.go:1916
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:502 lxc/storage_volume.go:1916
+#: lxc/storage_volume.go:503 lxc/storage_volume.go:1927
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4286,7 +4292,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2035
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4294,15 +4300,16 @@ msgstr ""
 msgid "OVN:"
 msgstr ""
 
-#: lxc/storage_volume.go:214 lxc/storage_volume.go:343
+#: lxc/storage_volume.go:214 lxc/storage_volume.go:344
+#: lxc/storage_volume.go:865 lxc/storage_volume.go:967
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2690
+#: lxc/storage_volume.go:2701
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:2489
+#: lxc/storage_volume.go:2500
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4314,11 +4321,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1418
+#: lxc/storage_volume.go:1429
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
-#: lxc/network.go:735 lxc/network.go:1298
+#: lxc/network.go:735 lxc/network.go:1307
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -4327,7 +4334,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:705 lxc/storage_volume.go:1566
+#: lxc/info.go:705 lxc/storage_volume.go:1577
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4357,7 +4364,7 @@ msgstr ""
 msgid "PID: %d"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1767
 msgid "POOL"
 msgstr ""
 
@@ -4373,7 +4380,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1762
+#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1773
 #: lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
@@ -4419,7 +4426,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:931
+#: lxc/cluster.go:932
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -4440,16 +4447,16 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:860
+#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
-#: lxc/config.go:1341 lxc/config_metadata.go:157 lxc/config_template.go:239
+#: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
 #: lxc/network_acl.go:699 lxc/network_forward.go:768
 #: lxc/network_load_balancer.go:739 lxc/network_peer.go:699
 #: lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596
 #: lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350
-#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1157
-#: lxc/storage_volume.go:1189
+#: lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168
+#: lxc/storage_volume.go:1200
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4566,7 +4573,7 @@ msgstr ""
 msgid "Property not found"
 msgstr ""
 
-#: lxc/storage_volume.go:1356
+#: lxc/storage_volume.go:1367
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, container and virtual-machine.\n"
@@ -4580,7 +4587,7 @@ msgid ""
 "\"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:1225
+#: lxc/storage_volume.go:1236
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4596,7 +4603,7 @@ msgid ""
 "pool \"default\"."
 msgstr ""
 
-#: lxc/storage_volume.go:2236
+#: lxc/storage_volume.go:2247
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4617,7 +4624,7 @@ msgid ""
 "called \"data\" in the \"default\" pool."
 msgstr ""
 
-#: lxc/storage_volume.go:1004
+#: lxc/storage_volume.go:1015
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4626,7 +4633,7 @@ msgid ""
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2081
+#: lxc/storage_volume.go:2092
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
@@ -4639,13 +4646,13 @@ msgid ""
 "pool \"default\" to seven days."
 msgstr ""
 
-#: lxc/storage_volume.go:2357
+#: lxc/storage_volume.go:2368
 msgid ""
 "Provide the type of the storage volume if it is not custom.\n"
 "Supported types are custom, image, container and virtual-machine.\n"
 "\n"
 "lxc storage volume unset default data size\n"
-"    Remotes the size/quota of a custom volume \"data\" in pool \"default\".\n"
+"    Removes the size/quota of a custom volume \"data\" in pool \"default\".\n"
 "\n"
 "lxc storage volume unset default virtual-machine/data snapshots.expiry\n"
 "    Removes the snapshot expiration period for a virtual machine \"data\" in "
@@ -4725,7 +4732,7 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:399
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
@@ -4908,7 +4915,7 @@ msgstr ""
 msgid "Rename network ACLs"
 msgstr ""
 
-#: lxc/network.go:1184 lxc/network.go:1185
+#: lxc/network.go:1193 lxc/network.go:1194
 msgid "Rename networks"
 msgstr ""
 
@@ -4924,15 +4931,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1949
+#: lxc/storage_volume.go:1960
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1948
+#: lxc/storage_volume.go:1959
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:2037 lxc/storage_volume.go:2057
+#: lxc/storage_volume.go:2048 lxc/storage_volume.go:2068
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4942,11 +4949,11 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:892 lxc/cluster.go:893
+#: lxc/cluster.go:893 lxc/cluster.go:894
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
-#: lxc/config.go:1032
+#: lxc/config.go:1033
 msgid "Requested UEFI variable does not exist"
 msgstr ""
 
@@ -4969,7 +4976,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1328 lxc/cluster.go:1329
+#: lxc/cluster.go:1329 lxc/cluster.go:1330
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4984,11 +4991,11 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2552 lxc/storage_volume.go:2553
+#: lxc/storage_volume.go:2563 lxc/storage_volume.go:2564
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1394
+#: lxc/cluster.go:1395
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -5010,7 +5017,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:1086
+#: lxc/cluster.go:1087
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -5060,7 +5067,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1088
+#: lxc/cluster.go:198 lxc/list.go:578 lxc/network.go:1097
 #: lxc/network_peer.go:151 lxc/storage.go:725
 msgid "STATE"
 msgstr ""
@@ -5123,7 +5130,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/config.go:1050 lxc/config.go:1051
+#: lxc/config.go:1051 lxc/config.go:1052
 msgid "Set UEFI variables for instance"
 msgstr ""
 
@@ -5187,11 +5194,11 @@ msgid ""
 "    lxc network set [<remote>:]<ACL> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1244
+#: lxc/network.go:1253
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1245
+#: lxc/network.go:1254
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -5308,11 +5315,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:2075
+#: lxc/storage_volume.go:2086
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2076
+#: lxc/storage_volume.go:2087
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5369,7 +5376,7 @@ msgstr ""
 msgid "Set the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1252
+#: lxc/network.go:1261
 msgid "Set the key as a network property"
 msgstr ""
 
@@ -5397,7 +5404,7 @@ msgstr ""
 msgid "Set the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2092
+#: lxc/storage_volume.go:2103
 msgid "Set the key as a storage volume property"
 msgstr ""
 
@@ -5466,7 +5473,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/config.go:1172 lxc/config.go:1173
+#: lxc/config.go:1173 lxc/config.go:1174
 msgid "Show instance UEFI variables"
 msgstr ""
 
@@ -5498,7 +5505,7 @@ msgstr ""
 msgid "Show network ACL log"
 msgstr ""
 
-#: lxc/network.go:1340 lxc/network.go:1341
+#: lxc/network.go:1349 lxc/network.go:1350
 msgid "Show network configurations"
 msgstr ""
 
@@ -5546,11 +5553,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:2233 lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2244 lxc/storage_volume.go:2245
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1353 lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1364 lxc/storage_volume.go:1365
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5573,7 +5580,7 @@ msgid "Show the expanded configuration"
 msgstr ""
 
 #: lxc/info.go:43
-msgid "Show the instance's last 100 log lines?"
+msgid "Show the instance's last 100 log lines"
 msgstr ""
 
 #: lxc/info.go:44
@@ -5618,15 +5625,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2416 lxc/storage_volume.go:2417
+#: lxc/storage_volume.go:2427 lxc/storage_volume.go:2428
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:2179
+#: lxc/storage_volume.go:2190
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:619 lxc/storage_volume.go:1491
+#: lxc/info.go:619 lxc/storage_volume.go:1502
 msgid "Snapshots:"
 msgstr ""
 
@@ -5731,21 +5738,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:702
+#: lxc/storage_volume.go:703
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:790
+#: lxc/storage_volume.go:791
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:515
+#: lxc/storage_volume.go:516
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:520
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5753,7 +5760,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1271
+#: lxc/cluster.go:1272
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5802,18 +5809,18 @@ msgstr ""
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
 
-#: lxc/cluster.go:1070 lxc/config_trust.go:515
+#: lxc/cluster.go:1071 lxc/config_trust.go:515
 msgid "TOKEN"
 msgstr ""
 
 #: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
-#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
-#: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
-#: lxc/storage_volume.go:1736 lxc/warning.go:216
+#: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
+#: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
+#: lxc/storage_volume.go:1747 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1563
+#: lxc/info.go:651 lxc/info.go:702 lxc/storage_volume.go:1574
 msgid "Taken at"
 msgstr ""
 
@@ -5970,12 +5977,12 @@ msgstr ""
 msgid "The property %q does not exist on the storage pool %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1329
+#: lxc/storage_volume.go:1340
 #, c-format
 msgid "The property %q does not exist on the storage pool volume %q: %v"
 msgstr ""
 
-#: lxc/storage_volume.go:1306
+#: lxc/storage_volume.go:1317
 #, c-format
 msgid ""
 "The property %q does not exist on the storage pool volume snapshot %s/%s: %v"
@@ -5994,8 +6001,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:881
-#: lxc/storage_volume.go:978
+#: lxc/network.go:533 lxc/network.go:630 lxc/storage_volume.go:887
+#: lxc/storage_volume.go:989
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -6015,11 +6022,11 @@ msgstr ""
 msgid "There is no config key to set on an instance snapshot."
 msgstr ""
 
-#: lxc/cluster.go:739
+#: lxc/cluster.go:740
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:729
+#: lxc/cluster.go:730
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -6070,7 +6077,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1476
+#: lxc/storage_volume.go:1487
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -6085,7 +6092,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1853
+#: lxc/storage_volume.go:1864
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -6093,7 +6100,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/storage_volume.go:393
+#: lxc/storage_volume.go:394
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -6152,7 +6159,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:1017 lxc/info.go:281 lxc/info.go:483 lxc/network.go:930
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1472
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -6174,13 +6181,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:995 lxc/storage_volume.go:1741
+#: lxc/project.go:995 lxc/storage_volume.go:1752
 msgid "USAGE"
 msgstr ""
 
-#: lxc/network.go:1087 lxc/network_acl.go:158 lxc/network_allocations.go:24
+#: lxc/network.go:1096 lxc/network_acl.go:158 lxc/network_allocations.go:24
 #: lxc/network_zone.go:149 lxc/profile.go:757 lxc/project.go:575
-#: lxc/storage.go:724 lxc/storage_volume.go:1740
+#: lxc/storage.go:724 lxc/storage_volume.go:1751
 msgid "USED BY"
 msgstr ""
 
@@ -6212,7 +6219,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1778
+#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1789
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6238,7 +6245,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/config.go:1141 lxc/config.go:1142
+#: lxc/config.go:1142 lxc/config.go:1143
 msgid "Unset UEFI variables for instance"
 msgstr ""
 
@@ -6266,7 +6273,7 @@ msgstr ""
 msgid "Unset network ACL configuration keys"
 msgstr ""
 
-#: lxc/network.go:1412 lxc/network.go:1413
+#: lxc/network.go:1421 lxc/network.go:1422
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -6318,7 +6325,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:2354 lxc/storage_volume.go:2355
+#: lxc/storage_volume.go:2365 lxc/storage_volume.go:2366
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -6342,7 +6349,7 @@ msgstr ""
 msgid "Unset the key as a network peer property"
 msgstr ""
 
-#: lxc/network.go:1417
+#: lxc/network.go:1426
 msgid "Unset the key as a network property"
 msgstr ""
 
@@ -6370,7 +6377,7 @@ msgstr ""
 msgid "Unset the key as a storage property"
 msgstr ""
 
-#: lxc/storage_volume.go:2368
+#: lxc/storage_volume.go:2379
 msgid "Unset the key as a storage volume property"
 msgstr ""
 
@@ -6378,7 +6385,7 @@ msgstr ""
 msgid "Unset the key as an instance property"
 msgstr ""
 
-#: lxc/storage_volume.go:247
+#: lxc/storage_volume.go:248
 msgid "Unsupported content type for attaching to instances"
 msgstr ""
 
@@ -6391,11 +6398,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:1174
+#: lxc/cluster.go:1175
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:1176
+#: lxc/cluster.go:1177
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6414,12 +6421,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1474
+#: lxc/storage_volume.go:1485
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2641
+#: lxc/export.go:42 lxc/storage_volume.go:2652
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6486,7 +6493,7 @@ msgstr ""
 msgid "View the current identity"
 msgstr ""
 
-#: lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:1576
 msgid "Volume Only"
 msgstr ""
 
@@ -6519,7 +6526,7 @@ msgid ""
 "re-initialize the instance if a different image or --empty is not specified."
 msgstr ""
 
-#: lxc/network.go:1060 lxc/operation.go:157 lxc/project.go:527
+#: lxc/network.go:1069 lxc/operation.go:157 lxc/project.go:527
 #: lxc/project.go:532 lxc/project.go:537 lxc/project.go:542 lxc/project.go:547
 #: lxc/project.go:552 lxc/remote.go:811 lxc/remote.go:816 lxc/remote.go:821
 msgid "YES"
@@ -6545,18 +6552,18 @@ msgstr ""
 msgid "You need to specify an image name or use --empty"
 msgstr ""
 
-#: lxc/storage_volume.go:903
+#: lxc/storage_volume.go:909
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:281
+#: lxc/storage_volume.go:282
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
 #: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
-#: lxc/cluster.go:120 lxc/cluster.go:975 lxc/cluster_group.go:437
+#: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
-#: lxc/network.go:1002 lxc/network_acl.go:92 lxc/network_zone.go:83
+#: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469
 #: lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid "[<remote>:]"
@@ -6566,7 +6573,7 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:1172
+#: lxc/cluster.go:1173
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
@@ -6729,7 +6736,7 @@ msgstr ""
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/config.go:1171 lxc/config.go:1225 lxc/config_device.go:329
+#: lxc/config.go:1172 lxc/config.go:1226 lxc/config_device.go:329
 #: lxc/config_device.go:761 lxc/config_metadata.go:54
 #: lxc/config_metadata.go:187 lxc/config_template.go:271 lxc/console.go:38
 msgid "[<remote>:]<instance>"
@@ -6751,11 +6758,11 @@ msgstr ""
 msgid "[<remote>:]<instance> <device> [key=value...]"
 msgstr ""
 
-#: lxc/config.go:994 lxc/config.go:1140
+#: lxc/config.go:995 lxc/config.go:1141
 msgid "[<remote>:]<instance> <key>"
 msgstr ""
 
-#: lxc/config.go:1049
+#: lxc/config.go:1050
 msgid "[<remote>:]<instance> <key>=<value>..."
 msgstr ""
 
@@ -6834,8 +6841,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:768
-#: lxc/cluster.go:1085 lxc/cluster.go:1297 lxc/cluster.go:1327
+#: lxc/cluster.go:213 lxc/cluster.go:270 lxc/cluster.go:583 lxc/cluster.go:769
+#: lxc/cluster.go:1086 lxc/cluster.go:1298 lxc/cluster.go:1328
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -6859,8 +6866,8 @@ msgstr ""
 msgid "[<remote>:]<member> <role[,role...]>"
 msgstr ""
 
-#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1104
-#: lxc/network.go:1339 lxc/network_forward.go:87
+#: lxc/network.go:402 lxc/network.go:655 lxc/network.go:872 lxc/network.go:1113
+#: lxc/network.go:1348 lxc/network_forward.go:87
 #: lxc/network_load_balancer.go:91 lxc/network_peer.go:79
 msgid "[<remote>:]<network>"
 msgstr ""
@@ -6873,11 +6880,11 @@ msgstr ""
 msgid "[<remote>:]<network> <instance> [<device name>] [<interface name>]"
 msgstr ""
 
-#: lxc/network.go:791 lxc/network.go:1411
+#: lxc/network.go:791 lxc/network.go:1420
 msgid "[<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/network.go:1243
+#: lxc/network.go:1252
 msgid "[<remote>:]<network> <key>=<value>..."
 msgstr ""
 
@@ -6922,7 +6929,7 @@ msgstr ""
 msgid "[<remote>:]<network> <listen_address> [<protocol>] [<listen_port(s)>]"
 msgstr ""
 
-#: lxc/network.go:1182
+#: lxc/network.go:1191
 msgid "[<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -6973,7 +6980,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2800
+#: lxc/storage_volume.go:2811
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -7008,13 +7015,13 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1947
+#: lxc/storage_volume.go:1958
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:805
+#: lxc/storage_volume.go:806
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -7022,51 +7029,51 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2551
+#: lxc/storage_volume.go:2562
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2634
+#: lxc/storage_volume.go:2645
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:2415
+#: lxc/storage_volume.go:2426
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:609
+#: lxc/storage_volume.go:610
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:717
+#: lxc/storage_volume.go:718
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1000 lxc/storage_volume.go:1352
+#: lxc/storage_volume.go:1011 lxc/storage_volume.go:1363
 msgid "[<remote>:]<pool> [<type>/]<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:2353
+#: lxc/storage_volume.go:2364
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:2074
+#: lxc/storage_volume.go:2085
 msgid "[<remote>:]<pool> [<type>/]<volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2232
+#: lxc/storage_volume.go:2243
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1221
+#: lxc/storage_volume.go:1232
 msgid "[<remote>:]<pool> [<type>/]<volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1847
+#: lxc/storage_volume.go:1858
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:387
+#: lxc/storage_volume.go:388
 msgid "[<remote>:]<pool>/<volume>[/<snapshot>] [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -7172,7 +7179,7 @@ msgstr ""
 msgid "[<remote>:][<instance>] <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:1590
+#: lxc/storage_volume.go:1601
 msgid "[<remote>:][<pool>] [<filter>...]"
 msgstr ""
 
@@ -7184,7 +7191,7 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:891
+#: lxc/cluster.go:892
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -7256,7 +7263,7 @@ msgid ""
 "group.yaml"
 msgstr ""
 
-#: lxc/cluster.go:772
+#: lxc/cluster.go:773
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7305,13 +7312,13 @@ msgid ""
 "    Will have LXD listen on IPv4 and IPv6 port 8443."
 msgstr ""
 
-#: lxc/config.go:1229
+#: lxc/config.go:1230
 msgid ""
 "lxc config uefi edit <instance> < instance_uefi_vars.yaml\n"
 "    Set the instance UEFI variables from instance_uefi_vars.yaml."
 msgstr ""
 
-#: lxc/config.go:1053
+#: lxc/config.go:1054
 msgid ""
 "lxc config uefi set [<remote>:]<instance> "
 "testvar-9073e4e0-60ec-4b6e-9903-4c223c260f3c=aabb\n"
@@ -7648,7 +7655,7 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:613
+#: lxc/storage_volume.go:614
 msgid ""
 "lxc storage volume create p1 v1\n"
 "\n"
@@ -7656,13 +7663,13 @@ msgid ""
 "\tCreate storage volume v1 for pool p1 with configuration from config.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2804
+#: lxc/storage_volume.go:2815
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:2419
+#: lxc/storage_volume.go:2430
 msgid ""
 "lxc storage volume snapshot create default v1 snap0\n"
 "       Create a snapshot of \"v1\" in pool \"default\" called \"snap0\".\n"


### PR DESCRIPTION
This PR fixes several typos and other small issues with lxc manpages, including:
- Clarifies how to confirm whether lxc is available on the network in `lxc cluster enable --help`
- Removes a redundancy in `lxc query --help` output due to automatic insertion of the default action, which currently causes the help text for the -X flag to appear as: "Action (defaults to GET) (default "GET")"
- Shows the correct list of possible types in `lxc list --help` 
  - This closes #14398 