### PR TITLE
Storage: Add NVMe and SDC storage connectors

### DIFF
--- a/lxd/storage/connectors/connector.go
+++ b/lxd/storage/connectors/connector.go
@@ -13,6 +13,9 @@ const (
 
 	// TypeNVME represents an NVMe/TCP storage connector.
 	TypeNVME string = "nvme"
+
+	// TypeSDC represents Dell SDC storage connector.
+	TypeSDC string = "sdc"
 )
 
 // session represents a connector session that is established with a target.
@@ -53,6 +56,11 @@ func NewConnector(connectorType string, serverUUID string) (Connector, error) {
 	switch connectorType {
 	case TypeNVME:
 		return &connectorNVMe{
+			common: common,
+		}, nil
+
+	case TypeSDC:
+		return &connectorSDC{
 			common: common,
 		}, nil
 

--- a/lxd/storage/connectors/connector.go
+++ b/lxd/storage/connectors/connector.go
@@ -70,3 +70,26 @@ func NewConnector(connectorType string, serverUUID string) (Connector, error) {
 		return nil, fmt.Errorf("Unknown storage connector type %q", connectorType)
 	}
 }
+
+// GetSupportedVersions returns the versions for the given connector types
+// ignoring those that produce an error when version is being retrieved
+// (e.g. due to a missing required tools).
+func GetSupportedVersions(connectorTypes []string) []string {
+	versions := make([]string, 0, len(connectorTypes))
+
+	// Iterate over the provided connector types, and extract
+	// their versions.
+	for _, connectorType := range connectorTypes {
+		connector, err := NewConnector(connectorType, "")
+		if err != nil {
+			continue
+		}
+
+		version, _ := connector.Version()
+		if version != "" {
+			versions = append(versions, version)
+		}
+	}
+
+	return versions
+}

--- a/lxd/storage/connectors/connector.go
+++ b/lxd/storage/connectors/connector.go
@@ -1,0 +1,34 @@
+package connectors
+
+import (
+	"context"
+
+	"github.com/canonical/lxd/shared/revert"
+)
+
+// session represents a connector session that is established with a target.
+type session struct {
+	// id is a unique identifier of the session.
+	id string
+
+	// targetQN is the qualified name of the target.
+	targetQN string
+
+	// addresses is a list of active addresses associated with the session.
+	addresses []string
+}
+
+// Connector represents a storage connector that handles connections through
+// appropriate storage subsystem.
+type Connector interface {
+	Type() string
+	Version() (string, error)
+	QualifiedName() (string, error)
+	LoadModules() error
+	Connect(ctx context.Context, targetQN string, targetAddrs ...string) (revert.Hook, error)
+	ConnectAll(ctx context.Context, targetAddr string) error
+	Disconnect(targetQN string) error
+	DisconnectAll() error
+	SessionID(targetQN string) (string, error)
+	findSession(targetQN string) (*session, error)
+}

--- a/lxd/storage/connectors/connector_common.go
+++ b/lxd/storage/connectors/connector_common.go
@@ -1,0 +1,5 @@
+package connectors
+
+type common struct {
+	serverUUID string
+}

--- a/lxd/storage/connectors/connector_nvme.go
+++ b/lxd/storage/connectors/connector_nvme.go
@@ -1,0 +1,258 @@
+package connectors
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/canonical/lxd/lxd/util"
+	"github.com/canonical/lxd/shared"
+	"github.com/canonical/lxd/shared/revert"
+)
+
+var _ Connector = &connectorNVMe{}
+
+type connectorNVMe struct {
+	common
+}
+
+// Type returns the type of the connector.
+func (c *connectorNVMe) Type() string {
+	return TypeNVME
+}
+
+// Version returns the version of the NVMe CLI.
+func (c *connectorNVMe) Version() (string, error) {
+	// Detect and record the version of the NVMe CLI.
+	out, err := shared.RunCommand("nvme", "version")
+	if err != nil {
+		return "", fmt.Errorf("Failed to get nvme-cli version: %w", err)
+	}
+
+	fields := strings.Split(strings.TrimSpace(out), " ")
+	if strings.HasPrefix(out, "nvme version ") && len(fields) > 2 {
+		return fmt.Sprintf("%s (nvme-cli)", fields[2]), nil
+	}
+
+	return "", fmt.Errorf("Failed to get nvme-cli version: Unexpected output %q", out)
+}
+
+// LoadModules loads the NVMe/TCP kernel modules.
+// Returns true if the modules can be loaded.
+func (c *connectorNVMe) LoadModules() error {
+	err := util.LoadModule("nvme_fabrics")
+	if err != nil {
+		return err
+	}
+
+	return util.LoadModule("nvme_tcp")
+}
+
+// QualifiedName returns a custom NQN generated from the server UUID.
+// Getting the NQN from /etc/nvme/hostnqn would require the nvme-cli
+// package to be installed on the host.
+func (c *connectorNVMe) QualifiedName() (string, error) {
+	return fmt.Sprintf("nqn.2014-08.org.nvmexpress:uuid:%s", c.serverUUID), nil
+}
+
+// Connect establishes a connection with the target on the given address.
+func (c *connectorNVMe) Connect(ctx context.Context, targetQN string, targetAddresses ...string) (revert.Hook, error) {
+	// Connects to the provided target address, if the connection is not yet established.
+	connectFunc := func(ctx context.Context, session *session, targetAddr string) error {
+		if session != nil && slices.Contains(session.addresses, targetAddr) {
+			// Already connected.
+			return nil
+		}
+
+		hostNQN, err := c.QualifiedName()
+		if err != nil {
+			return err
+		}
+
+		_, err = shared.RunCommandContext(ctx, "nvme", "connect", "--transport", "tcp", "--traddr", targetAddr, "--nqn", targetQN, "--hostnqn", hostNQN, "--hostid", c.serverUUID)
+		if err != nil {
+			return fmt.Errorf("Failed to connect to target %q on %q via NVMe: %w", targetQN, targetAddr, err)
+		}
+
+		return nil
+	}
+
+	return connect(ctx, c, targetQN, targetAddresses, connectFunc)
+}
+
+// ConnectAll establishes a connection with all targets available on the given address.
+func (c *connectorNVMe) ConnectAll(ctx context.Context, targetAddr string) error {
+	hostNQN, err := c.QualifiedName()
+	if err != nil {
+		return err
+	}
+
+	_, err = shared.RunCommandContext(ctx, "nvme", "connect-all", "--transport", "tcp", "--traddr", targetAddr, "--hostnqn", hostNQN, "--hostid", c.serverUUID)
+	if err != nil {
+		return fmt.Errorf("Failed to connect to any target on %q via NVMe: %w", targetAddr, err)
+	}
+
+	return nil
+}
+
+// Disconnect terminates a connection with the target.
+func (c *connectorNVMe) Disconnect(targetQN string) error {
+	// Find an existing NVMe session.
+	session, err := c.findSession(targetQN)
+	if err != nil {
+		return err
+	}
+
+	// Disconnect from the NVMe target if there is an existing session.
+	if session != nil {
+		// Do not restrict the context as the operation is relatively short
+		// and most importantly we do not want to "partially" disconnect from
+		// the target, potentially leaving some unclosed sessions.
+		_, err := shared.RunCommandContext(context.Background(), "nvme", "disconnect", "--nqn", targetQN)
+		if err != nil {
+			return fmt.Errorf("Failed disconnecting from NVMe target %q: %w", targetQN, err)
+		}
+	}
+
+	return nil
+}
+
+// DisconnectAll terminates all connections with all targets.
+func (c *connectorNVMe) DisconnectAll() error {
+	_, err := shared.RunCommand("nvme", "disconnect-all")
+	if err != nil {
+		return fmt.Errorf("Failed disconnecting from NVMe targets: %w", err)
+	}
+
+	return nil
+}
+
+// SessionID returns the identifier of a session that matches the targetQN.
+// If no session is found, an empty string is returned.
+func (c *connectorNVMe) SessionID(targetQN string) (string, error) {
+	session, err := c.findSession(targetQN)
+	if err != nil || session == nil {
+		return "", err
+	}
+
+	return session.id, nil
+}
+
+// findSession returns an active NVMe subsystem (referred to as session for
+// consistency across connectors) that matches the given targetQN.
+// If the session is not found, nil is returned.
+//
+// This function handles the distinction between an "inactive" session (with no
+// active controllers/connections) and a completely "non-existent" session. While
+// checking "/sys/class/nvme" for active controllers is sufficient to identify if
+// the session is currently in use, it does not account for cases where a session
+// exists but is temporarily inactive (e.g., due to network issues). Removing
+// such a session during this state would prevent it from automatically
+// recovering once the connection is restored.
+//
+// To ensure we detect "existing" sessions, we first check for the session's
+// presence in "/sys/class/nvme-subsystem", which tracks all associated NVMe
+// subsystems regardless of their current connection state. If such session is
+// found the function determines addresses of the active connections by checking
+// "/sys/class/nvme", and returns a non-nil result (except if an error occurs).
+func (c *connectorNVMe) findSession(targetQN string) (*session, error) {
+	// Base path for NVMe sessions/subsystems.
+	subsysBasePath := "/sys/class/nvme-subsystem"
+
+	// Retrieve the list of existing NVMe subsystems on this host.
+	subsystems, err := os.ReadDir(subsysBasePath)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			// If NVMe subsystems directory does not exist,
+			// there is no sessions.
+			return nil, nil
+		}
+
+		return nil, fmt.Errorf("Failed getting a list of existing NVMe subsystems: %w", err)
+	}
+
+	sessionID := ""
+	for _, subsys := range subsystems {
+		// Get the target NQN.
+		nqnBytes, err := os.ReadFile(filepath.Join(subsysBasePath, subsys.Name(), "subsysnqn"))
+		if err != nil {
+			return nil, fmt.Errorf("Failed getting the target NQN for subystem %q: %w", subsys.Name(), err)
+		}
+
+		// Compare using contains, as targetQN may not be the entire NQN.
+		// For example, PowerFlex targetQN is a substring of the full NQN.
+		if strings.Contains(string(nqnBytes), targetQN) {
+			// Found matching session.
+			sessionID = strings.TrimPrefix(subsys.Name(), "nvme-subsys")
+			break
+		}
+	}
+
+	if sessionID == "" {
+		// No matching session found.
+		return nil, nil
+	}
+
+	session := &session{
+		id:       sessionID,
+		targetQN: targetQN,
+	}
+
+	basePath := "/sys/class/nvme"
+
+	// Retrieve the list of currently active (operational) NVMe controllers.
+	controllers, err := os.ReadDir(basePath)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			// No active connections for any session.
+			return session, nil
+		}
+
+		return nil, fmt.Errorf("Failed getting a list of existing NVMe subsystems: %w", err)
+	}
+
+	// Iterate over active NVMe devices and extract addresses from those
+	// that correspond to the targetQN.
+	for _, c := range controllers {
+		// Get device's target NQN.
+		nqnBytes, err := os.ReadFile(filepath.Join(basePath, c.Name(), "subsysnqn"))
+		if err != nil {
+			return nil, fmt.Errorf("Failed getting the target NQN for controller %q: %w", c.Name(), err)
+		}
+
+		// Compare using contains, as targetQN may not be the entire NQN.
+		// For example, PowerFlex targetQN is a substring of the full NQN.
+		if !strings.Contains(string(nqnBytes), targetQN) {
+			// Subsystem does not belong to the targetQN.
+			continue
+		}
+
+		// Read address file of an active NVMe connection.
+		filePath := filepath.Join(basePath, c.Name(), "address")
+		fileBytes, err := os.ReadFile(filePath)
+		if err != nil {
+			return nil, fmt.Errorf("Failed getting connection address of controller %q for target %q: %w", c.Name(), targetQN, err)
+		}
+
+		// Extract the addresses from the file.
+		// The "address" file contains one line per connection,
+		// each in format "traddr=<ip>,trsvcid=<port>,...".
+		for _, line := range strings.Split(string(fileBytes), "\n") {
+			parts := strings.Split(strings.TrimSpace(line), ",")
+			for _, part := range parts {
+				addr, ok := strings.CutPrefix(part, "traddr=")
+				if ok {
+					session.addresses = append(session.addresses, addr)
+					break
+				}
+			}
+		}
+	}
+
+	return session, nil
+}

