### PR TITLE
VM: Fix live migration

### DIFF
--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -3254,24 +3254,23 @@ func (d *lxc) Render(options ...func(response any) error) (state any, etag any, 
 		etag := []any{d.expiryDate}
 
 		snapState := api.InstanceSnapshot{
-			CreatedAt:       d.creationDate,
-			ExpandedConfig:  d.expandedConfig,
-			ExpandedDevices: d.expandedDevices.CloneNative(),
-			LastUsedAt:      d.lastUsedDate,
 			Name:            strings.SplitN(d.name, "/", 2)[1],
+			Architecture:    architectureName,
+			Profiles:        profileNames,
+			Config:          d.localConfig,
+			ExpandedConfig:  d.expandedConfig,
+			Devices:         d.localDevices.CloneNative(),
+			ExpandedDevices: d.expandedDevices.CloneNative(),
+			CreatedAt:       d.creationDate,
+			LastUsedAt:      d.lastUsedDate,
+			ExpiresAt:       d.expiryDate,
+			Ephemeral:       d.ephemeral,
 			Stateful:        d.stateful,
 
 			// Default to uninitialised/error state (0 means no CoW usage).
 			// The size can then be populated optionally via the options argument.
 			Size: -1,
 		}
-
-		snapState.Architecture = architectureName
-		snapState.Config = d.localConfig
-		snapState.Devices = d.localDevices.CloneNative()
-		snapState.Ephemeral = d.ephemeral
-		snapState.Profiles = profileNames
-		snapState.ExpiresAt = d.expiryDate
 
 		for _, option := range options {
 			err := option(&snapState)
@@ -3287,12 +3286,22 @@ func (d *lxc) Render(options ...func(response any) error) (state any, etag any, 
 	etag = []any{d.architecture, d.localConfig, d.localDevices, d.ephemeral, d.profiles}
 
 	instState := api.Instance{
-		ExpandedConfig:  d.expandedConfig,
-		ExpandedDevices: d.expandedDevices.CloneNative(),
 		Name:            d.name,
-		StatusCode:      api.Error, // Default to error status for remote instances that are unreachable.
+		Description:     d.description,
+		Architecture:    architectureName,
+		Profiles:        profileNames,
+		Config:          d.localConfig,
+		ExpandedConfig:  d.expandedConfig,
+		Devices:         d.LocalDevices().CloneNative(),
+		ExpandedDevices: d.expandedDevices.CloneNative(),
+		CreatedAt:       d.creationDate,
+		LastUsedAt:      d.lastUsedDate,
+		Ephemeral:       d.ephemeral,
+		Stateful:        d.stateful,
+		Project:         d.project.Name,
 		Location:        d.node,
 		Type:            d.Type().String(),
+		StatusCode:      api.Error, // Default to error status for remote instances that are unreachable.
 	}
 
 	// If instance is local then request status.
@@ -3301,17 +3310,6 @@ func (d *lxc) Render(options ...func(response any) error) (state any, etag any, 
 	}
 
 	instState.Status = instState.StatusCode.String()
-
-	instState.Description = d.description
-	instState.Architecture = architectureName
-	instState.Config = d.localConfig
-	instState.CreatedAt = d.creationDate
-	instState.Devices = d.localDevices.CloneNative()
-	instState.Ephemeral = d.ephemeral
-	instState.LastUsedAt = d.lastUsedDate
-	instState.Profiles = profileNames
-	instState.Stateful = d.stateful
-	instState.Project = d.project.Name
 
 	for _, option := range options {
 		err := option(&instState)

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -3283,16 +3283,21 @@ func (d *lxc) Render(options ...func(response any) error) (state any, etag any, 
 	// Prepare the ETag
 	etag = []any{d.architecture, d.localConfig, d.localDevices, d.ephemeral, d.profiles}
 
-	statusCode := d.statusCode()
 	instState := api.Instance{
 		ExpandedConfig:  d.expandedConfig,
 		ExpandedDevices: d.expandedDevices.CloneNative(),
 		Name:            d.name,
-		Status:          statusCode.String(),
-		StatusCode:      statusCode,
+		StatusCode:      api.Error, // Default to error status for remote instances that are unreachable.
 		Location:        d.node,
 		Type:            d.Type().String(),
 	}
+
+	// If instance is local then request status.
+	if d.state.ServerName == d.Location() {
+		instState.StatusCode = d.statusCode()
+	}
+
+	instState.Status = instState.StatusCode.String()
 
 	instState.Description = d.description
 	instState.Architecture = architectureName

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -3260,7 +3260,10 @@ func (d *lxc) Render(options ...func(response any) error) (state any, etag any, 
 			LastUsedAt:      d.lastUsedDate,
 			Name:            strings.SplitN(d.name, "/", 2)[1],
 			Stateful:        d.stateful,
-			Size:            -1, // Default to uninitialised/error state (0 means no CoW usage).
+
+			// Default to uninitialised/error state (0 means no CoW usage).
+			// The size can then be populated optionally via the options argument.
+			Size: -1,
 		}
 
 		snapState.Architecture = architectureName

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -8151,11 +8151,6 @@ func (d *lxc) NextIdmap() (*idmap.IdmapSet, error) {
 
 // statusCode returns instance status code.
 func (d *lxc) statusCode() api.StatusCode {
-	// If instance is running on a remote cluster member, we cannot determine instance state.
-	if d.state.ServerName != d.Location() {
-		return api.Error
-	}
-
 	// Shortcut to avoid spamming liblxc during ongoing operations.
 	operationStatus := d.operationStatusCode()
 	if operationStatus != nil {

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -7808,17 +7808,22 @@ func (d *qemu) Render(options ...func(response any) error) (state any, etag any,
 
 	// Prepare the ETag
 	etag = []any{d.architecture, d.localConfig, d.localDevices, d.ephemeral, d.profiles}
-	statusCode := d.statusCode()
 
 	instState := api.Instance{
 		ExpandedConfig:  d.expandedConfig,
 		ExpandedDevices: d.expandedDevices.CloneNative(),
 		Name:            d.name,
-		Status:          statusCode.String(),
-		StatusCode:      statusCode,
 		Location:        d.node,
 		Type:            d.Type().String(),
+		StatusCode:      api.Error, // Default to error status for remote instances that are unreachable.
 	}
+
+	// If instance is local then request status.
+	if d.state.ServerName == d.Location() {
+		instState.StatusCode = d.statusCode()
+	}
+
+	instState.Status = instState.StatusCode.String()
 
 	instState.Description = d.description
 	instState.Architecture = d.architectureName

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -7777,24 +7777,23 @@ func (d *qemu) Render(options ...func(response any) error) (state any, etag any,
 		etag := []any{d.expiryDate}
 
 		snapState := api.InstanceSnapshot{
-			CreatedAt:       d.creationDate,
-			ExpandedConfig:  d.expandedConfig,
-			ExpandedDevices: d.expandedDevices.CloneNative(),
-			LastUsedAt:      d.lastUsedDate,
 			Name:            strings.SplitN(d.name, "/", 2)[1],
+			Architecture:    d.architectureName,
+			Profiles:        profileNames,
+			Config:          d.localConfig,
+			ExpandedConfig:  d.expandedConfig,
+			Devices:         d.localDevices.CloneNative(),
+			ExpandedDevices: d.expandedDevices.CloneNative(),
+			CreatedAt:       d.creationDate,
+			LastUsedAt:      d.lastUsedDate,
+			ExpiresAt:       d.expiryDate,
+			Ephemeral:       d.ephemeral,
 			Stateful:        d.stateful,
 
 			// Default to uninitialised/error state (0 means no CoW usage).
 			// The size can then be populated optionally via the options argument.
 			Size: -1,
 		}
-
-		snapState.Architecture = d.architectureName
-		snapState.Config = d.localConfig
-		snapState.Devices = d.localDevices.CloneNative()
-		snapState.Ephemeral = d.ephemeral
-		snapState.Profiles = profileNames
-		snapState.ExpiresAt = d.expiryDate
 
 		for _, option := range options {
 			err := option(&snapState)
@@ -7810,9 +7809,19 @@ func (d *qemu) Render(options ...func(response any) error) (state any, etag any,
 	etag = []any{d.architecture, d.localConfig, d.localDevices, d.ephemeral, d.profiles}
 
 	instState := api.Instance{
-		ExpandedConfig:  d.expandedConfig,
-		ExpandedDevices: d.expandedDevices.CloneNative(),
 		Name:            d.name,
+		Description:     d.description,
+		Architecture:    d.architectureName,
+		Profiles:        profileNames,
+		Config:          d.localConfig,
+		ExpandedConfig:  d.expandedConfig,
+		Devices:         d.localDevices.CloneNative(),
+		ExpandedDevices: d.expandedDevices.CloneNative(),
+		CreatedAt:       d.creationDate,
+		LastUsedAt:      d.lastUsedDate,
+		Ephemeral:       d.ephemeral,
+		Stateful:        d.stateful,
+		Project:         d.project.Name,
 		Location:        d.node,
 		Type:            d.Type().String(),
 		StatusCode:      api.Error, // Default to error status for remote instances that are unreachable.
@@ -7824,17 +7833,6 @@ func (d *qemu) Render(options ...func(response any) error) (state any, etag any,
 	}
 
 	instState.Status = instState.StatusCode.String()
-
-	instState.Description = d.description
-	instState.Architecture = d.architectureName
-	instState.Config = d.localConfig
-	instState.CreatedAt = d.creationDate
-	instState.Devices = d.localDevices.CloneNative()
-	instState.Ephemeral = d.ephemeral
-	instState.LastUsedAt = d.lastUsedDate
-	instState.Profiles = profileNames
-	instState.Stateful = d.stateful
-	instState.Project = d.project.Name
 
 	for _, option := range options {
 		err := option(&instState)

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -7783,7 +7783,10 @@ func (d *qemu) Render(options ...func(response any) error) (state any, etag any,
 			LastUsedAt:      d.lastUsedDate,
 			Name:            strings.SplitN(d.name, "/", 2)[1],
 			Stateful:        d.stateful,
-			Size:            -1, // Default to uninitialised/error state (0 means no CoW usage).
+
+			// Default to uninitialised/error state (0 means no CoW usage).
+			// The size can then be populated optionally via the options argument.
+			Size: -1,
 		}
 
 		snapState.Architecture = d.architectureName

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -8250,11 +8250,6 @@ func (d *qemu) InitPID() int {
 }
 
 func (d *qemu) statusCode() api.StatusCode {
-	// If instance is running on a remote cluster member, we cannot determine instance state.
-	if d.state.ServerName != d.Location() {
-		return api.Error
-	}
-
 	// Shortcut to avoid spamming QMP during ongoing operations.
 	operationStatus := d.operationStatusCode()
 	if operationStatus != nil {


### PR DESCRIPTION
PR https://github.com/canonical/lxd/pull/14539 broke live migration in commit https://github.com/canonical/lxd/pull/14539/commits/d734721b3d3e2000dd71bfc1c2cb7c92ff8c298d

This is because when live migrating a VM, the VM's `Start()` function is called on the target side (so that live migration can occur) before the Location of the instance is updated in the DB. This in turn calls `statusCode` during the start process.

The change to the `statusCode` function meant that this returned an error status because the instance was in theory non-local, and that prevented the qemu process from being started.

This PR reverts the `statusCode` error change and moves that logic into the Render function.

Fixes https://github.com/canonical/lxd/issues/14679