### PR TITLE
CLI: `lxc network forward` completion improvements

### DIFF
--- a/lxc/completion.go
+++ b/lxc/completion.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"io/fs"
+	"net"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -844,6 +845,48 @@ func (g *cmdGlobal) cmpNetworkForwards(networkName string) ([]string, cobra.Shel
 	results, err := resource.server.GetNetworkForwardAddresses(networkName)
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveError
+	}
+
+	return results, cmpDirectives
+}
+
+// cmpNetworkForwardPortTargetAddresses provides shell completion for network forward port target addresses.
+// It takes a network name and listen address to determine whether to return ipv4 or ipv6 target addresses and returns a list of target addresses.
+func (g *cmdGlobal) cmpNetworkForwardPortTargetAddresses(networkName string, listenAddress string) ([]string, cobra.ShellCompDirective) {
+	cmpDirectives := cobra.ShellCompDirectiveNoFileComp
+
+	resources, _ := g.ParseServers(networkName)
+	if len(resources) <= 0 {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	resource := resources[0]
+	instances, err := resource.server.GetInstancesFull(api.InstanceTypeAny)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	var results []string
+	listenAddressIsIP4 := net.ParseIP(listenAddress).To4() != nil
+	for _, instance := range instances {
+		if instance.IsActive() && instance.State != nil && instance.State.Network != nil {
+			for _, network := range instance.State.Network {
+				if network.Type == "loopback" {
+					continue
+				}
+
+				results = make([]string, 0, len(network.Addresses))
+				for _, address := range network.Addresses {
+					if shared.ValueInSlice(address.Scope, []string{"link", "local"}) {
+						continue
+					}
+
+					if (listenAddressIsIP4 && address.Family == "inet") || (!listenAddressIsIP4 && address.Family == "inet6") {
+						results = append(results, address.Address)
+					}
+				}
+			}
+		}
 	}
 
 	return results, cmpDirectives

--- a/lxc/completion.go
+++ b/lxc/completion.go
@@ -862,7 +862,7 @@ func (g *cmdGlobal) cmpNetworkLoadBalancers(networkName string) ([]string, cobra
 
 	resource := resources[0]
 
-	results, err := resource.server.GetNetworkForwardAddresses(networkName)
+	results, err := resource.server.GetNetworkLoadBalancerAddresses(networkName)
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveError
 	}

--- a/lxc/network_forward.go
+++ b/lxc/network_forward.go
@@ -264,6 +264,14 @@ lxc network forward create n1 127.0.0.1 < config.yaml
 	cmd.Flags().StringVar(&c.networkForward.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 	cmd.Flags().StringVar(&c.flagAllocate, "allocate", "", i18n.G("Auto-allocate an IPv4 or IPv6 listen address. One of 'ipv4', 'ipv6'.")+"``")
 
+	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) == 0 {
+			return c.global.cmpNetworks(toComplete)
+		}
+
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
 	return cmd
 }
 

--- a/lxc/network_forward.go
+++ b/lxc/network_forward.go
@@ -904,6 +904,10 @@ func (c *cmdNetworkForwardPort) commandAdd() *cobra.Command {
 			return []string{"tcp", "udp"}, cobra.ShellCompDirectiveNoFileComp
 		}
 
+		if len(args) == 4 {
+			return c.global.cmpNetworkForwardPortTargetAddresses(args[0], args[1])
+		}
+
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
@@ -984,6 +988,10 @@ func (c *cmdNetworkForwardPort) commandRemove() *cobra.Command {
 
 		if len(args) == 2 {
 			return []string{"tcp", "udp"}, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		if len(args) == 4 {
+			return c.global.cmpNetworkForwardPortTargetAddresses(args[0], args[1])
 		}
 
 		return nil, cobra.ShellCompDirectiveNoFileComp


### PR DESCRIPTION
Closes https://github.com/canonical/lxd/issues/14697.

Summary of changes:
- Fixes `cmpNetworkLoadBalancers`. `cmpNetworkLoadBalancers` should return load balancer addresses, not
network forward addresses.
- Adds `cmpNetworkForwardPortTargetAddresses` to provide target address completions for `lxc network forward port add`.
- Adds network completions to `lxc network forward` create.