--- a/lxd/storage/connectors/connector_sdc.go
+++ b/lxd/storage/connectors/connector_sdc.go
@@ -1,0 +1,64 @@
+package connectors
+
+import (
+	"context"
+
+	"github.com/canonical/lxd/shared/revert"
+)
+
+var _ Connector = &connectorSDC{}
+
+type connectorSDC struct {
+	common
+}
+
+// Type returns the type of the connector.
+func (c *connectorSDC) Type() string {
+	return TypeSDC
+}
+
+// Version returns an empty string and no error.
+func (c *connectorSDC) Version() (string, error) {
+	return "", nil
+}
+
+// LoadModules returns true. SDC does not require any kernel modules to be loaded.
+func (c *connectorSDC) LoadModules() error {
+	return nil
+}
+
+// QualifiedName returns an empty string and no error. SDC has no qualified name.
+func (c *connectorSDC) QualifiedName() (string, error) {
+	return "", nil
+}
+
+// SessionID returns an empty string and no error, as connections are handled by SDC.
+func (c *connectorSDC) SessionID(targetQN string) (string, error) {
+	return "", nil
+}
+
+// Connect does nothing. Connections are fully handled by SDC.
+func (c *connectorSDC) Connect(ctx context.Context, targetQN string, targetAddresses ...string) (revert.Hook, error) {
+	// Nothing to do. Connection is handled by Dell SDC.
+	return revert.New().Fail, nil
+}
+
+// ConnectAll does nothing. Connections are fully handled by SDC.
+func (c *connectorSDC) ConnectAll(ctx context.Context, targetAddr string) error {
+	// Nothing to do. Connection is handled by Dell SDC.
+	return nil
+}
+
+// Disconnect does nothing. Connections are fully handled by SDC.
+func (c *connectorSDC) Disconnect(targetQN string) error {
+	return nil
+}
+
+// DisconnectAll does nothing. Connections are fully handled by SDC.
+func (c *connectorSDC) DisconnectAll() error {
+	return nil
+}
+
+func (c *connectorSDC) findSession(targetQN string) (*session, error) {
+	return nil, nil
+}

