### PR TITLE
Remove `runtime.Caller` from `schema.DotGo`

### DIFF
--- a/lxd/db/cluster/update.go
+++ b/lxd/db/cluster/update.go
@@ -1,5 +1,7 @@
 package cluster
 
+//go:generate lxd-generate db schema cluster
+
 import (
 	"context"
 	"database/sql"

--- a/lxd/db/cluster/update.go
+++ b/lxd/db/cluster/update.go
@@ -30,7 +30,7 @@ func FreshSchema() string {
 // SchemaDotGo refreshes the schema.go file in this package, using the updates
 // defined here.
 func SchemaDotGo() error {
-	return schema.DotGo(updates, "schema")
+	return schema.DotGo(updates, "cluster", "schema.go")
 }
 
 // SchemaVersion is the current version of the cluster database schema.

--- a/lxd/db/generate/db.go
+++ b/lxd/db/generate/db.go
@@ -36,7 +36,11 @@ func newDbSchema() *cobra.Command {
 		Use:   "schema",
 		Short: "Generate database schema by applying updates.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return db.UpdateSchema()
+			if len(args) < 1 {
+				return fmt.Errorf(`Schema kind must be provided (must be "node", or "cluster")`)
+			}
+
+			return db.UpdateSchema(args[0])
 		},
 	}
 

--- a/lxd/db/generate/db/schema.go
+++ b/lxd/db/generate/db/schema.go
@@ -8,13 +8,17 @@ import (
 )
 
 // UpdateSchema updates the schema.go file of the cluster and node databases.
-func UpdateSchema() error {
-	err := cluster.SchemaDotGo()
-	if err != nil {
-		return fmt.Errorf("Update cluster database schema: %w", err)
+func UpdateSchema(kind string) error {
+	var err error
+	switch kind {
+	case "node":
+		err = node.SchemaDotGo()
+	case "cluster":
+		err = cluster.SchemaDotGo()
+	default:
+		return fmt.Errorf(`No such schema kind %q (must be "node", or "cluster")`, kind)
 	}
 
-	err = node.SchemaDotGo()
 	if err != nil {
 		return fmt.Errorf("Update node database schema: %w", err)
 	}

--- a/lxd/db/node/update.go
+++ b/lxd/db/node/update.go
@@ -1,5 +1,7 @@
 package node
 
+//go:generate lxd-generate db schema node
+
 import (
 	"context"
 	"database/sql"

--- a/lxd/db/node/update.go
+++ b/lxd/db/node/update.go
@@ -31,7 +31,7 @@ func FreshSchema() string {
 // SchemaDotGo refreshes the schema.go file in this package, using the updates
 // defined here.
 func SchemaDotGo() error {
-	return schema.DotGo(updates, "schema")
+	return schema.DotGo(updates, "node", "schema.go")
 }
 
 /* Database updates are one-time actions that are needed to move an

--- a/lxd/db/schema.go
+++ b/lxd/db/schema.go
@@ -1,7 +1,0 @@
-//go:build linux && cgo && !agent
-
-package db
-
-// Directive for regenerating both the cluster and node database schemas.
-//
-//go:generate lxd-generate db schema

--- a/lxd/db/schema/update_test.go
+++ b/lxd/db/schema/update_test.go
@@ -18,7 +18,7 @@ func TestDotGo(t *testing.T) {
 		2: updateInsertValue,
 	}
 
-	require.NoError(t, schema.DotGo(updates, "xyz"))
+	require.NoError(t, schema.DotGo(updates, "xyz", "xyz.go"))
 	require.Equal(t, true, shared.PathExists("xyz.go"))
 	require.NoError(t, os.Remove("xyz.go"))
 }


### PR DESCRIPTION
This is an alternative to #14704 

I didn't understand why `runtime.Caller` was required. It was because of where the `SchemaDotGo` functions were defined in the `node` and `cluster` packages.

We can instead just split the `go:generate` directives into their respective packages so that invocation there will cause the `schema.go` files to be created in the current directory.

As an aside, since `lxd-generate` is used by `micro*` packages, I'd also be in favour of removing the `schema` subcommand from it, as it only supports generating the LXD node or cluster schemas.