### PR TITLE
Storage: Add reverter to disk device update & test

### DIFF
--- a/lxd/storage_volumes_utils.go
+++ b/lxd/storage_volumes_utils.go
@@ -12,12 +12,17 @@ import (
 	storagePools "github.com/canonical/lxd/lxd/storage"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/lxd/shared/logger"
+	"github.com/canonical/lxd/shared/revert"
 	"github.com/canonical/lxd/shared/version"
 )
 
 var supportedVolumeTypes = []int{cluster.StoragePoolVolumeTypeContainer, cluster.StoragePoolVolumeTypeVM, cluster.StoragePoolVolumeTypeCustom, cluster.StoragePoolVolumeTypeImage}
 
-func storagePoolVolumeUpdateUsers(s *state.State, projectName string, oldPoolName string, oldVol *api.StorageVolume, newPoolName string, newVol *api.StorageVolume) error {
+func storagePoolVolumeUpdateUsers(s *state.State, projectName string, oldPoolName string, oldVol *api.StorageVolume, newPoolName string, newVol *api.StorageVolume) (revert.Hook, error) {
+	revert := revert.New()
+	defer revert.Fail()
+
 	// Update all instances that are using the volume with a local (non-expanded) device.
 	err := storagePools.VolumeUsedByInstanceDevices(s, oldPoolName, projectName, oldVol, false, func(dbInst db.InstanceArgs, project api.Project, usedByDevices []string) error {
 		inst, err := instance.Load(s, dbInst, project)
@@ -58,10 +63,17 @@ func storagePoolVolumeUpdateUsers(s *state.State, projectName string, oldPoolNam
 			return err
 		}
 
+		revert.Add(func() {
+			err := inst.Update(dbInst, false)
+			if err != nil {
+				logger.Error("Failed to revert instance update", logger.Ctx{"project": dbInst.Project, "instance": dbInst.Name, "error": err})
+			}
+		})
+
 		return nil
 	})
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// Update all profiles that are using the volume with a device.
@@ -100,13 +112,28 @@ func storagePoolVolumeUpdateUsers(s *state.State, projectName string, oldPoolNam
 			return err
 		}
 
+		revert.Add(func() {
+			original := api.ProfilePut{
+				Config:      profile.Config,
+				Description: profile.Description,
+				Devices:     profile.Devices,
+			}
+
+			err := doProfileUpdate(s, p, profile.Name, profileID, &profile, original)
+			if err != nil {
+				logger.Error("Failed reverting profile update", logger.Ctx{"project": p.Name, "profile": profile.Name, "error": err})
+			}
+		})
+
 		return nil
 	})
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	return nil
+	cleanup := revert.Clone().Fail
+	revert.Success()
+	return cleanup, nil
 }
 
 // storagePoolVolumeUsedByGet returns a list of URL resources that use the volume.

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -938,12 +938,47 @@ test_clustering_storage() {
     ! LXD_DIR="${LXD_TWO_DIR}" lxc storage volume rename data web webbaz || false
     ! LXD_DIR="${LXD_TWO_DIR}" lxc storage volume delete data web || false
 
-    # Specifying the --target parameter shows, renames and deletes the
-    # proper volume.
+    LXD_DIR="${LXD_TWO_DIR}" lxc init --empty c1 --target node1
+    LXD_DIR="${LXD_TWO_DIR}" lxc init --empty c2 --target node2
+    LXD_DIR="${LXD_TWO_DIR}" lxc init --empty c3 --target node2
+
+    LXD_DIR="${LXD_TWO_DIR}" lxc config device add c1 web disk pool=data source=web path=/mnt/web
+    LXD_DIR="${LXD_TWO_DIR}" lxc config device add c2 web disk pool=data source=web path=/mnt/web
+
+    # Specifying the --target parameter shows the proper volume.
     LXD_DIR="${LXD_TWO_DIR}" lxc storage volume show --target node1 data web | grep -q "location: node1"
     LXD_DIR="${LXD_TWO_DIR}" lxc storage volume show --target node2 data web | grep -q "location: node2"
+
+    # rename updates the disk devices that refer to the disk
     LXD_DIR="${LXD_TWO_DIR}" lxc storage volume rename --target node1 data web webbaz
+
+    [ "$(LXD_DIR=${LXD_TWO_DIR} lxc config device get c1 web source)" = "webbaz" ]
+    [ "$(LXD_DIR=${LXD_TWO_DIR} lxc config device get c2 web source)" = "web" ]
+
     LXD_DIR="${LXD_TWO_DIR}" lxc storage volume rename --target node2 data web webbaz
+
+    [ "$(LXD_DIR=${LXD_TWO_DIR} lxc config device get c1 web source)" = "webbaz" ]
+    [ "$(LXD_DIR=${LXD_TWO_DIR} lxc config device get c2 web source)" = "webbaz" ]
+
+    LXD_DIR="${LXD_TWO_DIR}" lxc config device remove c1 web
+
+    # renaming a local storage volume when attached via profile fails
+    LXD_DIR="${LXD_TWO_DIR}" lxc profile create stovol-webbaz
+    LXD_DIR="${LXD_TWO_DIR}" lxc profile device add stovol-webbaz webbaz disk pool=data source=webbaz path=/mnt/web
+
+    LXD_DIR="${LXD_TWO_DIR}" lxc profile add c3 stovol-webbaz # c2 and c3 both have webbaz attached
+
+    ! LXD_DIR="${LXD_TWO_DIR}" lxc storage volume rename --target node2 data webbaz webbaz2 || false
+
+    [ "$(LXD_DIR=${LXD_TWO_DIR} lxc profile device get stovol-webbaz webbaz source)" = "webbaz" ]
+    [ "$(LXD_DIR=${LXD_TWO_DIR} lxc config device get c2 web source)" = "webbaz" ]
+
+    LXD_DIR="${LXD_TWO_DIR}" lxc profile remove c3 stovol-webbaz
+    LXD_DIR="${LXD_TWO_DIR}" lxc profile delete stovol-webbaz
+
+    # clean up
+    LXD_DIR="${LXD_TWO_DIR}" lxc delete c1 c2 c3
+
     LXD_DIR="${LXD_TWO_DIR}" lxc storage volume delete --target node2 data webbaz
 
     # Since now there's only one volume in the pool left named webbaz,


### PR DESCRIPTION
This makes `storagePoolVolumeUpdateUsers` safe to call without using a reverter.

This also adds a few tests around renaming attached local custom storage volumes in a clustered context. As we've discussed previously (#14681), updating disk devices in profiles isn't necessarily sound. These tests give me a little more confidence that updates behave sanely for local storage volumes in a cluster.

We should consider eliminating this feature altogether and simply making it a hard error to rename a custom storage volume while it is referred to by any disk device.