--- a/lxd/storage/connectors/utils.go
+++ b/lxd/storage/connectors/utils.go
@@ -6,12 +6,16 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"golang.org/x/sys/unix"
 
+	"github.com/canonical/lxd/lxd/locking"
 	"github.com/canonical/lxd/lxd/resources"
 	"github.com/canonical/lxd/shared"
+	"github.com/canonical/lxd/shared/logger"
+	"github.com/canonical/lxd/shared/revert"
 )
 
 // devicePathFilterFunc is a function that accepts device path and returns true
@@ -126,4 +130,131 @@ func WaitDiskDeviceGone(ctx context.Context, diskPath string) bool {
 
 		time.Sleep(500 * time.Millisecond)
 	}
+}
+
+// connectFunc is invoked by "connect" for each provided address.
+// It receives a session and a target address. A non-nil session indicates
+// an existing session for the target.
+//
+// The function is responsible for establishing new connections or handling
+// necessary actions for already connected target addresses.
+type connectFunc func(ctx context.Context, s *session, addr string) error
+
+// connect attempts to establish connections to all provided addresses,
+// succeeding if at least one connection is successful.
+//
+// If all connection attempts fail, an error is returned, and the function
+// ensures the session is cleanup if one was created during this call.
+//
+// IMPORTANT:
+// If at least one connection succeeds, no error is returned. In this case,
+// the caller is responsible for disconnection by calling "connectors.Disconnect"
+// when safe. The returned reverter will only cancel ongoing connection attempts
+// but will **not** attempt disconnection.
+func connect(ctx context.Context, c Connector, targetQN string, targetAddrs []string, connectFunc connectFunc) (revert.Hook, error) {
+	// Acquire a lock to prevent concurrent connection attempts to the same
+	// target.
+	//
+	// The unlock is not deferred here because it must remain held until all
+	// connection attempts are complete. Releasing the lock prematurely after
+	// the first successful connection (when this function exits) could lead
+	// to race conditions if other connection attempts are still ongoing.
+	// For the same reason, relying on a higher-level lock from the caller
+	// (e.g., the storage driver) is insufficient.
+	unlock, err := locking.Lock(ctx, targetQN)
+	if err != nil {
+		return nil, err
+	}
+
+	// Once the lock is obtained, search for an existing session.
+	session, err := c.findSession(targetQN)
+	if err != nil {
+		return nil, err
+	}
+
+	// Set a maximum timeout of 30 seconds for connection attempts.
+	// The caller can override this with a shorter timeout if needed.
+	//
+	// Context cancellation is not deferred here to ensure connection attempts
+	// continue even if the function exits before all attempts are completed.
+	timeoutCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+
+	var wg sync.WaitGroup
+	resChan := make(chan bool, len(targetAddrs))
+
+	var successLock sync.Mutex
+	isSuccess := false
+
+	go func() {
+		// Connect to all target addresses.
+		for _, addr := range targetAddrs {
+			wg.Add(1)
+
+			go func(addr string) {
+				defer wg.Done()
+
+				err := connectFunc(timeoutCtx, session, addr)
+				if err != nil {
+					// Log warning for each failed connection attempt.
+					logger.Warn("Failed connecting to target", logger.Ctx{"target_qualified_name": targetQN, "target_address": addr, "err": err})
+				} else {
+					successLock.Lock()
+					isSuccess = true
+					successLock.Unlock()
+				}
+
+				resChan <- (err == nil)
+			}(addr)
+		}
+
+		// Wait for all connection attempts to complete.
+		wg.Wait()
+
+		// Cleanup.
+		close(resChan)
+		cancel()
+
+		// Ensure the session is removed if no successful connection was
+		// established and no session existed before.
+		//
+		// If at least one connection succeeded, the caller is responsible
+		// for handling disconnection to avoid inadvertently disconnecting
+		// subsequent operations that may have reused the session after
+		// this function releases the lock. The lock being released is also
+		// the reason why disconnect is not returned in the outer reverter.
+		//
+		// Additionally, do not disconnect a session that existed once
+		// this function has obtained a lock. Even if no connection was
+		// successful, retaining the session allows other devices using
+		// it to recover. For example, the remote storage may have become
+		// inaccessible due to power loss. Removing the session would prevent
+		// existing devices from reconnecting once the remote storage becomes
+		// accessible again.
+		if !isSuccess && session == nil {
+			_ = c.Disconnect(targetQN)
+		}
+
+		unlock()
+	}()
+
+	// Wait until either a successful connection is established
+	// or all connection attempts fail.
+	for success := range resChan {
+		if success {
+			// At least one connection succeeded.
+			//
+			// Return a reverter that cancels any ongoing connection
+			// attempts and waits for them to complete.
+			outerReverter := revert.New()
+			outerReverter.Add(func() {
+				cancel()
+				wg.Wait()
+			})
+
+			return outerReverter.Fail, nil
+		}
+	}
+
+	// All connections attempts have failed.
+	return nil, fmt.Errorf("Failed to connect to any address on target %q", targetQN)
 }

