### PR TITLE
VM: Avoid `Invalid compat argument` from `virtiofsd`

### DIFF
--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -1156,16 +1156,20 @@ func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 					return nil, fmt.Errorf(`Missing mount "path" setting`)
 				}
 
+				// Escaping to avoid invalid source errors.
+				devPath := d.virtiofsdSourceEncode(d.getDevicePath(d.name, d.config))
+
 				// Mount the source in the instance devices directory.
 				// This will ensure that if the exported directory configured as readonly that this
 				// takes effect event if using virtio-fs (which doesn't support read only mode) by
 				// having the underlying mount setup as readonly.
 				var revertFunc func()
-				revertFunc, mount.DevPath, _, err = d.createDevice(mount.DevPath)
+				revertFunc, _, err = d.createDevice(mount.DevPath, devPath)
 				if err != nil {
 					return nil, err
 				}
 
+				mount.DevPath = devPath
 				revert.Add(revertFunc)
 
 				mount.TargetPath = d.config["path"]

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -949,6 +949,13 @@ func (d *disk) detectVMPoolMountOpts() []string {
 	return opts
 }
 
+// virtiofsdSourceEncode encodes a path string to be used as part of a disk source on viriofsd.
+// virtiofsd fails if the source property contains an equal sign.
+// The encoding scheme replaces "-" with "--" and then "=" with "-".
+func (d *disk) virtiofsdSourceEncode(text string) string {
+	return strings.Replace(strings.Replace(text, "-", "--", -1), "=", "-", -1)
+}
+
 // startVM starts the disk device for a virtual machine instance.
 func (d *disk) startVM() (*deviceConfig.RunConfig, error) {
 	runConf := deviceConfig.RunConfig{}

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -880,7 +880,8 @@ func (d *disk) startContainer() (*deviceConfig.RunConfig, error) {
 		}
 
 		// Mount the source in the instance devices directory.
-		revertFunc, sourceDevPath, isFile, err := d.createDevice(srcPath)
+		devPath := d.getDevicePath(d.name, d.config)
+		revertFunc, isFile, err := d.createDevice(srcPath, devPath)
 		if err != nil {
 			return nil, err
 		}
@@ -896,7 +897,7 @@ func (d *disk) startContainer() (*deviceConfig.RunConfig, error) {
 		// Instruct LXD to perform the mount.
 		runConf.Mounts = append(runConf.Mounts, deviceConfig.MountEntryItem{
 			DevName:    d.name,
-			DevPath:    sourceDevPath,
+			DevPath:    devPath,
 			TargetPath: relativeDestPath,
 			FSType:     "none",
 			Opts:       options,

--- a/lxd/instance_put.go
+++ b/lxd/instance_put.go
@@ -73,7 +73,7 @@ func instancePut(d *Daemon, r *http.Request) response.Response {
 
 	projectName := request.ProjectParam(r)
 
-	// Get the container
+	// Get the instance's name
 	name, err := url.PathUnescape(mux.Vars(r)["name"])
 	if err != nil {
 		return response.SmartError(err)
@@ -83,7 +83,7 @@ func instancePut(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(fmt.Errorf("Invalid instance name"))
 	}
 
-	// Handle requests targeted to a container on a different node
+	// Handle requests targeted to an instance on a different node
 	resp, err := forwardedResponseIfInstanceIsRemote(s, r, projectName, name, instanceType)
 	if err != nil {
 		return response.SmartError(err)
@@ -164,7 +164,7 @@ func instancePut(d *Daemon, r *http.Request) response.Response {
 			return response.SmartError(err)
 		}
 
-		// Update container configuration
+		// Update instance configuration
 		do = func(op *operations.Operation) error {
 			defer unlock()
 


### PR DESCRIPTION
When using a `=` in a device path, as in `lxc storage volume attach default vol vm /mnt/path=`, we get a stale operation for that VM, the disk device set up freezes midway and further operations on that VM become impossible and always halts. Upon looking the `virtiofsd` logs we can see something like: `error: Invalid compat argument '-o source=/var/snap/lxd/common/lxd/devices/vm/disk.vol.path='`. As a fix, this PR escapes '=' from the source path for VMs.