### PR TITLE
CLI: Fix remote completions

### DIFF
--- a/lxc/completion.go
+++ b/lxc/completion.go
@@ -1317,7 +1317,7 @@ func (g *cmdGlobal) cmpRemotes(includeAll bool) ([]string, cobra.ShellCompDirect
 	results := make([]string, 0, len(g.conf.Remotes))
 
 	for remoteName, rc := range g.conf.Remotes {
-		if remoteName == "local" || (!includeAll && rc.Protocol != "lxd" && rc.Protocol != "") {
+		if remoteName == "local" && g.conf.DefaultRemote == "local" || remoteName == g.conf.DefaultRemote || (!includeAll && rc.Protocol != "lxd" && rc.Protocol != "") {
 			continue
 		}
 


### PR DESCRIPTION
This PR fixes the logic in `cmpRemotes` to ensure remotes are contextually completed correctly based on the current remote. While testing https://github.com/canonical/lxd-pkg-snap/pull/674, I noticed that the `local` remote was not completed while on a different remote.