--- a/lxd/storage/connectors/utils.go
+++ b/lxd/storage/connectors/utils.go
@@ -1,0 +1,129 @@
+package connectors
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/canonical/lxd/lxd/resources"
+	"github.com/canonical/lxd/shared"
+)
+
+// devicePathFilterFunc is a function that accepts device path and returns true
+// if the path matches the required criteria.
+type devicePathFilterFunc func(devPath string) bool
+
+// GetDiskDevicePath checks whether the disk device with a given prefix and suffix
+// exists in /dev/disk/by-id directory. A device path is returned if the device is
+// found, otherwise an error is returned.
+func GetDiskDevicePath(diskNamePrefix string, diskPathFilter devicePathFilterFunc) (string, error) {
+	devPath, err := findDiskDevicePath(diskNamePrefix, diskPathFilter)
+	if err != nil {
+		return "", err
+	}
+
+	if devPath == "" {
+		return "", fmt.Errorf("Device not found")
+	}
+
+	return devPath, nil
+}
+
+// WaitDiskDevicePath waits for the disk device to appear in /dev/disk/by-id.
+// It periodically checks for the device to appear and returns the device path
+// once it is found. If the device does not appear within the timeout, an error
+// is returned.
+func WaitDiskDevicePath(ctx context.Context, diskNamePrefix string, diskPathFilter devicePathFilterFunc) (string, error) {
+	var err error
+	var diskPath string
+
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	for {
+		// Check if the device is already present.
+		diskPath, err = findDiskDevicePath(diskNamePrefix, diskPathFilter)
+		if err != nil && !errors.Is(err, unix.ENOENT) {
+			return "", err
+		}
+
+		// If the device is found, return the device path.
+		if diskPath != "" {
+			break
+		}
+
+		// Check if context is cancelled.
+		err := ctx.Err()
+		if err != nil {
+			return "", err
+		}
+
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	return diskPath, nil
+}
+
+// findDiskDevivePath iterates over device names in /dev/disk/by-id directory and
+// returns the path to the disk device that matches the given prefix and suffix.
+// Disk partitions are skipped, and an error is returned if the device is not found.
+func findDiskDevicePath(diskNamePrefix string, diskPathFilter devicePathFilterFunc) (string, error) {
+	var diskPaths []string
+
+	// If there are no other disks on the system by id, the directory might not
+	// even be there. Returns ENOENT in case the by-id/ directory does not exist.
+	diskPaths, err := resources.GetDisksByID(diskNamePrefix)
+	if err != nil {
+		return "", err
+	}
+
+	for _, diskPath := range diskPaths {
+		// Skip the disk if it is only a partition of the actual volume.
+		if strings.Contains(diskPath, "-part") {
+			continue
+		}
+
+		// Use custom disk path filter, if one is provided.
+		if diskPathFilter != nil && !diskPathFilter(diskPath) {
+			continue
+		}
+
+		// The actual device might not already be created.
+		// Returns ENOENT in case the device does not exist.
+		devPath, err := filepath.EvalSymlinks(diskPath)
+		if err != nil {
+			return "", err
+		}
+
+		return devPath, nil
+	}
+
+	return "", nil
+}
+
+// WaitDiskDeviceGone waits for the disk device to disappear from /dev/disk/by-id.
+// It periodically checks for the device to disappear and returns once the device
+// is gone. If the device does not disappear within the timeout, an error is returned.
+func WaitDiskDeviceGone(ctx context.Context, diskPath string) bool {
+	// Set upper boundary for the timeout to ensure this function does not run
+	// indefinitely. The caller can set a shorter timeout if necessary.
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	for {
+		if !shared.PathExists(diskPath) {
+			return true
+		}
+
+		if ctx.Err() != nil {
+			return false
+		}
+
+		time.Sleep(500 * time.Millisecond)
+	}
+}

--- a/lxd/storage/drivers/driver_powerflex.go
+++ b/lxd/storage/drivers/driver_powerflex.go
@@ -280,6 +280,15 @@ func (d *powerflex) Validate(config map[string]string) error {
 		return err
 	}
 
+	newMode := config["powerflex.mode"]
+	oldMode := d.config["powerflex.mode"]
+
+	// Ensure powerflex.mode cannot be changed to avoid leaving volume mappings
+	// and to prevent disturbing running instances.
+	if oldMode != "" && oldMode != newMode {
+		return fmt.Errorf("PowerFlex mode cannot be changed")
+	}
+
 	// Check if the selected PowerFlex mode is supported on this node.
 	// Also when forming the storage pool on a LXD cluster, the mode
 	// that got discovered on the creating machine needs to be validated

--- a/lxd/storage/drivers/driver_powerflex_utils.go
+++ b/lxd/storage/drivers/driver_powerflex_utils.go
@@ -792,21 +792,6 @@ func (d *powerflex) getHostGUID() (string, error) {
 	return d.sdcGUID, nil
 }
 
-// getServerName returns the hostname of this host.
-// It prefers the value from the daemons state in case LXD is clustered.
-func (d *powerflex) getServerName() (string, error) {
-	if d.state.ServerName != "none" {
-		return d.state.ServerName, nil
-	}
-
-	hostname, err := os.Hostname()
-	if err != nil {
-		return "", fmt.Errorf("Failed to get hostname: %w", err)
-	}
-
-	return hostname, nil
-}
-
 // getVolumeType returns the selected provisioning type of the volume.
 // As a default it returns type thin.
 func (d *powerflex) getVolumeType(vol Volume) powerFlexVolumeType {
@@ -837,7 +822,7 @@ func (d *powerflex) createNVMeHost() (string, revert.Hook, error) {
 			return "", nil, err
 		}
 
-		hostname, err := d.getServerName()
+		hostname, err := ResolveServerName(d.state.ServerName)
 		if err != nil {
 			return "", nil, err
 		}

--- a/lxd/storage/drivers/driver_powerflex_volumes.go
+++ b/lxd/storage/drivers/driver_powerflex_volumes.go
@@ -241,7 +241,7 @@ func (d *powerflex) CreateVolumeFromCopy(vol VolumeCopy, srcVol VolumeCopy, allo
 		return nil
 	}
 
-	var srcVolumeSnapshots []string
+	srcVolumeSnapshots := make([]string, 0, len(vol.Snapshots))
 	for _, snapshot := range vol.Snapshots {
 		_, snapshotName, _ := api.GetParentAndSnapshotName(snapshot.name)
 		srcVolumeSnapshots = append(srcVolumeSnapshots, snapshotName)
@@ -984,7 +984,7 @@ func (d *powerflex) VolumeSnapshots(vol Volume, op *operations.Operation) ([]str
 		return nil, err
 	}
 
-	var snapshotNames []string
+	snapshotNames := make([]string, 0, len(volumeSnapshots))
 	for _, snapshot := range volumeSnapshots {
 		snapshotNames = append(snapshotNames, snapshot.Name)
 	}

--- a/lxd/storage/drivers/utils.go
+++ b/lxd/storage/drivers/utils.go
@@ -896,3 +896,18 @@ func roundAbove(above, val int64) int64 {
 
 	return rounded
 }
+
+// ResolveServerName returns the given server name if it is not "none".
+// If the server name is "none", it retrieves and returns the server's hostname.
+func ResolveServerName(serverName string) (string, error) {
+	if serverName != "none" {
+		return serverName, nil
+	}
+
+	hostname, err := os.Hostname()
+	if err != nil {
+		return "", fmt.Errorf("Failed to get hostname: %w", err)
+	}
+
+	return hostname, nil
+}

--- a/lxd/storage/drivers/utils.go
+++ b/lxd/storage/drivers/utils.go
@@ -220,23 +220,6 @@ func tryExists(ctx context.Context, path string) bool {
 	}
 }
 
-// waitGone waits for a file to not exist anymore or the context being cancelled.
-// The probe happens at intervals of 500 milliseconds.
-func waitGone(ctx context.Context, path string) bool {
-	for {
-		select {
-		case <-ctx.Done():
-			return false
-		default:
-			if !shared.PathExists(path) {
-				return true
-			}
-		}
-
-		time.Sleep(500 * time.Millisecond)
-	}
-}
-
 // fsUUID returns the filesystem UUID for the given block path.
 // error is returned if the given block device exists but has no UUID.
 func fsUUID(path string) (string, error) {


### PR DESCRIPTION
This PR contains cherry-picks from #14700 to include only connectors and PowerFlex changes (without Pure Storage bits)

The aim of the connector is to handle connections with the target storage. Currently, connectors support NVMe, and SDC.

Once PowerFlex will use `Connect`/`Diconnect`, the following connector functions can be removed:
- `ConnectAll`
- `DisconnectAll`
- `SessionID`

Closes https://github.com/canonical/lxd/pull/14708


