### PR TITLE
auth: Add entitlements to LXD entities (part 1: introduce `IsFineGrained` field)

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2557,3 +2557,10 @@ disk devices.
 
 Introduces per-project uplink IP limits for each available uplink network, adding `limits.networks.uplink_ips.ipv4.NETWORK_NAME` and `limits.networks.uplink_ips.ipv6.NETWORK_NAME` configuration keys for projects with `features.networks` enabled.
 These keys define the maximum value of IPs made available on a network named NETWORK_NAME to be assigned as uplink IPs for entities inside a certain project. These entities can be other networks, network forwards or load balancers.
+
+## `entities_with_entitlements`
+
+Adds `fine_grained` field to `GET /1.0/auth/identities/current` to indicate if the current identity
+interacting with the LXD API is fine-grained (that is, associated permissions are managed via group membership).
+Allows LXD entities to be returned with an `access_entitlements` field if the current identity is fine-grained and the
+GET request to fetch the LXD entities has the `with-access-entitlements=<comma_separated_list_of_candidate_entitlements>` query parameter.

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -829,6 +829,12 @@ definitions:
                     $ref: '#/definitions/Permission'
                 type: array
                 x-go-name: EffectivePermissions
+            fine_grained:
+                description: |-
+                    FineGrained is a boolean indicating whether the identity is fine-grained,
+                    meaning that permissions are managed via group membership.
+                type: boolean
+                x-go-name: FineGrained
             groups:
                 description: Groups is the list of groups for which the identity is a member.
                 example:

--- a/lxd/identities.go
+++ b/lxd/identities.go
@@ -1885,7 +1885,8 @@ func updateIdentityCacheFromLocal(d *Daemon) error {
 		return fmt.Errorf("Failed reading certificates from local database: %w", err)
 	}
 
-	var identityCacheEntries []identity.CacheEntry
+	// identityCacheEntries needs to be pre-allocated.
+	identityCacheEntries := make([]identity.CacheEntry, 0, len(localServerCerts))
 	for _, dbCert := range localServerCerts {
 		certBlock, _ := pem.Decode([]byte(dbCert.Certificate))
 		if certBlock == nil {

--- a/lxd/identities.go
+++ b/lxd/identities.go
@@ -1126,6 +1126,7 @@ func getCurrentIdentityInfo(d *Daemon, r *http.Request) response.Response {
 		Identity:             *apiIdentity,
 		EffectiveGroups:      effectiveGroups,
 		EffectivePermissions: effectivePermissions,
+		FineGrained:          identity.IsFineGrainedIdentityType(apiIdentity.Type),
 	})
 }
 

--- a/shared/api/auth.go
+++ b/shared/api/auth.go
@@ -99,6 +99,10 @@ type IdentityInfo struct {
 	// Effective permissions is the combined and deduplicated list of permissions that the identity has by virtue of
 	// direct membership to a LXD group, or effective membership of a LXD group via identity provider group mappings.
 	EffectivePermissions []Permission `json:"effective_permissions" yaml:"effective_permissions"`
+
+	// FineGrained is a boolean indicating whether the identity is fine-grained,
+	// meaning that permissions are managed via group membership.
+	FineGrained bool `json:"fine_grained" yaml:"fine_grained"`
 }
 
 // IdentityPut contains the editable fields of an IdentityInfo.

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -432,6 +432,7 @@ var APIExtensions = []string{
 	"network_zones_all_projects",
 	"instance_root_volume_attachment",
 	"projects_limits_uplink_ips",
+	"entities_with_entitlements",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
JIRA ticket: https://warthogs.atlassian.net/browse/LXD-2208
Specification link: https://docs.google.com/document/d/1GxWV5J57MLrjGEY5RDG7eS86J99A8RMmjKTpn0mEhgY/edit?tab=t.0

____

This is the first part of a group of three stacked PRs.

* Second part: https://github.com/canonical/lxd/pull/14746
* Third part: https://github.com/canonical/lxd/pull/14748

____

This introduces a new `FineGrained` boolean field in `IdentityInfo` (returned from `GET /1.0/auth/identities/current`) to let a user know if he is currently using a fine grained authentication method. This PR also introduce the `entities_with_entitlements` extension. 

____

## How to query the API using fine grained auth (this is just a reminder for me)

```bash
# Add TLS certificate to LXD (this can be done through LXD UI. Download the .pfx file)
# Create an auth group
lxc auth group create test-group

# Add an new identity to this group ("lxd-ui" is my TLS certificate identifier created by LXD UI)
lxc auth identity group add tls/lxd-ui test-group-1

# Create resources and add permissions to them
lxc auth group permission add test-group-1 instance c1 can_view project=default

# Create a .pfx certificate (with password "1234") and associate it to an auth group and give it some permissions. You can call the API like the following to perform fine-grained calls:
curl --insecure --cert-type P12 --cert lxd-ui-fine-grained-tls.pfx:1234 "https://127.0.0.1:8443/1.0/instances/c1?recursion=1&with-entitlements=can_view" | jq '.'
```

The CURL output should give you something like:

```json
{
  "type": "sync",
  "status": "Success",
  "status_code": 200,
  "operation": "",
  "error_code": 0,
  "error": "",
  "metadata": {
    "entitlements": [
      "can_view"
    ],
    "name": "c1",
    "description": "this is a test ",
    "status": "Running",
    "status_code": 103,
    "created_at": "2024-11-12T09:58:54.960586253Z",
    "last_used_at": "2024-11-16T12:15:13.572661467Z",
    "location": "none",
    "type": "container",
    ...
  }
}
```
