### PR TITLE
doc: revise explanation titles

### DIFF
--- a/doc/custom_conf.py
+++ b/doc/custom_conf.py
@@ -145,7 +145,8 @@ slug = "lxd"
 redirects = {
     'howto/instances_snapshots/index': '../instances_backup/',
     'reference/network_external/index': '../networks/',
-    'explanation/containers_and_vms/index': '../instances/'
+    'explanation/containers_and_vms/index': '../instances/',
+    'explanation/clustering/index': '../clusters/'
 }
 
 ############################################################

--- a/doc/database.md
+++ b/doc/database.md
@@ -3,7 +3,7 @@ relatedlinks: "[Canonical&#32;Dqlite](https://dqlite.io/), https://github.com/ca
 ---
 
 (database)=
-# About the LXD database
+# The LXD Dqlite database
 
 LXD uses a distributed database to store the server configuration and state, which allows for quicker queries than if the configuration was stored inside each instance's directory (as it is done by LXC, for example).
 
@@ -15,7 +15,7 @@ With a database, you can run a simple query on the database to retrieve this inf
 
 In a LXD cluster, all members of the cluster must share the same database state.
 Therefore, LXD uses [Dqlite](https://dqlite.io/), a distributed version of SQLite.
-Dqlite  provides replication, fault-tolerance, and automatic failover without the need of external database processes.
+Dqlite provides replication, fault-tolerance, and automatic failover without the need of external database processes.
 
 When using LXD as a single machine and not as a cluster, the Dqlite database effectively behaves like a regular SQLite database.
 

--- a/doc/explanation/clusters.md
+++ b/doc/explanation/clusters.md
@@ -2,8 +2,8 @@
 discourse: lxc:15728
 ---
 
-(exp-clustering)=
-# About clustering
+(exp-clusters)=
+# Clusters
 
 ```{youtube} https://www.youtube.com/watch?v=nrOR6yaO_MY
 ```

--- a/doc/explanation/index.md
+++ b/doc/explanation/index.md
@@ -25,7 +25,7 @@ See the {ref}`howtos` for instructions on how to work with these entities, and t
 :titlesonly:
 
 /image-handling
-About storage </explanation/storage>
+/explanation/storage
 /explanation/networks
 /database
 /explanation/lxc_show_info

--- a/doc/explanation/index.md
+++ b/doc/explanation/index.md
@@ -41,7 +41,7 @@ You can also restrict access to LXD entities by confining them to specific proje
 ```{toctree}
 :titlesonly:
 
-About authentication </authentication>
+/authentication
 About authorization </explanation/authorization>
 /explanation/projects
 ```

--- a/doc/explanation/index.md
+++ b/doc/explanation/index.md
@@ -54,7 +54,7 @@ When you're ready to move your LXD setup to production, you should read up on th
 ```{toctree}
 :titlesonly:
 
-/explanation/clustering
+/explanation/clusters
 /explanation/performance_tuning
 /explanation/security
 ```

--- a/doc/explanation/index.md
+++ b/doc/explanation/index.md
@@ -42,7 +42,7 @@ You can also restrict access to LXD entities by confining them to specific proje
 :titlesonly:
 
 /authentication
-About authorization </explanation/authorization>
+/explanation/authorization
 /explanation/projects
 ```
 

--- a/doc/explanation/instances.md
+++ b/doc/explanation/instances.md
@@ -4,7 +4,7 @@ relatedlinks: '[LXD&#32;virtual&#32;machines:&#32;an&#32;overview](https://ubunt
 ---
 
 (containers-and-vms)=
-# About containers and VMs
+# Containers and VMs
 
 LXD provides support for two different types of {ref}`instances <expl-instances>`: *system containers* and *virtual machines*.
 

--- a/doc/explanation/lxc_show_info.md
+++ b/doc/explanation/lxc_show_info.md
@@ -1,5 +1,5 @@
 (lxc-show-info)=
-# About `lxc` `show` and `info`
+# `lxc` `show` and `info`
 
 For the entities managed by LXD, the `lxc` command provides a `list` sub-command, and might provide `show` and `info` sub-commands.
 The purpose of the `info` sub-command is to show current state information, and the purpose of the `show` sub-command is to show configuration information and how the entity is used by other entities.

--- a/doc/explanation/lxd_lxc.md
+++ b/doc/explanation/lxd_lxc.md
@@ -3,7 +3,7 @@ discourse: lxc:24
 ---
 
 (lxd-lxc)=
-# About `lxd` and `lxc`
+# `lxd` and `lxc`
 
 LXD is frequently confused with LXC, and the fact that LXD provides both a `lxd` command and a `lxc` command doesn't make things easier.
 

--- a/doc/explanation/networks.md
+++ b/doc/explanation/networks.md
@@ -1,5 +1,5 @@
 (networks)=
-# About networking
+# Networking setups
 
 There are different ways to connect your instances to the Internet. The easiest method is to have LXD create a network bridge during initialization and use this bridge for all instances, but LXD supports many different and advanced setups for networking.
 

--- a/doc/explanation/performance_tuning.md
+++ b/doc/explanation/performance_tuning.md
@@ -3,7 +3,7 @@ relatedlinks: https://www.youtube.com/watch?v=QyXOOE_4cm0
 ---
 
 (performance-tuning)=
-# About performance tuning
+# Performance tuning
 
 When you are ready to move your LXD setup to production, you should take some time to optimize the performance of your system.
 There are different aspects that impact performance.

--- a/doc/explanation/projects.md
+++ b/doc/explanation/projects.md
@@ -1,5 +1,5 @@
 (exp-projects)=
-# About projects
+# Instances grouping with projects
 
 ```{youtube} https://www.youtube.com/watch?v=cUHkgg6TovM
 ```

--- a/doc/explanation/security.md
+++ b/doc/explanation/security.md
@@ -4,7 +4,7 @@ relatedlinks: https://linuxcontainers.org/lxc/security/
 
 (exp-security)=
 (security)=
-# About security
+# Security
 
 ```{youtube} https://www.youtube.com/watch?v=cOOzKdYHkus
 ```

--- a/doc/explanation/storage.md
+++ b/doc/explanation/storage.md
@@ -1,5 +1,5 @@
 (exp-storage)=
-# About storage pools, volumes and buckets
+# Storage pools, volumes, and buckets
 
 LXD stores its data in storage pools, divided into storage volumes of different content types (like images or instances).
 You could think of a storage pool as the disk that is used to store data, while storage volumes are different partitions on this disk that are used for specific purposes.

--- a/doc/howto/initialize.md
+++ b/doc/howto/initialize.md
@@ -19,7 +19,7 @@ The tool asks a series of questions to determine the required configuration.
 The questions are dynamically adapted to the answers that you give.
 They cover the following areas:
 
-Clustering (see {ref}`exp-clustering` and {ref}`cluster-form`)
+Clustering (see {ref}`exp-clusters` and {ref}`cluster-form`)
 : A cluster combines several LXD servers.
   The cluster members share the same distributed database and can be managed uniformly using the LXD client ([`lxc`](lxc.md)) or the REST API.
 

--- a/doc/image-handling.md
+++ b/doc/image-handling.md
@@ -1,5 +1,5 @@
 (about-images)=
-# About images
+# Local and remote images
 
 ```{youtube} https://www.youtube.com/watch?v=wT7IDjo0Wgg
 ```

--- a/doc/related_topics.yaml
+++ b/doc/related_topics.yaml
@@ -1,6 +1,6 @@
 # This file defines substitutions for links to related topics, which
 # should make it easier to keep links in sync.
-{clustering_exp: "Explanation:\n\n- {ref}`exp-clustering`",
+{clustering_exp: "Explanation:\n\n- {ref}`exp-clusters`",
 clustering_how: "How-to guides:\n\n- {ref}`clustering`",
 clustering_ref: "Reference:\n\n- {ref}`cluster-member-config`",
 getting_started_exp: "Explanation:\n\n- {ref}`containers-and-vms`",


### PR DESCRIPTION
- Remove repetitive "About" word for each Explanation article title in side navigation & Explanation index page
- Rephrase titles for increased specificity as well as to avoid duplicating titles from how-to/reference articles
- Update links to a renamed file and add redirect

This is a resubmit of #14551 (closed per git history issues in that PR)