### PR TITLE
lxc: Update auth group edit help text

### DIFF
--- a/lxc/auth.go
+++ b/lxc/auth.go
@@ -228,12 +228,10 @@ func (c *cmdGroupEdit) helpTemplate() string {
 ###   url: /1.0/projects/default
 ###   entitlement: can_view
 ### identities:
-### - authentication_method: oidc
-###   type: OIDC client
-###   identifier: jane.doe@example.com
-###   name: Jane Doe
-###   metadata:
-###     subject: auth0|123456789
+###   oidc:
+###   - jane.doe@example.com
+###   tls:
+###   - eaa46a1b73827350e0543949fb161410c50e950d4cb9802fc58dbfbd5700e508
 ### identity_provider_groups:
 ### - sales
 ### - operations

--- a/lxc/auth.go
+++ b/lxc/auth.go
@@ -220,7 +220,8 @@ func (c *cmdGroupEdit) helpTemplate() string {
 		`### This is a YAML representation of the group.
 ### Any line starting with a '# will be ignored.
 ###
-### A group has the following format:
+### NOTE: All group information is shown but only the description and permissions can be modified.
+### 
 ### name: my-first-group
 ### description: My first group.
 ### permissions:
@@ -235,8 +236,7 @@ func (c *cmdGroupEdit) helpTemplate() string {
 ### identity_provider_groups:
 ### - sales
 ### - operations
-###
-### Note that all group information is shown but only the description and permissions can be modified`)
+`)
 }
 
 func (c *cmdGroupEdit) run(cmd *cobra.Command, args []string) error {

--- a/lxc/auth.go
+++ b/lxc/auth.go
@@ -1540,7 +1540,7 @@ func (c *cmdPermissionList) run(cmd *cobra.Command, args []string) error {
 	}
 
 	i := 0
-	var displayPermissions []*displayPermission
+	displayPermissions := make([]*displayPermission, 0, len(permissionsInfo))
 	displayPermissionIdx := make(map[string]int)
 	for _, perm := range permissionsInfo {
 		idx, ok := displayPermissionIdx[perm.EntityReference]

--- a/po/ar.po
+++ b/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-19 16:04-0700\n"
+"POT-Creation-Date: 2025-01-07 15:23+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -130,34 +130,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:219
-msgid ""
-"### This is a YAML representation of the group.\n"
-"### Any line starting with a '# will be ignored.\n"
-"###\n"
-"### A group has the following format:\n"
-"### name: my-first-group\n"
-"### description: My first group.\n"
-"### permissions:\n"
-"### - entity_type: project\n"
-"###   url: /1.0/projects/default\n"
-"###   entitlement: can_view\n"
-"### identities:\n"
-"### - authentication_method: oidc\n"
-"###   type: OIDC client\n"
-"###   identifier: jane.doe@example.com\n"
-"###   name: Jane Doe\n"
-"###   metadata:\n"
-"###     subject: auth0|123456789\n"
-"### identity_provider_groups:\n"
-"### - sales\n"
-"### - operations\n"
-"###\n"
-"### Note that all group information is shown but only the description and "
-"permissions can be modified"
-msgstr ""
-
-#: lxc/auth.go:1121
+#: lxc/auth.go:1119
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -178,7 +151,31 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1793
+#: lxc/auth.go:219
+msgid ""
+"### This is a YAML representation of the group.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### NOTE: All group information is shown but only the description and "
+"permissions can be modified.\n"
+"### \n"
+"### name: my-first-group\n"
+"### description: My first group.\n"
+"### permissions:\n"
+"### - entity_type: project\n"
+"###   url: /1.0/projects/default\n"
+"###   entitlement: can_view\n"
+"### identities:\n"
+"###   oidc:\n"
+"###   - jane.doe@example.com\n"
+"###   tls:\n"
+"###   - eaa46a1b73827350e0543949fb161410c50e950d4cb9802fc58dbfbd5700e508\n"
+"### identity_provider_groups:\n"
+"### - sales\n"
+"### - operations\n"
+msgstr ""
+
+#: lxc/auth.go:1791
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -557,7 +554,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:966
+#: lxc/auth.go:964
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -595,11 +592,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1312 lxc/auth.go:1313
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2082 lxc/auth.go:2083
+#: lxc/auth.go:2080 lxc/auth.go:2081
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -668,7 +665,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:521 lxc/auth.go:522
+#: lxc/auth.go:519 lxc/auth.go:520
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -1344,12 +1341,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:306 lxc/auth.go:1868
+#: lxc/auth.go:304 lxc/auth.go:1866
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1207
+#: lxc/auth.go:1205
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1378,7 +1375,7 @@ msgstr ""
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:776
+#: lxc/auth.go:774
 msgid "Create a TLS identity"
 msgstr ""
 
@@ -1398,7 +1395,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:775
+#: lxc/auth.go:773
 msgid "Create an identity"
 msgstr ""
 
@@ -1418,7 +1415,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1679 lxc/auth.go:1680
+#: lxc/auth.go:1677 lxc/auth.go:1678
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1526,7 +1523,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1569,7 +1566,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1237 lxc/auth.go:1238
+#: lxc/auth.go:1235 lxc/auth.go:1236
 msgid "Delete an identity"
 msgstr ""
 
@@ -1581,7 +1578,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1729 lxc/auth.go:1730
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1660,14 +1657,14 @@ msgstr ""
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
 #: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
-#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
-#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
-#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
-#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
-#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
-#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
-#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
+#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
+#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
+#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
+#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
+#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
+#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -1936,7 +1933,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1108 lxc/auth.go:1109
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1952,7 +1949,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1780 lxc/auth.go:1781
+#: lxc/auth.go:1778 lxc/auth.go:1779
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2438,7 +2435,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
@@ -2496,7 +2493,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:970 lxc/auth.go:1944
+#: lxc/auth.go:968 lxc/auth.go:1942
 msgid "GROUPS"
 msgstr ""
 
@@ -2655,7 +2652,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:432 lxc/auth.go:1994
+#: lxc/auth.go:430 lxc/auth.go:1992
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2714,7 +2711,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:969
+#: lxc/auth.go:967
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2746,16 +2743,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:829
+#: lxc/auth.go:827
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1716
+#: lxc/auth.go:1714
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1766
+#: lxc/auth.go:1764
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2884,7 +2881,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1441 lxc/auth.go:1442
+#: lxc/auth.go:1439 lxc/auth.go:1440
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3188,15 +3185,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:337 lxc/auth.go:338
+#: lxc/auth.go:335 lxc/auth.go:336
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:917 lxc/auth.go:918
+#: lxc/auth.go:915 lxc/auth.go:916
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1900
+#: lxc/auth.go:1897 lxc/auth.go:1898
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3351,7 +3348,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1463 lxc/auth.go:1464
+#: lxc/auth.go:1461 lxc/auth.go:1462
 msgid "List permissions"
 msgstr ""
 
@@ -3519,7 +3516,7 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:823
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
@@ -3553,19 +3550,19 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1291 lxc/auth.go:1292
+#: lxc/auth.go:1289 lxc/auth.go:1290
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:736 lxc/auth.go:737
+#: lxc/auth.go:734 lxc/auth.go:735
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2059 lxc/auth.go:2060
+#: lxc/auth.go:2057 lxc/auth.go:2058
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3656,7 +3653,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:498 lxc/auth.go:499
+#: lxc/auth.go:496 lxc/auth.go:497
 msgid "Manage permissions"
 msgstr ""
 
@@ -3805,21 +3802,21 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
-#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
-#: lxc/auth.go:1339 lxc/auth.go:1397
+#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
+#: lxc/auth.go:1337 lxc/auth.go:1395
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
+#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2107 lxc/auth.go:2160
+#: lxc/auth.go:2105 lxc/auth.go:2158
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4040,7 +4037,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
@@ -4444,7 +4441,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4803,7 +4800,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1372 lxc/auth.go:1373
+#: lxc/auth.go:1370 lxc/auth.go:1371
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4839,7 +4836,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2135 lxc/auth.go:2136
+#: lxc/auth.go:2133 lxc/auth.go:2134
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4851,7 +4848,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:580 lxc/auth.go:581
+#: lxc/auth.go:578 lxc/auth.go:579
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4896,11 +4893,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:397 lxc/auth.go:398
+#: lxc/auth.go:395 lxc/auth.go:396
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1959 lxc/auth.go:1960
+#: lxc/auth.go:1957 lxc/auth.go:1958
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5421,7 +5418,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2008 lxc/auth.go:2009
+#: lxc/auth.go:2006 lxc/auth.go:2007
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5449,11 +5446,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:446 lxc/auth.go:447
+#: lxc/auth.go:444 lxc/auth.go:445
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:985
+#: lxc/auth.go:983
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5558,7 +5555,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1048
+#: lxc/auth.go:1046
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5796,12 +5793,12 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:876
+#: lxc/auth.go:874
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:902
+#: lxc/auth.go:900
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
@@ -5810,7 +5807,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1747 lxc/warning.go:216
@@ -6482,11 +6479,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:984
+#: lxc/auth.go:982
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1047
+#: lxc/auth.go:1045
 msgid "View the current identity"
 msgstr ""
 
@@ -6557,7 +6554,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6590,7 +6587,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1462
+#: lxc/auth.go:1460
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6651,17 +6648,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:772
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:983 lxc/auth.go:1235
+#: lxc/auth.go:981 lxc/auth.go:1233
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6669,13 +6666,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
-#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
+#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:520 lxc/auth.go:578
+#: lxc/auth.go:518 lxc/auth.go:576
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6685,19 +6682,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:395
+#: lxc/auth.go:393
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
+#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2081
+#: lxc/auth.go:2079
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1957
+#: lxc/auth.go:1955
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7245,14 +7242,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1111
+#: lxc/auth.go:1109
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1783
+#: lxc/auth.go:1781
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-19 16:04-0700\n"
+"POT-Creation-Date: 2025-01-07 15:23+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -133,34 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:219
-msgid ""
-"### This is a YAML representation of the group.\n"
-"### Any line starting with a '# will be ignored.\n"
-"###\n"
-"### A group has the following format:\n"
-"### name: my-first-group\n"
-"### description: My first group.\n"
-"### permissions:\n"
-"### - entity_type: project\n"
-"###   url: /1.0/projects/default\n"
-"###   entitlement: can_view\n"
-"### identities:\n"
-"### - authentication_method: oidc\n"
-"###   type: OIDC client\n"
-"###   identifier: jane.doe@example.com\n"
-"###   name: Jane Doe\n"
-"###   metadata:\n"
-"###     subject: auth0|123456789\n"
-"### identity_provider_groups:\n"
-"### - sales\n"
-"### - operations\n"
-"###\n"
-"### Note that all group information is shown but only the description and "
-"permissions can be modified"
-msgstr ""
-
-#: lxc/auth.go:1121
+#: lxc/auth.go:1119
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +154,31 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1793
+#: lxc/auth.go:219
+msgid ""
+"### This is a YAML representation of the group.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### NOTE: All group information is shown but only the description and "
+"permissions can be modified.\n"
+"### \n"
+"### name: my-first-group\n"
+"### description: My first group.\n"
+"### permissions:\n"
+"### - entity_type: project\n"
+"###   url: /1.0/projects/default\n"
+"###   entitlement: can_view\n"
+"### identities:\n"
+"###   oidc:\n"
+"###   - jane.doe@example.com\n"
+"###   tls:\n"
+"###   - eaa46a1b73827350e0543949fb161410c50e950d4cb9802fc58dbfbd5700e508\n"
+"### identity_provider_groups:\n"
+"### - sales\n"
+"### - operations\n"
+msgstr ""
+
+#: lxc/auth.go:1791
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -560,7 +557,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:966
+#: lxc/auth.go:964
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -598,11 +595,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1312 lxc/auth.go:1313
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2082 lxc/auth.go:2083
+#: lxc/auth.go:2080 lxc/auth.go:2081
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -671,7 +668,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:521 lxc/auth.go:522
+#: lxc/auth.go:519 lxc/auth.go:520
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -1347,12 +1344,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:306 lxc/auth.go:1868
+#: lxc/auth.go:304 lxc/auth.go:1866
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1207
+#: lxc/auth.go:1205
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1381,7 +1378,7 @@ msgstr ""
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:776
+#: lxc/auth.go:774
 msgid "Create a TLS identity"
 msgstr ""
 
@@ -1401,7 +1398,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:775
+#: lxc/auth.go:773
 msgid "Create an identity"
 msgstr ""
 
@@ -1421,7 +1418,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1679 lxc/auth.go:1680
+#: lxc/auth.go:1677 lxc/auth.go:1678
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1529,7 +1526,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1572,7 +1569,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1237 lxc/auth.go:1238
+#: lxc/auth.go:1235 lxc/auth.go:1236
 msgid "Delete an identity"
 msgstr ""
 
@@ -1584,7 +1581,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1729 lxc/auth.go:1730
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1663,14 +1660,14 @@ msgstr ""
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
 #: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
-#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
-#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
-#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
-#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
-#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
-#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
-#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
+#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
+#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
+#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
+#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
+#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
+#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -1939,7 +1936,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1108 lxc/auth.go:1109
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1955,7 +1952,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1780 lxc/auth.go:1781
+#: lxc/auth.go:1778 lxc/auth.go:1779
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2441,7 +2438,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
@@ -2499,7 +2496,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:970 lxc/auth.go:1944
+#: lxc/auth.go:968 lxc/auth.go:1942
 msgid "GROUPS"
 msgstr ""
 
@@ -2658,7 +2655,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:432 lxc/auth.go:1994
+#: lxc/auth.go:430 lxc/auth.go:1992
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2717,7 +2714,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:969
+#: lxc/auth.go:967
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2749,16 +2746,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:829
+#: lxc/auth.go:827
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1716
+#: lxc/auth.go:1714
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1766
+#: lxc/auth.go:1764
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2887,7 +2884,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1441 lxc/auth.go:1442
+#: lxc/auth.go:1439 lxc/auth.go:1440
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3191,15 +3188,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:337 lxc/auth.go:338
+#: lxc/auth.go:335 lxc/auth.go:336
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:917 lxc/auth.go:918
+#: lxc/auth.go:915 lxc/auth.go:916
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1900
+#: lxc/auth.go:1897 lxc/auth.go:1898
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3354,7 +3351,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1463 lxc/auth.go:1464
+#: lxc/auth.go:1461 lxc/auth.go:1462
 msgid "List permissions"
 msgstr ""
 
@@ -3522,7 +3519,7 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:823
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
@@ -3556,19 +3553,19 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1291 lxc/auth.go:1292
+#: lxc/auth.go:1289 lxc/auth.go:1290
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:736 lxc/auth.go:737
+#: lxc/auth.go:734 lxc/auth.go:735
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2059 lxc/auth.go:2060
+#: lxc/auth.go:2057 lxc/auth.go:2058
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3659,7 +3656,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:498 lxc/auth.go:499
+#: lxc/auth.go:496 lxc/auth.go:497
 msgid "Manage permissions"
 msgstr ""
 
@@ -3808,21 +3805,21 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
-#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
-#: lxc/auth.go:1339 lxc/auth.go:1397
+#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
+#: lxc/auth.go:1337 lxc/auth.go:1395
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
+#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2107 lxc/auth.go:2160
+#: lxc/auth.go:2105 lxc/auth.go:2158
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4043,7 +4040,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
@@ -4447,7 +4444,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4806,7 +4803,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1372 lxc/auth.go:1373
+#: lxc/auth.go:1370 lxc/auth.go:1371
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4842,7 +4839,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2135 lxc/auth.go:2136
+#: lxc/auth.go:2133 lxc/auth.go:2134
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4854,7 +4851,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:580 lxc/auth.go:581
+#: lxc/auth.go:578 lxc/auth.go:579
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4899,11 +4896,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:397 lxc/auth.go:398
+#: lxc/auth.go:395 lxc/auth.go:396
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1959 lxc/auth.go:1960
+#: lxc/auth.go:1957 lxc/auth.go:1958
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5424,7 +5421,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2008 lxc/auth.go:2009
+#: lxc/auth.go:2006 lxc/auth.go:2007
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5452,11 +5449,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:446 lxc/auth.go:447
+#: lxc/auth.go:444 lxc/auth.go:445
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:985
+#: lxc/auth.go:983
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5561,7 +5558,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1048
+#: lxc/auth.go:1046
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5799,12 +5796,12 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:876
+#: lxc/auth.go:874
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:902
+#: lxc/auth.go:900
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
@@ -5813,7 +5810,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1747 lxc/warning.go:216
@@ -6485,11 +6482,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:984
+#: lxc/auth.go:982
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1047
+#: lxc/auth.go:1045
 msgid "View the current identity"
 msgstr ""
 
@@ -6560,7 +6557,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6593,7 +6590,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1462
+#: lxc/auth.go:1460
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6654,17 +6651,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:772
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:983 lxc/auth.go:1235
+#: lxc/auth.go:981 lxc/auth.go:1233
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6672,13 +6669,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
-#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
+#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:520 lxc/auth.go:578
+#: lxc/auth.go:518 lxc/auth.go:576
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6688,19 +6685,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:395
+#: lxc/auth.go:393
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
+#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2081
+#: lxc/auth.go:2079
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1957
+#: lxc/auth.go:1955
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7248,14 +7245,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1111
+#: lxc/auth.go:1109
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1783
+#: lxc/auth.go:1781
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-19 16:04-0700\n"
+"POT-Creation-Date: 2025-01-07 15:23+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -133,34 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:219
-msgid ""
-"### This is a YAML representation of the group.\n"
-"### Any line starting with a '# will be ignored.\n"
-"###\n"
-"### A group has the following format:\n"
-"### name: my-first-group\n"
-"### description: My first group.\n"
-"### permissions:\n"
-"### - entity_type: project\n"
-"###   url: /1.0/projects/default\n"
-"###   entitlement: can_view\n"
-"### identities:\n"
-"### - authentication_method: oidc\n"
-"###   type: OIDC client\n"
-"###   identifier: jane.doe@example.com\n"
-"###   name: Jane Doe\n"
-"###   metadata:\n"
-"###     subject: auth0|123456789\n"
-"### identity_provider_groups:\n"
-"### - sales\n"
-"### - operations\n"
-"###\n"
-"### Note that all group information is shown but only the description and "
-"permissions can be modified"
-msgstr ""
-
-#: lxc/auth.go:1121
+#: lxc/auth.go:1119
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +154,31 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1793
+#: lxc/auth.go:219
+msgid ""
+"### This is a YAML representation of the group.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### NOTE: All group information is shown but only the description and "
+"permissions can be modified.\n"
+"### \n"
+"### name: my-first-group\n"
+"### description: My first group.\n"
+"### permissions:\n"
+"### - entity_type: project\n"
+"###   url: /1.0/projects/default\n"
+"###   entitlement: can_view\n"
+"### identities:\n"
+"###   oidc:\n"
+"###   - jane.doe@example.com\n"
+"###   tls:\n"
+"###   - eaa46a1b73827350e0543949fb161410c50e950d4cb9802fc58dbfbd5700e508\n"
+"### identity_provider_groups:\n"
+"### - sales\n"
+"### - operations\n"
+msgstr ""
+
+#: lxc/auth.go:1791
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -560,7 +557,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:966
+#: lxc/auth.go:964
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -598,11 +595,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1312 lxc/auth.go:1313
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2082 lxc/auth.go:2083
+#: lxc/auth.go:2080 lxc/auth.go:2081
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -671,7 +668,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:521 lxc/auth.go:522
+#: lxc/auth.go:519 lxc/auth.go:520
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -1347,12 +1344,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:306 lxc/auth.go:1868
+#: lxc/auth.go:304 lxc/auth.go:1866
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1207
+#: lxc/auth.go:1205
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1381,7 +1378,7 @@ msgstr ""
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:776
+#: lxc/auth.go:774
 msgid "Create a TLS identity"
 msgstr ""
 
@@ -1401,7 +1398,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:775
+#: lxc/auth.go:773
 msgid "Create an identity"
 msgstr ""
 
@@ -1421,7 +1418,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1679 lxc/auth.go:1680
+#: lxc/auth.go:1677 lxc/auth.go:1678
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1529,7 +1526,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1572,7 +1569,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1237 lxc/auth.go:1238
+#: lxc/auth.go:1235 lxc/auth.go:1236
 msgid "Delete an identity"
 msgstr ""
 
@@ -1584,7 +1581,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1729 lxc/auth.go:1730
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1663,14 +1660,14 @@ msgstr ""
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
 #: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
-#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
-#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
-#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
-#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
-#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
-#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
-#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
+#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
+#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
+#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
+#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
+#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
+#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -1939,7 +1936,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1108 lxc/auth.go:1109
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1955,7 +1952,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1780 lxc/auth.go:1781
+#: lxc/auth.go:1778 lxc/auth.go:1779
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2441,7 +2438,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
@@ -2499,7 +2496,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:970 lxc/auth.go:1944
+#: lxc/auth.go:968 lxc/auth.go:1942
 msgid "GROUPS"
 msgstr ""
 
@@ -2658,7 +2655,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:432 lxc/auth.go:1994
+#: lxc/auth.go:430 lxc/auth.go:1992
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2717,7 +2714,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:969
+#: lxc/auth.go:967
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2749,16 +2746,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:829
+#: lxc/auth.go:827
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1716
+#: lxc/auth.go:1714
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1766
+#: lxc/auth.go:1764
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2887,7 +2884,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1441 lxc/auth.go:1442
+#: lxc/auth.go:1439 lxc/auth.go:1440
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3191,15 +3188,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:337 lxc/auth.go:338
+#: lxc/auth.go:335 lxc/auth.go:336
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:917 lxc/auth.go:918
+#: lxc/auth.go:915 lxc/auth.go:916
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1900
+#: lxc/auth.go:1897 lxc/auth.go:1898
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3354,7 +3351,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1463 lxc/auth.go:1464
+#: lxc/auth.go:1461 lxc/auth.go:1462
 msgid "List permissions"
 msgstr ""
 
@@ -3522,7 +3519,7 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:823
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
@@ -3556,19 +3553,19 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1291 lxc/auth.go:1292
+#: lxc/auth.go:1289 lxc/auth.go:1290
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:736 lxc/auth.go:737
+#: lxc/auth.go:734 lxc/auth.go:735
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2059 lxc/auth.go:2060
+#: lxc/auth.go:2057 lxc/auth.go:2058
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3659,7 +3656,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:498 lxc/auth.go:499
+#: lxc/auth.go:496 lxc/auth.go:497
 msgid "Manage permissions"
 msgstr ""
 
@@ -3808,21 +3805,21 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
-#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
-#: lxc/auth.go:1339 lxc/auth.go:1397
+#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
+#: lxc/auth.go:1337 lxc/auth.go:1395
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
+#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2107 lxc/auth.go:2160
+#: lxc/auth.go:2105 lxc/auth.go:2158
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4043,7 +4040,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
@@ -4447,7 +4444,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4806,7 +4803,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1372 lxc/auth.go:1373
+#: lxc/auth.go:1370 lxc/auth.go:1371
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4842,7 +4839,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2135 lxc/auth.go:2136
+#: lxc/auth.go:2133 lxc/auth.go:2134
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4854,7 +4851,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:580 lxc/auth.go:581
+#: lxc/auth.go:578 lxc/auth.go:579
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4899,11 +4896,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:397 lxc/auth.go:398
+#: lxc/auth.go:395 lxc/auth.go:396
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1959 lxc/auth.go:1960
+#: lxc/auth.go:1957 lxc/auth.go:1958
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5424,7 +5421,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2008 lxc/auth.go:2009
+#: lxc/auth.go:2006 lxc/auth.go:2007
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5452,11 +5449,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:446 lxc/auth.go:447
+#: lxc/auth.go:444 lxc/auth.go:445
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:985
+#: lxc/auth.go:983
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5561,7 +5558,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1048
+#: lxc/auth.go:1046
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5799,12 +5796,12 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:876
+#: lxc/auth.go:874
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:902
+#: lxc/auth.go:900
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
@@ -5813,7 +5810,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1747 lxc/warning.go:216
@@ -6485,11 +6482,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:984
+#: lxc/auth.go:982
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1047
+#: lxc/auth.go:1045
 msgid "View the current identity"
 msgstr ""
 
@@ -6560,7 +6557,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6593,7 +6590,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1462
+#: lxc/auth.go:1460
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6654,17 +6651,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:772
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:983 lxc/auth.go:1235
+#: lxc/auth.go:981 lxc/auth.go:1233
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6672,13 +6669,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
-#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
+#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:520 lxc/auth.go:578
+#: lxc/auth.go:518 lxc/auth.go:576
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6688,19 +6685,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:395
+#: lxc/auth.go:393
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
+#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2081
+#: lxc/auth.go:2079
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1957
+#: lxc/auth.go:1955
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7248,14 +7245,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1111
+#: lxc/auth.go:1109
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1783
+#: lxc/auth.go:1781
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-19 16:04-0700\n"
+"POT-Creation-Date: 2025-01-07 15:23+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -133,34 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:219
-msgid ""
-"### This is a YAML representation of the group.\n"
-"### Any line starting with a '# will be ignored.\n"
-"###\n"
-"### A group has the following format:\n"
-"### name: my-first-group\n"
-"### description: My first group.\n"
-"### permissions:\n"
-"### - entity_type: project\n"
-"###   url: /1.0/projects/default\n"
-"###   entitlement: can_view\n"
-"### identities:\n"
-"### - authentication_method: oidc\n"
-"###   type: OIDC client\n"
-"###   identifier: jane.doe@example.com\n"
-"###   name: Jane Doe\n"
-"###   metadata:\n"
-"###     subject: auth0|123456789\n"
-"### identity_provider_groups:\n"
-"### - sales\n"
-"### - operations\n"
-"###\n"
-"### Note that all group information is shown but only the description and "
-"permissions can be modified"
-msgstr ""
-
-#: lxc/auth.go:1121
+#: lxc/auth.go:1119
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +154,31 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1793
+#: lxc/auth.go:219
+msgid ""
+"### This is a YAML representation of the group.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### NOTE: All group information is shown but only the description and "
+"permissions can be modified.\n"
+"### \n"
+"### name: my-first-group\n"
+"### description: My first group.\n"
+"### permissions:\n"
+"### - entity_type: project\n"
+"###   url: /1.0/projects/default\n"
+"###   entitlement: can_view\n"
+"### identities:\n"
+"###   oidc:\n"
+"###   - jane.doe@example.com\n"
+"###   tls:\n"
+"###   - eaa46a1b73827350e0543949fb161410c50e950d4cb9802fc58dbfbd5700e508\n"
+"### identity_provider_groups:\n"
+"### - sales\n"
+"### - operations\n"
+msgstr ""
+
+#: lxc/auth.go:1791
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -560,7 +557,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:966
+#: lxc/auth.go:964
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -598,11 +595,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1312 lxc/auth.go:1313
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2082 lxc/auth.go:2083
+#: lxc/auth.go:2080 lxc/auth.go:2081
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -671,7 +668,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:521 lxc/auth.go:522
+#: lxc/auth.go:519 lxc/auth.go:520
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -1347,12 +1344,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:306 lxc/auth.go:1868
+#: lxc/auth.go:304 lxc/auth.go:1866
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1207
+#: lxc/auth.go:1205
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1381,7 +1378,7 @@ msgstr ""
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:776
+#: lxc/auth.go:774
 msgid "Create a TLS identity"
 msgstr ""
 
@@ -1401,7 +1398,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:775
+#: lxc/auth.go:773
 msgid "Create an identity"
 msgstr ""
 
@@ -1421,7 +1418,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1679 lxc/auth.go:1680
+#: lxc/auth.go:1677 lxc/auth.go:1678
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1529,7 +1526,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1572,7 +1569,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1237 lxc/auth.go:1238
+#: lxc/auth.go:1235 lxc/auth.go:1236
 msgid "Delete an identity"
 msgstr ""
 
@@ -1584,7 +1581,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1729 lxc/auth.go:1730
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1663,14 +1660,14 @@ msgstr ""
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
 #: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
-#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
-#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
-#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
-#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
-#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
-#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
-#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
+#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
+#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
+#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
+#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
+#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
+#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -1939,7 +1936,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1108 lxc/auth.go:1109
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1955,7 +1952,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1780 lxc/auth.go:1781
+#: lxc/auth.go:1778 lxc/auth.go:1779
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2441,7 +2438,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
@@ -2499,7 +2496,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:970 lxc/auth.go:1944
+#: lxc/auth.go:968 lxc/auth.go:1942
 msgid "GROUPS"
 msgstr ""
 
@@ -2658,7 +2655,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:432 lxc/auth.go:1994
+#: lxc/auth.go:430 lxc/auth.go:1992
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2717,7 +2714,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:969
+#: lxc/auth.go:967
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2749,16 +2746,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:829
+#: lxc/auth.go:827
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1716
+#: lxc/auth.go:1714
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1766
+#: lxc/auth.go:1764
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2887,7 +2884,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1441 lxc/auth.go:1442
+#: lxc/auth.go:1439 lxc/auth.go:1440
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3191,15 +3188,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:337 lxc/auth.go:338
+#: lxc/auth.go:335 lxc/auth.go:336
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:917 lxc/auth.go:918
+#: lxc/auth.go:915 lxc/auth.go:916
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1900
+#: lxc/auth.go:1897 lxc/auth.go:1898
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3354,7 +3351,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1463 lxc/auth.go:1464
+#: lxc/auth.go:1461 lxc/auth.go:1462
 msgid "List permissions"
 msgstr ""
 
@@ -3522,7 +3519,7 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:823
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
@@ -3556,19 +3553,19 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1291 lxc/auth.go:1292
+#: lxc/auth.go:1289 lxc/auth.go:1290
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:736 lxc/auth.go:737
+#: lxc/auth.go:734 lxc/auth.go:735
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2059 lxc/auth.go:2060
+#: lxc/auth.go:2057 lxc/auth.go:2058
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3659,7 +3656,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:498 lxc/auth.go:499
+#: lxc/auth.go:496 lxc/auth.go:497
 msgid "Manage permissions"
 msgstr ""
 
@@ -3808,21 +3805,21 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
-#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
-#: lxc/auth.go:1339 lxc/auth.go:1397
+#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
+#: lxc/auth.go:1337 lxc/auth.go:1395
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
+#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2107 lxc/auth.go:2160
+#: lxc/auth.go:2105 lxc/auth.go:2158
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4043,7 +4040,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
@@ -4447,7 +4444,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4806,7 +4803,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1372 lxc/auth.go:1373
+#: lxc/auth.go:1370 lxc/auth.go:1371
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4842,7 +4839,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2135 lxc/auth.go:2136
+#: lxc/auth.go:2133 lxc/auth.go:2134
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4854,7 +4851,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:580 lxc/auth.go:581
+#: lxc/auth.go:578 lxc/auth.go:579
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4899,11 +4896,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:397 lxc/auth.go:398
+#: lxc/auth.go:395 lxc/auth.go:396
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1959 lxc/auth.go:1960
+#: lxc/auth.go:1957 lxc/auth.go:1958
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5424,7 +5421,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2008 lxc/auth.go:2009
+#: lxc/auth.go:2006 lxc/auth.go:2007
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5452,11 +5449,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:446 lxc/auth.go:447
+#: lxc/auth.go:444 lxc/auth.go:445
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:985
+#: lxc/auth.go:983
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5561,7 +5558,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1048
+#: lxc/auth.go:1046
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5799,12 +5796,12 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:876
+#: lxc/auth.go:874
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:902
+#: lxc/auth.go:900
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
@@ -5813,7 +5810,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1747 lxc/warning.go:216
@@ -6485,11 +6482,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:984
+#: lxc/auth.go:982
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1047
+#: lxc/auth.go:1045
 msgid "View the current identity"
 msgstr ""
 
@@ -6560,7 +6557,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6593,7 +6590,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1462
+#: lxc/auth.go:1460
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6654,17 +6651,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:772
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:983 lxc/auth.go:1235
+#: lxc/auth.go:981 lxc/auth.go:1233
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6672,13 +6669,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
-#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
+#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:520 lxc/auth.go:578
+#: lxc/auth.go:518 lxc/auth.go:576
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6688,19 +6685,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:395
+#: lxc/auth.go:393
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
+#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2081
+#: lxc/auth.go:2079
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1957
+#: lxc/auth.go:1955
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7248,14 +7245,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1111
+#: lxc/auth.go:1109
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1783
+#: lxc/auth.go:1781
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-19 16:04-0700\n"
+"POT-Creation-Date: 2025-01-07 15:23+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -133,34 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:219
-msgid ""
-"### This is a YAML representation of the group.\n"
-"### Any line starting with a '# will be ignored.\n"
-"###\n"
-"### A group has the following format:\n"
-"### name: my-first-group\n"
-"### description: My first group.\n"
-"### permissions:\n"
-"### - entity_type: project\n"
-"###   url: /1.0/projects/default\n"
-"###   entitlement: can_view\n"
-"### identities:\n"
-"### - authentication_method: oidc\n"
-"###   type: OIDC client\n"
-"###   identifier: jane.doe@example.com\n"
-"###   name: Jane Doe\n"
-"###   metadata:\n"
-"###     subject: auth0|123456789\n"
-"### identity_provider_groups:\n"
-"### - sales\n"
-"### - operations\n"
-"###\n"
-"### Note that all group information is shown but only the description and "
-"permissions can be modified"
-msgstr ""
-
-#: lxc/auth.go:1121
+#: lxc/auth.go:1119
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +154,31 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1793
+#: lxc/auth.go:219
+msgid ""
+"### This is a YAML representation of the group.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### NOTE: All group information is shown but only the description and "
+"permissions can be modified.\n"
+"### \n"
+"### name: my-first-group\n"
+"### description: My first group.\n"
+"### permissions:\n"
+"### - entity_type: project\n"
+"###   url: /1.0/projects/default\n"
+"###   entitlement: can_view\n"
+"### identities:\n"
+"###   oidc:\n"
+"###   - jane.doe@example.com\n"
+"###   tls:\n"
+"###   - eaa46a1b73827350e0543949fb161410c50e950d4cb9802fc58dbfbd5700e508\n"
+"### identity_provider_groups:\n"
+"### - sales\n"
+"### - operations\n"
+msgstr ""
+
+#: lxc/auth.go:1791
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -560,7 +557,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:966
+#: lxc/auth.go:964
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -598,11 +595,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1312 lxc/auth.go:1313
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2082 lxc/auth.go:2083
+#: lxc/auth.go:2080 lxc/auth.go:2081
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -671,7 +668,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:521 lxc/auth.go:522
+#: lxc/auth.go:519 lxc/auth.go:520
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -1347,12 +1344,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:306 lxc/auth.go:1868
+#: lxc/auth.go:304 lxc/auth.go:1866
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1207
+#: lxc/auth.go:1205
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1381,7 +1378,7 @@ msgstr ""
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:776
+#: lxc/auth.go:774
 msgid "Create a TLS identity"
 msgstr ""
 
@@ -1401,7 +1398,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:775
+#: lxc/auth.go:773
 msgid "Create an identity"
 msgstr ""
 
@@ -1421,7 +1418,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1679 lxc/auth.go:1680
+#: lxc/auth.go:1677 lxc/auth.go:1678
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1529,7 +1526,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1572,7 +1569,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1237 lxc/auth.go:1238
+#: lxc/auth.go:1235 lxc/auth.go:1236
 msgid "Delete an identity"
 msgstr ""
 
@@ -1584,7 +1581,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1729 lxc/auth.go:1730
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1663,14 +1660,14 @@ msgstr ""
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
 #: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
-#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
-#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
-#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
-#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
-#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
-#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
-#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
+#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
+#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
+#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
+#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
+#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
+#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -1939,7 +1936,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1108 lxc/auth.go:1109
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1955,7 +1952,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1780 lxc/auth.go:1781
+#: lxc/auth.go:1778 lxc/auth.go:1779
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2441,7 +2438,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
@@ -2499,7 +2496,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:970 lxc/auth.go:1944
+#: lxc/auth.go:968 lxc/auth.go:1942
 msgid "GROUPS"
 msgstr ""
 
@@ -2658,7 +2655,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:432 lxc/auth.go:1994
+#: lxc/auth.go:430 lxc/auth.go:1992
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2717,7 +2714,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:969
+#: lxc/auth.go:967
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2749,16 +2746,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:829
+#: lxc/auth.go:827
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1716
+#: lxc/auth.go:1714
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1766
+#: lxc/auth.go:1764
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2887,7 +2884,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1441 lxc/auth.go:1442
+#: lxc/auth.go:1439 lxc/auth.go:1440
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3191,15 +3188,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:337 lxc/auth.go:338
+#: lxc/auth.go:335 lxc/auth.go:336
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:917 lxc/auth.go:918
+#: lxc/auth.go:915 lxc/auth.go:916
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1900
+#: lxc/auth.go:1897 lxc/auth.go:1898
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3354,7 +3351,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1463 lxc/auth.go:1464
+#: lxc/auth.go:1461 lxc/auth.go:1462
 msgid "List permissions"
 msgstr ""
 
@@ -3522,7 +3519,7 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:823
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
@@ -3556,19 +3553,19 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1291 lxc/auth.go:1292
+#: lxc/auth.go:1289 lxc/auth.go:1290
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:736 lxc/auth.go:737
+#: lxc/auth.go:734 lxc/auth.go:735
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2059 lxc/auth.go:2060
+#: lxc/auth.go:2057 lxc/auth.go:2058
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3659,7 +3656,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:498 lxc/auth.go:499
+#: lxc/auth.go:496 lxc/auth.go:497
 msgid "Manage permissions"
 msgstr ""
 
@@ -3808,21 +3805,21 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
-#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
-#: lxc/auth.go:1339 lxc/auth.go:1397
+#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
+#: lxc/auth.go:1337 lxc/auth.go:1395
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
+#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2107 lxc/auth.go:2160
+#: lxc/auth.go:2105 lxc/auth.go:2158
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4043,7 +4040,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
@@ -4447,7 +4444,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4806,7 +4803,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1372 lxc/auth.go:1373
+#: lxc/auth.go:1370 lxc/auth.go:1371
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4842,7 +4839,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2135 lxc/auth.go:2136
+#: lxc/auth.go:2133 lxc/auth.go:2134
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4854,7 +4851,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:580 lxc/auth.go:581
+#: lxc/auth.go:578 lxc/auth.go:579
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4899,11 +4896,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:397 lxc/auth.go:398
+#: lxc/auth.go:395 lxc/auth.go:396
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1959 lxc/auth.go:1960
+#: lxc/auth.go:1957 lxc/auth.go:1958
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5424,7 +5421,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2008 lxc/auth.go:2009
+#: lxc/auth.go:2006 lxc/auth.go:2007
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5452,11 +5449,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:446 lxc/auth.go:447
+#: lxc/auth.go:444 lxc/auth.go:445
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:985
+#: lxc/auth.go:983
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5561,7 +5558,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1048
+#: lxc/auth.go:1046
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5799,12 +5796,12 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:876
+#: lxc/auth.go:874
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:902
+#: lxc/auth.go:900
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
@@ -5813,7 +5810,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1747 lxc/warning.go:216
@@ -6485,11 +6482,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:984
+#: lxc/auth.go:982
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1047
+#: lxc/auth.go:1045
 msgid "View the current identity"
 msgstr ""
 
@@ -6560,7 +6557,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6593,7 +6590,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1462
+#: lxc/auth.go:1460
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6654,17 +6651,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:772
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:983 lxc/auth.go:1235
+#: lxc/auth.go:981 lxc/auth.go:1233
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6672,13 +6669,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
-#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
+#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:520 lxc/auth.go:578
+#: lxc/auth.go:518 lxc/auth.go:576
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6688,19 +6685,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:395
+#: lxc/auth.go:393
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
+#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2081
+#: lxc/auth.go:2079
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1957
+#: lxc/auth.go:1955
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7248,14 +7245,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1111
+#: lxc/auth.go:1109
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1783
+#: lxc/auth.go:1781
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-19 16:04-0700\n"
+"POT-Creation-Date: 2025-01-07 15:23+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -198,34 +198,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: lxc/auth.go:219
-msgid ""
-"### This is a YAML representation of the group.\n"
-"### Any line starting with a '# will be ignored.\n"
-"###\n"
-"### A group has the following format:\n"
-"### name: my-first-group\n"
-"### description: My first group.\n"
-"### permissions:\n"
-"### - entity_type: project\n"
-"###   url: /1.0/projects/default\n"
-"###   entitlement: can_view\n"
-"### identities:\n"
-"### - authentication_method: oidc\n"
-"###   type: OIDC client\n"
-"###   identifier: jane.doe@example.com\n"
-"###   name: Jane Doe\n"
-"###   metadata:\n"
-"###     subject: auth0|123456789\n"
-"### identity_provider_groups:\n"
-"### - sales\n"
-"### - operations\n"
-"###\n"
-"### Note that all group information is shown but only the description and "
-"permissions can be modified"
-msgstr ""
-
-#: lxc/auth.go:1121
+#: lxc/auth.go:1119
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -246,7 +219,31 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1793
+#: lxc/auth.go:219
+msgid ""
+"### This is a YAML representation of the group.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### NOTE: All group information is shown but only the description and "
+"permissions can be modified.\n"
+"### \n"
+"### name: my-first-group\n"
+"### description: My first group.\n"
+"### permissions:\n"
+"### - entity_type: project\n"
+"###   url: /1.0/projects/default\n"
+"###   entitlement: can_view\n"
+"### identities:\n"
+"###   oidc:\n"
+"###   - jane.doe@example.com\n"
+"###   tls:\n"
+"###   - eaa46a1b73827350e0543949fb161410c50e950d4cb9802fc58dbfbd5700e508\n"
+"### identity_provider_groups:\n"
+"### - sales\n"
+"### - operations\n"
+msgstr ""
+
+#: lxc/auth.go:1791
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -824,7 +821,7 @@ msgstr "ARCHITEKTUR"
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:966
+#: lxc/auth.go:964
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -866,11 +863,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1312 lxc/auth.go:1313
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2082 lxc/auth.go:2083
+#: lxc/auth.go:2080 lxc/auth.go:2081
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -942,7 +939,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:521 lxc/auth.go:522
+#: lxc/auth.go:519 lxc/auth.go:520
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -1658,12 +1655,12 @@ msgstr "Fingerabdruck des Zertifikats: % x\n"
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:306 lxc/auth.go:1868
+#: lxc/auth.go:304 lxc/auth.go:1866
 #, fuzzy, c-format
 msgid "Could not parse group: %s"
 msgstr "YAML Analyse Fehler %v\n"
 
-#: lxc/auth.go:1207
+#: lxc/auth.go:1205
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1692,7 +1689,7 @@ msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:776
+#: lxc/auth.go:774
 msgid "Create a TLS identity"
 msgstr ""
 
@@ -1714,7 +1711,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/auth.go:775
+#: lxc/auth.go:773
 #, fuzzy
 msgid "Create an identity"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -1738,7 +1735,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Create groups"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/auth.go:1679 lxc/auth.go:1680
+#: lxc/auth.go:1677 lxc/auth.go:1678
 #, fuzzy
 msgid "Create identity provider groups"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -1863,7 +1860,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1906,7 +1903,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1237 lxc/auth.go:1238
+#: lxc/auth.go:1235 lxc/auth.go:1236
 msgid "Delete an identity"
 msgstr ""
 
@@ -1920,7 +1917,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Delete groups"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1729 lxc/auth.go:1730
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -2008,14 +2005,14 @@ msgstr ""
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
 #: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
-#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
-#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
-#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
-#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
-#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
-#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
-#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
+#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
+#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
+#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
+#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
+#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
+#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -2301,7 +2298,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1108 lxc/auth.go:1109
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -2320,7 +2317,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Edit groups as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/auth.go:1780 lxc/auth.go:1781
+#: lxc/auth.go:1778 lxc/auth.go:1779
 #, fuzzy
 msgid "Edit identity provider groups as YAML"
 msgstr "Alternatives config Verzeichnis."
@@ -2837,7 +2834,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
@@ -2895,7 +2892,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:970 lxc/auth.go:1944
+#: lxc/auth.go:968 lxc/auth.go:1942
 msgid "GROUPS"
 msgstr ""
 
@@ -3075,7 +3072,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Group %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/auth.go:432 lxc/auth.go:1994
+#: lxc/auth.go:430 lxc/auth.go:1992
 #, fuzzy, c-format
 msgid "Group %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
@@ -3135,7 +3132,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:969
+#: lxc/auth.go:967
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -3169,16 +3166,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:829
+#: lxc/auth.go:827
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1716
+#: lxc/auth.go:1714
 #, fuzzy, c-format
 msgid "Identity provider group %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/auth.go:1766
+#: lxc/auth.go:1764
 #, fuzzy, c-format
 msgid "Identity provider group %s deleted"
 msgstr "Profil %s erstellt\n"
@@ -3311,7 +3308,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1441 lxc/auth.go:1442
+#: lxc/auth.go:1439 lxc/auth.go:1440
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3632,16 +3629,16 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:337 lxc/auth.go:338
+#: lxc/auth.go:335 lxc/auth.go:336
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:917 lxc/auth.go:918
+#: lxc/auth.go:915 lxc/auth.go:916
 #, fuzzy
 msgid "List identities"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/auth.go:1899 lxc/auth.go:1900
+#: lxc/auth.go:1897 lxc/auth.go:1898
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3814,7 +3811,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/auth.go:1463 lxc/auth.go:1464
+#: lxc/auth.go:1461 lxc/auth.go:1462
 #, fuzzy
 msgid "List permissions"
 msgstr "Aliasse:\n"
@@ -3994,7 +3991,7 @@ msgstr "Veröffentliche Abbild"
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:823
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
@@ -4033,21 +4030,21 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Manage files in instances"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
 #, fuzzy
 msgid "Manage groups"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/auth.go:1291 lxc/auth.go:1292
+#: lxc/auth.go:1289 lxc/auth.go:1290
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:736 lxc/auth.go:737
+#: lxc/auth.go:734 lxc/auth.go:735
 #, fuzzy
 msgid "Manage identities"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/auth.go:2059 lxc/auth.go:2060
+#: lxc/auth.go:2057 lxc/auth.go:2058
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -4154,7 +4151,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Manage network zones"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/auth.go:498 lxc/auth.go:499
+#: lxc/auth.go:496 lxc/auth.go:497
 #, fuzzy
 msgid "Manage permissions"
 msgstr "Fehlerhafte Profil URL %s"
@@ -4319,24 +4316,24 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "Missing cluster member name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
-#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
 #, fuzzy
 msgid "Missing group name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
-#: lxc/auth.go:1339 lxc/auth.go:1397
+#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
+#: lxc/auth.go:1337 lxc/auth.go:1395
 #, fuzzy
 msgid "Missing identity argument"
 msgstr "Fehlende Zusammenfassung."
 
-#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
+#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
 #, fuzzy
 msgid "Missing identity provider group name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/auth.go:2107 lxc/auth.go:2160
+#: lxc/auth.go:2105 lxc/auth.go:2158
 #, fuzzy
 msgid "Missing identity provider group name argument"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -4577,7 +4574,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
@@ -4992,7 +4989,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -5364,7 +5361,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/auth.go:1372 lxc/auth.go:1373
+#: lxc/auth.go:1370 lxc/auth.go:1371
 #, fuzzy
 msgid "Remove a group from an identity"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -5406,7 +5403,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "Remove entries from a network zone record"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/auth.go:2135 lxc/auth.go:2136
+#: lxc/auth.go:2133 lxc/auth.go:2134
 #, fuzzy
 msgid "Remove identities from groups"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -5420,7 +5417,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:580 lxc/auth.go:581
+#: lxc/auth.go:578 lxc/auth.go:579
 #, fuzzy
 msgid "Remove permissions from groups"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -5471,12 +5468,12 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:397 lxc/auth.go:398
+#: lxc/auth.go:395 lxc/auth.go:396
 #, fuzzy
 msgid "Rename groups"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/auth.go:1959 lxc/auth.go:1960
+#: lxc/auth.go:1957 lxc/auth.go:1958
 #, fuzzy
 msgid "Rename identity provider groups"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -6038,7 +6035,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2008 lxc/auth.go:2009
+#: lxc/auth.go:2006 lxc/auth.go:2007
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -6069,12 +6066,12 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr "Geräte zu Containern oder Profilen hinzufügen"
 
-#: lxc/auth.go:446 lxc/auth.go:447
+#: lxc/auth.go:444 lxc/auth.go:445
 #, fuzzy
 msgid "Show group configurations"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/auth.go:985
+#: lxc/auth.go:983
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -6195,7 +6192,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Show storage volume state information"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/auth.go:1048
+#: lxc/auth.go:1046
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -6445,12 +6442,12 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:876
+#: lxc/auth.go:874
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:902
+#: lxc/auth.go:900
 #, fuzzy, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr "Abbild mit Fingerabdruck %s importiert\n"
@@ -6459,7 +6456,7 @@ msgstr "Abbild mit Fingerabdruck %s importiert\n"
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1747 lxc/warning.go:216
@@ -7177,11 +7174,11 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: lxc/auth.go:984
+#: lxc/auth.go:982
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1047
+#: lxc/auth.go:1045
 msgid "View the current identity"
 msgstr ""
 
@@ -7269,7 +7266,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -7333,7 +7330,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/auth.go:1462
+#: lxc/auth.go:1460
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -7453,17 +7450,17 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/auth.go:774
+#: lxc/auth.go:772
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:983 lxc/auth.go:1235
+#: lxc/auth.go:981 lxc/auth.go:1233
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -7476,8 +7473,8 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
-#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
+#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 #, fuzzy
 msgid "[<remote>:]<group>"
@@ -7486,7 +7483,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/auth.go:520 lxc/auth.go:578
+#: lxc/auth.go:518 lxc/auth.go:576
 #, fuzzy
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
@@ -7504,7 +7501,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/auth.go:395
+#: lxc/auth.go:393
 #, fuzzy
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
@@ -7512,7 +7509,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
+#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
@@ -7520,7 +7517,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/auth.go:2081
+#: lxc/auth.go:2079
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
@@ -7529,7 +7526,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/auth.go:1957
+#: lxc/auth.go:1955
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
@@ -8575,14 +8572,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1111
+#: lxc/auth.go:1109
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1783
+#: lxc/auth.go:1781
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-19 16:04-0700\n"
+"POT-Creation-Date: 2025-01-07 15:23+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -133,34 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:219
-msgid ""
-"### This is a YAML representation of the group.\n"
-"### Any line starting with a '# will be ignored.\n"
-"###\n"
-"### A group has the following format:\n"
-"### name: my-first-group\n"
-"### description: My first group.\n"
-"### permissions:\n"
-"### - entity_type: project\n"
-"###   url: /1.0/projects/default\n"
-"###   entitlement: can_view\n"
-"### identities:\n"
-"### - authentication_method: oidc\n"
-"###   type: OIDC client\n"
-"###   identifier: jane.doe@example.com\n"
-"###   name: Jane Doe\n"
-"###   metadata:\n"
-"###     subject: auth0|123456789\n"
-"### identity_provider_groups:\n"
-"### - sales\n"
-"### - operations\n"
-"###\n"
-"### Note that all group information is shown but only the description and "
-"permissions can be modified"
-msgstr ""
-
-#: lxc/auth.go:1121
+#: lxc/auth.go:1119
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +154,31 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1793
+#: lxc/auth.go:219
+msgid ""
+"### This is a YAML representation of the group.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### NOTE: All group information is shown but only the description and "
+"permissions can be modified.\n"
+"### \n"
+"### name: my-first-group\n"
+"### description: My first group.\n"
+"### permissions:\n"
+"### - entity_type: project\n"
+"###   url: /1.0/projects/default\n"
+"###   entitlement: can_view\n"
+"### identities:\n"
+"###   oidc:\n"
+"###   - jane.doe@example.com\n"
+"###   tls:\n"
+"###   - eaa46a1b73827350e0543949fb161410c50e950d4cb9802fc58dbfbd5700e508\n"
+"### identity_provider_groups:\n"
+"### - sales\n"
+"### - operations\n"
+msgstr ""
+
+#: lxc/auth.go:1791
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -560,7 +557,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:966
+#: lxc/auth.go:964
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -599,11 +596,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1312 lxc/auth.go:1313
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2082 lxc/auth.go:2083
+#: lxc/auth.go:2080 lxc/auth.go:2081
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -673,7 +670,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:521 lxc/auth.go:522
+#: lxc/auth.go:519 lxc/auth.go:520
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -1351,12 +1348,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:306 lxc/auth.go:1868
+#: lxc/auth.go:304 lxc/auth.go:1866
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1207
+#: lxc/auth.go:1205
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1385,7 +1382,7 @@ msgstr ""
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:776
+#: lxc/auth.go:774
 msgid "Create a TLS identity"
 msgstr ""
 
@@ -1405,7 +1402,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:775
+#: lxc/auth.go:773
 msgid "Create an identity"
 msgstr ""
 
@@ -1425,7 +1422,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1679 lxc/auth.go:1680
+#: lxc/auth.go:1677 lxc/auth.go:1678
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1536,7 +1533,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1579,7 +1576,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1237 lxc/auth.go:1238
+#: lxc/auth.go:1235 lxc/auth.go:1236
 msgid "Delete an identity"
 msgstr ""
 
@@ -1592,7 +1589,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1729 lxc/auth.go:1730
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1675,14 +1672,14 @@ msgstr ""
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
 #: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
-#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
-#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
-#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
-#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
-#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
-#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
-#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
+#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
+#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
+#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
+#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
+#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
+#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -1956,7 +1953,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1108 lxc/auth.go:1109
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1972,7 +1969,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1780 lxc/auth.go:1781
+#: lxc/auth.go:1778 lxc/auth.go:1779
 #, fuzzy
 msgid "Edit identity provider groups as YAML"
 msgstr "  Χρήση δικτύου:"
@@ -2464,7 +2461,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
@@ -2522,7 +2519,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:970 lxc/auth.go:1944
+#: lxc/auth.go:968 lxc/auth.go:1942
 msgid "GROUPS"
 msgstr ""
 
@@ -2694,7 +2691,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Group %s deleted"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/auth.go:432 lxc/auth.go:1994
+#: lxc/auth.go:430 lxc/auth.go:1992
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2753,7 +2750,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:969
+#: lxc/auth.go:967
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2785,16 +2782,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:829
+#: lxc/auth.go:827
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1716
+#: lxc/auth.go:1714
 #, fuzzy, c-format
 msgid "Identity provider group %s created"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/auth.go:1766
+#: lxc/auth.go:1764
 #, fuzzy, c-format
 msgid "Identity provider group %s deleted"
 msgstr "  Χρήση δικτύου:"
@@ -2923,7 +2920,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1441 lxc/auth.go:1442
+#: lxc/auth.go:1439 lxc/auth.go:1440
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3229,15 +3226,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:337 lxc/auth.go:338
+#: lxc/auth.go:335 lxc/auth.go:336
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:917 lxc/auth.go:918
+#: lxc/auth.go:915 lxc/auth.go:916
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1900
+#: lxc/auth.go:1897 lxc/auth.go:1898
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3392,7 +3389,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1463 lxc/auth.go:1464
+#: lxc/auth.go:1461 lxc/auth.go:1462
 msgid "List permissions"
 msgstr ""
 
@@ -3560,7 +3557,7 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:823
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
@@ -3595,20 +3592,20 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
 #, fuzzy
 msgid "Manage groups"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/auth.go:1291 lxc/auth.go:1292
+#: lxc/auth.go:1289 lxc/auth.go:1290
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:736 lxc/auth.go:737
+#: lxc/auth.go:734 lxc/auth.go:735
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2059 lxc/auth.go:2060
+#: lxc/auth.go:2057 lxc/auth.go:2058
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3706,7 +3703,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Manage network zones"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/auth.go:498 lxc/auth.go:499
+#: lxc/auth.go:496 lxc/auth.go:497
 #, fuzzy
 msgid "Manage permissions"
 msgstr "  Χρήση δικτύου:"
@@ -3864,24 +3861,24 @@ msgstr "  Χρήση δικτύου:"
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
-#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
 #, fuzzy
 msgid "Missing group name"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
-#: lxc/auth.go:1339 lxc/auth.go:1397
+#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
+#: lxc/auth.go:1337 lxc/auth.go:1395
 #, fuzzy
 msgid "Missing identity argument"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
+#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
 #, fuzzy
 msgid "Missing identity provider group name"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/auth.go:2107 lxc/auth.go:2160
+#: lxc/auth.go:2105 lxc/auth.go:2158
 #, fuzzy
 msgid "Missing identity provider group name argument"
 msgstr "  Χρήση δικτύου:"
@@ -4106,7 +4103,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
@@ -4513,7 +4510,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4872,7 +4869,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1372 lxc/auth.go:1373
+#: lxc/auth.go:1370 lxc/auth.go:1371
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4911,7 +4908,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2135 lxc/auth.go:2136
+#: lxc/auth.go:2133 lxc/auth.go:2134
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4923,7 +4920,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:580 lxc/auth.go:581
+#: lxc/auth.go:578 lxc/auth.go:579
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4970,11 +4967,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:397 lxc/auth.go:398
+#: lxc/auth.go:395 lxc/auth.go:396
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1959 lxc/auth.go:1960
+#: lxc/auth.go:1957 lxc/auth.go:1958
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5509,7 +5506,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2008 lxc/auth.go:2009
+#: lxc/auth.go:2006 lxc/auth.go:2007
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5538,12 +5535,12 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:446 lxc/auth.go:447
+#: lxc/auth.go:444 lxc/auth.go:445
 #, fuzzy
 msgid "Show group configurations"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/auth.go:985
+#: lxc/auth.go:983
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5656,7 +5653,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1048
+#: lxc/auth.go:1046
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5895,12 +5892,12 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:876
+#: lxc/auth.go:874
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:902
+#: lxc/auth.go:900
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
@@ -5909,7 +5906,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1747 lxc/warning.go:216
@@ -6599,11 +6596,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:984
+#: lxc/auth.go:982
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1047
+#: lxc/auth.go:1045
 msgid "View the current identity"
 msgstr ""
 
@@ -6674,7 +6671,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6707,7 +6704,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1462
+#: lxc/auth.go:1460
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6768,17 +6765,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:772
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:983 lxc/auth.go:1235
+#: lxc/auth.go:981 lxc/auth.go:1233
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6786,13 +6783,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
-#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
+#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:520 lxc/auth.go:578
+#: lxc/auth.go:518 lxc/auth.go:576
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6802,19 +6799,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:395
+#: lxc/auth.go:393
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
+#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2081
+#: lxc/auth.go:2079
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1957
+#: lxc/auth.go:1955
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7362,14 +7359,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1111
+#: lxc/auth.go:1109
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1783
+#: lxc/auth.go:1781
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-19 16:04-0700\n"
+"POT-Creation-Date: 2025-01-07 15:23+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -133,34 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:219
-msgid ""
-"### This is a YAML representation of the group.\n"
-"### Any line starting with a '# will be ignored.\n"
-"###\n"
-"### A group has the following format:\n"
-"### name: my-first-group\n"
-"### description: My first group.\n"
-"### permissions:\n"
-"### - entity_type: project\n"
-"###   url: /1.0/projects/default\n"
-"###   entitlement: can_view\n"
-"### identities:\n"
-"### - authentication_method: oidc\n"
-"###   type: OIDC client\n"
-"###   identifier: jane.doe@example.com\n"
-"###   name: Jane Doe\n"
-"###   metadata:\n"
-"###     subject: auth0|123456789\n"
-"### identity_provider_groups:\n"
-"### - sales\n"
-"### - operations\n"
-"###\n"
-"### Note that all group information is shown but only the description and "
-"permissions can be modified"
-msgstr ""
-
-#: lxc/auth.go:1121
+#: lxc/auth.go:1119
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +154,31 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1793
+#: lxc/auth.go:219
+msgid ""
+"### This is a YAML representation of the group.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### NOTE: All group information is shown but only the description and "
+"permissions can be modified.\n"
+"### \n"
+"### name: my-first-group\n"
+"### description: My first group.\n"
+"### permissions:\n"
+"### - entity_type: project\n"
+"###   url: /1.0/projects/default\n"
+"###   entitlement: can_view\n"
+"### identities:\n"
+"###   oidc:\n"
+"###   - jane.doe@example.com\n"
+"###   tls:\n"
+"###   - eaa46a1b73827350e0543949fb161410c50e950d4cb9802fc58dbfbd5700e508\n"
+"### identity_provider_groups:\n"
+"### - sales\n"
+"### - operations\n"
+msgstr ""
+
+#: lxc/auth.go:1791
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -560,7 +557,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:966
+#: lxc/auth.go:964
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -598,11 +595,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1312 lxc/auth.go:1313
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2082 lxc/auth.go:2083
+#: lxc/auth.go:2080 lxc/auth.go:2081
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -671,7 +668,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:521 lxc/auth.go:522
+#: lxc/auth.go:519 lxc/auth.go:520
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -1347,12 +1344,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:306 lxc/auth.go:1868
+#: lxc/auth.go:304 lxc/auth.go:1866
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1207
+#: lxc/auth.go:1205
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1381,7 +1378,7 @@ msgstr ""
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:776
+#: lxc/auth.go:774
 msgid "Create a TLS identity"
 msgstr ""
 
@@ -1401,7 +1398,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:775
+#: lxc/auth.go:773
 msgid "Create an identity"
 msgstr ""
 
@@ -1421,7 +1418,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1679 lxc/auth.go:1680
+#: lxc/auth.go:1677 lxc/auth.go:1678
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1529,7 +1526,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1572,7 +1569,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1237 lxc/auth.go:1238
+#: lxc/auth.go:1235 lxc/auth.go:1236
 msgid "Delete an identity"
 msgstr ""
 
@@ -1584,7 +1581,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1729 lxc/auth.go:1730
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1663,14 +1660,14 @@ msgstr ""
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
 #: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
-#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
-#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
-#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
-#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
-#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
-#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
-#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
+#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
+#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
+#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
+#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
+#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
+#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -1939,7 +1936,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1108 lxc/auth.go:1109
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1955,7 +1952,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1780 lxc/auth.go:1781
+#: lxc/auth.go:1778 lxc/auth.go:1779
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2441,7 +2438,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
@@ -2499,7 +2496,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:970 lxc/auth.go:1944
+#: lxc/auth.go:968 lxc/auth.go:1942
 msgid "GROUPS"
 msgstr ""
 
@@ -2658,7 +2655,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:432 lxc/auth.go:1994
+#: lxc/auth.go:430 lxc/auth.go:1992
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2717,7 +2714,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:969
+#: lxc/auth.go:967
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2749,16 +2746,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:829
+#: lxc/auth.go:827
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1716
+#: lxc/auth.go:1714
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1766
+#: lxc/auth.go:1764
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2887,7 +2884,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1441 lxc/auth.go:1442
+#: lxc/auth.go:1439 lxc/auth.go:1440
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3191,15 +3188,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:337 lxc/auth.go:338
+#: lxc/auth.go:335 lxc/auth.go:336
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:917 lxc/auth.go:918
+#: lxc/auth.go:915 lxc/auth.go:916
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1900
+#: lxc/auth.go:1897 lxc/auth.go:1898
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3354,7 +3351,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1463 lxc/auth.go:1464
+#: lxc/auth.go:1461 lxc/auth.go:1462
 msgid "List permissions"
 msgstr ""
 
@@ -3522,7 +3519,7 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:823
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
@@ -3556,19 +3553,19 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1291 lxc/auth.go:1292
+#: lxc/auth.go:1289 lxc/auth.go:1290
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:736 lxc/auth.go:737
+#: lxc/auth.go:734 lxc/auth.go:735
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2059 lxc/auth.go:2060
+#: lxc/auth.go:2057 lxc/auth.go:2058
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3659,7 +3656,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:498 lxc/auth.go:499
+#: lxc/auth.go:496 lxc/auth.go:497
 msgid "Manage permissions"
 msgstr ""
 
@@ -3808,21 +3805,21 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
-#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
-#: lxc/auth.go:1339 lxc/auth.go:1397
+#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
+#: lxc/auth.go:1337 lxc/auth.go:1395
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
+#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2107 lxc/auth.go:2160
+#: lxc/auth.go:2105 lxc/auth.go:2158
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4043,7 +4040,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
@@ -4447,7 +4444,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4806,7 +4803,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1372 lxc/auth.go:1373
+#: lxc/auth.go:1370 lxc/auth.go:1371
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4842,7 +4839,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2135 lxc/auth.go:2136
+#: lxc/auth.go:2133 lxc/auth.go:2134
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4854,7 +4851,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:580 lxc/auth.go:581
+#: lxc/auth.go:578 lxc/auth.go:579
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4899,11 +4896,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:397 lxc/auth.go:398
+#: lxc/auth.go:395 lxc/auth.go:396
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1959 lxc/auth.go:1960
+#: lxc/auth.go:1957 lxc/auth.go:1958
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5424,7 +5421,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2008 lxc/auth.go:2009
+#: lxc/auth.go:2006 lxc/auth.go:2007
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5452,11 +5449,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:446 lxc/auth.go:447
+#: lxc/auth.go:444 lxc/auth.go:445
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:985
+#: lxc/auth.go:983
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5561,7 +5558,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1048
+#: lxc/auth.go:1046
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5799,12 +5796,12 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:876
+#: lxc/auth.go:874
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:902
+#: lxc/auth.go:900
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
@@ -5813,7 +5810,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1747 lxc/warning.go:216
@@ -6485,11 +6482,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:984
+#: lxc/auth.go:982
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1047
+#: lxc/auth.go:1045
 msgid "View the current identity"
 msgstr ""
 
@@ -6560,7 +6557,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6593,7 +6590,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1462
+#: lxc/auth.go:1460
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6654,17 +6651,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:772
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:983 lxc/auth.go:1235
+#: lxc/auth.go:981 lxc/auth.go:1233
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6672,13 +6669,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
-#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
+#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:520 lxc/auth.go:578
+#: lxc/auth.go:518 lxc/auth.go:576
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6688,19 +6685,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:395
+#: lxc/auth.go:393
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
+#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2081
+#: lxc/auth.go:2079
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1957
+#: lxc/auth.go:1955
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7248,14 +7245,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1111
+#: lxc/auth.go:1109
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1783
+#: lxc/auth.go:1781
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-19 16:04-0700\n"
+"POT-Creation-Date: 2025-01-07 15:23+0000\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -202,34 +202,7 @@ msgstr ""
 "###\n"
 "### Note que el nombre se muestra pero no puede ser cambiado"
 
-#: lxc/auth.go:219
-msgid ""
-"### This is a YAML representation of the group.\n"
-"### Any line starting with a '# will be ignored.\n"
-"###\n"
-"### A group has the following format:\n"
-"### name: my-first-group\n"
-"### description: My first group.\n"
-"### permissions:\n"
-"### - entity_type: project\n"
-"###   url: /1.0/projects/default\n"
-"###   entitlement: can_view\n"
-"### identities:\n"
-"### - authentication_method: oidc\n"
-"###   type: OIDC client\n"
-"###   identifier: jane.doe@example.com\n"
-"###   name: Jane Doe\n"
-"###   metadata:\n"
-"###     subject: auth0|123456789\n"
-"### identity_provider_groups:\n"
-"### - sales\n"
-"### - operations\n"
-"###\n"
-"### Note that all group information is shown but only the description and "
-"permissions can be modified"
-msgstr ""
-
-#: lxc/auth.go:1121
+#: lxc/auth.go:1119
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -250,7 +223,31 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1793
+#: lxc/auth.go:219
+msgid ""
+"### This is a YAML representation of the group.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### NOTE: All group information is shown but only the description and "
+"permissions can be modified.\n"
+"### \n"
+"### name: my-first-group\n"
+"### description: My first group.\n"
+"### permissions:\n"
+"### - entity_type: project\n"
+"###   url: /1.0/projects/default\n"
+"###   entitlement: can_view\n"
+"### identities:\n"
+"###   oidc:\n"
+"###   - jane.doe@example.com\n"
+"###   tls:\n"
+"###   - eaa46a1b73827350e0543949fb161410c50e950d4cb9802fc58dbfbd5700e508\n"
+"### identity_provider_groups:\n"
+"### - sales\n"
+"### - operations\n"
+msgstr ""
+
+#: lxc/auth.go:1791
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -803,7 +800,7 @@ msgstr "ARQUITECTURA"
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:966
+#: lxc/auth.go:964
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -842,11 +839,11 @@ msgstr "El filtrado no está soportado aún"
 msgid "Add a cluster member to a cluster group"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1312 lxc/auth.go:1313
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2082 lxc/auth.go:2083
+#: lxc/auth.go:2080 lxc/auth.go:2081
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -917,7 +914,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:521 lxc/auth.go:522
+#: lxc/auth.go:519 lxc/auth.go:520
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -1607,12 +1604,12 @@ msgstr "Certificado de la huella digital: %s"
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:306 lxc/auth.go:1868
+#: lxc/auth.go:304 lxc/auth.go:1866
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1207
+#: lxc/auth.go:1205
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1641,7 +1638,7 @@ msgstr "Certificado de la huella digital: %s"
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:776
+#: lxc/auth.go:774
 msgid "Create a TLS identity"
 msgstr ""
 
@@ -1663,7 +1660,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr "Creando el contenedor"
 
-#: lxc/auth.go:775
+#: lxc/auth.go:773
 #, fuzzy
 msgid "Create an identity"
 msgstr "Creando el contenedor"
@@ -1686,7 +1683,7 @@ msgstr "Creando el contenedor"
 msgid "Create groups"
 msgstr "Creado: %s"
 
-#: lxc/auth.go:1679 lxc/auth.go:1680
+#: lxc/auth.go:1677 lxc/auth.go:1678
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1799,7 +1796,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1842,7 +1839,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1237 lxc/auth.go:1238
+#: lxc/auth.go:1235 lxc/auth.go:1236
 msgid "Delete an identity"
 msgstr ""
 
@@ -1855,7 +1852,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr "Eliminar imágenes"
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1729 lxc/auth.go:1730
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1939,14 +1936,14 @@ msgstr ""
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
 #: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
-#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
-#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
-#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
-#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
-#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
-#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
-#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
+#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
+#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
+#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
+#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
+#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
+#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -2221,7 +2218,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1108 lxc/auth.go:1109
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -2237,7 +2234,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1780 lxc/auth.go:1781
+#: lxc/auth.go:1778 lxc/auth.go:1779
 #, fuzzy
 msgid "Edit identity provider groups as YAML"
 msgstr "Perfil %s creado"
@@ -2734,7 +2731,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
@@ -2792,7 +2789,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:970 lxc/auth.go:1944
+#: lxc/auth.go:968 lxc/auth.go:1942
 msgid "GROUPS"
 msgstr ""
 
@@ -2965,7 +2962,7 @@ msgstr "Perfil %s creado"
 msgid "Group %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: lxc/auth.go:432 lxc/auth.go:1994
+#: lxc/auth.go:430 lxc/auth.go:1992
 #, fuzzy, c-format
 msgid "Group %s renamed to %s"
 msgstr "Perfil %s renombrado a %s"
@@ -3025,7 +3022,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:969
+#: lxc/auth.go:967
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -3059,16 +3056,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:829
+#: lxc/auth.go:827
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1716
+#: lxc/auth.go:1714
 #, fuzzy, c-format
 msgid "Identity provider group %s created"
 msgstr "Perfil %s creado"
 
-#: lxc/auth.go:1766
+#: lxc/auth.go:1764
 #, fuzzy, c-format
 msgid "Identity provider group %s deleted"
 msgstr "Perfil %s creado"
@@ -3198,7 +3195,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1441 lxc/auth.go:1442
+#: lxc/auth.go:1439 lxc/auth.go:1440
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3515,16 +3512,16 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:337 lxc/auth.go:338
+#: lxc/auth.go:335 lxc/auth.go:336
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:917 lxc/auth.go:918
+#: lxc/auth.go:915 lxc/auth.go:916
 #, fuzzy
 msgid "List identities"
 msgstr "Aliases:"
 
-#: lxc/auth.go:1899 lxc/auth.go:1900
+#: lxc/auth.go:1897 lxc/auth.go:1898
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3681,7 +3678,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/auth.go:1463 lxc/auth.go:1464
+#: lxc/auth.go:1461 lxc/auth.go:1462
 #, fuzzy
 msgid "List permissions"
 msgstr "Aliases:"
@@ -3853,7 +3850,7 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:823
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
@@ -3888,20 +3885,20 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
 #, fuzzy
 msgid "Manage groups"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/auth.go:1291 lxc/auth.go:1292
+#: lxc/auth.go:1289 lxc/auth.go:1290
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:736 lxc/auth.go:737
+#: lxc/auth.go:734 lxc/auth.go:735
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2059 lxc/auth.go:2060
+#: lxc/auth.go:2057 lxc/auth.go:2058
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3999,7 +3996,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Manage network zones"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/auth.go:498 lxc/auth.go:499
+#: lxc/auth.go:496 lxc/auth.go:497
 #, fuzzy
 msgid "Manage permissions"
 msgstr "Nombre del contenedor es: %s"
@@ -4158,24 +4155,24 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Missing cluster member name"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
-#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
 #, fuzzy
 msgid "Missing group name"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
-#: lxc/auth.go:1339 lxc/auth.go:1397
+#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
+#: lxc/auth.go:1337 lxc/auth.go:1395
 #, fuzzy
 msgid "Missing identity argument"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
+#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
 #, fuzzy
 msgid "Missing identity provider group name"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/auth.go:2107 lxc/auth.go:2160
+#: lxc/auth.go:2105 lxc/auth.go:2158
 #, fuzzy
 msgid "Missing identity provider group name argument"
 msgstr "Nombre del Miembro del Cluster"
@@ -4409,7 +4406,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
@@ -4814,7 +4811,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -5181,7 +5178,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/auth.go:1372 lxc/auth.go:1373
+#: lxc/auth.go:1370 lxc/auth.go:1371
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -5220,7 +5217,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2135 lxc/auth.go:2136
+#: lxc/auth.go:2133 lxc/auth.go:2134
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -5232,7 +5229,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:580 lxc/auth.go:581
+#: lxc/auth.go:578 lxc/auth.go:579
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -5279,11 +5276,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:397 lxc/auth.go:398
+#: lxc/auth.go:395 lxc/auth.go:396
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1959 lxc/auth.go:1960
+#: lxc/auth.go:1957 lxc/auth.go:1958
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5825,7 +5822,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2008 lxc/auth.go:2009
+#: lxc/auth.go:2006 lxc/auth.go:2007
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5854,12 +5851,12 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:446 lxc/auth.go:447
+#: lxc/auth.go:444 lxc/auth.go:445
 #, fuzzy
 msgid "Show group configurations"
 msgstr "Perfil %s creado"
 
-#: lxc/auth.go:985
+#: lxc/auth.go:983
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5973,7 +5970,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1048
+#: lxc/auth.go:1046
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -6213,12 +6210,12 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:876
+#: lxc/auth.go:874
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:902
+#: lxc/auth.go:900
 #, fuzzy, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr "Contenedor publicado con huella digital: %s"
@@ -6227,7 +6224,7 @@ msgstr "Contenedor publicado con huella digital: %s"
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1747 lxc/warning.go:216
@@ -6924,11 +6921,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr "Cacheado: %s"
 
-#: lxc/auth.go:984
+#: lxc/auth.go:982
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1047
+#: lxc/auth.go:1045
 msgid "View the current identity"
 msgstr ""
 
@@ -7001,7 +6998,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -7041,7 +7038,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:] [<filters>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/auth.go:1462
+#: lxc/auth.go:1460
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -7116,17 +7113,17 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<alias> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/auth.go:774
+#: lxc/auth.go:772
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:983 lxc/auth.go:1235
+#: lxc/auth.go:981 lxc/auth.go:1233
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -7135,14 +7132,14 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
-#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
+#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 #, fuzzy
 msgid "[<remote>:]<group>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/auth.go:520 lxc/auth.go:578
+#: lxc/auth.go:518 lxc/auth.go:576
 #, fuzzy
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
@@ -7154,22 +7151,22 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<group> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/auth.go:395
+#: lxc/auth.go:393
 #, fuzzy
 msgid "[<remote>:]<group> <new_name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
+#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/auth.go:2081
+#: lxc/auth.go:2079
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/auth.go:1957
+#: lxc/auth.go:1955
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7832,14 +7829,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1111
+#: lxc/auth.go:1109
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1783
+#: lxc/auth.go:1781
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-19 16:04-0700\n"
+"POT-Creation-Date: 2025-01-07 15:23+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -133,34 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:219
-msgid ""
-"### This is a YAML representation of the group.\n"
-"### Any line starting with a '# will be ignored.\n"
-"###\n"
-"### A group has the following format:\n"
-"### name: my-first-group\n"
-"### description: My first group.\n"
-"### permissions:\n"
-"### - entity_type: project\n"
-"###   url: /1.0/projects/default\n"
-"###   entitlement: can_view\n"
-"### identities:\n"
-"### - authentication_method: oidc\n"
-"###   type: OIDC client\n"
-"###   identifier: jane.doe@example.com\n"
-"###   name: Jane Doe\n"
-"###   metadata:\n"
-"###     subject: auth0|123456789\n"
-"### identity_provider_groups:\n"
-"### - sales\n"
-"### - operations\n"
-"###\n"
-"### Note that all group information is shown but only the description and "
-"permissions can be modified"
-msgstr ""
-
-#: lxc/auth.go:1121
+#: lxc/auth.go:1119
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +154,31 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1793
+#: lxc/auth.go:219
+msgid ""
+"### This is a YAML representation of the group.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### NOTE: All group information is shown but only the description and "
+"permissions can be modified.\n"
+"### \n"
+"### name: my-first-group\n"
+"### description: My first group.\n"
+"### permissions:\n"
+"### - entity_type: project\n"
+"###   url: /1.0/projects/default\n"
+"###   entitlement: can_view\n"
+"### identities:\n"
+"###   oidc:\n"
+"###   - jane.doe@example.com\n"
+"###   tls:\n"
+"###   - eaa46a1b73827350e0543949fb161410c50e950d4cb9802fc58dbfbd5700e508\n"
+"### identity_provider_groups:\n"
+"### - sales\n"
+"### - operations\n"
+msgstr ""
+
+#: lxc/auth.go:1791
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -560,7 +557,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:966
+#: lxc/auth.go:964
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -598,11 +595,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1312 lxc/auth.go:1313
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2082 lxc/auth.go:2083
+#: lxc/auth.go:2080 lxc/auth.go:2081
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -671,7 +668,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:521 lxc/auth.go:522
+#: lxc/auth.go:519 lxc/auth.go:520
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -1347,12 +1344,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:306 lxc/auth.go:1868
+#: lxc/auth.go:304 lxc/auth.go:1866
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1207
+#: lxc/auth.go:1205
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1381,7 +1378,7 @@ msgstr ""
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:776
+#: lxc/auth.go:774
 msgid "Create a TLS identity"
 msgstr ""
 
@@ -1401,7 +1398,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:775
+#: lxc/auth.go:773
 msgid "Create an identity"
 msgstr ""
 
@@ -1421,7 +1418,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1679 lxc/auth.go:1680
+#: lxc/auth.go:1677 lxc/auth.go:1678
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1529,7 +1526,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1572,7 +1569,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1237 lxc/auth.go:1238
+#: lxc/auth.go:1235 lxc/auth.go:1236
 msgid "Delete an identity"
 msgstr ""
 
@@ -1584,7 +1581,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1729 lxc/auth.go:1730
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1663,14 +1660,14 @@ msgstr ""
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
 #: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
-#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
-#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
-#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
-#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
-#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
-#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
-#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
+#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
+#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
+#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
+#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
+#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
+#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -1939,7 +1936,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1108 lxc/auth.go:1109
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1955,7 +1952,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1780 lxc/auth.go:1781
+#: lxc/auth.go:1778 lxc/auth.go:1779
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2441,7 +2438,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
@@ -2499,7 +2496,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:970 lxc/auth.go:1944
+#: lxc/auth.go:968 lxc/auth.go:1942
 msgid "GROUPS"
 msgstr ""
 
@@ -2658,7 +2655,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:432 lxc/auth.go:1994
+#: lxc/auth.go:430 lxc/auth.go:1992
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2717,7 +2714,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:969
+#: lxc/auth.go:967
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2749,16 +2746,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:829
+#: lxc/auth.go:827
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1716
+#: lxc/auth.go:1714
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1766
+#: lxc/auth.go:1764
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2887,7 +2884,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1441 lxc/auth.go:1442
+#: lxc/auth.go:1439 lxc/auth.go:1440
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3191,15 +3188,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:337 lxc/auth.go:338
+#: lxc/auth.go:335 lxc/auth.go:336
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:917 lxc/auth.go:918
+#: lxc/auth.go:915 lxc/auth.go:916
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1900
+#: lxc/auth.go:1897 lxc/auth.go:1898
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3354,7 +3351,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1463 lxc/auth.go:1464
+#: lxc/auth.go:1461 lxc/auth.go:1462
 msgid "List permissions"
 msgstr ""
 
@@ -3522,7 +3519,7 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:823
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
@@ -3556,19 +3553,19 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1291 lxc/auth.go:1292
+#: lxc/auth.go:1289 lxc/auth.go:1290
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:736 lxc/auth.go:737
+#: lxc/auth.go:734 lxc/auth.go:735
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2059 lxc/auth.go:2060
+#: lxc/auth.go:2057 lxc/auth.go:2058
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3659,7 +3656,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:498 lxc/auth.go:499
+#: lxc/auth.go:496 lxc/auth.go:497
 msgid "Manage permissions"
 msgstr ""
 
@@ -3808,21 +3805,21 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
-#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
-#: lxc/auth.go:1339 lxc/auth.go:1397
+#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
+#: lxc/auth.go:1337 lxc/auth.go:1395
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
+#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2107 lxc/auth.go:2160
+#: lxc/auth.go:2105 lxc/auth.go:2158
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4043,7 +4040,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
@@ -4447,7 +4444,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4806,7 +4803,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1372 lxc/auth.go:1373
+#: lxc/auth.go:1370 lxc/auth.go:1371
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4842,7 +4839,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2135 lxc/auth.go:2136
+#: lxc/auth.go:2133 lxc/auth.go:2134
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4854,7 +4851,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:580 lxc/auth.go:581
+#: lxc/auth.go:578 lxc/auth.go:579
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4899,11 +4896,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:397 lxc/auth.go:398
+#: lxc/auth.go:395 lxc/auth.go:396
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1959 lxc/auth.go:1960
+#: lxc/auth.go:1957 lxc/auth.go:1958
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5424,7 +5421,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2008 lxc/auth.go:2009
+#: lxc/auth.go:2006 lxc/auth.go:2007
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5452,11 +5449,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:446 lxc/auth.go:447
+#: lxc/auth.go:444 lxc/auth.go:445
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:985
+#: lxc/auth.go:983
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5561,7 +5558,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1048
+#: lxc/auth.go:1046
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5799,12 +5796,12 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:876
+#: lxc/auth.go:874
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:902
+#: lxc/auth.go:900
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
@@ -5813,7 +5810,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1747 lxc/warning.go:216
@@ -6485,11 +6482,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:984
+#: lxc/auth.go:982
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1047
+#: lxc/auth.go:1045
 msgid "View the current identity"
 msgstr ""
 
@@ -6560,7 +6557,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6593,7 +6590,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1462
+#: lxc/auth.go:1460
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6654,17 +6651,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:772
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:983 lxc/auth.go:1235
+#: lxc/auth.go:981 lxc/auth.go:1233
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6672,13 +6669,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
-#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
+#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:520 lxc/auth.go:578
+#: lxc/auth.go:518 lxc/auth.go:576
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6688,19 +6685,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:395
+#: lxc/auth.go:393
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
+#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2081
+#: lxc/auth.go:2079
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1957
+#: lxc/auth.go:1955
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7248,14 +7245,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1111
+#: lxc/auth.go:1109
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1783
+#: lxc/auth.go:1781
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-19 16:04-0700\n"
+"POT-Creation-Date: 2025-01-07 15:23+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -133,34 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:219
-msgid ""
-"### This is a YAML representation of the group.\n"
-"### Any line starting with a '# will be ignored.\n"
-"###\n"
-"### A group has the following format:\n"
-"### name: my-first-group\n"
-"### description: My first group.\n"
-"### permissions:\n"
-"### - entity_type: project\n"
-"###   url: /1.0/projects/default\n"
-"###   entitlement: can_view\n"
-"### identities:\n"
-"### - authentication_method: oidc\n"
-"###   type: OIDC client\n"
-"###   identifier: jane.doe@example.com\n"
-"###   name: Jane Doe\n"
-"###   metadata:\n"
-"###     subject: auth0|123456789\n"
-"### identity_provider_groups:\n"
-"### - sales\n"
-"### - operations\n"
-"###\n"
-"### Note that all group information is shown but only the description and "
-"permissions can be modified"
-msgstr ""
-
-#: lxc/auth.go:1121
+#: lxc/auth.go:1119
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +154,31 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1793
+#: lxc/auth.go:219
+msgid ""
+"### This is a YAML representation of the group.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### NOTE: All group information is shown but only the description and "
+"permissions can be modified.\n"
+"### \n"
+"### name: my-first-group\n"
+"### description: My first group.\n"
+"### permissions:\n"
+"### - entity_type: project\n"
+"###   url: /1.0/projects/default\n"
+"###   entitlement: can_view\n"
+"### identities:\n"
+"###   oidc:\n"
+"###   - jane.doe@example.com\n"
+"###   tls:\n"
+"###   - eaa46a1b73827350e0543949fb161410c50e950d4cb9802fc58dbfbd5700e508\n"
+"### identity_provider_groups:\n"
+"### - sales\n"
+"### - operations\n"
+msgstr ""
+
+#: lxc/auth.go:1791
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -560,7 +557,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:966
+#: lxc/auth.go:964
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -598,11 +595,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1312 lxc/auth.go:1313
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2082 lxc/auth.go:2083
+#: lxc/auth.go:2080 lxc/auth.go:2081
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -671,7 +668,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:521 lxc/auth.go:522
+#: lxc/auth.go:519 lxc/auth.go:520
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -1347,12 +1344,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:306 lxc/auth.go:1868
+#: lxc/auth.go:304 lxc/auth.go:1866
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1207
+#: lxc/auth.go:1205
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1381,7 +1378,7 @@ msgstr ""
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:776
+#: lxc/auth.go:774
 msgid "Create a TLS identity"
 msgstr ""
 
@@ -1401,7 +1398,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:775
+#: lxc/auth.go:773
 msgid "Create an identity"
 msgstr ""
 
@@ -1421,7 +1418,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1679 lxc/auth.go:1680
+#: lxc/auth.go:1677 lxc/auth.go:1678
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1529,7 +1526,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1572,7 +1569,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1237 lxc/auth.go:1238
+#: lxc/auth.go:1235 lxc/auth.go:1236
 msgid "Delete an identity"
 msgstr ""
 
@@ -1584,7 +1581,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1729 lxc/auth.go:1730
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1663,14 +1660,14 @@ msgstr ""
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
 #: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
-#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
-#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
-#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
-#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
-#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
-#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
-#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
+#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
+#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
+#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
+#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
+#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
+#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -1939,7 +1936,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1108 lxc/auth.go:1109
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1955,7 +1952,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1780 lxc/auth.go:1781
+#: lxc/auth.go:1778 lxc/auth.go:1779
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2441,7 +2438,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
@@ -2499,7 +2496,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:970 lxc/auth.go:1944
+#: lxc/auth.go:968 lxc/auth.go:1942
 msgid "GROUPS"
 msgstr ""
 
@@ -2658,7 +2655,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:432 lxc/auth.go:1994
+#: lxc/auth.go:430 lxc/auth.go:1992
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2717,7 +2714,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:969
+#: lxc/auth.go:967
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2749,16 +2746,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:829
+#: lxc/auth.go:827
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1716
+#: lxc/auth.go:1714
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1766
+#: lxc/auth.go:1764
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2887,7 +2884,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1441 lxc/auth.go:1442
+#: lxc/auth.go:1439 lxc/auth.go:1440
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3191,15 +3188,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:337 lxc/auth.go:338
+#: lxc/auth.go:335 lxc/auth.go:336
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:917 lxc/auth.go:918
+#: lxc/auth.go:915 lxc/auth.go:916
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1900
+#: lxc/auth.go:1897 lxc/auth.go:1898
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3354,7 +3351,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1463 lxc/auth.go:1464
+#: lxc/auth.go:1461 lxc/auth.go:1462
 msgid "List permissions"
 msgstr ""
 
@@ -3522,7 +3519,7 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:823
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
@@ -3556,19 +3553,19 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1291 lxc/auth.go:1292
+#: lxc/auth.go:1289 lxc/auth.go:1290
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:736 lxc/auth.go:737
+#: lxc/auth.go:734 lxc/auth.go:735
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2059 lxc/auth.go:2060
+#: lxc/auth.go:2057 lxc/auth.go:2058
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3659,7 +3656,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:498 lxc/auth.go:499
+#: lxc/auth.go:496 lxc/auth.go:497
 msgid "Manage permissions"
 msgstr ""
 
@@ -3808,21 +3805,21 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
-#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
-#: lxc/auth.go:1339 lxc/auth.go:1397
+#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
+#: lxc/auth.go:1337 lxc/auth.go:1395
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
+#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2107 lxc/auth.go:2160
+#: lxc/auth.go:2105 lxc/auth.go:2158
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4043,7 +4040,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
@@ -4447,7 +4444,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4806,7 +4803,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1372 lxc/auth.go:1373
+#: lxc/auth.go:1370 lxc/auth.go:1371
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4842,7 +4839,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2135 lxc/auth.go:2136
+#: lxc/auth.go:2133 lxc/auth.go:2134
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4854,7 +4851,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:580 lxc/auth.go:581
+#: lxc/auth.go:578 lxc/auth.go:579
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4899,11 +4896,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:397 lxc/auth.go:398
+#: lxc/auth.go:395 lxc/auth.go:396
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1959 lxc/auth.go:1960
+#: lxc/auth.go:1957 lxc/auth.go:1958
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5424,7 +5421,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2008 lxc/auth.go:2009
+#: lxc/auth.go:2006 lxc/auth.go:2007
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5452,11 +5449,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:446 lxc/auth.go:447
+#: lxc/auth.go:444 lxc/auth.go:445
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:985
+#: lxc/auth.go:983
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5561,7 +5558,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1048
+#: lxc/auth.go:1046
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5799,12 +5796,12 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:876
+#: lxc/auth.go:874
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:902
+#: lxc/auth.go:900
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
@@ -5813,7 +5810,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1747 lxc/warning.go:216
@@ -6485,11 +6482,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:984
+#: lxc/auth.go:982
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1047
+#: lxc/auth.go:1045
 msgid "View the current identity"
 msgstr ""
 
@@ -6560,7 +6557,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6593,7 +6590,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1462
+#: lxc/auth.go:1460
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6654,17 +6651,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:772
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:983 lxc/auth.go:1235
+#: lxc/auth.go:981 lxc/auth.go:1233
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6672,13 +6669,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
-#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
+#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:520 lxc/auth.go:578
+#: lxc/auth.go:518 lxc/auth.go:576
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6688,19 +6685,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:395
+#: lxc/auth.go:393
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
+#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2081
+#: lxc/auth.go:2079
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1957
+#: lxc/auth.go:1955
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7248,14 +7245,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1111
+#: lxc/auth.go:1109
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1783
+#: lxc/auth.go:1781
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-19 16:04-0700\n"
+"POT-Creation-Date: 2025-01-07 15:23+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -200,34 +200,7 @@ msgstr ""
 "###\n"
 "### Notez que le nom est affiché mais ne peut être modifié"
 
-#: lxc/auth.go:219
-msgid ""
-"### This is a YAML representation of the group.\n"
-"### Any line starting with a '# will be ignored.\n"
-"###\n"
-"### A group has the following format:\n"
-"### name: my-first-group\n"
-"### description: My first group.\n"
-"### permissions:\n"
-"### - entity_type: project\n"
-"###   url: /1.0/projects/default\n"
-"###   entitlement: can_view\n"
-"### identities:\n"
-"### - authentication_method: oidc\n"
-"###   type: OIDC client\n"
-"###   identifier: jane.doe@example.com\n"
-"###   name: Jane Doe\n"
-"###   metadata:\n"
-"###     subject: auth0|123456789\n"
-"### identity_provider_groups:\n"
-"### - sales\n"
-"### - operations\n"
-"###\n"
-"### Note that all group information is shown but only the description and "
-"permissions can be modified"
-msgstr ""
-
-#: lxc/auth.go:1121
+#: lxc/auth.go:1119
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -248,7 +221,31 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1793
+#: lxc/auth.go:219
+msgid ""
+"### This is a YAML representation of the group.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### NOTE: All group information is shown but only the description and "
+"permissions can be modified.\n"
+"### \n"
+"### name: my-first-group\n"
+"### description: My first group.\n"
+"### permissions:\n"
+"### - entity_type: project\n"
+"###   url: /1.0/projects/default\n"
+"###   entitlement: can_view\n"
+"### identities:\n"
+"###   oidc:\n"
+"###   - jane.doe@example.com\n"
+"###   tls:\n"
+"###   - eaa46a1b73827350e0543949fb161410c50e950d4cb9802fc58dbfbd5700e508\n"
+"### identity_provider_groups:\n"
+"### - sales\n"
+"### - operations\n"
+msgstr ""
+
+#: lxc/auth.go:1791
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -822,7 +819,7 @@ msgstr "ARCHITECTURE"
 msgid "AUTH TYPE"
 msgstr "TYPE"
 
-#: lxc/auth.go:966
+#: lxc/auth.go:964
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -862,11 +859,11 @@ msgstr "Le type d'authentification '%s' n'est pas supporté par le serveur"
 msgid "Add a cluster member to a cluster group"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1312 lxc/auth.go:1313
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2082 lxc/auth.go:2083
+#: lxc/auth.go:2080 lxc/auth.go:2081
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -947,7 +944,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:521 lxc/auth.go:522
+#: lxc/auth.go:519 lxc/auth.go:520
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -1661,12 +1658,12 @@ msgstr "Impossible d'assainir le chemin %s"
 msgid "Could not find certificate key file path: %s"
 msgstr "Impossible d'assainir le chemin %s"
 
-#: lxc/auth.go:306 lxc/auth.go:1868
+#: lxc/auth.go:304 lxc/auth.go:1866
 #, fuzzy, c-format
 msgid "Could not parse group: %s"
 msgstr "Erreur lors de la lecture de la configuration : %s"
 
-#: lxc/auth.go:1207
+#: lxc/auth.go:1205
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1695,7 +1692,7 @@ msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:776
+#: lxc/auth.go:774
 #, fuzzy
 msgid "Create a TLS identity"
 msgstr "Récupération de l'image : %s"
@@ -1718,7 +1715,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr "Création du conteneur"
 
-#: lxc/auth.go:775
+#: lxc/auth.go:773
 #, fuzzy
 msgid "Create an identity"
 msgstr "Récupération de l'image : %s"
@@ -1742,7 +1739,7 @@ msgstr "Créer tous répertoires nécessaires"
 msgid "Create groups"
 msgstr "Créé : %s"
 
-#: lxc/auth.go:1679 lxc/auth.go:1680
+#: lxc/auth.go:1677 lxc/auth.go:1678
 #, fuzzy
 msgid "Create identity provider groups"
 msgstr "Copie de l'image : %s"
@@ -1883,7 +1880,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1928,7 +1925,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/auth.go:1237 lxc/auth.go:1238
+#: lxc/auth.go:1235 lxc/auth.go:1236
 #, fuzzy
 msgid "Delete an identity"
 msgstr "Récupération de l'image : %s"
@@ -1943,7 +1940,7 @@ msgstr "Création du conteneur"
 msgid "Delete groups"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1729 lxc/auth.go:1730
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -2034,14 +2031,14 @@ msgstr "Récupération de l'image : %s"
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
 #: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
-#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
-#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
-#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
-#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
-#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
-#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
-#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
+#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
+#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
+#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
+#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
+#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
+#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -2322,7 +2319,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1108 lxc/auth.go:1109
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -2341,7 +2338,7 @@ msgstr "Création du conteneur"
 msgid "Edit groups as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/auth.go:1780 lxc/auth.go:1781
+#: lxc/auth.go:1778 lxc/auth.go:1779
 #, fuzzy
 msgid "Edit identity provider groups as YAML"
 msgstr "Clé de configuration invalide"
@@ -2872,7 +2869,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
@@ -2930,7 +2927,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:970 lxc/auth.go:1944
+#: lxc/auth.go:968 lxc/auth.go:1942
 msgid "GROUPS"
 msgstr ""
 
@@ -3111,7 +3108,7 @@ msgstr "Profil %s créé"
 msgid "Group %s deleted"
 msgstr "Profil %s supprimé"
 
-#: lxc/auth.go:432 lxc/auth.go:1994
+#: lxc/auth.go:430 lxc/auth.go:1992
 #, fuzzy, c-format
 msgid "Group %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
@@ -3173,7 +3170,7 @@ msgstr "Pid : %d"
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:969
+#: lxc/auth.go:967
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -3207,16 +3204,16 @@ msgstr "IPv6"
 msgid "ISSUE DATE"
 msgstr "DATE D'ÉMISSION"
 
-#: lxc/auth.go:829
+#: lxc/auth.go:827
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1716
+#: lxc/auth.go:1714
 #, fuzzy, c-format
 msgid "Identity provider group %s created"
 msgstr "Profil %s créé"
 
-#: lxc/auth.go:1766
+#: lxc/auth.go:1764
 #, fuzzy, c-format
 msgid "Identity provider group %s deleted"
 msgstr "Profil %s créé"
@@ -3355,7 +3352,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1441 lxc/auth.go:1442
+#: lxc/auth.go:1439 lxc/auth.go:1440
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3675,16 +3672,16 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:337 lxc/auth.go:338
+#: lxc/auth.go:335 lxc/auth.go:336
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:917 lxc/auth.go:918
+#: lxc/auth.go:915 lxc/auth.go:916
 #, fuzzy
 msgid "List identities"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/auth.go:1899 lxc/auth.go:1900
+#: lxc/auth.go:1897 lxc/auth.go:1898
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3903,7 +3900,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/auth.go:1463 lxc/auth.go:1464
+#: lxc/auth.go:1461 lxc/auth.go:1462
 #, fuzzy
 msgid "List permissions"
 msgstr "Alias :"
@@ -4079,7 +4076,7 @@ msgstr "Rendre l'image publique"
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:823
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
@@ -4117,21 +4114,21 @@ msgstr "Création du conteneur"
 msgid "Manage files in instances"
 msgstr "Transfert de l'image : %s"
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
 #, fuzzy
 msgid "Manage groups"
 msgstr "Copie de l'image : %s"
 
-#: lxc/auth.go:1291 lxc/auth.go:1292
+#: lxc/auth.go:1289 lxc/auth.go:1290
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:736 lxc/auth.go:737
+#: lxc/auth.go:734 lxc/auth.go:735
 #, fuzzy
 msgid "Manage identities"
 msgstr "Création du conteneur"
 
-#: lxc/auth.go:2059 lxc/auth.go:2060
+#: lxc/auth.go:2057 lxc/auth.go:2058
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -4239,7 +4236,7 @@ msgstr "Nom du réseau"
 msgid "Manage network zones"
 msgstr "Nom du réseau"
 
-#: lxc/auth.go:498 lxc/auth.go:499
+#: lxc/auth.go:496 lxc/auth.go:497
 #, fuzzy
 msgid "Manage permissions"
 msgstr "Rendre l'image publique"
@@ -4405,24 +4402,24 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "Missing cluster member name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
-#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
 #, fuzzy
 msgid "Missing group name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
-#: lxc/auth.go:1339 lxc/auth.go:1397
+#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
+#: lxc/auth.go:1337 lxc/auth.go:1395
 #, fuzzy
 msgid "Missing identity argument"
 msgstr "Résumé manquant."
 
-#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
+#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
 #, fuzzy
 msgid "Missing identity provider group name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/auth.go:2107 lxc/auth.go:2160
+#: lxc/auth.go:2105 lxc/auth.go:2158
 #, fuzzy
 msgid "Missing identity provider group name argument"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -4667,7 +4664,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
@@ -5095,7 +5092,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -5471,7 +5468,7 @@ msgstr "Supprimer %s (oui/non) : "
 msgid "Remove a cluster member from a cluster group"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/auth.go:1372 lxc/auth.go:1373
+#: lxc/auth.go:1370 lxc/auth.go:1371
 #, fuzzy
 msgid "Remove a group from an identity"
 msgstr "Création du conteneur"
@@ -5513,7 +5510,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "Remove entries from a network zone record"
 msgstr "Création du conteneur"
 
-#: lxc/auth.go:2135 lxc/auth.go:2136
+#: lxc/auth.go:2133 lxc/auth.go:2134
 #, fuzzy
 msgid "Remove identities from groups"
 msgstr "Création du conteneur"
@@ -5527,7 +5524,7 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:580 lxc/auth.go:581
+#: lxc/auth.go:578 lxc/auth.go:579
 #, fuzzy
 msgid "Remove permissions from groups"
 msgstr "Création du conteneur"
@@ -5579,12 +5576,12 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:397 lxc/auth.go:398
+#: lxc/auth.go:395 lxc/auth.go:396
 #, fuzzy
 msgid "Rename groups"
 msgstr "Copie de l'image : %s"
 
-#: lxc/auth.go:1959 lxc/auth.go:1960
+#: lxc/auth.go:1957 lxc/auth.go:1958
 #, fuzzy
 msgid "Rename identity provider groups"
 msgstr "Copie de l'image : %s"
@@ -6167,7 +6164,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2008 lxc/auth.go:2009
+#: lxc/auth.go:2006 lxc/auth.go:2007
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -6198,12 +6195,12 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/auth.go:446 lxc/auth.go:447
+#: lxc/auth.go:444 lxc/auth.go:445
 #, fuzzy
 msgid "Show group configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/auth.go:985
+#: lxc/auth.go:983
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -6329,7 +6326,7 @@ msgstr "Afficher la configuration étendue"
 msgid "Show storage volume state information"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/auth.go:1048
+#: lxc/auth.go:1046
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -6583,12 +6580,12 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:876
+#: lxc/auth.go:874
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:902
+#: lxc/auth.go:900
 #, fuzzy, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr "Image importée avec l'empreinte : %s"
@@ -6597,7 +6594,7 @@ msgstr "Image importée avec l'empreinte : %s"
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1747 lxc/warning.go:216
@@ -7321,11 +7318,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr "Créé : %s"
 
-#: lxc/auth.go:984
+#: lxc/auth.go:982
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1047
+#: lxc/auth.go:1045
 #, fuzzy
 msgid "View the current identity"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -7414,7 +7411,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -7484,7 +7481,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/auth.go:1462
+#: lxc/auth.go:1460
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -7610,17 +7607,17 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:774
+#: lxc/auth.go:772
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:983 lxc/auth.go:1235
+#: lxc/auth.go:981 lxc/auth.go:1233
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -7636,8 +7633,8 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
-#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
+#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 #, fuzzy
 msgid "[<remote>:]<group>"
@@ -7646,7 +7643,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:520 lxc/auth.go:578
+#: lxc/auth.go:518 lxc/auth.go:576
 #, fuzzy
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
@@ -7664,7 +7661,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:395
+#: lxc/auth.go:393
 #, fuzzy
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
@@ -7672,7 +7669,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
+#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
@@ -7680,7 +7677,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:2081
+#: lxc/auth.go:2079
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
@@ -7692,7 +7689,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/auth.go:1957
+#: lxc/auth.go:1955
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
@@ -8838,14 +8835,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1111
+#: lxc/auth.go:1109
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1783
+#: lxc/auth.go:1781
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-19 16:04-0700\n"
+"POT-Creation-Date: 2025-01-07 15:23+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -134,34 +134,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:219
-msgid ""
-"### This is a YAML representation of the group.\n"
-"### Any line starting with a '# will be ignored.\n"
-"###\n"
-"### A group has the following format:\n"
-"### name: my-first-group\n"
-"### description: My first group.\n"
-"### permissions:\n"
-"### - entity_type: project\n"
-"###   url: /1.0/projects/default\n"
-"###   entitlement: can_view\n"
-"### identities:\n"
-"### - authentication_method: oidc\n"
-"###   type: OIDC client\n"
-"###   identifier: jane.doe@example.com\n"
-"###   name: Jane Doe\n"
-"###   metadata:\n"
-"###     subject: auth0|123456789\n"
-"### identity_provider_groups:\n"
-"### - sales\n"
-"### - operations\n"
-"###\n"
-"### Note that all group information is shown but only the description and "
-"permissions can be modified"
-msgstr ""
-
-#: lxc/auth.go:1121
+#: lxc/auth.go:1119
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -182,7 +155,31 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1793
+#: lxc/auth.go:219
+msgid ""
+"### This is a YAML representation of the group.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### NOTE: All group information is shown but only the description and "
+"permissions can be modified.\n"
+"### \n"
+"### name: my-first-group\n"
+"### description: My first group.\n"
+"### permissions:\n"
+"### - entity_type: project\n"
+"###   url: /1.0/projects/default\n"
+"###   entitlement: can_view\n"
+"### identities:\n"
+"###   oidc:\n"
+"###   - jane.doe@example.com\n"
+"###   tls:\n"
+"###   - eaa46a1b73827350e0543949fb161410c50e950d4cb9802fc58dbfbd5700e508\n"
+"### identity_provider_groups:\n"
+"### - sales\n"
+"### - operations\n"
+msgstr ""
+
+#: lxc/auth.go:1791
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -561,7 +558,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:966
+#: lxc/auth.go:964
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -599,11 +596,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1312 lxc/auth.go:1313
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2082 lxc/auth.go:2083
+#: lxc/auth.go:2080 lxc/auth.go:2081
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -672,7 +669,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:521 lxc/auth.go:522
+#: lxc/auth.go:519 lxc/auth.go:520
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -1348,12 +1345,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:306 lxc/auth.go:1868
+#: lxc/auth.go:304 lxc/auth.go:1866
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1207
+#: lxc/auth.go:1205
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1382,7 +1379,7 @@ msgstr ""
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:776
+#: lxc/auth.go:774
 msgid "Create a TLS identity"
 msgstr ""
 
@@ -1402,7 +1399,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:775
+#: lxc/auth.go:773
 msgid "Create an identity"
 msgstr ""
 
@@ -1422,7 +1419,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1679 lxc/auth.go:1680
+#: lxc/auth.go:1677 lxc/auth.go:1678
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1530,7 +1527,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1573,7 +1570,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1237 lxc/auth.go:1238
+#: lxc/auth.go:1235 lxc/auth.go:1236
 msgid "Delete an identity"
 msgstr ""
 
@@ -1585,7 +1582,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1729 lxc/auth.go:1730
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1664,14 +1661,14 @@ msgstr ""
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
 #: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
-#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
-#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
-#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
-#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
-#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
-#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
-#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
+#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
+#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
+#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
+#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
+#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
+#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -1940,7 +1937,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1108 lxc/auth.go:1109
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1956,7 +1953,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1780 lxc/auth.go:1781
+#: lxc/auth.go:1778 lxc/auth.go:1779
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2442,7 +2439,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
@@ -2500,7 +2497,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:970 lxc/auth.go:1944
+#: lxc/auth.go:968 lxc/auth.go:1942
 msgid "GROUPS"
 msgstr ""
 
@@ -2659,7 +2656,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:432 lxc/auth.go:1994
+#: lxc/auth.go:430 lxc/auth.go:1992
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2718,7 +2715,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:969
+#: lxc/auth.go:967
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2750,16 +2747,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:829
+#: lxc/auth.go:827
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1716
+#: lxc/auth.go:1714
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1766
+#: lxc/auth.go:1764
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2888,7 +2885,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1441 lxc/auth.go:1442
+#: lxc/auth.go:1439 lxc/auth.go:1440
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3192,15 +3189,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:337 lxc/auth.go:338
+#: lxc/auth.go:335 lxc/auth.go:336
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:917 lxc/auth.go:918
+#: lxc/auth.go:915 lxc/auth.go:916
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1900
+#: lxc/auth.go:1897 lxc/auth.go:1898
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3355,7 +3352,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1463 lxc/auth.go:1464
+#: lxc/auth.go:1461 lxc/auth.go:1462
 msgid "List permissions"
 msgstr ""
 
@@ -3523,7 +3520,7 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:823
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
@@ -3557,19 +3554,19 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1291 lxc/auth.go:1292
+#: lxc/auth.go:1289 lxc/auth.go:1290
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:736 lxc/auth.go:737
+#: lxc/auth.go:734 lxc/auth.go:735
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2059 lxc/auth.go:2060
+#: lxc/auth.go:2057 lxc/auth.go:2058
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3660,7 +3657,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:498 lxc/auth.go:499
+#: lxc/auth.go:496 lxc/auth.go:497
 msgid "Manage permissions"
 msgstr ""
 
@@ -3809,21 +3806,21 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
-#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
-#: lxc/auth.go:1339 lxc/auth.go:1397
+#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
+#: lxc/auth.go:1337 lxc/auth.go:1395
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
+#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2107 lxc/auth.go:2160
+#: lxc/auth.go:2105 lxc/auth.go:2158
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4044,7 +4041,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
@@ -4448,7 +4445,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4807,7 +4804,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1372 lxc/auth.go:1373
+#: lxc/auth.go:1370 lxc/auth.go:1371
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4843,7 +4840,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2135 lxc/auth.go:2136
+#: lxc/auth.go:2133 lxc/auth.go:2134
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4855,7 +4852,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:580 lxc/auth.go:581
+#: lxc/auth.go:578 lxc/auth.go:579
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4900,11 +4897,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:397 lxc/auth.go:398
+#: lxc/auth.go:395 lxc/auth.go:396
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1959 lxc/auth.go:1960
+#: lxc/auth.go:1957 lxc/auth.go:1958
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5425,7 +5422,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2008 lxc/auth.go:2009
+#: lxc/auth.go:2006 lxc/auth.go:2007
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5453,11 +5450,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:446 lxc/auth.go:447
+#: lxc/auth.go:444 lxc/auth.go:445
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:985
+#: lxc/auth.go:983
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5562,7 +5559,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1048
+#: lxc/auth.go:1046
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5800,12 +5797,12 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:876
+#: lxc/auth.go:874
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:902
+#: lxc/auth.go:900
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
@@ -5814,7 +5811,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1747 lxc/warning.go:216
@@ -6486,11 +6483,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:984
+#: lxc/auth.go:982
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1047
+#: lxc/auth.go:1045
 msgid "View the current identity"
 msgstr ""
 
@@ -6561,7 +6558,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6594,7 +6591,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1462
+#: lxc/auth.go:1460
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6655,17 +6652,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:772
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:983 lxc/auth.go:1235
+#: lxc/auth.go:981 lxc/auth.go:1233
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6673,13 +6670,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
-#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
+#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:520 lxc/auth.go:578
+#: lxc/auth.go:518 lxc/auth.go:576
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6689,19 +6686,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:395
+#: lxc/auth.go:393
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
+#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2081
+#: lxc/auth.go:2079
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1957
+#: lxc/auth.go:1955
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7249,14 +7246,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1111
+#: lxc/auth.go:1109
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1783
+#: lxc/auth.go:1781
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-19 16:04-0700\n"
+"POT-Creation-Date: 2025-01-07 15:23+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -133,34 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:219
-msgid ""
-"### This is a YAML representation of the group.\n"
-"### Any line starting with a '# will be ignored.\n"
-"###\n"
-"### A group has the following format:\n"
-"### name: my-first-group\n"
-"### description: My first group.\n"
-"### permissions:\n"
-"### - entity_type: project\n"
-"###   url: /1.0/projects/default\n"
-"###   entitlement: can_view\n"
-"### identities:\n"
-"### - authentication_method: oidc\n"
-"###   type: OIDC client\n"
-"###   identifier: jane.doe@example.com\n"
-"###   name: Jane Doe\n"
-"###   metadata:\n"
-"###     subject: auth0|123456789\n"
-"### identity_provider_groups:\n"
-"### - sales\n"
-"### - operations\n"
-"###\n"
-"### Note that all group information is shown but only the description and "
-"permissions can be modified"
-msgstr ""
-
-#: lxc/auth.go:1121
+#: lxc/auth.go:1119
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +154,31 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1793
+#: lxc/auth.go:219
+msgid ""
+"### This is a YAML representation of the group.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### NOTE: All group information is shown but only the description and "
+"permissions can be modified.\n"
+"### \n"
+"### name: my-first-group\n"
+"### description: My first group.\n"
+"### permissions:\n"
+"### - entity_type: project\n"
+"###   url: /1.0/projects/default\n"
+"###   entitlement: can_view\n"
+"### identities:\n"
+"###   oidc:\n"
+"###   - jane.doe@example.com\n"
+"###   tls:\n"
+"###   - eaa46a1b73827350e0543949fb161410c50e950d4cb9802fc58dbfbd5700e508\n"
+"### identity_provider_groups:\n"
+"### - sales\n"
+"### - operations\n"
+msgstr ""
+
+#: lxc/auth.go:1791
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -560,7 +557,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:966
+#: lxc/auth.go:964
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -598,11 +595,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1312 lxc/auth.go:1313
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2082 lxc/auth.go:2083
+#: lxc/auth.go:2080 lxc/auth.go:2081
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -671,7 +668,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:521 lxc/auth.go:522
+#: lxc/auth.go:519 lxc/auth.go:520
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -1347,12 +1344,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:306 lxc/auth.go:1868
+#: lxc/auth.go:304 lxc/auth.go:1866
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1207
+#: lxc/auth.go:1205
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1381,7 +1378,7 @@ msgstr ""
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:776
+#: lxc/auth.go:774
 msgid "Create a TLS identity"
 msgstr ""
 
@@ -1401,7 +1398,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:775
+#: lxc/auth.go:773
 msgid "Create an identity"
 msgstr ""
 
@@ -1421,7 +1418,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1679 lxc/auth.go:1680
+#: lxc/auth.go:1677 lxc/auth.go:1678
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1529,7 +1526,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1572,7 +1569,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1237 lxc/auth.go:1238
+#: lxc/auth.go:1235 lxc/auth.go:1236
 msgid "Delete an identity"
 msgstr ""
 
@@ -1584,7 +1581,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1729 lxc/auth.go:1730
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1663,14 +1660,14 @@ msgstr ""
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
 #: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
-#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
-#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
-#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
-#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
-#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
-#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
-#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
+#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
+#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
+#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
+#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
+#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
+#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -1939,7 +1936,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1108 lxc/auth.go:1109
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1955,7 +1952,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1780 lxc/auth.go:1781
+#: lxc/auth.go:1778 lxc/auth.go:1779
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2441,7 +2438,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
@@ -2499,7 +2496,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:970 lxc/auth.go:1944
+#: lxc/auth.go:968 lxc/auth.go:1942
 msgid "GROUPS"
 msgstr ""
 
@@ -2658,7 +2655,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:432 lxc/auth.go:1994
+#: lxc/auth.go:430 lxc/auth.go:1992
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2717,7 +2714,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:969
+#: lxc/auth.go:967
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2749,16 +2746,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:829
+#: lxc/auth.go:827
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1716
+#: lxc/auth.go:1714
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1766
+#: lxc/auth.go:1764
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2887,7 +2884,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1441 lxc/auth.go:1442
+#: lxc/auth.go:1439 lxc/auth.go:1440
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3191,15 +3188,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:337 lxc/auth.go:338
+#: lxc/auth.go:335 lxc/auth.go:336
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:917 lxc/auth.go:918
+#: lxc/auth.go:915 lxc/auth.go:916
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1900
+#: lxc/auth.go:1897 lxc/auth.go:1898
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3354,7 +3351,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1463 lxc/auth.go:1464
+#: lxc/auth.go:1461 lxc/auth.go:1462
 msgid "List permissions"
 msgstr ""
 
@@ -3522,7 +3519,7 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:823
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
@@ -3556,19 +3553,19 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1291 lxc/auth.go:1292
+#: lxc/auth.go:1289 lxc/auth.go:1290
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:736 lxc/auth.go:737
+#: lxc/auth.go:734 lxc/auth.go:735
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2059 lxc/auth.go:2060
+#: lxc/auth.go:2057 lxc/auth.go:2058
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3659,7 +3656,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:498 lxc/auth.go:499
+#: lxc/auth.go:496 lxc/auth.go:497
 msgid "Manage permissions"
 msgstr ""
 
@@ -3808,21 +3805,21 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
-#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
-#: lxc/auth.go:1339 lxc/auth.go:1397
+#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
+#: lxc/auth.go:1337 lxc/auth.go:1395
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
+#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2107 lxc/auth.go:2160
+#: lxc/auth.go:2105 lxc/auth.go:2158
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4043,7 +4040,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
@@ -4447,7 +4444,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4806,7 +4803,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1372 lxc/auth.go:1373
+#: lxc/auth.go:1370 lxc/auth.go:1371
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4842,7 +4839,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2135 lxc/auth.go:2136
+#: lxc/auth.go:2133 lxc/auth.go:2134
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4854,7 +4851,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:580 lxc/auth.go:581
+#: lxc/auth.go:578 lxc/auth.go:579
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4899,11 +4896,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:397 lxc/auth.go:398
+#: lxc/auth.go:395 lxc/auth.go:396
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1959 lxc/auth.go:1960
+#: lxc/auth.go:1957 lxc/auth.go:1958
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5424,7 +5421,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2008 lxc/auth.go:2009
+#: lxc/auth.go:2006 lxc/auth.go:2007
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5452,11 +5449,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:446 lxc/auth.go:447
+#: lxc/auth.go:444 lxc/auth.go:445
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:985
+#: lxc/auth.go:983
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5561,7 +5558,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1048
+#: lxc/auth.go:1046
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5799,12 +5796,12 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:876
+#: lxc/auth.go:874
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:902
+#: lxc/auth.go:900
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
@@ -5813,7 +5810,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1747 lxc/warning.go:216
@@ -6485,11 +6482,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:984
+#: lxc/auth.go:982
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1047
+#: lxc/auth.go:1045
 msgid "View the current identity"
 msgstr ""
 
@@ -6560,7 +6557,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6593,7 +6590,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1462
+#: lxc/auth.go:1460
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6654,17 +6651,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:772
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:983 lxc/auth.go:1235
+#: lxc/auth.go:981 lxc/auth.go:1233
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6672,13 +6669,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
-#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
+#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:520 lxc/auth.go:578
+#: lxc/auth.go:518 lxc/auth.go:576
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6688,19 +6685,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:395
+#: lxc/auth.go:393
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
+#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2081
+#: lxc/auth.go:2079
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1957
+#: lxc/auth.go:1955
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7248,14 +7245,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1111
+#: lxc/auth.go:1109
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1783
+#: lxc/auth.go:1781
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-19 16:04-0700\n"
+"POT-Creation-Date: 2025-01-07 15:23+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -133,34 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:219
-msgid ""
-"### This is a YAML representation of the group.\n"
-"### Any line starting with a '# will be ignored.\n"
-"###\n"
-"### A group has the following format:\n"
-"### name: my-first-group\n"
-"### description: My first group.\n"
-"### permissions:\n"
-"### - entity_type: project\n"
-"###   url: /1.0/projects/default\n"
-"###   entitlement: can_view\n"
-"### identities:\n"
-"### - authentication_method: oidc\n"
-"###   type: OIDC client\n"
-"###   identifier: jane.doe@example.com\n"
-"###   name: Jane Doe\n"
-"###   metadata:\n"
-"###     subject: auth0|123456789\n"
-"### identity_provider_groups:\n"
-"### - sales\n"
-"### - operations\n"
-"###\n"
-"### Note that all group information is shown but only the description and "
-"permissions can be modified"
-msgstr ""
-
-#: lxc/auth.go:1121
+#: lxc/auth.go:1119
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +154,31 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1793
+#: lxc/auth.go:219
+msgid ""
+"### This is a YAML representation of the group.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### NOTE: All group information is shown but only the description and "
+"permissions can be modified.\n"
+"### \n"
+"### name: my-first-group\n"
+"### description: My first group.\n"
+"### permissions:\n"
+"### - entity_type: project\n"
+"###   url: /1.0/projects/default\n"
+"###   entitlement: can_view\n"
+"### identities:\n"
+"###   oidc:\n"
+"###   - jane.doe@example.com\n"
+"###   tls:\n"
+"###   - eaa46a1b73827350e0543949fb161410c50e950d4cb9802fc58dbfbd5700e508\n"
+"### identity_provider_groups:\n"
+"### - sales\n"
+"### - operations\n"
+msgstr ""
+
+#: lxc/auth.go:1791
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -560,7 +557,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:966
+#: lxc/auth.go:964
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -598,11 +595,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1312 lxc/auth.go:1313
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2082 lxc/auth.go:2083
+#: lxc/auth.go:2080 lxc/auth.go:2081
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -671,7 +668,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:521 lxc/auth.go:522
+#: lxc/auth.go:519 lxc/auth.go:520
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -1347,12 +1344,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:306 lxc/auth.go:1868
+#: lxc/auth.go:304 lxc/auth.go:1866
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1207
+#: lxc/auth.go:1205
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1381,7 +1378,7 @@ msgstr ""
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:776
+#: lxc/auth.go:774
 msgid "Create a TLS identity"
 msgstr ""
 
@@ -1401,7 +1398,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:775
+#: lxc/auth.go:773
 msgid "Create an identity"
 msgstr ""
 
@@ -1421,7 +1418,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1679 lxc/auth.go:1680
+#: lxc/auth.go:1677 lxc/auth.go:1678
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1529,7 +1526,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1572,7 +1569,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1237 lxc/auth.go:1238
+#: lxc/auth.go:1235 lxc/auth.go:1236
 msgid "Delete an identity"
 msgstr ""
 
@@ -1584,7 +1581,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1729 lxc/auth.go:1730
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1663,14 +1660,14 @@ msgstr ""
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
 #: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
-#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
-#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
-#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
-#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
-#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
-#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
-#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
+#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
+#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
+#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
+#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
+#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
+#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -1939,7 +1936,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1108 lxc/auth.go:1109
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1955,7 +1952,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1780 lxc/auth.go:1781
+#: lxc/auth.go:1778 lxc/auth.go:1779
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2441,7 +2438,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
@@ -2499,7 +2496,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:970 lxc/auth.go:1944
+#: lxc/auth.go:968 lxc/auth.go:1942
 msgid "GROUPS"
 msgstr ""
 
@@ -2658,7 +2655,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:432 lxc/auth.go:1994
+#: lxc/auth.go:430 lxc/auth.go:1992
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2717,7 +2714,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:969
+#: lxc/auth.go:967
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2749,16 +2746,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:829
+#: lxc/auth.go:827
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1716
+#: lxc/auth.go:1714
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1766
+#: lxc/auth.go:1764
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2887,7 +2884,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1441 lxc/auth.go:1442
+#: lxc/auth.go:1439 lxc/auth.go:1440
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3191,15 +3188,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:337 lxc/auth.go:338
+#: lxc/auth.go:335 lxc/auth.go:336
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:917 lxc/auth.go:918
+#: lxc/auth.go:915 lxc/auth.go:916
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1900
+#: lxc/auth.go:1897 lxc/auth.go:1898
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3354,7 +3351,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1463 lxc/auth.go:1464
+#: lxc/auth.go:1461 lxc/auth.go:1462
 msgid "List permissions"
 msgstr ""
 
@@ -3522,7 +3519,7 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:823
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
@@ -3556,19 +3553,19 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1291 lxc/auth.go:1292
+#: lxc/auth.go:1289 lxc/auth.go:1290
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:736 lxc/auth.go:737
+#: lxc/auth.go:734 lxc/auth.go:735
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2059 lxc/auth.go:2060
+#: lxc/auth.go:2057 lxc/auth.go:2058
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3659,7 +3656,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:498 lxc/auth.go:499
+#: lxc/auth.go:496 lxc/auth.go:497
 msgid "Manage permissions"
 msgstr ""
 
@@ -3808,21 +3805,21 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
-#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
-#: lxc/auth.go:1339 lxc/auth.go:1397
+#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
+#: lxc/auth.go:1337 lxc/auth.go:1395
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
+#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2107 lxc/auth.go:2160
+#: lxc/auth.go:2105 lxc/auth.go:2158
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4043,7 +4040,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
@@ -4447,7 +4444,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4806,7 +4803,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1372 lxc/auth.go:1373
+#: lxc/auth.go:1370 lxc/auth.go:1371
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4842,7 +4839,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2135 lxc/auth.go:2136
+#: lxc/auth.go:2133 lxc/auth.go:2134
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4854,7 +4851,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:580 lxc/auth.go:581
+#: lxc/auth.go:578 lxc/auth.go:579
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4899,11 +4896,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:397 lxc/auth.go:398
+#: lxc/auth.go:395 lxc/auth.go:396
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1959 lxc/auth.go:1960
+#: lxc/auth.go:1957 lxc/auth.go:1958
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5424,7 +5421,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2008 lxc/auth.go:2009
+#: lxc/auth.go:2006 lxc/auth.go:2007
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5452,11 +5449,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:446 lxc/auth.go:447
+#: lxc/auth.go:444 lxc/auth.go:445
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:985
+#: lxc/auth.go:983
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5561,7 +5558,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1048
+#: lxc/auth.go:1046
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5799,12 +5796,12 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:876
+#: lxc/auth.go:874
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:902
+#: lxc/auth.go:900
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
@@ -5813,7 +5810,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1747 lxc/warning.go:216
@@ -6485,11 +6482,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:984
+#: lxc/auth.go:982
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1047
+#: lxc/auth.go:1045
 msgid "View the current identity"
 msgstr ""
 
@@ -6560,7 +6557,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6593,7 +6590,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1462
+#: lxc/auth.go:1460
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6654,17 +6651,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:772
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:983 lxc/auth.go:1235
+#: lxc/auth.go:981 lxc/auth.go:1233
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6672,13 +6669,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
-#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
+#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:520 lxc/auth.go:578
+#: lxc/auth.go:518 lxc/auth.go:576
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6688,19 +6685,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:395
+#: lxc/auth.go:393
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
+#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2081
+#: lxc/auth.go:2079
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1957
+#: lxc/auth.go:1955
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7248,14 +7245,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1111
+#: lxc/auth.go:1109
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1783
+#: lxc/auth.go:1781
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-19 16:04-0700\n"
+"POT-Creation-Date: 2025-01-07 15:23+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -209,34 +209,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/auth.go:219
-msgid ""
-"### This is a YAML representation of the group.\n"
-"### Any line starting with a '# will be ignored.\n"
-"###\n"
-"### A group has the following format:\n"
-"### name: my-first-group\n"
-"### description: My first group.\n"
-"### permissions:\n"
-"### - entity_type: project\n"
-"###   url: /1.0/projects/default\n"
-"###   entitlement: can_view\n"
-"### identities:\n"
-"### - authentication_method: oidc\n"
-"###   type: OIDC client\n"
-"###   identifier: jane.doe@example.com\n"
-"###   name: Jane Doe\n"
-"###   metadata:\n"
-"###     subject: auth0|123456789\n"
-"### identity_provider_groups:\n"
-"### - sales\n"
-"### - operations\n"
-"###\n"
-"### Note that all group information is shown but only the description and "
-"permissions can be modified"
-msgstr ""
-
-#: lxc/auth.go:1121
+#: lxc/auth.go:1119
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -257,7 +230,31 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1793
+#: lxc/auth.go:219
+msgid ""
+"### This is a YAML representation of the group.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### NOTE: All group information is shown but only the description and "
+"permissions can be modified.\n"
+"### \n"
+"### name: my-first-group\n"
+"### description: My first group.\n"
+"### permissions:\n"
+"### - entity_type: project\n"
+"###   url: /1.0/projects/default\n"
+"###   entitlement: can_view\n"
+"### identities:\n"
+"###   oidc:\n"
+"###   - jane.doe@example.com\n"
+"###   tls:\n"
+"###   - eaa46a1b73827350e0543949fb161410c50e950d4cb9802fc58dbfbd5700e508\n"
+"### identity_provider_groups:\n"
+"### - sales\n"
+"### - operations\n"
+msgstr ""
+
+#: lxc/auth.go:1791
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -805,7 +802,7 @@ msgstr "ARCHITETTURA"
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:966
+#: lxc/auth.go:964
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -844,11 +841,11 @@ msgstr "'%s' non è un tipo di file supportato."
 msgid "Add a cluster member to a cluster group"
 msgstr "Il nome del container è: %s"
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1312 lxc/auth.go:1313
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2082 lxc/auth.go:2083
+#: lxc/auth.go:2080 lxc/auth.go:2081
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -919,7 +916,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:521 lxc/auth.go:522
+#: lxc/auth.go:519 lxc/auth.go:520
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -1602,12 +1599,12 @@ msgstr "Certificato del client salvato dal server: "
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:306 lxc/auth.go:1868
+#: lxc/auth.go:304 lxc/auth.go:1866
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1207
+#: lxc/auth.go:1205
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1636,7 +1633,7 @@ msgstr "Certificato del client salvato dal server: "
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:776
+#: lxc/auth.go:774
 msgid "Create a TLS identity"
 msgstr ""
 
@@ -1658,7 +1655,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:775
+#: lxc/auth.go:773
 #, fuzzy
 msgid "Create an identity"
 msgstr "Creazione del container in corso"
@@ -1681,7 +1678,7 @@ msgstr "Creazione del container in corso"
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1679 lxc/auth.go:1680
+#: lxc/auth.go:1677 lxc/auth.go:1678
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1796,7 +1793,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1839,7 +1836,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1237 lxc/auth.go:1238
+#: lxc/auth.go:1235 lxc/auth.go:1236
 msgid "Delete an identity"
 msgstr ""
 
@@ -1852,7 +1849,7 @@ msgstr "Creazione del container in corso"
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1729 lxc/auth.go:1730
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1935,14 +1932,14 @@ msgstr ""
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
 #: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
-#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
-#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
-#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
-#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
-#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
-#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
-#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
+#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
+#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
+#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
+#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
+#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
+#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -2219,7 +2216,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1108 lxc/auth.go:1109
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -2236,7 +2233,7 @@ msgstr "Creazione del container in corso"
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1780 lxc/auth.go:1781
+#: lxc/auth.go:1778 lxc/auth.go:1779
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2732,7 +2729,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
@@ -2790,7 +2787,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:970 lxc/auth.go:1944
+#: lxc/auth.go:968 lxc/auth.go:1942
 msgid "GROUPS"
 msgstr ""
 
@@ -2960,7 +2957,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:432 lxc/auth.go:1994
+#: lxc/auth.go:430 lxc/auth.go:1992
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -3020,7 +3017,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:969
+#: lxc/auth.go:967
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -3052,16 +3049,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:829
+#: lxc/auth.go:827
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1716
+#: lxc/auth.go:1714
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1766
+#: lxc/auth.go:1764
 #, fuzzy, c-format
 msgid "Identity provider group %s deleted"
 msgstr "Il nome del container è: %s"
@@ -3192,7 +3189,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1441 lxc/auth.go:1442
+#: lxc/auth.go:1439 lxc/auth.go:1440
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3509,16 +3506,16 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:337 lxc/auth.go:338
+#: lxc/auth.go:335 lxc/auth.go:336
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:917 lxc/auth.go:918
+#: lxc/auth.go:915 lxc/auth.go:916
 #, fuzzy
 msgid "List identities"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:1899 lxc/auth.go:1900
+#: lxc/auth.go:1897 lxc/auth.go:1898
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3676,7 +3673,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:1463 lxc/auth.go:1464
+#: lxc/auth.go:1461 lxc/auth.go:1462
 #, fuzzy
 msgid "List permissions"
 msgstr "Alias:"
@@ -3849,7 +3846,7 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:823
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
@@ -3886,21 +3883,21 @@ msgstr "Creazione del container in corso"
 msgid "Manage files in instances"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
 #, fuzzy
 msgid "Manage groups"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:1291 lxc/auth.go:1292
+#: lxc/auth.go:1289 lxc/auth.go:1290
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:736 lxc/auth.go:737
+#: lxc/auth.go:734 lxc/auth.go:735
 #, fuzzy
 msgid "Manage identities"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:2059 lxc/auth.go:2060
+#: lxc/auth.go:2057 lxc/auth.go:2058
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -4000,7 +3997,7 @@ msgstr "Creazione del container in corso"
 msgid "Manage network zones"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:498 lxc/auth.go:499
+#: lxc/auth.go:496 lxc/auth.go:497
 #, fuzzy
 msgid "Manage permissions"
 msgstr "Creazione del container in corso"
@@ -4158,24 +4155,24 @@ msgstr "Il nome del container è: %s"
 msgid "Missing cluster member name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
-#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
 #, fuzzy
 msgid "Missing group name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
-#: lxc/auth.go:1339 lxc/auth.go:1397
+#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
+#: lxc/auth.go:1337 lxc/auth.go:1395
 #, fuzzy
 msgid "Missing identity argument"
 msgstr "Il nome del container è: %s"
 
-#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
+#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
 #, fuzzy
 msgid "Missing identity provider group name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/auth.go:2107 lxc/auth.go:2160
+#: lxc/auth.go:2105 lxc/auth.go:2158
 #, fuzzy
 msgid "Missing identity provider group name argument"
 msgstr "Il nome del container è: %s"
@@ -4408,7 +4405,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
@@ -4816,7 +4813,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -5182,7 +5179,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr "Il nome del container è: %s"
 
-#: lxc/auth.go:1372 lxc/auth.go:1373
+#: lxc/auth.go:1370 lxc/auth.go:1371
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -5221,7 +5218,7 @@ msgstr "Il nome del container è: %s"
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2135 lxc/auth.go:2136
+#: lxc/auth.go:2133 lxc/auth.go:2134
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -5234,7 +5231,7 @@ msgstr "Creazione del container in corso"
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:580 lxc/auth.go:581
+#: lxc/auth.go:578 lxc/auth.go:579
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -5281,11 +5278,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:397 lxc/auth.go:398
+#: lxc/auth.go:395 lxc/auth.go:396
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1959 lxc/auth.go:1960
+#: lxc/auth.go:1957 lxc/auth.go:1958
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5823,7 +5820,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2008 lxc/auth.go:2009
+#: lxc/auth.go:2006 lxc/auth.go:2007
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5852,12 +5849,12 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:446 lxc/auth.go:447
+#: lxc/auth.go:444 lxc/auth.go:445
 #, fuzzy
 msgid "Show group configurations"
 msgstr "Il nome del container è: %s"
 
-#: lxc/auth.go:985
+#: lxc/auth.go:983
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5971,7 +5968,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1048
+#: lxc/auth.go:1046
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -6214,12 +6211,12 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:876
+#: lxc/auth.go:874
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:902
+#: lxc/auth.go:900
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
@@ -6228,7 +6225,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1747 lxc/warning.go:216
@@ -6921,11 +6918,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:984
+#: lxc/auth.go:982
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1047
+#: lxc/auth.go:1045
 msgid "View the current identity"
 msgstr ""
 
@@ -7001,7 +6998,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -7041,7 +7038,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:] [<filters>...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:1462
+#: lxc/auth.go:1460
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -7116,17 +7113,17 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<alias> <new-name>"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:774
+#: lxc/auth.go:772
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:983 lxc/auth.go:1235
+#: lxc/auth.go:981 lxc/auth.go:1233
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -7135,14 +7132,14 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
-#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
+#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 #, fuzzy
 msgid "[<remote>:]<group>"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:520 lxc/auth.go:578
+#: lxc/auth.go:518 lxc/auth.go:576
 #, fuzzy
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
@@ -7154,22 +7151,22 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<group> <new-name>"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:395
+#: lxc/auth.go:393
 #, fuzzy
 msgid "[<remote>:]<group> <new_name>"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
+#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group>"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:2081
+#: lxc/auth.go:2079
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr "Creazione del container in corso"
 
-#: lxc/auth.go:1957
+#: lxc/auth.go:1955
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr "Creazione del container in corso"
@@ -7832,14 +7829,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1111
+#: lxc/auth.go:1109
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1783
+#: lxc/auth.go:1781
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-19 16:04-0700\n"
+"POT-Creation-Date: 2025-01-07 15:23+0000\n"
 "PO-Revision-Date: 2023-03-10 15:14+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -188,34 +188,7 @@ msgstr ""
 "###\n"
 "### Note that the name is shown but cannot be changed"
 
-#: lxc/auth.go:219
-msgid ""
-"### This is a YAML representation of the group.\n"
-"### Any line starting with a '# will be ignored.\n"
-"###\n"
-"### A group has the following format:\n"
-"### name: my-first-group\n"
-"### description: My first group.\n"
-"### permissions:\n"
-"### - entity_type: project\n"
-"###   url: /1.0/projects/default\n"
-"###   entitlement: can_view\n"
-"### identities:\n"
-"### - authentication_method: oidc\n"
-"###   type: OIDC client\n"
-"###   identifier: jane.doe@example.com\n"
-"###   name: Jane Doe\n"
-"###   metadata:\n"
-"###     subject: auth0|123456789\n"
-"### identity_provider_groups:\n"
-"### - sales\n"
-"### - operations\n"
-"###\n"
-"### Note that all group information is shown but only the description and "
-"permissions can be modified"
-msgstr ""
-
-#: lxc/auth.go:1121
+#: lxc/auth.go:1119
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -236,7 +209,31 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1793
+#: lxc/auth.go:219
+msgid ""
+"### This is a YAML representation of the group.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### NOTE: All group information is shown but only the description and "
+"permissions can be modified.\n"
+"### \n"
+"### name: my-first-group\n"
+"### description: My first group.\n"
+"### permissions:\n"
+"### - entity_type: project\n"
+"###   url: /1.0/projects/default\n"
+"###   entitlement: can_view\n"
+"### identities:\n"
+"###   oidc:\n"
+"###   - jane.doe@example.com\n"
+"###   tls:\n"
+"###   - eaa46a1b73827350e0543949fb161410c50e950d4cb9802fc58dbfbd5700e508\n"
+"### identity_provider_groups:\n"
+"### - sales\n"
+"### - operations\n"
+msgstr ""
+
+#: lxc/auth.go:1791
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -796,7 +793,7 @@ msgstr "ARCHITECTURE"
 msgid "AUTH TYPE"
 msgstr "AUTH TYPE"
 
-#: lxc/auth.go:966
+#: lxc/auth.go:964
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -835,11 +832,11 @@ msgstr "%q はこのツールではサポートされていません"
 msgid "Add a cluster member to a cluster group"
 msgstr "クラスタグループからメンバを削除します"
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1312 lxc/auth.go:1313
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2082 lxc/auth.go:2083
+#: lxc/auth.go:2080 lxc/auth.go:2081
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -927,7 +924,7 @@ msgstr ""
 "使ったトークンは無効化されます。\n"
 "証明書と同様に、トークンも 1 つ以上のプロジェクトに制限できます。\n"
 
-#: lxc/auth.go:521 lxc/auth.go:522
+#: lxc/auth.go:519 lxc/auth.go:520
 #, fuzzy
 msgid "Add permissions to groups"
 msgstr "グループからメンバーを削除します"
@@ -1637,12 +1634,12 @@ msgstr "証明書のファイルパスが見つかりません: %s"
 msgid "Could not find certificate key file path: %s"
 msgstr "証明書の鍵のパスが見つかりません: %s"
 
-#: lxc/auth.go:306 lxc/auth.go:1868
+#: lxc/auth.go:304 lxc/auth.go:1866
 #, fuzzy, c-format
 msgid "Could not parse group: %s"
 msgstr "設定の構文エラー: %s"
 
-#: lxc/auth.go:1207
+#: lxc/auth.go:1205
 #, fuzzy, c-format
 msgid "Could not parse identity: %s"
 msgstr "設定キーを設定できません: %s"
@@ -1671,7 +1668,7 @@ msgstr "サーバ証明書ファイル %q を書き込めません: %w"
 msgid "Couldn't find a matching entry"
 msgstr "一致するエントリを見つけられませんでした"
 
-#: lxc/auth.go:776
+#: lxc/auth.go:774
 #, fuzzy
 msgid "Create a TLS identity"
 msgstr "警告を削除します"
@@ -1692,7 +1689,7 @@ msgstr "既存のイメージに対するエイリアスを作成します"
 msgid "Create an empty instance"
 msgstr "空のインスタンスを作成"
 
-#: lxc/auth.go:775
+#: lxc/auth.go:773
 #, fuzzy
 msgid "Create an identity"
 msgstr "警告を削除します"
@@ -1715,7 +1712,7 @@ msgstr "必要なディレクトリをすべて作成します"
 msgid "Create groups"
 msgstr "プロファイルを作成します"
 
-#: lxc/auth.go:1679 lxc/auth.go:1680
+#: lxc/auth.go:1677 lxc/auth.go:1678
 #, fuzzy
 msgid "Create identity provider groups"
 msgstr "新たにクラスターグループを作成します"
@@ -1828,7 +1825,7 @@ msgstr "現在の VF 数: %d"
 msgid "DEFAULT TARGET ADDRESS"
 msgstr "DEFAULT TARGET ADDRESS"
 
-#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1871,7 +1868,7 @@ msgstr "クラスタグループを削除します"
 msgid "Delete all warnings"
 msgstr "警告をすべて削除します"
 
-#: lxc/auth.go:1237 lxc/auth.go:1238
+#: lxc/auth.go:1235 lxc/auth.go:1236
 #, fuzzy
 msgid "Delete an identity"
 msgstr "警告を削除します"
@@ -1885,7 +1882,7 @@ msgstr "インスタンス内のファイルを削除します"
 msgid "Delete groups"
 msgstr "プロファイルを削除します"
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1729 lxc/auth.go:1730
 #, fuzzy
 msgid "Delete identity provider groups"
 msgstr "クラスタグループを削除します"
@@ -1965,14 +1962,14 @@ msgstr "警告を削除します"
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
 #: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
-#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
-#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
-#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
-#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
-#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
-#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
-#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
+#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
+#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
+#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
+#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
+#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
+#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -2251,7 +2248,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr "クラスタグループを編集します"
 
-#: lxc/auth.go:1108 lxc/auth.go:1109
+#: lxc/auth.go:1106 lxc/auth.go:1107
 #, fuzzy
 msgid "Edit an identity as YAML"
 msgstr "ストレージバケットの設定をYAMLで編集します"
@@ -2269,7 +2266,7 @@ msgstr "インスタンス内のファイルを編集します"
 msgid "Edit groups as YAML"
 msgstr "信頼済みクライアント設定をYAMLで編集します"
 
-#: lxc/auth.go:1780 lxc/auth.go:1781
+#: lxc/auth.go:1778 lxc/auth.go:1779
 #, fuzzy
 msgid "Edit identity provider groups as YAML"
 msgstr "プロファイル設定をYAMLで編集します"
@@ -2800,7 +2797,7 @@ msgstr ""
 "\n"
 "本当に強制的に %s を削除してもよろしいですか? (yes/no): "
 
-#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
@@ -2858,7 +2855,7 @@ msgstr "GPU:"
 msgid "GPUs:"
 msgstr "GPUs:"
 
-#: lxc/auth.go:970 lxc/auth.go:1944
+#: lxc/auth.go:968 lxc/auth.go:1942
 msgid "GROUPS"
 msgstr ""
 
@@ -3027,7 +3024,7 @@ msgstr "プロファイル %s を作成しました"
 msgid "Group %s deleted"
 msgstr "プロファイル %s を削除しました"
 
-#: lxc/auth.go:432 lxc/auth.go:1994
+#: lxc/auth.go:430 lxc/auth.go:1992
 #, fuzzy, c-format
 msgid "Group %s renamed to %s"
 msgstr "プロファイル名 %s を %s に変更しました"
@@ -3087,7 +3084,7 @@ msgstr "ID: %d"
 msgid "ID: %s"
 msgstr "ID: %s"
 
-#: lxc/auth.go:969
+#: lxc/auth.go:967
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -3119,16 +3116,16 @@ msgstr "IPV6"
 msgid "ISSUE DATE"
 msgstr "ISSUE DATE"
 
-#: lxc/auth.go:829
+#: lxc/auth.go:827
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1716
+#: lxc/auth.go:1714
 #, fuzzy, c-format
 msgid "Identity provider group %s created"
 msgstr "クラスターグループ %s を作成しました"
 
-#: lxc/auth.go:1766
+#: lxc/auth.go:1764
 #, fuzzy, c-format
 msgid "Identity provider group %s deleted"
 msgstr "クラスターグループ %s を作成しました"
@@ -3270,7 +3267,7 @@ msgstr "Infiniband:"
 msgid "Input data"
 msgstr "入力するデータ"
 
-#: lxc/auth.go:1441 lxc/auth.go:1442
+#: lxc/auth.go:1439 lxc/auth.go:1440
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3586,17 +3583,17 @@ msgstr "利用可能なストレージプールを一覧表示します"
 msgid "List background operations"
 msgstr "バックグラウンド操作を一覧表示します"
 
-#: lxc/auth.go:337 lxc/auth.go:338
+#: lxc/auth.go:335 lxc/auth.go:336
 #, fuzzy
 msgid "List groups"
 msgstr "プロファイルを一覧表示します"
 
-#: lxc/auth.go:917 lxc/auth.go:918
+#: lxc/auth.go:915 lxc/auth.go:916
 #, fuzzy
 msgid "List identities"
 msgstr "インスタンスを一覧表示します"
 
-#: lxc/auth.go:1899 lxc/auth.go:1900
+#: lxc/auth.go:1897 lxc/auth.go:1898
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3859,7 +3856,7 @@ msgstr "証明書の使用を制限するプロジェクトのリスト"
 msgid "List operations from all projects"
 msgstr "すべてのプロジェクトのインスタンスを表示します"
 
-#: lxc/auth.go:1463 lxc/auth.go:1464
+#: lxc/auth.go:1461 lxc/auth.go:1462
 #, fuzzy
 msgid "List permissions"
 msgstr "プロファイルを一覧表示します"
@@ -4061,7 +4058,7 @@ msgstr "イメージを public にする"
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:823
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
@@ -4095,22 +4092,22 @@ msgstr "デバイスを管理します"
 msgid "Manage files in instances"
 msgstr "インスタンス内のファイルを管理します"
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
 #, fuzzy
 msgid "Manage groups"
 msgstr "クラスタグループを管理します"
 
-#: lxc/auth.go:1291 lxc/auth.go:1292
+#: lxc/auth.go:1289 lxc/auth.go:1290
 #, fuzzy
 msgid "Manage groups for the identity"
 msgstr "信頼済みのクライアントを管理します"
 
-#: lxc/auth.go:736 lxc/auth.go:737
+#: lxc/auth.go:734 lxc/auth.go:735
 #, fuzzy
 msgid "Manage identities"
 msgstr "デバイスを管理します"
 
-#: lxc/auth.go:2059 lxc/auth.go:2060
+#: lxc/auth.go:2057 lxc/auth.go:2058
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -4215,7 +4212,7 @@ msgstr "ネットワークゾーンレコードを管理します"
 msgid "Manage network zones"
 msgstr "ネットワークゾーンを管理します"
 
-#: lxc/auth.go:498 lxc/auth.go:499
+#: lxc/auth.go:496 lxc/auth.go:497
 #, fuzzy
 msgid "Manage permissions"
 msgstr "プロファイルを管理します"
@@ -4370,24 +4367,24 @@ msgstr "クラスターグループ名がありません"
 msgid "Missing cluster member name"
 msgstr "クラスターメンバー名がありません"
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
-#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
 #, fuzzy
 msgid "Missing group name"
 msgstr "クラスターグループ名がありません"
 
-#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
-#: lxc/auth.go:1339 lxc/auth.go:1397
+#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
+#: lxc/auth.go:1337 lxc/auth.go:1395
 #, fuzzy
 msgid "Missing identity argument"
 msgstr "鍵の名前を指定する必要があります"
 
-#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
+#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
 #, fuzzy
 msgid "Missing identity provider group name"
 msgstr "クラスターグループ名がありません"
 
-#: lxc/auth.go:2107 lxc/auth.go:2160
+#: lxc/auth.go:2105 lxc/auth.go:2158
 #, fuzzy
 msgid "Missing identity provider group name argument"
 msgstr "クラスターグループ名がありません"
@@ -4627,7 +4624,7 @@ msgstr "ディレクトリからのインポートは root で実行する必要
 msgid "Must supply instance name for: "
 msgstr "インスタンス名を指定する必要があります: "
 
-#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
@@ -5038,7 +5035,7 @@ msgstr "ポート:"
 msgid "Press ctrl+c to finish"
 msgstr "終了するには ctrl+c を押してください"
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -5408,7 +5405,7 @@ msgstr "%s を消去しますか (yes/no): "
 msgid "Remove a cluster member from a cluster group"
 msgstr "クラスタグループからメンバを削除します"
 
-#: lxc/auth.go:1372 lxc/auth.go:1373
+#: lxc/auth.go:1370 lxc/auth.go:1371
 #, fuzzy
 msgid "Remove a group from an identity"
 msgstr "ACL からルールを削除します"
@@ -5445,7 +5442,7 @@ msgstr "ロードバランサーからバックエンドを削除します"
 msgid "Remove entries from a network zone record"
 msgstr "ネットワークゾーンレコードからエントリを削除します"
 
-#: lxc/auth.go:2135 lxc/auth.go:2136
+#: lxc/auth.go:2133 lxc/auth.go:2134
 #, fuzzy
 msgid "Remove identities from groups"
 msgstr "グループからメンバーを削除します"
@@ -5458,7 +5455,7 @@ msgstr "インスタンスのデバイスを削除します"
 msgid "Remove member from group"
 msgstr "グループからメンバーを削除します"
 
-#: lxc/auth.go:580 lxc/auth.go:581
+#: lxc/auth.go:578 lxc/auth.go:579
 #, fuzzy
 msgid "Remove permissions from groups"
 msgstr "グループからメンバーを削除します"
@@ -5504,12 +5501,12 @@ msgstr "クラスタメンバの名前を変更します"
 msgid "Rename aliases"
 msgstr "エイリアスの名前を変更します"
 
-#: lxc/auth.go:397 lxc/auth.go:398
+#: lxc/auth.go:395 lxc/auth.go:396
 #, fuzzy
 msgid "Rename groups"
 msgstr "リモートサーバ名を変更します"
 
-#: lxc/auth.go:1959 lxc/auth.go:1960
+#: lxc/auth.go:1957 lxc/auth.go:1958
 #, fuzzy
 msgid "Rename identity provider groups"
 msgstr "クラスタグループの名前を変更します"
@@ -6112,7 +6109,7 @@ msgstr "デバッグメッセージをすべて表示します"
 msgid "Show all information messages"
 msgstr "詳細な情報を出力します"
 
-#: lxc/auth.go:2008 lxc/auth.go:2009
+#: lxc/auth.go:2006 lxc/auth.go:2007
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -6140,12 +6137,12 @@ msgstr "すべてのプロジェクトのイベントを表示します"
 msgid "Show full device configuration"
 msgstr "デバイスの設定をすべて表示します"
 
-#: lxc/auth.go:446 lxc/auth.go:447
+#: lxc/auth.go:444 lxc/auth.go:445
 #, fuzzy
 msgid "Show group configurations"
 msgstr "信頼済みクライアントの設定を表示します"
 
-#: lxc/auth.go:985
+#: lxc/auth.go:983
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -6251,7 +6248,7 @@ msgstr "ストレージボリュームの設定を表示する"
 msgid "Show storage volume state information"
 msgstr "ストレージボリュームの状態を表示します"
 
-#: lxc/auth.go:1048
+#: lxc/auth.go:1046
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -6490,12 +6487,12 @@ msgstr ""
 msgid "TARGET"
 msgstr "TARGET"
 
-#: lxc/auth.go:876
+#: lxc/auth.go:874
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:902
+#: lxc/auth.go:900
 #, fuzzy, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr "イメージは以下のフィンガープリントでインポートされました: %s"
@@ -6504,7 +6501,7 @@ msgstr "イメージは以下のフィンガープリントでインポートさ
 msgid "TOKEN"
 msgstr "TOKEN"
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1747 lxc/warning.go:216
@@ -7224,11 +7221,11 @@ msgstr "ベンダ: %v (%v)"
 msgid "Verb: %s (%s)"
 msgstr "Verb: %s (%s)"
 
-#: lxc/auth.go:984
+#: lxc/auth.go:982
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1047
+#: lxc/auth.go:1045
 #, fuzzy
 msgid "View the current identity"
 msgstr "現在のプロジェクトを切り替えます"
@@ -7305,7 +7302,7 @@ msgstr "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 
-#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -7338,7 +7335,7 @@ msgstr "[<remote>:] [<filter>...]"
 msgid "[<remote>:] [<filters>...]"
 msgstr "[<remote>:] [<filters>...]"
 
-#: lxc/auth.go:1462
+#: lxc/auth.go:1460
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -7399,17 +7396,17 @@ msgstr "[<remote>:]<alias> <fingerprint>"
 msgid "[<remote>:]<alias> <new-name>"
 msgstr "[<remote>:]<alias> <new-name>"
 
-#: lxc/auth.go:774
+#: lxc/auth.go:772
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:983 lxc/auth.go:1235
+#: lxc/auth.go:981 lxc/auth.go:1233
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -7417,13 +7414,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr "[<remote>:]<fingerprint>"
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
-#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
+#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr "[<remote>:]<group>"
 
-#: lxc/auth.go:520 lxc/auth.go:578
+#: lxc/auth.go:518 lxc/auth.go:576
 #, fuzzy
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
@@ -7434,22 +7431,22 @@ msgstr "[<remote>:]<pool> <volume> <key>=<value>..."
 msgid "[<remote>:]<group> <new-name>"
 msgstr "[<remote>:]<group> <new-name>"
 
-#: lxc/auth.go:395
+#: lxc/auth.go:393
 #, fuzzy
 msgid "[<remote>:]<group> <new_name>"
 msgstr "[<remote>:]<group> <new-name>"
 
-#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
+#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group>"
 msgstr "[<remote>:]<group>"
 
-#: lxc/auth.go:2081
+#: lxc/auth.go:2079
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr "[<remote>:]<member> <group>"
 
-#: lxc/auth.go:1957
+#: lxc/auth.go:1955
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr "[<remote>:]<group> <new-name>"
@@ -8034,7 +8031,7 @@ msgstr ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    profile.yaml の内容でプロファイルを更新します"
 
-#: lxc/auth.go:1111
+#: lxc/auth.go:1109
 #, fuzzy
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
@@ -8044,7 +8041,7 @@ msgstr ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    profile.yaml の内容でプロファイルを更新します"
 
-#: lxc/auth.go:1783
+#: lxc/auth.go:1781
 #, fuzzy
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"

--- a/po/ka.po
+++ b/po/ka.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-19 16:04-0700\n"
+"POT-Creation-Date: 2025-01-07 15:23+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -130,34 +130,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:219
-msgid ""
-"### This is a YAML representation of the group.\n"
-"### Any line starting with a '# will be ignored.\n"
-"###\n"
-"### A group has the following format:\n"
-"### name: my-first-group\n"
-"### description: My first group.\n"
-"### permissions:\n"
-"### - entity_type: project\n"
-"###   url: /1.0/projects/default\n"
-"###   entitlement: can_view\n"
-"### identities:\n"
-"### - authentication_method: oidc\n"
-"###   type: OIDC client\n"
-"###   identifier: jane.doe@example.com\n"
-"###   name: Jane Doe\n"
-"###   metadata:\n"
-"###     subject: auth0|123456789\n"
-"### identity_provider_groups:\n"
-"### - sales\n"
-"### - operations\n"
-"###\n"
-"### Note that all group information is shown but only the description and "
-"permissions can be modified"
-msgstr ""
-
-#: lxc/auth.go:1121
+#: lxc/auth.go:1119
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -178,7 +151,31 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1793
+#: lxc/auth.go:219
+msgid ""
+"### This is a YAML representation of the group.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### NOTE: All group information is shown but only the description and "
+"permissions can be modified.\n"
+"### \n"
+"### name: my-first-group\n"
+"### description: My first group.\n"
+"### permissions:\n"
+"### - entity_type: project\n"
+"###   url: /1.0/projects/default\n"
+"###   entitlement: can_view\n"
+"### identities:\n"
+"###   oidc:\n"
+"###   - jane.doe@example.com\n"
+"###   tls:\n"
+"###   - eaa46a1b73827350e0543949fb161410c50e950d4cb9802fc58dbfbd5700e508\n"
+"### identity_provider_groups:\n"
+"### - sales\n"
+"### - operations\n"
+msgstr ""
+
+#: lxc/auth.go:1791
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -557,7 +554,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:966
+#: lxc/auth.go:964
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -595,11 +592,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1312 lxc/auth.go:1313
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2082 lxc/auth.go:2083
+#: lxc/auth.go:2080 lxc/auth.go:2081
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -668,7 +665,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:521 lxc/auth.go:522
+#: lxc/auth.go:519 lxc/auth.go:520
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -1344,12 +1341,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:306 lxc/auth.go:1868
+#: lxc/auth.go:304 lxc/auth.go:1866
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1207
+#: lxc/auth.go:1205
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1378,7 +1375,7 @@ msgstr ""
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:776
+#: lxc/auth.go:774
 msgid "Create a TLS identity"
 msgstr ""
 
@@ -1398,7 +1395,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:775
+#: lxc/auth.go:773
 msgid "Create an identity"
 msgstr ""
 
@@ -1418,7 +1415,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1679 lxc/auth.go:1680
+#: lxc/auth.go:1677 lxc/auth.go:1678
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1526,7 +1523,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1569,7 +1566,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1237 lxc/auth.go:1238
+#: lxc/auth.go:1235 lxc/auth.go:1236
 msgid "Delete an identity"
 msgstr ""
 
@@ -1581,7 +1578,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1729 lxc/auth.go:1730
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1660,14 +1657,14 @@ msgstr ""
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
 #: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
-#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
-#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
-#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
-#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
-#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
-#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
-#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
+#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
+#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
+#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
+#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
+#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
+#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -1936,7 +1933,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1108 lxc/auth.go:1109
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1952,7 +1949,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1780 lxc/auth.go:1781
+#: lxc/auth.go:1778 lxc/auth.go:1779
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2438,7 +2435,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
@@ -2496,7 +2493,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:970 lxc/auth.go:1944
+#: lxc/auth.go:968 lxc/auth.go:1942
 msgid "GROUPS"
 msgstr ""
 
@@ -2655,7 +2652,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:432 lxc/auth.go:1994
+#: lxc/auth.go:430 lxc/auth.go:1992
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2714,7 +2711,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:969
+#: lxc/auth.go:967
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2746,16 +2743,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:829
+#: lxc/auth.go:827
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1716
+#: lxc/auth.go:1714
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1766
+#: lxc/auth.go:1764
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2884,7 +2881,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1441 lxc/auth.go:1442
+#: lxc/auth.go:1439 lxc/auth.go:1440
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3188,15 +3185,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:337 lxc/auth.go:338
+#: lxc/auth.go:335 lxc/auth.go:336
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:917 lxc/auth.go:918
+#: lxc/auth.go:915 lxc/auth.go:916
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1900
+#: lxc/auth.go:1897 lxc/auth.go:1898
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3351,7 +3348,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1463 lxc/auth.go:1464
+#: lxc/auth.go:1461 lxc/auth.go:1462
 msgid "List permissions"
 msgstr ""
 
@@ -3519,7 +3516,7 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:823
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
@@ -3553,19 +3550,19 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1291 lxc/auth.go:1292
+#: lxc/auth.go:1289 lxc/auth.go:1290
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:736 lxc/auth.go:737
+#: lxc/auth.go:734 lxc/auth.go:735
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2059 lxc/auth.go:2060
+#: lxc/auth.go:2057 lxc/auth.go:2058
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3656,7 +3653,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:498 lxc/auth.go:499
+#: lxc/auth.go:496 lxc/auth.go:497
 msgid "Manage permissions"
 msgstr ""
 
@@ -3805,21 +3802,21 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
-#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
-#: lxc/auth.go:1339 lxc/auth.go:1397
+#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
+#: lxc/auth.go:1337 lxc/auth.go:1395
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
+#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2107 lxc/auth.go:2160
+#: lxc/auth.go:2105 lxc/auth.go:2158
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4040,7 +4037,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
@@ -4444,7 +4441,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4803,7 +4800,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1372 lxc/auth.go:1373
+#: lxc/auth.go:1370 lxc/auth.go:1371
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4839,7 +4836,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2135 lxc/auth.go:2136
+#: lxc/auth.go:2133 lxc/auth.go:2134
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4851,7 +4848,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:580 lxc/auth.go:581
+#: lxc/auth.go:578 lxc/auth.go:579
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4896,11 +4893,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:397 lxc/auth.go:398
+#: lxc/auth.go:395 lxc/auth.go:396
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1959 lxc/auth.go:1960
+#: lxc/auth.go:1957 lxc/auth.go:1958
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5421,7 +5418,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2008 lxc/auth.go:2009
+#: lxc/auth.go:2006 lxc/auth.go:2007
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5449,11 +5446,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:446 lxc/auth.go:447
+#: lxc/auth.go:444 lxc/auth.go:445
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:985
+#: lxc/auth.go:983
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5558,7 +5555,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1048
+#: lxc/auth.go:1046
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5796,12 +5793,12 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:876
+#: lxc/auth.go:874
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:902
+#: lxc/auth.go:900
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
@@ -5810,7 +5807,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1747 lxc/warning.go:216
@@ -6482,11 +6479,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:984
+#: lxc/auth.go:982
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1047
+#: lxc/auth.go:1045
 msgid "View the current identity"
 msgstr ""
 
@@ -6557,7 +6554,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6590,7 +6587,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1462
+#: lxc/auth.go:1460
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6651,17 +6648,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:772
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:983 lxc/auth.go:1235
+#: lxc/auth.go:981 lxc/auth.go:1233
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6669,13 +6666,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
-#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
+#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:520 lxc/auth.go:578
+#: lxc/auth.go:518 lxc/auth.go:576
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6685,19 +6682,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:395
+#: lxc/auth.go:393
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
+#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2081
+#: lxc/auth.go:2079
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1957
+#: lxc/auth.go:1955
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7245,14 +7242,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1111
+#: lxc/auth.go:1109
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1783
+#: lxc/auth.go:1781
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-19 16:04-0700\n"
+"POT-Creation-Date: 2025-01-07 15:23+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -133,34 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:219
-msgid ""
-"### This is a YAML representation of the group.\n"
-"### Any line starting with a '# will be ignored.\n"
-"###\n"
-"### A group has the following format:\n"
-"### name: my-first-group\n"
-"### description: My first group.\n"
-"### permissions:\n"
-"### - entity_type: project\n"
-"###   url: /1.0/projects/default\n"
-"###   entitlement: can_view\n"
-"### identities:\n"
-"### - authentication_method: oidc\n"
-"###   type: OIDC client\n"
-"###   identifier: jane.doe@example.com\n"
-"###   name: Jane Doe\n"
-"###   metadata:\n"
-"###     subject: auth0|123456789\n"
-"### identity_provider_groups:\n"
-"### - sales\n"
-"### - operations\n"
-"###\n"
-"### Note that all group information is shown but only the description and "
-"permissions can be modified"
-msgstr ""
-
-#: lxc/auth.go:1121
+#: lxc/auth.go:1119
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +154,31 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1793
+#: lxc/auth.go:219
+msgid ""
+"### This is a YAML representation of the group.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### NOTE: All group information is shown but only the description and "
+"permissions can be modified.\n"
+"### \n"
+"### name: my-first-group\n"
+"### description: My first group.\n"
+"### permissions:\n"
+"### - entity_type: project\n"
+"###   url: /1.0/projects/default\n"
+"###   entitlement: can_view\n"
+"### identities:\n"
+"###   oidc:\n"
+"###   - jane.doe@example.com\n"
+"###   tls:\n"
+"###   - eaa46a1b73827350e0543949fb161410c50e950d4cb9802fc58dbfbd5700e508\n"
+"### identity_provider_groups:\n"
+"### - sales\n"
+"### - operations\n"
+msgstr ""
+
+#: lxc/auth.go:1791
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -560,7 +557,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:966
+#: lxc/auth.go:964
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -598,11 +595,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1312 lxc/auth.go:1313
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2082 lxc/auth.go:2083
+#: lxc/auth.go:2080 lxc/auth.go:2081
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -671,7 +668,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:521 lxc/auth.go:522
+#: lxc/auth.go:519 lxc/auth.go:520
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -1347,12 +1344,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:306 lxc/auth.go:1868
+#: lxc/auth.go:304 lxc/auth.go:1866
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1207
+#: lxc/auth.go:1205
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1381,7 +1378,7 @@ msgstr ""
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:776
+#: lxc/auth.go:774
 msgid "Create a TLS identity"
 msgstr ""
 
@@ -1401,7 +1398,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:775
+#: lxc/auth.go:773
 msgid "Create an identity"
 msgstr ""
 
@@ -1421,7 +1418,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1679 lxc/auth.go:1680
+#: lxc/auth.go:1677 lxc/auth.go:1678
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1529,7 +1526,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1572,7 +1569,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1237 lxc/auth.go:1238
+#: lxc/auth.go:1235 lxc/auth.go:1236
 msgid "Delete an identity"
 msgstr ""
 
@@ -1584,7 +1581,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1729 lxc/auth.go:1730
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1663,14 +1660,14 @@ msgstr ""
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
 #: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
-#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
-#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
-#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
-#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
-#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
-#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
-#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
+#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
+#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
+#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
+#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
+#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
+#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -1939,7 +1936,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1108 lxc/auth.go:1109
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1955,7 +1952,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1780 lxc/auth.go:1781
+#: lxc/auth.go:1778 lxc/auth.go:1779
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2441,7 +2438,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
@@ -2499,7 +2496,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:970 lxc/auth.go:1944
+#: lxc/auth.go:968 lxc/auth.go:1942
 msgid "GROUPS"
 msgstr ""
 
@@ -2658,7 +2655,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:432 lxc/auth.go:1994
+#: lxc/auth.go:430 lxc/auth.go:1992
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2717,7 +2714,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:969
+#: lxc/auth.go:967
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2749,16 +2746,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:829
+#: lxc/auth.go:827
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1716
+#: lxc/auth.go:1714
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1766
+#: lxc/auth.go:1764
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2887,7 +2884,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1441 lxc/auth.go:1442
+#: lxc/auth.go:1439 lxc/auth.go:1440
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3191,15 +3188,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:337 lxc/auth.go:338
+#: lxc/auth.go:335 lxc/auth.go:336
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:917 lxc/auth.go:918
+#: lxc/auth.go:915 lxc/auth.go:916
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1900
+#: lxc/auth.go:1897 lxc/auth.go:1898
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3354,7 +3351,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1463 lxc/auth.go:1464
+#: lxc/auth.go:1461 lxc/auth.go:1462
 msgid "List permissions"
 msgstr ""
 
@@ -3522,7 +3519,7 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:823
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
@@ -3556,19 +3553,19 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1291 lxc/auth.go:1292
+#: lxc/auth.go:1289 lxc/auth.go:1290
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:736 lxc/auth.go:737
+#: lxc/auth.go:734 lxc/auth.go:735
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2059 lxc/auth.go:2060
+#: lxc/auth.go:2057 lxc/auth.go:2058
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3659,7 +3656,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:498 lxc/auth.go:499
+#: lxc/auth.go:496 lxc/auth.go:497
 msgid "Manage permissions"
 msgstr ""
 
@@ -3808,21 +3805,21 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
-#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
-#: lxc/auth.go:1339 lxc/auth.go:1397
+#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
+#: lxc/auth.go:1337 lxc/auth.go:1395
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
+#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2107 lxc/auth.go:2160
+#: lxc/auth.go:2105 lxc/auth.go:2158
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4043,7 +4040,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
@@ -4447,7 +4444,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4806,7 +4803,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1372 lxc/auth.go:1373
+#: lxc/auth.go:1370 lxc/auth.go:1371
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4842,7 +4839,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2135 lxc/auth.go:2136
+#: lxc/auth.go:2133 lxc/auth.go:2134
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4854,7 +4851,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:580 lxc/auth.go:581
+#: lxc/auth.go:578 lxc/auth.go:579
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4899,11 +4896,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:397 lxc/auth.go:398
+#: lxc/auth.go:395 lxc/auth.go:396
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1959 lxc/auth.go:1960
+#: lxc/auth.go:1957 lxc/auth.go:1958
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5424,7 +5421,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2008 lxc/auth.go:2009
+#: lxc/auth.go:2006 lxc/auth.go:2007
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5452,11 +5449,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:446 lxc/auth.go:447
+#: lxc/auth.go:444 lxc/auth.go:445
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:985
+#: lxc/auth.go:983
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5561,7 +5558,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1048
+#: lxc/auth.go:1046
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5799,12 +5796,12 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:876
+#: lxc/auth.go:874
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:902
+#: lxc/auth.go:900
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
@@ -5813,7 +5810,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1747 lxc/warning.go:216
@@ -6485,11 +6482,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:984
+#: lxc/auth.go:982
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1047
+#: lxc/auth.go:1045
 msgid "View the current identity"
 msgstr ""
 
@@ -6560,7 +6557,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6593,7 +6590,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1462
+#: lxc/auth.go:1460
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6654,17 +6651,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:772
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:983 lxc/auth.go:1235
+#: lxc/auth.go:981 lxc/auth.go:1233
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6672,13 +6669,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
-#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
+#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:520 lxc/auth.go:578
+#: lxc/auth.go:518 lxc/auth.go:576
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6688,19 +6685,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:395
+#: lxc/auth.go:393
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
+#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2081
+#: lxc/auth.go:2079
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1957
+#: lxc/auth.go:1955
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7248,14 +7245,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1111
+#: lxc/auth.go:1109
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1783
+#: lxc/auth.go:1781
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-        "POT-Creation-Date: 2024-12-19 16:04-0700\n"
+        "POT-Creation-Date: 2025-01-07 15:23+0000\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -122,32 +122,7 @@ msgid   "### This is a YAML representation of the configuration.\n"
         "### Note that the name is shown but cannot be changed"
 msgstr  ""
 
-#: lxc/auth.go:219
-msgid   "### This is a YAML representation of the group.\n"
-        "### Any line starting with a '# will be ignored.\n"
-        "###\n"
-        "### A group has the following format:\n"
-        "### name: my-first-group\n"
-        "### description: My first group.\n"
-        "### permissions:\n"
-        "### - entity_type: project\n"
-        "###   url: /1.0/projects/default\n"
-        "###   entitlement: can_view\n"
-        "### identities:\n"
-        "### - authentication_method: oidc\n"
-        "###   type: OIDC client\n"
-        "###   identifier: jane.doe@example.com\n"
-        "###   name: Jane Doe\n"
-        "###   metadata:\n"
-        "###     subject: auth0|123456789\n"
-        "### identity_provider_groups:\n"
-        "### - sales\n"
-        "### - operations\n"
-        "###\n"
-        "### Note that all group information is shown but only the description and permissions can be modified"
-msgstr  ""
-
-#: lxc/auth.go:1121
+#: lxc/auth.go:1119
 msgid   "### This is a YAML representation of the group.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -166,7 +141,29 @@ msgid   "### This is a YAML representation of the group.\n"
         "### Note that all identity information is shown but only the projects and groups can be modified"
 msgstr  ""
 
-#: lxc/auth.go:1793
+#: lxc/auth.go:219
+msgid   "### This is a YAML representation of the group.\n"
+        "### Any line starting with a '# will be ignored.\n"
+        "###\n"
+        "### NOTE: All group information is shown but only the description and permissions can be modified.\n"
+        "### \n"
+        "### name: my-first-group\n"
+        "### description: My first group.\n"
+        "### permissions:\n"
+        "### - entity_type: project\n"
+        "###   url: /1.0/projects/default\n"
+        "###   entitlement: can_view\n"
+        "### identities:\n"
+        "###   oidc:\n"
+        "###   - jane.doe@example.com\n"
+        "###   tls:\n"
+        "###   - eaa46a1b73827350e0543949fb161410c50e950d4cb9802fc58dbfbd5700e508\n"
+        "### identity_provider_groups:\n"
+        "### - sales\n"
+        "### - operations\n"
+msgstr  ""
+
+#: lxc/auth.go:1791
 msgid   "### This is a YAML representation of the identity provider group.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -526,7 +523,7 @@ msgstr  ""
 msgid   "AUTH TYPE"
 msgstr  ""
 
-#: lxc/auth.go:966
+#: lxc/auth.go:964
 msgid   "AUTHENTICATION METHOD"
 msgstr  ""
 
@@ -564,11 +561,11 @@ msgstr  ""
 msgid   "Add a cluster member to a cluster group"
 msgstr  ""
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1312 lxc/auth.go:1313
 msgid   "Add a group to an identity"
 msgstr  ""
 
-#: lxc/auth.go:2082 lxc/auth.go:2083
+#: lxc/auth.go:2080 lxc/auth.go:2081
 msgid   "Add a group to an identity provider group"
 msgstr  ""
 
@@ -630,7 +627,7 @@ msgid   "Add new trusted client\n"
         "restricted to one or more projects.\n"
 msgstr  ""
 
-#: lxc/auth.go:521 lxc/auth.go:522
+#: lxc/auth.go:519 lxc/auth.go:520
 msgid   "Add permissions to groups"
 msgstr  ""
 
@@ -1258,12 +1255,12 @@ msgstr  ""
 msgid   "Could not find certificate key file path: %s"
 msgstr  ""
 
-#: lxc/auth.go:306 lxc/auth.go:1868
+#: lxc/auth.go:304 lxc/auth.go:1866
 #, c-format
 msgid   "Could not parse group: %s"
 msgstr  ""
 
-#: lxc/auth.go:1207
+#: lxc/auth.go:1205
 #, c-format
 msgid   "Could not parse identity: %s"
 msgstr  ""
@@ -1292,7 +1289,7 @@ msgstr  ""
 msgid   "Couldn't find a matching entry"
 msgstr  ""
 
-#: lxc/auth.go:776
+#: lxc/auth.go:774
 msgid   "Create a TLS identity"
 msgstr  ""
 
@@ -1312,7 +1309,7 @@ msgstr  ""
 msgid   "Create an empty instance"
 msgstr  ""
 
-#: lxc/auth.go:775
+#: lxc/auth.go:773
 msgid   "Create an identity"
 msgstr  ""
 
@@ -1332,7 +1329,7 @@ msgstr  ""
 msgid   "Create groups"
 msgstr  ""
 
-#: lxc/auth.go:1679 lxc/auth.go:1680
+#: lxc/auth.go:1677 lxc/auth.go:1678
 msgid   "Create identity provider groups"
 msgstr  ""
 
@@ -1439,7 +1436,7 @@ msgstr  ""
 msgid   "DEFAULT TARGET ADDRESS"
 msgstr  ""
 
-#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504 lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095 lxc/network_acl.go:157 lxc/network_forward.go:157 lxc/network_load_balancer.go:160 lxc/network_peer.go:149 lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173 lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723 lxc/storage_bucket.go:513 lxc/storage_bucket.go:833 lxc/storage_volume.go:1749
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504 lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095 lxc/network_acl.go:157 lxc/network_forward.go:157 lxc/network_load_balancer.go:160 lxc/network_peer.go:149 lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173 lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723 lxc/storage_bucket.go:513 lxc/storage_bucket.go:833 lxc/storage_volume.go:1749
 msgid   "DESCRIPTION"
 msgstr  ""
 
@@ -1475,7 +1472,7 @@ msgstr  ""
 msgid   "Delete all warnings"
 msgstr  ""
 
-#: lxc/auth.go:1237 lxc/auth.go:1238
+#: lxc/auth.go:1235 lxc/auth.go:1236
 msgid   "Delete an identity"
 msgstr  ""
 
@@ -1487,7 +1484,7 @@ msgstr  ""
 msgid   "Delete groups"
 msgstr  ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1729 lxc/auth.go:1730
 msgid   "Delete identity provider groups"
 msgstr  ""
 
@@ -1563,7 +1560,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104 lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398 lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581 lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985 lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292 lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464 lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781 lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060 lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088 lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330 lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170 lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957 lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174 lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409 lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634 lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28 lxc/config_metadata.go:56 lxc/config_metadata.go:189 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:119 lxc/config_template.go:173 lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689 lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602 lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194 lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422 lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53 lxc/network_forward.go:33 lxc/network_forward.go:90 lxc/network_forward.go:179 lxc/network_forward.go:256 lxc/network_forward.go:404 lxc/network_forward.go:489 lxc/network_forward.go:599 lxc/network_forward.go:646 lxc/network_forward.go:800 lxc/network_forward.go:874 lxc/network_forward.go:889 lxc/network_forward.go:970 lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121 lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:165 lxc/network_zone.go:228 lxc/network_zone.go:301 lxc/network_zone.go:396 lxc/network_zone.go:484 lxc/network_zone.go:527 lxc/network_zone.go:654 lxc/network_zone.go:710 lxc/network_zone.go:767 lxc/network_zone.go:845 lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083 lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349 lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483 lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749 lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018 lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250 lxc/storage_bucket.go:383 lxc/storage_bucket.go:459 lxc/storage_bucket.go:536 lxc/storage_bucket.go:630 lxc/storage_bucket.go:699 lxc/storage_bucket.go:733 lxc/storage_bucket.go:774 lxc/storage_bucket.go:853 lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158 lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:284 lxc/storage_volume.go:391 lxc/storage_volume.go:612 lxc/storage_volume.go:721 lxc/storage_volume.go:808 lxc/storage_volume.go:911 lxc/storage_volume.go:1013 lxc/storage_volume.go:1234 lxc/storage_volume.go:1365 lxc/storage_volume.go:1524 lxc/storage_volume.go:1608 lxc/storage_volume.go:1861 lxc/storage_volume.go:1960 lxc/storage_volume.go:2087 lxc/storage_volume.go:2245 lxc/storage_volume.go:2366 lxc/storage_volume.go:2428 lxc/storage_volume.go:2564 lxc/storage_volume.go:2647 lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104 lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396 lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579 lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983 lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290 lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462 lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779 lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058 lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088 lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330 lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170 lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542 lxc/config.go:772 lxc/config.go:904 lxc/config.go:957 lxc/config.go:997 lxc/config.go:1052 lxc/config.go:1143 lxc/config.go:1174 lxc/config.go:1228 lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409 lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634 lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28 lxc/config_metadata.go:56 lxc/config_metadata.go:189 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:119 lxc/config_template.go:173 lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689 lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1091 lxc/image.go:1445 lxc/image.go:1536 lxc/image.go:1602 lxc/image.go:1666 lxc/image.go:1729 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1006 lxc/network.go:1115 lxc/network.go:1194 lxc/network.go:1254 lxc/network.go:1350 lxc/network.go:1422 lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53 lxc/network_forward.go:33 lxc/network_forward.go:90 lxc/network_forward.go:179 lxc/network_forward.go:256 lxc/network_forward.go:404 lxc/network_forward.go:489 lxc/network_forward.go:599 lxc/network_forward.go:646 lxc/network_forward.go:800 lxc/network_forward.go:874 lxc/network_forward.go:889 lxc/network_forward.go:970 lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121 lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:165 lxc/network_zone.go:228 lxc/network_zone.go:301 lxc/network_zone.go:396 lxc/network_zone.go:484 lxc/network_zone.go:527 lxc/network_zone.go:654 lxc/network_zone.go:710 lxc/network_zone.go:767 lxc/network_zone.go:845 lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083 lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349 lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483 lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:749 lxc/remote.go:787 lxc/remote.go:873 lxc/remote.go:954 lxc/remote.go:1018 lxc/remote.go:1066 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250 lxc/storage_bucket.go:383 lxc/storage_bucket.go:459 lxc/storage_bucket.go:536 lxc/storage_bucket.go:630 lxc/storage_bucket.go:699 lxc/storage_bucket.go:733 lxc/storage_bucket.go:774 lxc/storage_bucket.go:853 lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158 lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:284 lxc/storage_volume.go:391 lxc/storage_volume.go:612 lxc/storage_volume.go:721 lxc/storage_volume.go:808 lxc/storage_volume.go:911 lxc/storage_volume.go:1013 lxc/storage_volume.go:1234 lxc/storage_volume.go:1365 lxc/storage_volume.go:1524 lxc/storage_volume.go:1608 lxc/storage_volume.go:1861 lxc/storage_volume.go:1960 lxc/storage_volume.go:2087 lxc/storage_volume.go:2245 lxc/storage_volume.go:2366 lxc/storage_volume.go:2428 lxc/storage_volume.go:2564 lxc/storage_volume.go:2647 lxc/storage_volume.go:2813 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid   "Description"
 msgstr  ""
 
@@ -1727,7 +1724,7 @@ msgstr  ""
 msgid   "Edit a cluster group"
 msgstr  ""
 
-#: lxc/auth.go:1108 lxc/auth.go:1109
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid   "Edit an identity as YAML"
 msgstr  ""
 
@@ -1743,7 +1740,7 @@ msgstr  ""
 msgid   "Edit groups as YAML"
 msgstr  ""
 
-#: lxc/auth.go:1780 lxc/auth.go:1781
+#: lxc/auth.go:1778 lxc/auth.go:1779
 msgid   "Edit identity provider groups as YAML"
 msgstr  ""
 
@@ -2203,7 +2200,7 @@ msgid   "Forcefully removing a server from the cluster should only be done as a 
         "Are you really sure you want to force removing %s? (yes/no): "
 msgstr  ""
 
-#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904 lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442 lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434 lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010 lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59 lxc/network_forward.go:93 lxc/network_load_balancer.go:97 lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770 lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474 lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657 lxc/storage_bucket.go:460 lxc/storage_bucket.go:775 lxc/storage_volume.go:1625 lxc/warning.go:94
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902 lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442 lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434 lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010 lxc/network.go:1117 lxc/network_acl.go:98 lxc/network_allocations.go:59 lxc/network_forward.go:93 lxc/network_load_balancer.go:97 lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770 lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474 lxc/project.go:919 lxc/remote.go:791 lxc/storage.go:657 lxc/storage_bucket.go:460 lxc/storage_bucket.go:775 lxc/storage_volume.go:1625 lxc/warning.go:94
 msgid   "Format (csv|json|table|yaml|compact)"
 msgstr  ""
 
@@ -2251,7 +2248,7 @@ msgstr  ""
 msgid   "GPUs:"
 msgstr  ""
 
-#: lxc/auth.go:970 lxc/auth.go:1944
+#: lxc/auth.go:968 lxc/auth.go:1942
 msgid   "GROUPS"
 msgstr  ""
 
@@ -2410,7 +2407,7 @@ msgstr  ""
 msgid   "Group %s deleted"
 msgstr  ""
 
-#: lxc/auth.go:432 lxc/auth.go:1994
+#: lxc/auth.go:430 lxc/auth.go:1992
 #, c-format
 msgid   "Group %s renamed to %s"
 msgstr  ""
@@ -2469,7 +2466,7 @@ msgstr  ""
 msgid   "ID: %s"
 msgstr  ""
 
-#: lxc/auth.go:969
+#: lxc/auth.go:967
 msgid   "IDENTIFIER"
 msgstr  ""
 
@@ -2501,16 +2498,16 @@ msgstr  ""
 msgid   "ISSUE DATE"
 msgstr  ""
 
-#: lxc/auth.go:829
+#: lxc/auth.go:827
 msgid   "Identity creation only supported for TLS identities"
 msgstr  ""
 
-#: lxc/auth.go:1716
+#: lxc/auth.go:1714
 #, c-format
 msgid   "Identity provider group %s created"
 msgstr  ""
 
-#: lxc/auth.go:1766
+#: lxc/auth.go:1764
 #, c-format
 msgid   "Identity provider group %s deleted"
 msgstr  ""
@@ -2635,7 +2632,7 @@ msgstr  ""
 msgid   "Input data"
 msgstr  ""
 
-#: lxc/auth.go:1441 lxc/auth.go:1442
+#: lxc/auth.go:1439 lxc/auth.go:1440
 msgid   "Inspect permissions"
 msgstr  ""
 
@@ -2933,15 +2930,15 @@ msgstr  ""
 msgid   "List background operations"
 msgstr  ""
 
-#: lxc/auth.go:337 lxc/auth.go:338
+#: lxc/auth.go:335 lxc/auth.go:336
 msgid   "List groups"
 msgstr  ""
 
-#: lxc/auth.go:917 lxc/auth.go:918
+#: lxc/auth.go:915 lxc/auth.go:916
 msgid   "List identities"
 msgstr  ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1900
+#: lxc/auth.go:1897 lxc/auth.go:1898
 msgid   "List identity provider groups"
 msgstr  ""
 
@@ -3085,7 +3082,7 @@ msgstr  ""
 msgid   "List operations from all projects"
 msgstr  ""
 
-#: lxc/auth.go:1463 lxc/auth.go:1464
+#: lxc/auth.go:1461 lxc/auth.go:1462
 msgid   "List permissions"
 msgstr  ""
 
@@ -3251,7 +3248,7 @@ msgstr  ""
 msgid   "Make the image public (accessible to unauthenticated clients as well)"
 msgstr  ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:823
 msgid   "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, got "
 msgstr  ""
 
@@ -3283,19 +3280,19 @@ msgstr  ""
 msgid   "Manage files in instances"
 msgstr  ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
 msgid   "Manage groups"
 msgstr  ""
 
-#: lxc/auth.go:1291 lxc/auth.go:1292
+#: lxc/auth.go:1289 lxc/auth.go:1290
 msgid   "Manage groups for the identity"
 msgstr  ""
 
-#: lxc/auth.go:736 lxc/auth.go:737
+#: lxc/auth.go:734 lxc/auth.go:735
 msgid   "Manage identities"
 msgstr  ""
 
-#: lxc/auth.go:2059 lxc/auth.go:2060
+#: lxc/auth.go:2057 lxc/auth.go:2058
 msgid   "Manage identity provider group mappings"
 msgstr  ""
 
@@ -3385,7 +3382,7 @@ msgstr  ""
 msgid   "Manage network zones"
 msgstr  ""
 
-#: lxc/auth.go:498 lxc/auth.go:499
+#: lxc/auth.go:496 lxc/auth.go:497
 msgid   "Manage permissions"
 msgstr  ""
 
@@ -3523,19 +3520,19 @@ msgstr  ""
 msgid   "Missing cluster member name"
 msgstr  ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422 lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420 lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
 msgid   "Missing group name"
 msgstr  ""
 
-#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273 lxc/auth.go:1339 lxc/auth.go:1397
+#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271 lxc/auth.go:1337 lxc/auth.go:1395
 msgid   "Missing identity argument"
 msgstr  ""
 
-#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
+#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
 msgid   "Missing identity provider group name"
 msgstr  ""
 
-#: lxc/auth.go:2107 lxc/auth.go:2160
+#: lxc/auth.go:2105 lxc/auth.go:2158
 msgid   "Missing identity provider group name argument"
 msgstr  ""
 
@@ -3696,7 +3693,7 @@ msgstr  ""
 msgid   "Must supply instance name for: "
 msgstr  ""
 
-#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192 lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090 lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147 lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567 lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512 lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192 lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409 lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090 lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147 lxc/network_zone.go:827 lxc/profile.go:755 lxc/project.go:567 lxc/remote.go:849 lxc/storage.go:715 lxc/storage_bucket.go:512 lxc/storage_bucket.go:832 lxc/storage_volume.go:1748
 msgid   "NAME"
 msgstr  ""
 
@@ -4088,7 +4085,7 @@ msgstr  ""
 msgid   "Press ctrl+c to finish"
 msgstr  ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861 lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357 lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239 lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760 lxc/network_acl.go:699 lxc/network_forward.go:768 lxc/network_load_balancer.go:739 lxc/network_peer.go:699 lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596 lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350 lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168 lxc/storage_volume.go:1200
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861 lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357 lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239 lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760 lxc/network_acl.go:699 lxc/network_forward.go:768 lxc/network_load_balancer.go:739 lxc/network_peer.go:699 lxc/network_zone.go:622 lxc/network_zone.go:1317 lxc/profile.go:596 lxc/project.go:365 lxc/storage.go:360 lxc/storage_bucket.go:350 lxc/storage_bucket.go:1127 lxc/storage_volume.go:1168 lxc/storage_volume.go:1200
 msgid   "Press enter to open the editor again or ctrl+c to abort change"
 msgstr  ""
 
@@ -4421,7 +4418,7 @@ msgstr  ""
 msgid   "Remove a cluster member from a cluster group"
 msgstr  ""
 
-#: lxc/auth.go:1372 lxc/auth.go:1373
+#: lxc/auth.go:1370 lxc/auth.go:1371
 msgid   "Remove a group from an identity"
 msgstr  ""
 
@@ -4457,7 +4454,7 @@ msgstr  ""
 msgid   "Remove entries from a network zone record"
 msgstr  ""
 
-#: lxc/auth.go:2135 lxc/auth.go:2136
+#: lxc/auth.go:2133 lxc/auth.go:2134
 msgid   "Remove identities from groups"
 msgstr  ""
 
@@ -4469,7 +4466,7 @@ msgstr  ""
 msgid   "Remove member from group"
 msgstr  ""
 
-#: lxc/auth.go:580 lxc/auth.go:581
+#: lxc/auth.go:578 lxc/auth.go:579
 msgid   "Remove permissions from groups"
 msgstr  ""
 
@@ -4513,11 +4510,11 @@ msgstr  ""
 msgid   "Rename aliases"
 msgstr  ""
 
-#: lxc/auth.go:397 lxc/auth.go:398
+#: lxc/auth.go:395 lxc/auth.go:396
 msgid   "Rename groups"
 msgstr  ""
 
-#: lxc/auth.go:1959 lxc/auth.go:1960
+#: lxc/auth.go:1957 lxc/auth.go:1958
 msgid   "Rename identity provider groups"
 msgstr  ""
 
@@ -5007,7 +5004,7 @@ msgstr  ""
 msgid   "Show all information messages"
 msgstr  ""
 
-#: lxc/auth.go:2008 lxc/auth.go:2009
+#: lxc/auth.go:2006 lxc/auth.go:2007
 msgid   "Show an identity provider group"
 msgstr  ""
 
@@ -5035,11 +5032,11 @@ msgstr  ""
 msgid   "Show full device configuration"
 msgstr  ""
 
-#: lxc/auth.go:446 lxc/auth.go:447
+#: lxc/auth.go:444 lxc/auth.go:445
 msgid   "Show group configurations"
 msgstr  ""
 
-#: lxc/auth.go:985
+#: lxc/auth.go:983
 msgid   "Show identity configurations\n"
         "\n"
         "The argument must be a concatenation of the authentication method and either the\n"
@@ -5140,7 +5137,7 @@ msgstr  ""
 msgid   "Show storage volume state information"
 msgstr  ""
 
-#: lxc/auth.go:1048
+#: lxc/auth.go:1046
 msgid   "Show the current identity\n"
         "\n"
         "This command will display permissions for the current user.\n"
@@ -5376,12 +5373,12 @@ msgstr  ""
 msgid   "TARGET"
 msgstr  ""
 
-#: lxc/auth.go:876
+#: lxc/auth.go:874
 #, c-format
 msgid   "TLS identity %q (%s) pending identity token:"
 msgstr  ""
 
-#: lxc/auth.go:902
+#: lxc/auth.go:900
 #, c-format
 msgid   "TLS identity %q created with fingerprint %q"
 msgstr  ""
@@ -5390,7 +5387,7 @@ msgstr  ""
 msgid   "TOKEN"
 msgstr  ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147 lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091 lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172 lxc/storage_volume.go:1747 lxc/warning.go:216
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147 lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091 lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172 lxc/storage_volume.go:1747 lxc/warning.go:216
 msgid   "TYPE"
 msgstr  ""
 
@@ -6036,11 +6033,11 @@ msgstr  ""
 msgid   "Verb: %s (%s)"
 msgstr  ""
 
-#: lxc/auth.go:984
+#: lxc/auth.go:982
 msgid   "View an identity"
 msgstr  ""
 
-#: lxc/auth.go:1047
+#: lxc/auth.go:1045
 msgid   "View the current identity"
 msgstr  ""
 
@@ -6105,7 +6102,7 @@ msgstr  ""
 msgid   "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr  ""
 
-#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897 lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437 lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32 lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83 lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469 lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895 lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437 lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32 lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83 lxc/operation.go:104 lxc/profile.go:700 lxc/project.go:469 lxc/storage.go:652 lxc/version.go:20 lxc/warning.go:69
 msgid   "[<remote>:]"
 msgstr  ""
 
@@ -6133,7 +6130,7 @@ msgstr  ""
 msgid   "[<remote>:] [<filters>...]"
 msgstr  ""
 
-#: lxc/auth.go:1462
+#: lxc/auth.go:1460
 msgid   "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr  ""
 
@@ -6193,15 +6190,15 @@ msgstr  ""
 msgid   "[<remote>:]<alias> <new-name>"
 msgstr  ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:772
 msgid   "[<remote>:]<authentication_method>/<name> [<path to PEM encoded certificate>] [[--group <group_name>]]"
 msgstr  ""
 
-#: lxc/auth.go:983 lxc/auth.go:1235
+#: lxc/auth.go:981 lxc/auth.go:1233
 msgid   "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr  ""
 
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
 msgid   "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr  ""
 
@@ -6209,11 +6206,11 @@ msgstr  ""
 msgid   "[<remote>:]<fingerprint>"
 msgstr  ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445 lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168 lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443 lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168 lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid   "[<remote>:]<group>"
 msgstr  ""
 
-#: lxc/auth.go:520 lxc/auth.go:578
+#: lxc/auth.go:518 lxc/auth.go:576
 msgid   "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> [<key>=<value>...]"
 msgstr  ""
 
@@ -6221,19 +6218,19 @@ msgstr  ""
 msgid   "[<remote>:]<group> <new-name>"
 msgstr  ""
 
-#: lxc/auth.go:395
+#: lxc/auth.go:393
 msgid   "[<remote>:]<group> <new_name>"
 msgstr  ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
+#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
 msgid   "[<remote>:]<identity_provider_group>"
 msgstr  ""
 
-#: lxc/auth.go:2081
+#: lxc/auth.go:2079
 msgid   "[<remote>:]<identity_provider_group> <group>"
 msgstr  ""
 
-#: lxc/auth.go:1957
+#: lxc/auth.go:1955
 msgid   "[<remote>:]<identity_provider_group> <new_name>"
 msgstr  ""
 
@@ -6750,12 +6747,12 @@ msgid   "lxc auth group edit <group> < group.yaml\n"
         "   Update a group using the content of group.yaml"
 msgstr  ""
 
-#: lxc/auth.go:1111
+#: lxc/auth.go:1109
 msgid   "lxc auth identity edit <authentication_method>/<name_or_identifier> < identity.yaml\n"
         "   Update an identity using the content of identity.yaml"
 msgstr  ""
 
-#: lxc/auth.go:1783
+#: lxc/auth.go:1781
 msgid   "lxc auth identity-provider-group edit <identity_provider_group> < identity-provider-group.yaml\n"
         "   Update an identity provider group using the content of identity-provider-group.yaml"
 msgstr  ""

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-19 16:04-0700\n"
+"POT-Creation-Date: 2025-01-07 15:23+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -133,34 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:219
-msgid ""
-"### This is a YAML representation of the group.\n"
-"### Any line starting with a '# will be ignored.\n"
-"###\n"
-"### A group has the following format:\n"
-"### name: my-first-group\n"
-"### description: My first group.\n"
-"### permissions:\n"
-"### - entity_type: project\n"
-"###   url: /1.0/projects/default\n"
-"###   entitlement: can_view\n"
-"### identities:\n"
-"### - authentication_method: oidc\n"
-"###   type: OIDC client\n"
-"###   identifier: jane.doe@example.com\n"
-"###   name: Jane Doe\n"
-"###   metadata:\n"
-"###     subject: auth0|123456789\n"
-"### identity_provider_groups:\n"
-"### - sales\n"
-"### - operations\n"
-"###\n"
-"### Note that all group information is shown but only the description and "
-"permissions can be modified"
-msgstr ""
-
-#: lxc/auth.go:1121
+#: lxc/auth.go:1119
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +154,31 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1793
+#: lxc/auth.go:219
+msgid ""
+"### This is a YAML representation of the group.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### NOTE: All group information is shown but only the description and "
+"permissions can be modified.\n"
+"### \n"
+"### name: my-first-group\n"
+"### description: My first group.\n"
+"### permissions:\n"
+"### - entity_type: project\n"
+"###   url: /1.0/projects/default\n"
+"###   entitlement: can_view\n"
+"### identities:\n"
+"###   oidc:\n"
+"###   - jane.doe@example.com\n"
+"###   tls:\n"
+"###   - eaa46a1b73827350e0543949fb161410c50e950d4cb9802fc58dbfbd5700e508\n"
+"### identity_provider_groups:\n"
+"### - sales\n"
+"### - operations\n"
+msgstr ""
+
+#: lxc/auth.go:1791
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -560,7 +557,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:966
+#: lxc/auth.go:964
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -598,11 +595,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1312 lxc/auth.go:1313
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2082 lxc/auth.go:2083
+#: lxc/auth.go:2080 lxc/auth.go:2081
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -671,7 +668,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:521 lxc/auth.go:522
+#: lxc/auth.go:519 lxc/auth.go:520
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -1347,12 +1344,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:306 lxc/auth.go:1868
+#: lxc/auth.go:304 lxc/auth.go:1866
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1207
+#: lxc/auth.go:1205
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1381,7 +1378,7 @@ msgstr ""
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:776
+#: lxc/auth.go:774
 msgid "Create a TLS identity"
 msgstr ""
 
@@ -1401,7 +1398,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:775
+#: lxc/auth.go:773
 msgid "Create an identity"
 msgstr ""
 
@@ -1421,7 +1418,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1679 lxc/auth.go:1680
+#: lxc/auth.go:1677 lxc/auth.go:1678
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1529,7 +1526,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1572,7 +1569,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1237 lxc/auth.go:1238
+#: lxc/auth.go:1235 lxc/auth.go:1236
 msgid "Delete an identity"
 msgstr ""
 
@@ -1584,7 +1581,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1729 lxc/auth.go:1730
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1663,14 +1660,14 @@ msgstr ""
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
 #: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
-#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
-#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
-#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
-#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
-#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
-#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
-#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
+#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
+#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
+#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
+#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
+#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
+#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -1939,7 +1936,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1108 lxc/auth.go:1109
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1955,7 +1952,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1780 lxc/auth.go:1781
+#: lxc/auth.go:1778 lxc/auth.go:1779
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2441,7 +2438,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
@@ -2499,7 +2496,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:970 lxc/auth.go:1944
+#: lxc/auth.go:968 lxc/auth.go:1942
 msgid "GROUPS"
 msgstr ""
 
@@ -2658,7 +2655,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:432 lxc/auth.go:1994
+#: lxc/auth.go:430 lxc/auth.go:1992
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2717,7 +2714,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:969
+#: lxc/auth.go:967
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2749,16 +2746,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:829
+#: lxc/auth.go:827
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1716
+#: lxc/auth.go:1714
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1766
+#: lxc/auth.go:1764
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2887,7 +2884,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1441 lxc/auth.go:1442
+#: lxc/auth.go:1439 lxc/auth.go:1440
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3191,15 +3188,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:337 lxc/auth.go:338
+#: lxc/auth.go:335 lxc/auth.go:336
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:917 lxc/auth.go:918
+#: lxc/auth.go:915 lxc/auth.go:916
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1900
+#: lxc/auth.go:1897 lxc/auth.go:1898
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3354,7 +3351,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1463 lxc/auth.go:1464
+#: lxc/auth.go:1461 lxc/auth.go:1462
 msgid "List permissions"
 msgstr ""
 
@@ -3522,7 +3519,7 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:823
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
@@ -3556,19 +3553,19 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1291 lxc/auth.go:1292
+#: lxc/auth.go:1289 lxc/auth.go:1290
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:736 lxc/auth.go:737
+#: lxc/auth.go:734 lxc/auth.go:735
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2059 lxc/auth.go:2060
+#: lxc/auth.go:2057 lxc/auth.go:2058
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3659,7 +3656,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:498 lxc/auth.go:499
+#: lxc/auth.go:496 lxc/auth.go:497
 msgid "Manage permissions"
 msgstr ""
 
@@ -3808,21 +3805,21 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
-#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
-#: lxc/auth.go:1339 lxc/auth.go:1397
+#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
+#: lxc/auth.go:1337 lxc/auth.go:1395
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
+#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2107 lxc/auth.go:2160
+#: lxc/auth.go:2105 lxc/auth.go:2158
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4043,7 +4040,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
@@ -4447,7 +4444,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4806,7 +4803,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1372 lxc/auth.go:1373
+#: lxc/auth.go:1370 lxc/auth.go:1371
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4842,7 +4839,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2135 lxc/auth.go:2136
+#: lxc/auth.go:2133 lxc/auth.go:2134
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4854,7 +4851,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:580 lxc/auth.go:581
+#: lxc/auth.go:578 lxc/auth.go:579
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4899,11 +4896,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:397 lxc/auth.go:398
+#: lxc/auth.go:395 lxc/auth.go:396
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1959 lxc/auth.go:1960
+#: lxc/auth.go:1957 lxc/auth.go:1958
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5424,7 +5421,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2008 lxc/auth.go:2009
+#: lxc/auth.go:2006 lxc/auth.go:2007
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5452,11 +5449,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:446 lxc/auth.go:447
+#: lxc/auth.go:444 lxc/auth.go:445
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:985
+#: lxc/auth.go:983
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5561,7 +5558,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1048
+#: lxc/auth.go:1046
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5799,12 +5796,12 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:876
+#: lxc/auth.go:874
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:902
+#: lxc/auth.go:900
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
@@ -5813,7 +5810,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1747 lxc/warning.go:216
@@ -6485,11 +6482,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:984
+#: lxc/auth.go:982
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1047
+#: lxc/auth.go:1045
 msgid "View the current identity"
 msgstr ""
 
@@ -6560,7 +6557,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6593,7 +6590,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1462
+#: lxc/auth.go:1460
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6654,17 +6651,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:772
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:983 lxc/auth.go:1235
+#: lxc/auth.go:981 lxc/auth.go:1233
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6672,13 +6669,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
-#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
+#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:520 lxc/auth.go:578
+#: lxc/auth.go:518 lxc/auth.go:576
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6688,19 +6685,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:395
+#: lxc/auth.go:393
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
+#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2081
+#: lxc/auth.go:2079
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1957
+#: lxc/auth.go:1955
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7248,14 +7245,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1111
+#: lxc/auth.go:1109
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1783
+#: lxc/auth.go:1781
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-19 16:04-0700\n"
+"POT-Creation-Date: 2025-01-07 15:23+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -133,34 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:219
-msgid ""
-"### This is a YAML representation of the group.\n"
-"### Any line starting with a '# will be ignored.\n"
-"###\n"
-"### A group has the following format:\n"
-"### name: my-first-group\n"
-"### description: My first group.\n"
-"### permissions:\n"
-"### - entity_type: project\n"
-"###   url: /1.0/projects/default\n"
-"###   entitlement: can_view\n"
-"### identities:\n"
-"### - authentication_method: oidc\n"
-"###   type: OIDC client\n"
-"###   identifier: jane.doe@example.com\n"
-"###   name: Jane Doe\n"
-"###   metadata:\n"
-"###     subject: auth0|123456789\n"
-"### identity_provider_groups:\n"
-"### - sales\n"
-"### - operations\n"
-"###\n"
-"### Note that all group information is shown but only the description and "
-"permissions can be modified"
-msgstr ""
-
-#: lxc/auth.go:1121
+#: lxc/auth.go:1119
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +154,31 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1793
+#: lxc/auth.go:219
+msgid ""
+"### This is a YAML representation of the group.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### NOTE: All group information is shown but only the description and "
+"permissions can be modified.\n"
+"### \n"
+"### name: my-first-group\n"
+"### description: My first group.\n"
+"### permissions:\n"
+"### - entity_type: project\n"
+"###   url: /1.0/projects/default\n"
+"###   entitlement: can_view\n"
+"### identities:\n"
+"###   oidc:\n"
+"###   - jane.doe@example.com\n"
+"###   tls:\n"
+"###   - eaa46a1b73827350e0543949fb161410c50e950d4cb9802fc58dbfbd5700e508\n"
+"### identity_provider_groups:\n"
+"### - sales\n"
+"### - operations\n"
+msgstr ""
+
+#: lxc/auth.go:1791
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -560,7 +557,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:966
+#: lxc/auth.go:964
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -598,11 +595,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1312 lxc/auth.go:1313
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2082 lxc/auth.go:2083
+#: lxc/auth.go:2080 lxc/auth.go:2081
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -671,7 +668,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:521 lxc/auth.go:522
+#: lxc/auth.go:519 lxc/auth.go:520
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -1347,12 +1344,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:306 lxc/auth.go:1868
+#: lxc/auth.go:304 lxc/auth.go:1866
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1207
+#: lxc/auth.go:1205
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1381,7 +1378,7 @@ msgstr ""
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:776
+#: lxc/auth.go:774
 msgid "Create a TLS identity"
 msgstr ""
 
@@ -1401,7 +1398,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:775
+#: lxc/auth.go:773
 msgid "Create an identity"
 msgstr ""
 
@@ -1421,7 +1418,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1679 lxc/auth.go:1680
+#: lxc/auth.go:1677 lxc/auth.go:1678
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1529,7 +1526,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1572,7 +1569,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1237 lxc/auth.go:1238
+#: lxc/auth.go:1235 lxc/auth.go:1236
 msgid "Delete an identity"
 msgstr ""
 
@@ -1584,7 +1581,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1729 lxc/auth.go:1730
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1663,14 +1660,14 @@ msgstr ""
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
 #: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
-#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
-#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
-#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
-#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
-#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
-#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
-#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
+#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
+#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
+#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
+#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
+#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
+#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -1939,7 +1936,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1108 lxc/auth.go:1109
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1955,7 +1952,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1780 lxc/auth.go:1781
+#: lxc/auth.go:1778 lxc/auth.go:1779
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2441,7 +2438,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
@@ -2499,7 +2496,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:970 lxc/auth.go:1944
+#: lxc/auth.go:968 lxc/auth.go:1942
 msgid "GROUPS"
 msgstr ""
 
@@ -2658,7 +2655,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:432 lxc/auth.go:1994
+#: lxc/auth.go:430 lxc/auth.go:1992
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2717,7 +2714,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:969
+#: lxc/auth.go:967
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2749,16 +2746,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:829
+#: lxc/auth.go:827
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1716
+#: lxc/auth.go:1714
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1766
+#: lxc/auth.go:1764
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2887,7 +2884,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1441 lxc/auth.go:1442
+#: lxc/auth.go:1439 lxc/auth.go:1440
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3191,15 +3188,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:337 lxc/auth.go:338
+#: lxc/auth.go:335 lxc/auth.go:336
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:917 lxc/auth.go:918
+#: lxc/auth.go:915 lxc/auth.go:916
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1900
+#: lxc/auth.go:1897 lxc/auth.go:1898
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3354,7 +3351,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1463 lxc/auth.go:1464
+#: lxc/auth.go:1461 lxc/auth.go:1462
 msgid "List permissions"
 msgstr ""
 
@@ -3522,7 +3519,7 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:823
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
@@ -3556,19 +3553,19 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1291 lxc/auth.go:1292
+#: lxc/auth.go:1289 lxc/auth.go:1290
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:736 lxc/auth.go:737
+#: lxc/auth.go:734 lxc/auth.go:735
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2059 lxc/auth.go:2060
+#: lxc/auth.go:2057 lxc/auth.go:2058
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3659,7 +3656,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:498 lxc/auth.go:499
+#: lxc/auth.go:496 lxc/auth.go:497
 msgid "Manage permissions"
 msgstr ""
 
@@ -3808,21 +3805,21 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
-#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
-#: lxc/auth.go:1339 lxc/auth.go:1397
+#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
+#: lxc/auth.go:1337 lxc/auth.go:1395
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
+#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2107 lxc/auth.go:2160
+#: lxc/auth.go:2105 lxc/auth.go:2158
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4043,7 +4040,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
@@ -4447,7 +4444,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4806,7 +4803,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1372 lxc/auth.go:1373
+#: lxc/auth.go:1370 lxc/auth.go:1371
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4842,7 +4839,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2135 lxc/auth.go:2136
+#: lxc/auth.go:2133 lxc/auth.go:2134
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4854,7 +4851,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:580 lxc/auth.go:581
+#: lxc/auth.go:578 lxc/auth.go:579
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4899,11 +4896,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:397 lxc/auth.go:398
+#: lxc/auth.go:395 lxc/auth.go:396
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1959 lxc/auth.go:1960
+#: lxc/auth.go:1957 lxc/auth.go:1958
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5424,7 +5421,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2008 lxc/auth.go:2009
+#: lxc/auth.go:2006 lxc/auth.go:2007
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5452,11 +5449,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:446 lxc/auth.go:447
+#: lxc/auth.go:444 lxc/auth.go:445
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:985
+#: lxc/auth.go:983
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5561,7 +5558,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1048
+#: lxc/auth.go:1046
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5799,12 +5796,12 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:876
+#: lxc/auth.go:874
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:902
+#: lxc/auth.go:900
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
@@ -5813,7 +5810,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1747 lxc/warning.go:216
@@ -6485,11 +6482,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:984
+#: lxc/auth.go:982
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1047
+#: lxc/auth.go:1045
 msgid "View the current identity"
 msgstr ""
 
@@ -6560,7 +6557,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6593,7 +6590,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1462
+#: lxc/auth.go:1460
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6654,17 +6651,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:772
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:983 lxc/auth.go:1235
+#: lxc/auth.go:981 lxc/auth.go:1233
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6672,13 +6669,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
-#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
+#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:520 lxc/auth.go:578
+#: lxc/auth.go:518 lxc/auth.go:576
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6688,19 +6685,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:395
+#: lxc/auth.go:393
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
+#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2081
+#: lxc/auth.go:2079
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1957
+#: lxc/auth.go:1955
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7248,14 +7245,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1111
+#: lxc/auth.go:1109
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1783
+#: lxc/auth.go:1781
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-19 16:04-0700\n"
+"POT-Creation-Date: 2025-01-07 15:23+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -201,34 +201,7 @@ msgstr ""
 "###\n"
 "### NB: de naam is weergegeven, maar kan niet worden veranderd"
 
-#: lxc/auth.go:219
-msgid ""
-"### This is a YAML representation of the group.\n"
-"### Any line starting with a '# will be ignored.\n"
-"###\n"
-"### A group has the following format:\n"
-"### name: my-first-group\n"
-"### description: My first group.\n"
-"### permissions:\n"
-"### - entity_type: project\n"
-"###   url: /1.0/projects/default\n"
-"###   entitlement: can_view\n"
-"### identities:\n"
-"### - authentication_method: oidc\n"
-"###   type: OIDC client\n"
-"###   identifier: jane.doe@example.com\n"
-"###   name: Jane Doe\n"
-"###   metadata:\n"
-"###     subject: auth0|123456789\n"
-"### identity_provider_groups:\n"
-"### - sales\n"
-"### - operations\n"
-"###\n"
-"### Note that all group information is shown but only the description and "
-"permissions can be modified"
-msgstr ""
-
-#: lxc/auth.go:1121
+#: lxc/auth.go:1119
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -249,7 +222,31 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1793
+#: lxc/auth.go:219
+msgid ""
+"### This is a YAML representation of the group.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### NOTE: All group information is shown but only the description and "
+"permissions can be modified.\n"
+"### \n"
+"### name: my-first-group\n"
+"### description: My first group.\n"
+"### permissions:\n"
+"### - entity_type: project\n"
+"###   url: /1.0/projects/default\n"
+"###   entitlement: can_view\n"
+"### identities:\n"
+"###   oidc:\n"
+"###   - jane.doe@example.com\n"
+"###   tls:\n"
+"###   - eaa46a1b73827350e0543949fb161410c50e950d4cb9802fc58dbfbd5700e508\n"
+"### identity_provider_groups:\n"
+"### - sales\n"
+"### - operations\n"
+msgstr ""
+
+#: lxc/auth.go:1791
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -784,7 +781,7 @@ msgstr "ARCHITECTUUR"
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:966
+#: lxc/auth.go:964
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -822,11 +819,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1312 lxc/auth.go:1313
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2082 lxc/auth.go:2083
+#: lxc/auth.go:2080 lxc/auth.go:2081
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -895,7 +892,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:521 lxc/auth.go:522
+#: lxc/auth.go:519 lxc/auth.go:520
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -1571,12 +1568,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:306 lxc/auth.go:1868
+#: lxc/auth.go:304 lxc/auth.go:1866
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1207
+#: lxc/auth.go:1205
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1605,7 +1602,7 @@ msgstr ""
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:776
+#: lxc/auth.go:774
 msgid "Create a TLS identity"
 msgstr ""
 
@@ -1625,7 +1622,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:775
+#: lxc/auth.go:773
 msgid "Create an identity"
 msgstr ""
 
@@ -1645,7 +1642,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1679 lxc/auth.go:1680
+#: lxc/auth.go:1677 lxc/auth.go:1678
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1753,7 +1750,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1796,7 +1793,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1237 lxc/auth.go:1238
+#: lxc/auth.go:1235 lxc/auth.go:1236
 msgid "Delete an identity"
 msgstr ""
 
@@ -1808,7 +1805,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1729 lxc/auth.go:1730
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1887,14 +1884,14 @@ msgstr ""
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
 #: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
-#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
-#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
-#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
-#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
-#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
-#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
-#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
+#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
+#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
+#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
+#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
+#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
+#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -2163,7 +2160,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1108 lxc/auth.go:1109
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -2179,7 +2176,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1780 lxc/auth.go:1781
+#: lxc/auth.go:1778 lxc/auth.go:1779
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2665,7 +2662,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
@@ -2723,7 +2720,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:970 lxc/auth.go:1944
+#: lxc/auth.go:968 lxc/auth.go:1942
 msgid "GROUPS"
 msgstr ""
 
@@ -2882,7 +2879,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:432 lxc/auth.go:1994
+#: lxc/auth.go:430 lxc/auth.go:1992
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2941,7 +2938,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:969
+#: lxc/auth.go:967
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2973,16 +2970,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:829
+#: lxc/auth.go:827
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1716
+#: lxc/auth.go:1714
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1766
+#: lxc/auth.go:1764
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -3111,7 +3108,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1441 lxc/auth.go:1442
+#: lxc/auth.go:1439 lxc/auth.go:1440
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3415,15 +3412,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:337 lxc/auth.go:338
+#: lxc/auth.go:335 lxc/auth.go:336
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:917 lxc/auth.go:918
+#: lxc/auth.go:915 lxc/auth.go:916
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1900
+#: lxc/auth.go:1897 lxc/auth.go:1898
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3578,7 +3575,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1463 lxc/auth.go:1464
+#: lxc/auth.go:1461 lxc/auth.go:1462
 msgid "List permissions"
 msgstr ""
 
@@ -3746,7 +3743,7 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:823
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
@@ -3780,19 +3777,19 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1291 lxc/auth.go:1292
+#: lxc/auth.go:1289 lxc/auth.go:1290
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:736 lxc/auth.go:737
+#: lxc/auth.go:734 lxc/auth.go:735
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2059 lxc/auth.go:2060
+#: lxc/auth.go:2057 lxc/auth.go:2058
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3883,7 +3880,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:498 lxc/auth.go:499
+#: lxc/auth.go:496 lxc/auth.go:497
 msgid "Manage permissions"
 msgstr ""
 
@@ -4032,21 +4029,21 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
-#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
-#: lxc/auth.go:1339 lxc/auth.go:1397
+#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
+#: lxc/auth.go:1337 lxc/auth.go:1395
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
+#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2107 lxc/auth.go:2160
+#: lxc/auth.go:2105 lxc/auth.go:2158
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4267,7 +4264,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
@@ -4671,7 +4668,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -5030,7 +5027,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1372 lxc/auth.go:1373
+#: lxc/auth.go:1370 lxc/auth.go:1371
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -5066,7 +5063,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2135 lxc/auth.go:2136
+#: lxc/auth.go:2133 lxc/auth.go:2134
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -5078,7 +5075,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:580 lxc/auth.go:581
+#: lxc/auth.go:578 lxc/auth.go:579
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -5123,11 +5120,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:397 lxc/auth.go:398
+#: lxc/auth.go:395 lxc/auth.go:396
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1959 lxc/auth.go:1960
+#: lxc/auth.go:1957 lxc/auth.go:1958
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5648,7 +5645,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2008 lxc/auth.go:2009
+#: lxc/auth.go:2006 lxc/auth.go:2007
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5676,11 +5673,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:446 lxc/auth.go:447
+#: lxc/auth.go:444 lxc/auth.go:445
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:985
+#: lxc/auth.go:983
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5785,7 +5782,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1048
+#: lxc/auth.go:1046
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -6023,12 +6020,12 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:876
+#: lxc/auth.go:874
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:902
+#: lxc/auth.go:900
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
@@ -6037,7 +6034,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1747 lxc/warning.go:216
@@ -6709,11 +6706,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:984
+#: lxc/auth.go:982
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1047
+#: lxc/auth.go:1045
 msgid "View the current identity"
 msgstr ""
 
@@ -6784,7 +6781,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6817,7 +6814,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1462
+#: lxc/auth.go:1460
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6878,17 +6875,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:772
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:983 lxc/auth.go:1235
+#: lxc/auth.go:981 lxc/auth.go:1233
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6896,13 +6893,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
-#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
+#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:520 lxc/auth.go:578
+#: lxc/auth.go:518 lxc/auth.go:576
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6912,19 +6909,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:395
+#: lxc/auth.go:393
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
+#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2081
+#: lxc/auth.go:2079
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1957
+#: lxc/auth.go:1955
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7472,14 +7469,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1111
+#: lxc/auth.go:1109
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1783
+#: lxc/auth.go:1781
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-19 16:04-0700\n"
+"POT-Creation-Date: 2025-01-07 15:23+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -133,34 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:219
-msgid ""
-"### This is a YAML representation of the group.\n"
-"### Any line starting with a '# will be ignored.\n"
-"###\n"
-"### A group has the following format:\n"
-"### name: my-first-group\n"
-"### description: My first group.\n"
-"### permissions:\n"
-"### - entity_type: project\n"
-"###   url: /1.0/projects/default\n"
-"###   entitlement: can_view\n"
-"### identities:\n"
-"### - authentication_method: oidc\n"
-"###   type: OIDC client\n"
-"###   identifier: jane.doe@example.com\n"
-"###   name: Jane Doe\n"
-"###   metadata:\n"
-"###     subject: auth0|123456789\n"
-"### identity_provider_groups:\n"
-"### - sales\n"
-"### - operations\n"
-"###\n"
-"### Note that all group information is shown but only the description and "
-"permissions can be modified"
-msgstr ""
-
-#: lxc/auth.go:1121
+#: lxc/auth.go:1119
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +154,31 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1793
+#: lxc/auth.go:219
+msgid ""
+"### This is a YAML representation of the group.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### NOTE: All group information is shown but only the description and "
+"permissions can be modified.\n"
+"### \n"
+"### name: my-first-group\n"
+"### description: My first group.\n"
+"### permissions:\n"
+"### - entity_type: project\n"
+"###   url: /1.0/projects/default\n"
+"###   entitlement: can_view\n"
+"### identities:\n"
+"###   oidc:\n"
+"###   - jane.doe@example.com\n"
+"###   tls:\n"
+"###   - eaa46a1b73827350e0543949fb161410c50e950d4cb9802fc58dbfbd5700e508\n"
+"### identity_provider_groups:\n"
+"### - sales\n"
+"### - operations\n"
+msgstr ""
+
+#: lxc/auth.go:1791
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -560,7 +557,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:966
+#: lxc/auth.go:964
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -598,11 +595,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1312 lxc/auth.go:1313
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2082 lxc/auth.go:2083
+#: lxc/auth.go:2080 lxc/auth.go:2081
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -671,7 +668,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:521 lxc/auth.go:522
+#: lxc/auth.go:519 lxc/auth.go:520
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -1347,12 +1344,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:306 lxc/auth.go:1868
+#: lxc/auth.go:304 lxc/auth.go:1866
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1207
+#: lxc/auth.go:1205
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1381,7 +1378,7 @@ msgstr ""
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:776
+#: lxc/auth.go:774
 msgid "Create a TLS identity"
 msgstr ""
 
@@ -1401,7 +1398,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:775
+#: lxc/auth.go:773
 msgid "Create an identity"
 msgstr ""
 
@@ -1421,7 +1418,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1679 lxc/auth.go:1680
+#: lxc/auth.go:1677 lxc/auth.go:1678
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1529,7 +1526,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1572,7 +1569,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1237 lxc/auth.go:1238
+#: lxc/auth.go:1235 lxc/auth.go:1236
 msgid "Delete an identity"
 msgstr ""
 
@@ -1584,7 +1581,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1729 lxc/auth.go:1730
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1663,14 +1660,14 @@ msgstr ""
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
 #: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
-#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
-#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
-#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
-#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
-#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
-#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
-#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
+#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
+#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
+#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
+#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
+#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
+#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -1939,7 +1936,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1108 lxc/auth.go:1109
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1955,7 +1952,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1780 lxc/auth.go:1781
+#: lxc/auth.go:1778 lxc/auth.go:1779
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2441,7 +2438,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
@@ -2499,7 +2496,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:970 lxc/auth.go:1944
+#: lxc/auth.go:968 lxc/auth.go:1942
 msgid "GROUPS"
 msgstr ""
 
@@ -2658,7 +2655,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:432 lxc/auth.go:1994
+#: lxc/auth.go:430 lxc/auth.go:1992
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2717,7 +2714,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:969
+#: lxc/auth.go:967
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2749,16 +2746,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:829
+#: lxc/auth.go:827
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1716
+#: lxc/auth.go:1714
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1766
+#: lxc/auth.go:1764
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2887,7 +2884,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1441 lxc/auth.go:1442
+#: lxc/auth.go:1439 lxc/auth.go:1440
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3191,15 +3188,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:337 lxc/auth.go:338
+#: lxc/auth.go:335 lxc/auth.go:336
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:917 lxc/auth.go:918
+#: lxc/auth.go:915 lxc/auth.go:916
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1900
+#: lxc/auth.go:1897 lxc/auth.go:1898
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3354,7 +3351,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1463 lxc/auth.go:1464
+#: lxc/auth.go:1461 lxc/auth.go:1462
 msgid "List permissions"
 msgstr ""
 
@@ -3522,7 +3519,7 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:823
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
@@ -3556,19 +3553,19 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1291 lxc/auth.go:1292
+#: lxc/auth.go:1289 lxc/auth.go:1290
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:736 lxc/auth.go:737
+#: lxc/auth.go:734 lxc/auth.go:735
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2059 lxc/auth.go:2060
+#: lxc/auth.go:2057 lxc/auth.go:2058
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3659,7 +3656,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:498 lxc/auth.go:499
+#: lxc/auth.go:496 lxc/auth.go:497
 msgid "Manage permissions"
 msgstr ""
 
@@ -3808,21 +3805,21 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
-#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
-#: lxc/auth.go:1339 lxc/auth.go:1397
+#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
+#: lxc/auth.go:1337 lxc/auth.go:1395
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
+#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2107 lxc/auth.go:2160
+#: lxc/auth.go:2105 lxc/auth.go:2158
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4043,7 +4040,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
@@ -4447,7 +4444,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4806,7 +4803,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1372 lxc/auth.go:1373
+#: lxc/auth.go:1370 lxc/auth.go:1371
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4842,7 +4839,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2135 lxc/auth.go:2136
+#: lxc/auth.go:2133 lxc/auth.go:2134
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4854,7 +4851,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:580 lxc/auth.go:581
+#: lxc/auth.go:578 lxc/auth.go:579
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4899,11 +4896,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:397 lxc/auth.go:398
+#: lxc/auth.go:395 lxc/auth.go:396
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1959 lxc/auth.go:1960
+#: lxc/auth.go:1957 lxc/auth.go:1958
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5424,7 +5421,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2008 lxc/auth.go:2009
+#: lxc/auth.go:2006 lxc/auth.go:2007
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5452,11 +5449,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:446 lxc/auth.go:447
+#: lxc/auth.go:444 lxc/auth.go:445
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:985
+#: lxc/auth.go:983
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5561,7 +5558,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1048
+#: lxc/auth.go:1046
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5799,12 +5796,12 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:876
+#: lxc/auth.go:874
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:902
+#: lxc/auth.go:900
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
@@ -5813,7 +5810,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1747 lxc/warning.go:216
@@ -6485,11 +6482,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:984
+#: lxc/auth.go:982
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1047
+#: lxc/auth.go:1045
 msgid "View the current identity"
 msgstr ""
 
@@ -6560,7 +6557,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6593,7 +6590,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1462
+#: lxc/auth.go:1460
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6654,17 +6651,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:772
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:983 lxc/auth.go:1235
+#: lxc/auth.go:981 lxc/auth.go:1233
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6672,13 +6669,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
-#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
+#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:520 lxc/auth.go:578
+#: lxc/auth.go:518 lxc/auth.go:576
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6688,19 +6685,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:395
+#: lxc/auth.go:393
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
+#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2081
+#: lxc/auth.go:2079
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1957
+#: lxc/auth.go:1955
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7248,14 +7245,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1111
+#: lxc/auth.go:1109
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1783
+#: lxc/auth.go:1781
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-19 16:04-0700\n"
+"POT-Creation-Date: 2025-01-07 15:23+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -207,34 +207,7 @@ msgstr ""
 "###\n"
 "### Nazwa jest widoczna, ale nie może zostać zmieniona"
 
-#: lxc/auth.go:219
-msgid ""
-"### This is a YAML representation of the group.\n"
-"### Any line starting with a '# will be ignored.\n"
-"###\n"
-"### A group has the following format:\n"
-"### name: my-first-group\n"
-"### description: My first group.\n"
-"### permissions:\n"
-"### - entity_type: project\n"
-"###   url: /1.0/projects/default\n"
-"###   entitlement: can_view\n"
-"### identities:\n"
-"### - authentication_method: oidc\n"
-"###   type: OIDC client\n"
-"###   identifier: jane.doe@example.com\n"
-"###   name: Jane Doe\n"
-"###   metadata:\n"
-"###     subject: auth0|123456789\n"
-"### identity_provider_groups:\n"
-"### - sales\n"
-"### - operations\n"
-"###\n"
-"### Note that all group information is shown but only the description and "
-"permissions can be modified"
-msgstr ""
-
-#: lxc/auth.go:1121
+#: lxc/auth.go:1119
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -255,7 +228,31 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1793
+#: lxc/auth.go:219
+msgid ""
+"### This is a YAML representation of the group.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### NOTE: All group information is shown but only the description and "
+"permissions can be modified.\n"
+"### \n"
+"### name: my-first-group\n"
+"### description: My first group.\n"
+"### permissions:\n"
+"### - entity_type: project\n"
+"###   url: /1.0/projects/default\n"
+"###   entitlement: can_view\n"
+"### identities:\n"
+"###   oidc:\n"
+"###   - jane.doe@example.com\n"
+"###   tls:\n"
+"###   - eaa46a1b73827350e0543949fb161410c50e950d4cb9802fc58dbfbd5700e508\n"
+"### identity_provider_groups:\n"
+"### - sales\n"
+"### - operations\n"
+msgstr ""
+
+#: lxc/auth.go:1791
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -822,7 +819,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:966
+#: lxc/auth.go:964
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -860,11 +857,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1312 lxc/auth.go:1313
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2082 lxc/auth.go:2083
+#: lxc/auth.go:2080 lxc/auth.go:2081
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -933,7 +930,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:521 lxc/auth.go:522
+#: lxc/auth.go:519 lxc/auth.go:520
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -1609,12 +1606,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:306 lxc/auth.go:1868
+#: lxc/auth.go:304 lxc/auth.go:1866
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1207
+#: lxc/auth.go:1205
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1643,7 +1640,7 @@ msgstr ""
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:776
+#: lxc/auth.go:774
 msgid "Create a TLS identity"
 msgstr ""
 
@@ -1663,7 +1660,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:775
+#: lxc/auth.go:773
 msgid "Create an identity"
 msgstr ""
 
@@ -1683,7 +1680,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1679 lxc/auth.go:1680
+#: lxc/auth.go:1677 lxc/auth.go:1678
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1791,7 +1788,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1834,7 +1831,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1237 lxc/auth.go:1238
+#: lxc/auth.go:1235 lxc/auth.go:1236
 msgid "Delete an identity"
 msgstr ""
 
@@ -1846,7 +1843,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1729 lxc/auth.go:1730
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1925,14 +1922,14 @@ msgstr ""
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
 #: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
-#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
-#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
-#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
-#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
-#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
-#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
-#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
+#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
+#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
+#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
+#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
+#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
+#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -2201,7 +2198,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1108 lxc/auth.go:1109
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -2217,7 +2214,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1780 lxc/auth.go:1781
+#: lxc/auth.go:1778 lxc/auth.go:1779
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2703,7 +2700,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
@@ -2761,7 +2758,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:970 lxc/auth.go:1944
+#: lxc/auth.go:968 lxc/auth.go:1942
 msgid "GROUPS"
 msgstr ""
 
@@ -2920,7 +2917,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:432 lxc/auth.go:1994
+#: lxc/auth.go:430 lxc/auth.go:1992
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2979,7 +2976,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:969
+#: lxc/auth.go:967
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -3011,16 +3008,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:829
+#: lxc/auth.go:827
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1716
+#: lxc/auth.go:1714
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1766
+#: lxc/auth.go:1764
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -3149,7 +3146,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1441 lxc/auth.go:1442
+#: lxc/auth.go:1439 lxc/auth.go:1440
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3453,15 +3450,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:337 lxc/auth.go:338
+#: lxc/auth.go:335 lxc/auth.go:336
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:917 lxc/auth.go:918
+#: lxc/auth.go:915 lxc/auth.go:916
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1900
+#: lxc/auth.go:1897 lxc/auth.go:1898
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3616,7 +3613,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1463 lxc/auth.go:1464
+#: lxc/auth.go:1461 lxc/auth.go:1462
 msgid "List permissions"
 msgstr ""
 
@@ -3784,7 +3781,7 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:823
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
@@ -3818,19 +3815,19 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1291 lxc/auth.go:1292
+#: lxc/auth.go:1289 lxc/auth.go:1290
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:736 lxc/auth.go:737
+#: lxc/auth.go:734 lxc/auth.go:735
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2059 lxc/auth.go:2060
+#: lxc/auth.go:2057 lxc/auth.go:2058
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3921,7 +3918,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:498 lxc/auth.go:499
+#: lxc/auth.go:496 lxc/auth.go:497
 msgid "Manage permissions"
 msgstr ""
 
@@ -4070,21 +4067,21 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
-#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
-#: lxc/auth.go:1339 lxc/auth.go:1397
+#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
+#: lxc/auth.go:1337 lxc/auth.go:1395
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
+#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2107 lxc/auth.go:2160
+#: lxc/auth.go:2105 lxc/auth.go:2158
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4305,7 +4302,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
@@ -4709,7 +4706,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -5068,7 +5065,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1372 lxc/auth.go:1373
+#: lxc/auth.go:1370 lxc/auth.go:1371
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -5104,7 +5101,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2135 lxc/auth.go:2136
+#: lxc/auth.go:2133 lxc/auth.go:2134
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -5116,7 +5113,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:580 lxc/auth.go:581
+#: lxc/auth.go:578 lxc/auth.go:579
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -5161,11 +5158,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:397 lxc/auth.go:398
+#: lxc/auth.go:395 lxc/auth.go:396
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1959 lxc/auth.go:1960
+#: lxc/auth.go:1957 lxc/auth.go:1958
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5686,7 +5683,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2008 lxc/auth.go:2009
+#: lxc/auth.go:2006 lxc/auth.go:2007
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5714,11 +5711,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:446 lxc/auth.go:447
+#: lxc/auth.go:444 lxc/auth.go:445
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:985
+#: lxc/auth.go:983
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5823,7 +5820,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1048
+#: lxc/auth.go:1046
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -6061,12 +6058,12 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:876
+#: lxc/auth.go:874
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:902
+#: lxc/auth.go:900
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
@@ -6075,7 +6072,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1747 lxc/warning.go:216
@@ -6747,11 +6744,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:984
+#: lxc/auth.go:982
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1047
+#: lxc/auth.go:1045
 msgid "View the current identity"
 msgstr ""
 
@@ -6822,7 +6819,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6855,7 +6852,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1462
+#: lxc/auth.go:1460
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6916,17 +6913,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:772
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:983 lxc/auth.go:1235
+#: lxc/auth.go:981 lxc/auth.go:1233
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6934,13 +6931,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
-#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
+#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:520 lxc/auth.go:578
+#: lxc/auth.go:518 lxc/auth.go:576
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6950,19 +6947,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:395
+#: lxc/auth.go:393
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
+#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2081
+#: lxc/auth.go:2079
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1957
+#: lxc/auth.go:1955
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7510,14 +7507,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1111
+#: lxc/auth.go:1109
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1783
+#: lxc/auth.go:1781
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-19 16:04-0700\n"
+"POT-Creation-Date: 2025-01-07 15:23+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -130,34 +130,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:219
-msgid ""
-"### This is a YAML representation of the group.\n"
-"### Any line starting with a '# will be ignored.\n"
-"###\n"
-"### A group has the following format:\n"
-"### name: my-first-group\n"
-"### description: My first group.\n"
-"### permissions:\n"
-"### - entity_type: project\n"
-"###   url: /1.0/projects/default\n"
-"###   entitlement: can_view\n"
-"### identities:\n"
-"### - authentication_method: oidc\n"
-"###   type: OIDC client\n"
-"###   identifier: jane.doe@example.com\n"
-"###   name: Jane Doe\n"
-"###   metadata:\n"
-"###     subject: auth0|123456789\n"
-"### identity_provider_groups:\n"
-"### - sales\n"
-"### - operations\n"
-"###\n"
-"### Note that all group information is shown but only the description and "
-"permissions can be modified"
-msgstr ""
-
-#: lxc/auth.go:1121
+#: lxc/auth.go:1119
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -178,7 +151,31 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1793
+#: lxc/auth.go:219
+msgid ""
+"### This is a YAML representation of the group.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### NOTE: All group information is shown but only the description and "
+"permissions can be modified.\n"
+"### \n"
+"### name: my-first-group\n"
+"### description: My first group.\n"
+"### permissions:\n"
+"### - entity_type: project\n"
+"###   url: /1.0/projects/default\n"
+"###   entitlement: can_view\n"
+"### identities:\n"
+"###   oidc:\n"
+"###   - jane.doe@example.com\n"
+"###   tls:\n"
+"###   - eaa46a1b73827350e0543949fb161410c50e950d4cb9802fc58dbfbd5700e508\n"
+"### identity_provider_groups:\n"
+"### - sales\n"
+"### - operations\n"
+msgstr ""
+
+#: lxc/auth.go:1791
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -557,7 +554,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:966
+#: lxc/auth.go:964
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -595,11 +592,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1312 lxc/auth.go:1313
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2082 lxc/auth.go:2083
+#: lxc/auth.go:2080 lxc/auth.go:2081
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -668,7 +665,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:521 lxc/auth.go:522
+#: lxc/auth.go:519 lxc/auth.go:520
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -1344,12 +1341,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:306 lxc/auth.go:1868
+#: lxc/auth.go:304 lxc/auth.go:1866
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1207
+#: lxc/auth.go:1205
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1378,7 +1375,7 @@ msgstr ""
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:776
+#: lxc/auth.go:774
 msgid "Create a TLS identity"
 msgstr ""
 
@@ -1398,7 +1395,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:775
+#: lxc/auth.go:773
 msgid "Create an identity"
 msgstr ""
 
@@ -1418,7 +1415,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1679 lxc/auth.go:1680
+#: lxc/auth.go:1677 lxc/auth.go:1678
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1526,7 +1523,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1569,7 +1566,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1237 lxc/auth.go:1238
+#: lxc/auth.go:1235 lxc/auth.go:1236
 msgid "Delete an identity"
 msgstr ""
 
@@ -1581,7 +1578,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1729 lxc/auth.go:1730
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1660,14 +1657,14 @@ msgstr ""
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
 #: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
-#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
-#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
-#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
-#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
-#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
-#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
-#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
+#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
+#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
+#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
+#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
+#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
+#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -1936,7 +1933,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1108 lxc/auth.go:1109
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1952,7 +1949,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1780 lxc/auth.go:1781
+#: lxc/auth.go:1778 lxc/auth.go:1779
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2438,7 +2435,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
@@ -2496,7 +2493,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:970 lxc/auth.go:1944
+#: lxc/auth.go:968 lxc/auth.go:1942
 msgid "GROUPS"
 msgstr ""
 
@@ -2655,7 +2652,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:432 lxc/auth.go:1994
+#: lxc/auth.go:430 lxc/auth.go:1992
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2714,7 +2711,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:969
+#: lxc/auth.go:967
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2746,16 +2743,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:829
+#: lxc/auth.go:827
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1716
+#: lxc/auth.go:1714
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1766
+#: lxc/auth.go:1764
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2884,7 +2881,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1441 lxc/auth.go:1442
+#: lxc/auth.go:1439 lxc/auth.go:1440
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3188,15 +3185,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:337 lxc/auth.go:338
+#: lxc/auth.go:335 lxc/auth.go:336
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:917 lxc/auth.go:918
+#: lxc/auth.go:915 lxc/auth.go:916
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1900
+#: lxc/auth.go:1897 lxc/auth.go:1898
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3351,7 +3348,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1463 lxc/auth.go:1464
+#: lxc/auth.go:1461 lxc/auth.go:1462
 msgid "List permissions"
 msgstr ""
 
@@ -3519,7 +3516,7 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:823
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
@@ -3553,19 +3550,19 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1291 lxc/auth.go:1292
+#: lxc/auth.go:1289 lxc/auth.go:1290
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:736 lxc/auth.go:737
+#: lxc/auth.go:734 lxc/auth.go:735
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2059 lxc/auth.go:2060
+#: lxc/auth.go:2057 lxc/auth.go:2058
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3656,7 +3653,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:498 lxc/auth.go:499
+#: lxc/auth.go:496 lxc/auth.go:497
 msgid "Manage permissions"
 msgstr ""
 
@@ -3805,21 +3802,21 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
-#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
-#: lxc/auth.go:1339 lxc/auth.go:1397
+#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
+#: lxc/auth.go:1337 lxc/auth.go:1395
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
+#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2107 lxc/auth.go:2160
+#: lxc/auth.go:2105 lxc/auth.go:2158
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4040,7 +4037,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
@@ -4444,7 +4441,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4803,7 +4800,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1372 lxc/auth.go:1373
+#: lxc/auth.go:1370 lxc/auth.go:1371
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4839,7 +4836,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2135 lxc/auth.go:2136
+#: lxc/auth.go:2133 lxc/auth.go:2134
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4851,7 +4848,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:580 lxc/auth.go:581
+#: lxc/auth.go:578 lxc/auth.go:579
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4896,11 +4893,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:397 lxc/auth.go:398
+#: lxc/auth.go:395 lxc/auth.go:396
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1959 lxc/auth.go:1960
+#: lxc/auth.go:1957 lxc/auth.go:1958
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5421,7 +5418,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2008 lxc/auth.go:2009
+#: lxc/auth.go:2006 lxc/auth.go:2007
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5449,11 +5446,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:446 lxc/auth.go:447
+#: lxc/auth.go:444 lxc/auth.go:445
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:985
+#: lxc/auth.go:983
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5558,7 +5555,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1048
+#: lxc/auth.go:1046
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5796,12 +5793,12 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:876
+#: lxc/auth.go:874
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:902
+#: lxc/auth.go:900
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
@@ -5810,7 +5807,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1747 lxc/warning.go:216
@@ -6482,11 +6479,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:984
+#: lxc/auth.go:982
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1047
+#: lxc/auth.go:1045
 msgid "View the current identity"
 msgstr ""
 
@@ -6557,7 +6554,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6590,7 +6587,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1462
+#: lxc/auth.go:1460
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6651,17 +6648,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:772
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:983 lxc/auth.go:1235
+#: lxc/auth.go:981 lxc/auth.go:1233
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6669,13 +6666,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
-#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
+#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:520 lxc/auth.go:578
+#: lxc/auth.go:518 lxc/auth.go:576
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6685,19 +6682,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:395
+#: lxc/auth.go:393
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
+#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2081
+#: lxc/auth.go:2079
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1957
+#: lxc/auth.go:1955
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7245,14 +7242,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1111
+#: lxc/auth.go:1109
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1783
+#: lxc/auth.go:1781
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-19 16:04-0700\n"
+"POT-Creation-Date: 2025-01-07 15:23+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -204,34 +204,7 @@ msgstr ""
 "###\n"
 "### Observe que o nome é exibido mas não pode ser modificado"
 
-#: lxc/auth.go:219
-msgid ""
-"### This is a YAML representation of the group.\n"
-"### Any line starting with a '# will be ignored.\n"
-"###\n"
-"### A group has the following format:\n"
-"### name: my-first-group\n"
-"### description: My first group.\n"
-"### permissions:\n"
-"### - entity_type: project\n"
-"###   url: /1.0/projects/default\n"
-"###   entitlement: can_view\n"
-"### identities:\n"
-"### - authentication_method: oidc\n"
-"###   type: OIDC client\n"
-"###   identifier: jane.doe@example.com\n"
-"###   name: Jane Doe\n"
-"###   metadata:\n"
-"###     subject: auth0|123456789\n"
-"### identity_provider_groups:\n"
-"### - sales\n"
-"### - operations\n"
-"###\n"
-"### Note that all group information is shown but only the description and "
-"permissions can be modified"
-msgstr ""
-
-#: lxc/auth.go:1121
+#: lxc/auth.go:1119
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -252,7 +225,31 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1793
+#: lxc/auth.go:219
+msgid ""
+"### This is a YAML representation of the group.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### NOTE: All group information is shown but only the description and "
+"permissions can be modified.\n"
+"### \n"
+"### name: my-first-group\n"
+"### description: My first group.\n"
+"### permissions:\n"
+"### - entity_type: project\n"
+"###   url: /1.0/projects/default\n"
+"###   entitlement: can_view\n"
+"### identities:\n"
+"###   oidc:\n"
+"###   - jane.doe@example.com\n"
+"###   tls:\n"
+"###   - eaa46a1b73827350e0543949fb161410c50e950d4cb9802fc58dbfbd5700e508\n"
+"### identity_provider_groups:\n"
+"### - sales\n"
+"### - operations\n"
+msgstr ""
+
+#: lxc/auth.go:1791
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -819,7 +816,7 @@ msgstr "ARQUITETURA"
 msgid "AUTH TYPE"
 msgstr "TIPO DE AUTENTICAÇÃO"
 
-#: lxc/auth.go:966
+#: lxc/auth.go:964
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -859,11 +856,11 @@ msgstr "Tipo de autenticação '%s' não suportada pelo servidor"
 msgid "Add a cluster member to a cluster group"
 msgstr "Nome de membro do cluster"
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1312 lxc/auth.go:1313
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2082 lxc/auth.go:2083
+#: lxc/auth.go:2080 lxc/auth.go:2081
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -935,7 +932,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:521 lxc/auth.go:522
+#: lxc/auth.go:519 lxc/auth.go:520
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -1639,12 +1636,12 @@ msgstr "Certificado fingerprint: %s"
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:306 lxc/auth.go:1868
+#: lxc/auth.go:304 lxc/auth.go:1866
 #, fuzzy, c-format
 msgid "Could not parse group: %s"
 msgstr "Erro de análise de configuração: %s"
 
-#: lxc/auth.go:1207
+#: lxc/auth.go:1205
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1673,7 +1670,7 @@ msgstr "Impossível criar diretório para certificado do servidor"
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:776
+#: lxc/auth.go:774
 #, fuzzy
 msgid "Create a TLS identity"
 msgstr "Editar configurações de rede como YAML"
@@ -1695,7 +1692,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:775
+#: lxc/auth.go:773
 #, fuzzy
 msgid "Create an identity"
 msgstr "Editar configurações de rede como YAML"
@@ -1718,7 +1715,7 @@ msgstr "Editar arquivos no container"
 msgid "Create groups"
 msgstr "Criar perfis"
 
-#: lxc/auth.go:1679 lxc/auth.go:1680
+#: lxc/auth.go:1677 lxc/auth.go:1678
 #, fuzzy
 msgid "Create identity provider groups"
 msgstr "Criar novas redes"
@@ -1841,7 +1838,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1886,7 +1883,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr "Apagar nomes alternativos da imagem"
 
-#: lxc/auth.go:1237 lxc/auth.go:1238
+#: lxc/auth.go:1235 lxc/auth.go:1236
 #, fuzzy
 msgid "Delete an identity"
 msgstr "Editar configurações de rede como YAML"
@@ -1901,7 +1898,7 @@ msgstr "Editar arquivos no container"
 msgid "Delete groups"
 msgstr "Apagar projetos"
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1729 lxc/auth.go:1730
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1989,14 +1986,14 @@ msgstr ""
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
 #: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
-#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
-#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
-#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
-#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
-#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
-#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
-#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
+#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
+#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
+#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
+#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
+#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
+#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -2274,7 +2271,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1108 lxc/auth.go:1109
+#: lxc/auth.go:1106 lxc/auth.go:1107
 #, fuzzy
 msgid "Edit an identity as YAML"
 msgstr "Editar configurações de rede como YAML"
@@ -2294,7 +2291,7 @@ msgstr "Editar arquivos no container"
 msgid "Edit groups as YAML"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/auth.go:1780 lxc/auth.go:1781
+#: lxc/auth.go:1778 lxc/auth.go:1779
 #, fuzzy
 msgid "Edit identity provider groups as YAML"
 msgstr "Editar configurações de perfil como YAML"
@@ -2796,7 +2793,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
@@ -2854,7 +2851,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:970 lxc/auth.go:1944
+#: lxc/auth.go:968 lxc/auth.go:1942
 msgid "GROUPS"
 msgstr ""
 
@@ -3033,7 +3030,7 @@ msgstr "Clustering ativado"
 msgid "Group %s deleted"
 msgstr "Clustering ativado"
 
-#: lxc/auth.go:432 lxc/auth.go:1994
+#: lxc/auth.go:430 lxc/auth.go:1992
 #, fuzzy, c-format
 msgid "Group %s renamed to %s"
 msgstr "Dispositivo %s adicionado a %s"
@@ -3092,7 +3089,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:969
+#: lxc/auth.go:967
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -3124,16 +3121,16 @@ msgstr "IPV6"
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:829
+#: lxc/auth.go:827
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1716
+#: lxc/auth.go:1714
 #, fuzzy, c-format
 msgid "Identity provider group %s created"
 msgstr "Clustering ativado"
 
-#: lxc/auth.go:1766
+#: lxc/auth.go:1764
 #, fuzzy, c-format
 msgid "Identity provider group %s deleted"
 msgstr "Clustering ativado"
@@ -3264,7 +3261,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1441 lxc/auth.go:1442
+#: lxc/auth.go:1439 lxc/auth.go:1440
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3576,15 +3573,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:337 lxc/auth.go:338
+#: lxc/auth.go:335 lxc/auth.go:336
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:917 lxc/auth.go:918
+#: lxc/auth.go:915 lxc/auth.go:916
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1900
+#: lxc/auth.go:1897 lxc/auth.go:1898
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3742,7 +3739,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr "Criar projetos"
 
-#: lxc/auth.go:1463 lxc/auth.go:1464
+#: lxc/auth.go:1461 lxc/auth.go:1462
 msgid "List permissions"
 msgstr ""
 
@@ -3912,7 +3909,7 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:823
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
@@ -3949,21 +3946,21 @@ msgstr "Editar arquivos no container"
 msgid "Manage files in instances"
 msgstr "Editar arquivos no container"
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
 #, fuzzy
 msgid "Manage groups"
 msgstr "Editar arquivos no container"
 
-#: lxc/auth.go:1291 lxc/auth.go:1292
+#: lxc/auth.go:1289 lxc/auth.go:1290
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:736 lxc/auth.go:737
+#: lxc/auth.go:734 lxc/auth.go:735
 #, fuzzy
 msgid "Manage identities"
 msgstr "Editar arquivos no container"
 
-#: lxc/auth.go:2059 lxc/auth.go:2060
+#: lxc/auth.go:2057 lxc/auth.go:2058
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -4068,7 +4065,7 @@ msgstr "Criar novas redes"
 msgid "Manage network zones"
 msgstr "Criar novas redes"
 
-#: lxc/auth.go:498 lxc/auth.go:499
+#: lxc/auth.go:496 lxc/auth.go:497
 #, fuzzy
 msgid "Manage permissions"
 msgstr "Editar arquivos no container"
@@ -4228,24 +4225,24 @@ msgstr "Nome de membro do cluster"
 msgid "Missing cluster member name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
-#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
 #, fuzzy
 msgid "Missing group name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
-#: lxc/auth.go:1339 lxc/auth.go:1397
+#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
+#: lxc/auth.go:1337 lxc/auth.go:1395
 #, fuzzy
 msgid "Missing identity argument"
 msgstr "Nome de membro do cluster"
 
-#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
+#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
 #, fuzzy
 msgid "Missing identity provider group name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/auth.go:2107 lxc/auth.go:2160
+#: lxc/auth.go:2105 lxc/auth.go:2158
 #, fuzzy
 msgid "Missing identity provider group name argument"
 msgstr "Nome de membro do cluster"
@@ -4476,7 +4473,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
@@ -4881,7 +4878,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -5251,7 +5248,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr "Nome de membro do cluster"
 
-#: lxc/auth.go:1372 lxc/auth.go:1373
+#: lxc/auth.go:1370 lxc/auth.go:1371
 #, fuzzy
 msgid "Remove a group from an identity"
 msgstr "Adicionar perfis aos containers"
@@ -5292,7 +5289,7 @@ msgstr "Nome de membro do cluster"
 msgid "Remove entries from a network zone record"
 msgstr "Adicionar perfis aos containers"
 
-#: lxc/auth.go:2135 lxc/auth.go:2136
+#: lxc/auth.go:2133 lxc/auth.go:2134
 #, fuzzy
 msgid "Remove identities from groups"
 msgstr "Adicionar perfis aos containers"
@@ -5305,7 +5302,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:580 lxc/auth.go:581
+#: lxc/auth.go:578 lxc/auth.go:579
 #, fuzzy
 msgid "Remove permissions from groups"
 msgstr "Adicionar perfis aos containers"
@@ -5357,11 +5354,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:397 lxc/auth.go:398
+#: lxc/auth.go:395 lxc/auth.go:396
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1959 lxc/auth.go:1960
+#: lxc/auth.go:1957 lxc/auth.go:1958
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5913,7 +5910,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2008 lxc/auth.go:2009
+#: lxc/auth.go:2006 lxc/auth.go:2007
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5944,12 +5941,12 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr "Adicionar dispositivos aos containers ou perfis"
 
-#: lxc/auth.go:446 lxc/auth.go:447
+#: lxc/auth.go:444 lxc/auth.go:445
 #, fuzzy
 msgid "Show group configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/auth.go:985
+#: lxc/auth.go:983
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -6069,7 +6066,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/auth.go:1048
+#: lxc/auth.go:1046
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -6311,12 +6308,12 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:876
+#: lxc/auth.go:874
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:902
+#: lxc/auth.go:900
 #, fuzzy, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr "Certificado fingerprint: %s"
@@ -6325,7 +6322,7 @@ msgstr "Certificado fingerprint: %s"
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1747 lxc/warning.go:216
@@ -7032,11 +7029,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr "Em cache: %s"
 
-#: lxc/auth.go:984
+#: lxc/auth.go:982
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1047
+#: lxc/auth.go:1045
 msgid "View the current identity"
 msgstr ""
 
@@ -7108,7 +7105,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "Criar perfis"
 
-#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -7144,7 +7141,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1462
+#: lxc/auth.go:1460
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -7215,17 +7212,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:772
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:983 lxc/auth.go:1235
+#: lxc/auth.go:981 lxc/auth.go:1233
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -7234,14 +7231,14 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr "Criar perfis"
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
-#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
+#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 #, fuzzy
 msgid "[<remote>:]<group>"
 msgstr "Criar perfis"
 
-#: lxc/auth.go:520 lxc/auth.go:578
+#: lxc/auth.go:518 lxc/auth.go:576
 #, fuzzy
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
@@ -7253,22 +7250,22 @@ msgstr "Criar perfis"
 msgid "[<remote>:]<group> <new-name>"
 msgstr "Criar perfis"
 
-#: lxc/auth.go:395
+#: lxc/auth.go:393
 #, fuzzy
 msgid "[<remote>:]<group> <new_name>"
 msgstr "Criar perfis"
 
-#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
+#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group>"
 msgstr "Criar perfis"
 
-#: lxc/auth.go:2081
+#: lxc/auth.go:2079
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/auth.go:1957
+#: lxc/auth.go:1955
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr "Criar perfis"
@@ -7871,14 +7868,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1111
+#: lxc/auth.go:1109
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1783
+#: lxc/auth.go:1781
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-19 16:04-0700\n"
+"POT-Creation-Date: 2025-01-07 15:23+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -208,34 +208,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что имя отображается, но не может быть изменено"
 
-#: lxc/auth.go:219
-msgid ""
-"### This is a YAML representation of the group.\n"
-"### Any line starting with a '# will be ignored.\n"
-"###\n"
-"### A group has the following format:\n"
-"### name: my-first-group\n"
-"### description: My first group.\n"
-"### permissions:\n"
-"### - entity_type: project\n"
-"###   url: /1.0/projects/default\n"
-"###   entitlement: can_view\n"
-"### identities:\n"
-"### - authentication_method: oidc\n"
-"###   type: OIDC client\n"
-"###   identifier: jane.doe@example.com\n"
-"###   name: Jane Doe\n"
-"###   metadata:\n"
-"###     subject: auth0|123456789\n"
-"### identity_provider_groups:\n"
-"### - sales\n"
-"### - operations\n"
-"###\n"
-"### Note that all group information is shown but only the description and "
-"permissions can be modified"
-msgstr ""
-
-#: lxc/auth.go:1121
+#: lxc/auth.go:1119
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -256,7 +229,31 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1793
+#: lxc/auth.go:219
+msgid ""
+"### This is a YAML representation of the group.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### NOTE: All group information is shown but only the description and "
+"permissions can be modified.\n"
+"### \n"
+"### name: my-first-group\n"
+"### description: My first group.\n"
+"### permissions:\n"
+"### - entity_type: project\n"
+"###   url: /1.0/projects/default\n"
+"###   entitlement: can_view\n"
+"### identities:\n"
+"###   oidc:\n"
+"###   - jane.doe@example.com\n"
+"###   tls:\n"
+"###   - eaa46a1b73827350e0543949fb161410c50e950d4cb9802fc58dbfbd5700e508\n"
+"### identity_provider_groups:\n"
+"### - sales\n"
+"### - operations\n"
+msgstr ""
+
+#: lxc/auth.go:1791
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -823,7 +820,7 @@ msgstr "АРХИТЕКТУРА"
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:966
+#: lxc/auth.go:964
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -862,11 +859,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1312 lxc/auth.go:1313
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2082 lxc/auth.go:2083
+#: lxc/auth.go:2080 lxc/auth.go:2081
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -938,7 +935,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:521 lxc/auth.go:522
+#: lxc/auth.go:519 lxc/auth.go:520
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -1630,12 +1627,12 @@ msgstr "Не удалось очистить путь %s"
 msgid "Could not find certificate key file path: %s"
 msgstr "Не удалось очистить путь %s"
 
-#: lxc/auth.go:306 lxc/auth.go:1868
+#: lxc/auth.go:304 lxc/auth.go:1866
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1207
+#: lxc/auth.go:1205
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1664,7 +1661,7 @@ msgstr "Не удалось создать каталог сертификата
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:776
+#: lxc/auth.go:774
 msgid "Create a TLS identity"
 msgstr ""
 
@@ -1686,7 +1683,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/auth.go:775
+#: lxc/auth.go:773
 #, fuzzy
 msgid "Create an identity"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -1709,7 +1706,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Create groups"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:1679 lxc/auth.go:1680
+#: lxc/auth.go:1677 lxc/auth.go:1678
 #, fuzzy
 msgid "Create identity provider groups"
 msgstr "Копирование образа: %s"
@@ -1832,7 +1829,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1875,7 +1872,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1237 lxc/auth.go:1238
+#: lxc/auth.go:1235 lxc/auth.go:1236
 msgid "Delete an identity"
 msgstr ""
 
@@ -1889,7 +1886,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Delete groups"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1729 lxc/auth.go:1730
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1976,14 +1973,14 @@ msgstr ""
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
 #: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
-#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
-#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
-#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
-#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
-#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
-#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
-#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
+#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
+#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
+#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
+#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
+#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
+#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -2260,7 +2257,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1108 lxc/auth.go:1109
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -2276,7 +2273,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1780 lxc/auth.go:1781
+#: lxc/auth.go:1778 lxc/auth.go:1779
 #, fuzzy
 msgid "Edit identity provider groups as YAML"
 msgstr "Копирование образа: %s"
@@ -2781,7 +2778,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
@@ -2839,7 +2836,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:970 lxc/auth.go:1944
+#: lxc/auth.go:968 lxc/auth.go:1942
 msgid "GROUPS"
 msgstr ""
 
@@ -3014,7 +3011,7 @@ msgstr " Использование сети:"
 msgid "Group %s deleted"
 msgstr " Использование сети:"
 
-#: lxc/auth.go:432 lxc/auth.go:1994
+#: lxc/auth.go:430 lxc/auth.go:1992
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -3074,7 +3071,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:969
+#: lxc/auth.go:967
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -3106,16 +3103,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:829
+#: lxc/auth.go:827
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1716
+#: lxc/auth.go:1714
 #, fuzzy, c-format
 msgid "Identity provider group %s created"
 msgstr " Использование сети:"
 
-#: lxc/auth.go:1766
+#: lxc/auth.go:1764
 #, fuzzy, c-format
 msgid "Identity provider group %s deleted"
 msgstr " Использование сети:"
@@ -3248,7 +3245,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1441 lxc/auth.go:1442
+#: lxc/auth.go:1439 lxc/auth.go:1440
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3565,16 +3562,16 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:337 lxc/auth.go:338
+#: lxc/auth.go:335 lxc/auth.go:336
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:917 lxc/auth.go:918
+#: lxc/auth.go:915 lxc/auth.go:916
 #, fuzzy
 msgid "List identities"
 msgstr "Псевдонимы:"
 
-#: lxc/auth.go:1899 lxc/auth.go:1900
+#: lxc/auth.go:1897 lxc/auth.go:1898
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3733,7 +3730,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:1463 lxc/auth.go:1464
+#: lxc/auth.go:1461 lxc/auth.go:1462
 #, fuzzy
 msgid "List permissions"
 msgstr "Псевдонимы:"
@@ -3908,7 +3905,7 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:823
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
@@ -3945,21 +3942,21 @@ msgstr "Копирование образа: %s"
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
 #, fuzzy
 msgid "Manage groups"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:1291 lxc/auth.go:1292
+#: lxc/auth.go:1289 lxc/auth.go:1290
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:736 lxc/auth.go:737
+#: lxc/auth.go:734 lxc/auth.go:735
 #, fuzzy
 msgid "Manage identities"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:2059 lxc/auth.go:2060
+#: lxc/auth.go:2057 lxc/auth.go:2058
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -4063,7 +4060,7 @@ msgstr "Копирование образа: %s"
 msgid "Manage network zones"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:498 lxc/auth.go:499
+#: lxc/auth.go:496 lxc/auth.go:497
 #, fuzzy
 msgid "Manage permissions"
 msgstr "Копирование образа: %s"
@@ -4226,24 +4223,24 @@ msgstr "Копирование образа: %s"
 msgid "Missing cluster member name"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
-#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
 #, fuzzy
 msgid "Missing group name"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
-#: lxc/auth.go:1339 lxc/auth.go:1397
+#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
+#: lxc/auth.go:1337 lxc/auth.go:1395
 #, fuzzy
 msgid "Missing identity argument"
 msgstr "Имя контейнера: %s"
 
-#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
+#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
 #, fuzzy
 msgid "Missing identity provider group name"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:2107 lxc/auth.go:2160
+#: lxc/auth.go:2105 lxc/auth.go:2158
 #, fuzzy
 msgid "Missing identity provider group name argument"
 msgstr "Копирование образа: %s"
@@ -4478,7 +4475,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
@@ -4887,7 +4884,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -5252,7 +5249,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:1372 lxc/auth.go:1373
+#: lxc/auth.go:1370 lxc/auth.go:1371
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -5291,7 +5288,7 @@ msgstr "Копирование образа: %s"
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2135 lxc/auth.go:2136
+#: lxc/auth.go:2133 lxc/auth.go:2134
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -5304,7 +5301,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:580 lxc/auth.go:581
+#: lxc/auth.go:578 lxc/auth.go:579
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -5351,12 +5348,12 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:397 lxc/auth.go:398
+#: lxc/auth.go:395 lxc/auth.go:396
 #, fuzzy
 msgid "Rename groups"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:1959 lxc/auth.go:1960
+#: lxc/auth.go:1957 lxc/auth.go:1958
 #, fuzzy
 msgid "Rename identity provider groups"
 msgstr "Копирование образа: %s"
@@ -5904,7 +5901,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2008 lxc/auth.go:2009
+#: lxc/auth.go:2006 lxc/auth.go:2007
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5934,12 +5931,12 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:446 lxc/auth.go:447
+#: lxc/auth.go:444 lxc/auth.go:445
 #, fuzzy
 msgid "Show group configurations"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:985
+#: lxc/auth.go:983
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -6056,7 +6053,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr "Копирование образа: %s"
 
-#: lxc/auth.go:1048
+#: lxc/auth.go:1046
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -6302,12 +6299,12 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:876
+#: lxc/auth.go:874
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:902
+#: lxc/auth.go:900
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
@@ -6316,7 +6313,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1747 lxc/warning.go:216
@@ -7012,11 +7009,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:984
+#: lxc/auth.go:982
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1047
+#: lxc/auth.go:1045
 msgid "View the current identity"
 msgstr ""
 
@@ -7095,7 +7092,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -7156,7 +7153,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:1462
+#: lxc/auth.go:1460
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -7273,17 +7270,17 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:774
+#: lxc/auth.go:772
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:983 lxc/auth.go:1235
+#: lxc/auth.go:981 lxc/auth.go:1233
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -7295,8 +7292,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
-#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
+#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 #, fuzzy
 msgid "[<remote>:]<group>"
@@ -7305,7 +7302,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:520 lxc/auth.go:578
+#: lxc/auth.go:518 lxc/auth.go:576
 #, fuzzy
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
@@ -7323,7 +7320,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:395
+#: lxc/auth.go:393
 #, fuzzy
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
@@ -7331,7 +7328,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
+#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
@@ -7339,7 +7336,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:2081
+#: lxc/auth.go:2079
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
@@ -7347,7 +7344,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/auth.go:1957
+#: lxc/auth.go:1955
 #, fuzzy
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
@@ -8359,14 +8356,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1111
+#: lxc/auth.go:1109
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1783
+#: lxc/auth.go:1781
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-19 16:04-0700\n"
+"POT-Creation-Date: 2025-01-07 15:23+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -133,34 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:219
-msgid ""
-"### This is a YAML representation of the group.\n"
-"### Any line starting with a '# will be ignored.\n"
-"###\n"
-"### A group has the following format:\n"
-"### name: my-first-group\n"
-"### description: My first group.\n"
-"### permissions:\n"
-"### - entity_type: project\n"
-"###   url: /1.0/projects/default\n"
-"###   entitlement: can_view\n"
-"### identities:\n"
-"### - authentication_method: oidc\n"
-"###   type: OIDC client\n"
-"###   identifier: jane.doe@example.com\n"
-"###   name: Jane Doe\n"
-"###   metadata:\n"
-"###     subject: auth0|123456789\n"
-"### identity_provider_groups:\n"
-"### - sales\n"
-"### - operations\n"
-"###\n"
-"### Note that all group information is shown but only the description and "
-"permissions can be modified"
-msgstr ""
-
-#: lxc/auth.go:1121
+#: lxc/auth.go:1119
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +154,31 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1793
+#: lxc/auth.go:219
+msgid ""
+"### This is a YAML representation of the group.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### NOTE: All group information is shown but only the description and "
+"permissions can be modified.\n"
+"### \n"
+"### name: my-first-group\n"
+"### description: My first group.\n"
+"### permissions:\n"
+"### - entity_type: project\n"
+"###   url: /1.0/projects/default\n"
+"###   entitlement: can_view\n"
+"### identities:\n"
+"###   oidc:\n"
+"###   - jane.doe@example.com\n"
+"###   tls:\n"
+"###   - eaa46a1b73827350e0543949fb161410c50e950d4cb9802fc58dbfbd5700e508\n"
+"### identity_provider_groups:\n"
+"### - sales\n"
+"### - operations\n"
+msgstr ""
+
+#: lxc/auth.go:1791
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -560,7 +557,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:966
+#: lxc/auth.go:964
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -598,11 +595,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1312 lxc/auth.go:1313
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2082 lxc/auth.go:2083
+#: lxc/auth.go:2080 lxc/auth.go:2081
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -671,7 +668,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:521 lxc/auth.go:522
+#: lxc/auth.go:519 lxc/auth.go:520
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -1347,12 +1344,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:306 lxc/auth.go:1868
+#: lxc/auth.go:304 lxc/auth.go:1866
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1207
+#: lxc/auth.go:1205
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1381,7 +1378,7 @@ msgstr ""
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:776
+#: lxc/auth.go:774
 msgid "Create a TLS identity"
 msgstr ""
 
@@ -1401,7 +1398,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:775
+#: lxc/auth.go:773
 msgid "Create an identity"
 msgstr ""
 
@@ -1421,7 +1418,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1679 lxc/auth.go:1680
+#: lxc/auth.go:1677 lxc/auth.go:1678
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1529,7 +1526,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1572,7 +1569,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1237 lxc/auth.go:1238
+#: lxc/auth.go:1235 lxc/auth.go:1236
 msgid "Delete an identity"
 msgstr ""
 
@@ -1584,7 +1581,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1729 lxc/auth.go:1730
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1663,14 +1660,14 @@ msgstr ""
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
 #: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
-#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
-#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
-#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
-#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
-#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
-#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
-#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
+#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
+#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
+#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
+#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
+#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
+#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -1939,7 +1936,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1108 lxc/auth.go:1109
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1955,7 +1952,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1780 lxc/auth.go:1781
+#: lxc/auth.go:1778 lxc/auth.go:1779
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2441,7 +2438,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
@@ -2499,7 +2496,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:970 lxc/auth.go:1944
+#: lxc/auth.go:968 lxc/auth.go:1942
 msgid "GROUPS"
 msgstr ""
 
@@ -2658,7 +2655,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:432 lxc/auth.go:1994
+#: lxc/auth.go:430 lxc/auth.go:1992
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2717,7 +2714,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:969
+#: lxc/auth.go:967
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2749,16 +2746,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:829
+#: lxc/auth.go:827
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1716
+#: lxc/auth.go:1714
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1766
+#: lxc/auth.go:1764
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2887,7 +2884,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1441 lxc/auth.go:1442
+#: lxc/auth.go:1439 lxc/auth.go:1440
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3191,15 +3188,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:337 lxc/auth.go:338
+#: lxc/auth.go:335 lxc/auth.go:336
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:917 lxc/auth.go:918
+#: lxc/auth.go:915 lxc/auth.go:916
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1900
+#: lxc/auth.go:1897 lxc/auth.go:1898
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3354,7 +3351,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1463 lxc/auth.go:1464
+#: lxc/auth.go:1461 lxc/auth.go:1462
 msgid "List permissions"
 msgstr ""
 
@@ -3522,7 +3519,7 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:823
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
@@ -3556,19 +3553,19 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1291 lxc/auth.go:1292
+#: lxc/auth.go:1289 lxc/auth.go:1290
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:736 lxc/auth.go:737
+#: lxc/auth.go:734 lxc/auth.go:735
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2059 lxc/auth.go:2060
+#: lxc/auth.go:2057 lxc/auth.go:2058
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3659,7 +3656,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:498 lxc/auth.go:499
+#: lxc/auth.go:496 lxc/auth.go:497
 msgid "Manage permissions"
 msgstr ""
 
@@ -3808,21 +3805,21 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
-#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
-#: lxc/auth.go:1339 lxc/auth.go:1397
+#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
+#: lxc/auth.go:1337 lxc/auth.go:1395
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
+#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2107 lxc/auth.go:2160
+#: lxc/auth.go:2105 lxc/auth.go:2158
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4043,7 +4040,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
@@ -4447,7 +4444,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4806,7 +4803,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1372 lxc/auth.go:1373
+#: lxc/auth.go:1370 lxc/auth.go:1371
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4842,7 +4839,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2135 lxc/auth.go:2136
+#: lxc/auth.go:2133 lxc/auth.go:2134
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4854,7 +4851,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:580 lxc/auth.go:581
+#: lxc/auth.go:578 lxc/auth.go:579
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4899,11 +4896,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:397 lxc/auth.go:398
+#: lxc/auth.go:395 lxc/auth.go:396
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1959 lxc/auth.go:1960
+#: lxc/auth.go:1957 lxc/auth.go:1958
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5424,7 +5421,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2008 lxc/auth.go:2009
+#: lxc/auth.go:2006 lxc/auth.go:2007
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5452,11 +5449,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:446 lxc/auth.go:447
+#: lxc/auth.go:444 lxc/auth.go:445
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:985
+#: lxc/auth.go:983
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5561,7 +5558,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1048
+#: lxc/auth.go:1046
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5799,12 +5796,12 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:876
+#: lxc/auth.go:874
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:902
+#: lxc/auth.go:900
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
@@ -5813,7 +5810,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1747 lxc/warning.go:216
@@ -6485,11 +6482,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:984
+#: lxc/auth.go:982
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1047
+#: lxc/auth.go:1045
 msgid "View the current identity"
 msgstr ""
 
@@ -6560,7 +6557,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6593,7 +6590,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1462
+#: lxc/auth.go:1460
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6654,17 +6651,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:772
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:983 lxc/auth.go:1235
+#: lxc/auth.go:981 lxc/auth.go:1233
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6672,13 +6669,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
-#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
+#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:520 lxc/auth.go:578
+#: lxc/auth.go:518 lxc/auth.go:576
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6688,19 +6685,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:395
+#: lxc/auth.go:393
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
+#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2081
+#: lxc/auth.go:2079
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1957
+#: lxc/auth.go:1955
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7248,14 +7245,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1111
+#: lxc/auth.go:1109
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1783
+#: lxc/auth.go:1781
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-19 16:04-0700\n"
+"POT-Creation-Date: 2025-01-07 15:23+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -134,34 +134,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:219
-msgid ""
-"### This is a YAML representation of the group.\n"
-"### Any line starting with a '# will be ignored.\n"
-"###\n"
-"### A group has the following format:\n"
-"### name: my-first-group\n"
-"### description: My first group.\n"
-"### permissions:\n"
-"### - entity_type: project\n"
-"###   url: /1.0/projects/default\n"
-"###   entitlement: can_view\n"
-"### identities:\n"
-"### - authentication_method: oidc\n"
-"###   type: OIDC client\n"
-"###   identifier: jane.doe@example.com\n"
-"###   name: Jane Doe\n"
-"###   metadata:\n"
-"###     subject: auth0|123456789\n"
-"### identity_provider_groups:\n"
-"### - sales\n"
-"### - operations\n"
-"###\n"
-"### Note that all group information is shown but only the description and "
-"permissions can be modified"
-msgstr ""
-
-#: lxc/auth.go:1121
+#: lxc/auth.go:1119
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -182,7 +155,31 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1793
+#: lxc/auth.go:219
+msgid ""
+"### This is a YAML representation of the group.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### NOTE: All group information is shown but only the description and "
+"permissions can be modified.\n"
+"### \n"
+"### name: my-first-group\n"
+"### description: My first group.\n"
+"### permissions:\n"
+"### - entity_type: project\n"
+"###   url: /1.0/projects/default\n"
+"###   entitlement: can_view\n"
+"### identities:\n"
+"###   oidc:\n"
+"###   - jane.doe@example.com\n"
+"###   tls:\n"
+"###   - eaa46a1b73827350e0543949fb161410c50e950d4cb9802fc58dbfbd5700e508\n"
+"### identity_provider_groups:\n"
+"### - sales\n"
+"### - operations\n"
+msgstr ""
+
+#: lxc/auth.go:1791
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -561,7 +558,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:966
+#: lxc/auth.go:964
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -599,11 +596,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1312 lxc/auth.go:1313
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2082 lxc/auth.go:2083
+#: lxc/auth.go:2080 lxc/auth.go:2081
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -672,7 +669,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:521 lxc/auth.go:522
+#: lxc/auth.go:519 lxc/auth.go:520
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -1348,12 +1345,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:306 lxc/auth.go:1868
+#: lxc/auth.go:304 lxc/auth.go:1866
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1207
+#: lxc/auth.go:1205
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1382,7 +1379,7 @@ msgstr ""
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:776
+#: lxc/auth.go:774
 msgid "Create a TLS identity"
 msgstr ""
 
@@ -1402,7 +1399,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:775
+#: lxc/auth.go:773
 msgid "Create an identity"
 msgstr ""
 
@@ -1422,7 +1419,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1679 lxc/auth.go:1680
+#: lxc/auth.go:1677 lxc/auth.go:1678
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1530,7 +1527,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1573,7 +1570,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1237 lxc/auth.go:1238
+#: lxc/auth.go:1235 lxc/auth.go:1236
 msgid "Delete an identity"
 msgstr ""
 
@@ -1585,7 +1582,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1729 lxc/auth.go:1730
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1664,14 +1661,14 @@ msgstr ""
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
 #: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
-#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
-#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
-#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
-#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
-#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
-#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
-#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
+#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
+#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
+#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
+#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
+#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
+#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -1940,7 +1937,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1108 lxc/auth.go:1109
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1956,7 +1953,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1780 lxc/auth.go:1781
+#: lxc/auth.go:1778 lxc/auth.go:1779
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2442,7 +2439,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
@@ -2500,7 +2497,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:970 lxc/auth.go:1944
+#: lxc/auth.go:968 lxc/auth.go:1942
 msgid "GROUPS"
 msgstr ""
 
@@ -2659,7 +2656,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:432 lxc/auth.go:1994
+#: lxc/auth.go:430 lxc/auth.go:1992
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2718,7 +2715,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:969
+#: lxc/auth.go:967
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2750,16 +2747,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:829
+#: lxc/auth.go:827
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1716
+#: lxc/auth.go:1714
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1766
+#: lxc/auth.go:1764
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2888,7 +2885,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1441 lxc/auth.go:1442
+#: lxc/auth.go:1439 lxc/auth.go:1440
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3192,15 +3189,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:337 lxc/auth.go:338
+#: lxc/auth.go:335 lxc/auth.go:336
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:917 lxc/auth.go:918
+#: lxc/auth.go:915 lxc/auth.go:916
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1900
+#: lxc/auth.go:1897 lxc/auth.go:1898
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3355,7 +3352,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1463 lxc/auth.go:1464
+#: lxc/auth.go:1461 lxc/auth.go:1462
 msgid "List permissions"
 msgstr ""
 
@@ -3523,7 +3520,7 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:823
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
@@ -3557,19 +3554,19 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1291 lxc/auth.go:1292
+#: lxc/auth.go:1289 lxc/auth.go:1290
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:736 lxc/auth.go:737
+#: lxc/auth.go:734 lxc/auth.go:735
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2059 lxc/auth.go:2060
+#: lxc/auth.go:2057 lxc/auth.go:2058
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3660,7 +3657,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:498 lxc/auth.go:499
+#: lxc/auth.go:496 lxc/auth.go:497
 msgid "Manage permissions"
 msgstr ""
 
@@ -3809,21 +3806,21 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
-#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
-#: lxc/auth.go:1339 lxc/auth.go:1397
+#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
+#: lxc/auth.go:1337 lxc/auth.go:1395
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
+#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2107 lxc/auth.go:2160
+#: lxc/auth.go:2105 lxc/auth.go:2158
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4044,7 +4041,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
@@ -4448,7 +4445,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4807,7 +4804,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1372 lxc/auth.go:1373
+#: lxc/auth.go:1370 lxc/auth.go:1371
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4843,7 +4840,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2135 lxc/auth.go:2136
+#: lxc/auth.go:2133 lxc/auth.go:2134
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4855,7 +4852,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:580 lxc/auth.go:581
+#: lxc/auth.go:578 lxc/auth.go:579
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4900,11 +4897,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:397 lxc/auth.go:398
+#: lxc/auth.go:395 lxc/auth.go:396
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1959 lxc/auth.go:1960
+#: lxc/auth.go:1957 lxc/auth.go:1958
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5425,7 +5422,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2008 lxc/auth.go:2009
+#: lxc/auth.go:2006 lxc/auth.go:2007
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5453,11 +5450,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:446 lxc/auth.go:447
+#: lxc/auth.go:444 lxc/auth.go:445
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:985
+#: lxc/auth.go:983
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5562,7 +5559,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1048
+#: lxc/auth.go:1046
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5800,12 +5797,12 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:876
+#: lxc/auth.go:874
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:902
+#: lxc/auth.go:900
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
@@ -5814,7 +5811,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1747 lxc/warning.go:216
@@ -6486,11 +6483,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:984
+#: lxc/auth.go:982
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1047
+#: lxc/auth.go:1045
 msgid "View the current identity"
 msgstr ""
 
@@ -6561,7 +6558,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6594,7 +6591,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1462
+#: lxc/auth.go:1460
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6655,17 +6652,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:772
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:983 lxc/auth.go:1235
+#: lxc/auth.go:981 lxc/auth.go:1233
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6673,13 +6670,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
-#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
+#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:520 lxc/auth.go:578
+#: lxc/auth.go:518 lxc/auth.go:576
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6689,19 +6686,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:395
+#: lxc/auth.go:393
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
+#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2081
+#: lxc/auth.go:2079
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1957
+#: lxc/auth.go:1955
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7249,14 +7246,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1111
+#: lxc/auth.go:1109
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1783
+#: lxc/auth.go:1781
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-19 16:04-0700\n"
+"POT-Creation-Date: 2025-01-07 15:23+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -134,34 +134,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:219
-msgid ""
-"### This is a YAML representation of the group.\n"
-"### Any line starting with a '# will be ignored.\n"
-"###\n"
-"### A group has the following format:\n"
-"### name: my-first-group\n"
-"### description: My first group.\n"
-"### permissions:\n"
-"### - entity_type: project\n"
-"###   url: /1.0/projects/default\n"
-"###   entitlement: can_view\n"
-"### identities:\n"
-"### - authentication_method: oidc\n"
-"###   type: OIDC client\n"
-"###   identifier: jane.doe@example.com\n"
-"###   name: Jane Doe\n"
-"###   metadata:\n"
-"###     subject: auth0|123456789\n"
-"### identity_provider_groups:\n"
-"### - sales\n"
-"### - operations\n"
-"###\n"
-"### Note that all group information is shown but only the description and "
-"permissions can be modified"
-msgstr ""
-
-#: lxc/auth.go:1121
+#: lxc/auth.go:1119
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -182,7 +155,31 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1793
+#: lxc/auth.go:219
+msgid ""
+"### This is a YAML representation of the group.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### NOTE: All group information is shown but only the description and "
+"permissions can be modified.\n"
+"### \n"
+"### name: my-first-group\n"
+"### description: My first group.\n"
+"### permissions:\n"
+"### - entity_type: project\n"
+"###   url: /1.0/projects/default\n"
+"###   entitlement: can_view\n"
+"### identities:\n"
+"###   oidc:\n"
+"###   - jane.doe@example.com\n"
+"###   tls:\n"
+"###   - eaa46a1b73827350e0543949fb161410c50e950d4cb9802fc58dbfbd5700e508\n"
+"### identity_provider_groups:\n"
+"### - sales\n"
+"### - operations\n"
+msgstr ""
+
+#: lxc/auth.go:1791
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -561,7 +558,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:966
+#: lxc/auth.go:964
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -599,11 +596,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1312 lxc/auth.go:1313
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2082 lxc/auth.go:2083
+#: lxc/auth.go:2080 lxc/auth.go:2081
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -672,7 +669,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:521 lxc/auth.go:522
+#: lxc/auth.go:519 lxc/auth.go:520
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -1348,12 +1345,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:306 lxc/auth.go:1868
+#: lxc/auth.go:304 lxc/auth.go:1866
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1207
+#: lxc/auth.go:1205
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1382,7 +1379,7 @@ msgstr ""
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:776
+#: lxc/auth.go:774
 msgid "Create a TLS identity"
 msgstr ""
 
@@ -1402,7 +1399,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:775
+#: lxc/auth.go:773
 msgid "Create an identity"
 msgstr ""
 
@@ -1422,7 +1419,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1679 lxc/auth.go:1680
+#: lxc/auth.go:1677 lxc/auth.go:1678
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1530,7 +1527,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1573,7 +1570,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1237 lxc/auth.go:1238
+#: lxc/auth.go:1235 lxc/auth.go:1236
 msgid "Delete an identity"
 msgstr ""
 
@@ -1585,7 +1582,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1729 lxc/auth.go:1730
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1664,14 +1661,14 @@ msgstr ""
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
 #: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
-#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
-#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
-#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
-#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
-#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
-#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
-#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
+#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
+#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
+#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
+#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
+#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
+#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -1940,7 +1937,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1108 lxc/auth.go:1109
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1956,7 +1953,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1780 lxc/auth.go:1781
+#: lxc/auth.go:1778 lxc/auth.go:1779
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2442,7 +2439,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
@@ -2500,7 +2497,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:970 lxc/auth.go:1944
+#: lxc/auth.go:968 lxc/auth.go:1942
 msgid "GROUPS"
 msgstr ""
 
@@ -2659,7 +2656,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:432 lxc/auth.go:1994
+#: lxc/auth.go:430 lxc/auth.go:1992
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2718,7 +2715,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:969
+#: lxc/auth.go:967
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2750,16 +2747,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:829
+#: lxc/auth.go:827
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1716
+#: lxc/auth.go:1714
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1766
+#: lxc/auth.go:1764
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2888,7 +2885,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1441 lxc/auth.go:1442
+#: lxc/auth.go:1439 lxc/auth.go:1440
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3192,15 +3189,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:337 lxc/auth.go:338
+#: lxc/auth.go:335 lxc/auth.go:336
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:917 lxc/auth.go:918
+#: lxc/auth.go:915 lxc/auth.go:916
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1900
+#: lxc/auth.go:1897 lxc/auth.go:1898
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3355,7 +3352,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1463 lxc/auth.go:1464
+#: lxc/auth.go:1461 lxc/auth.go:1462
 msgid "List permissions"
 msgstr ""
 
@@ -3523,7 +3520,7 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:823
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
@@ -3557,19 +3554,19 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1291 lxc/auth.go:1292
+#: lxc/auth.go:1289 lxc/auth.go:1290
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:736 lxc/auth.go:737
+#: lxc/auth.go:734 lxc/auth.go:735
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2059 lxc/auth.go:2060
+#: lxc/auth.go:2057 lxc/auth.go:2058
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3660,7 +3657,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:498 lxc/auth.go:499
+#: lxc/auth.go:496 lxc/auth.go:497
 msgid "Manage permissions"
 msgstr ""
 
@@ -3809,21 +3806,21 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
-#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
-#: lxc/auth.go:1339 lxc/auth.go:1397
+#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
+#: lxc/auth.go:1337 lxc/auth.go:1395
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
+#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2107 lxc/auth.go:2160
+#: lxc/auth.go:2105 lxc/auth.go:2158
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4044,7 +4041,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
@@ -4448,7 +4445,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4807,7 +4804,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1372 lxc/auth.go:1373
+#: lxc/auth.go:1370 lxc/auth.go:1371
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4843,7 +4840,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2135 lxc/auth.go:2136
+#: lxc/auth.go:2133 lxc/auth.go:2134
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4855,7 +4852,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:580 lxc/auth.go:581
+#: lxc/auth.go:578 lxc/auth.go:579
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4900,11 +4897,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:397 lxc/auth.go:398
+#: lxc/auth.go:395 lxc/auth.go:396
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1959 lxc/auth.go:1960
+#: lxc/auth.go:1957 lxc/auth.go:1958
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5425,7 +5422,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2008 lxc/auth.go:2009
+#: lxc/auth.go:2006 lxc/auth.go:2007
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5453,11 +5450,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:446 lxc/auth.go:447
+#: lxc/auth.go:444 lxc/auth.go:445
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:985
+#: lxc/auth.go:983
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5562,7 +5559,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1048
+#: lxc/auth.go:1046
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5800,12 +5797,12 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:876
+#: lxc/auth.go:874
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:902
+#: lxc/auth.go:900
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
@@ -5814,7 +5811,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1747 lxc/warning.go:216
@@ -6486,11 +6483,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:984
+#: lxc/auth.go:982
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1047
+#: lxc/auth.go:1045
 msgid "View the current identity"
 msgstr ""
 
@@ -6561,7 +6558,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6594,7 +6591,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1462
+#: lxc/auth.go:1460
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6655,17 +6652,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:772
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:983 lxc/auth.go:1235
+#: lxc/auth.go:981 lxc/auth.go:1233
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6673,13 +6670,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
-#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
+#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:520 lxc/auth.go:578
+#: lxc/auth.go:518 lxc/auth.go:576
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6689,19 +6686,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:395
+#: lxc/auth.go:393
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
+#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2081
+#: lxc/auth.go:2079
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1957
+#: lxc/auth.go:1955
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7249,14 +7246,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1111
+#: lxc/auth.go:1109
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1783
+#: lxc/auth.go:1781
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-19 16:04-0700\n"
+"POT-Creation-Date: 2025-01-07 15:23+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -133,34 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:219
-msgid ""
-"### This is a YAML representation of the group.\n"
-"### Any line starting with a '# will be ignored.\n"
-"###\n"
-"### A group has the following format:\n"
-"### name: my-first-group\n"
-"### description: My first group.\n"
-"### permissions:\n"
-"### - entity_type: project\n"
-"###   url: /1.0/projects/default\n"
-"###   entitlement: can_view\n"
-"### identities:\n"
-"### - authentication_method: oidc\n"
-"###   type: OIDC client\n"
-"###   identifier: jane.doe@example.com\n"
-"###   name: Jane Doe\n"
-"###   metadata:\n"
-"###     subject: auth0|123456789\n"
-"### identity_provider_groups:\n"
-"### - sales\n"
-"### - operations\n"
-"###\n"
-"### Note that all group information is shown but only the description and "
-"permissions can be modified"
-msgstr ""
-
-#: lxc/auth.go:1121
+#: lxc/auth.go:1119
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +154,31 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1793
+#: lxc/auth.go:219
+msgid ""
+"### This is a YAML representation of the group.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### NOTE: All group information is shown but only the description and "
+"permissions can be modified.\n"
+"### \n"
+"### name: my-first-group\n"
+"### description: My first group.\n"
+"### permissions:\n"
+"### - entity_type: project\n"
+"###   url: /1.0/projects/default\n"
+"###   entitlement: can_view\n"
+"### identities:\n"
+"###   oidc:\n"
+"###   - jane.doe@example.com\n"
+"###   tls:\n"
+"###   - eaa46a1b73827350e0543949fb161410c50e950d4cb9802fc58dbfbd5700e508\n"
+"### identity_provider_groups:\n"
+"### - sales\n"
+"### - operations\n"
+msgstr ""
+
+#: lxc/auth.go:1791
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -560,7 +557,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:966
+#: lxc/auth.go:964
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -598,11 +595,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1312 lxc/auth.go:1313
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2082 lxc/auth.go:2083
+#: lxc/auth.go:2080 lxc/auth.go:2081
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -671,7 +668,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:521 lxc/auth.go:522
+#: lxc/auth.go:519 lxc/auth.go:520
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -1347,12 +1344,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:306 lxc/auth.go:1868
+#: lxc/auth.go:304 lxc/auth.go:1866
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1207
+#: lxc/auth.go:1205
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1381,7 +1378,7 @@ msgstr ""
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:776
+#: lxc/auth.go:774
 msgid "Create a TLS identity"
 msgstr ""
 
@@ -1401,7 +1398,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:775
+#: lxc/auth.go:773
 msgid "Create an identity"
 msgstr ""
 
@@ -1421,7 +1418,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1679 lxc/auth.go:1680
+#: lxc/auth.go:1677 lxc/auth.go:1678
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1529,7 +1526,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1572,7 +1569,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1237 lxc/auth.go:1238
+#: lxc/auth.go:1235 lxc/auth.go:1236
 msgid "Delete an identity"
 msgstr ""
 
@@ -1584,7 +1581,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1729 lxc/auth.go:1730
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1663,14 +1660,14 @@ msgstr ""
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
 #: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
-#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
-#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
-#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
-#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
-#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
-#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
-#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
+#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
+#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
+#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
+#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
+#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
+#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -1939,7 +1936,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1108 lxc/auth.go:1109
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1955,7 +1952,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1780 lxc/auth.go:1781
+#: lxc/auth.go:1778 lxc/auth.go:1779
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2441,7 +2438,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
@@ -2499,7 +2496,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:970 lxc/auth.go:1944
+#: lxc/auth.go:968 lxc/auth.go:1942
 msgid "GROUPS"
 msgstr ""
 
@@ -2658,7 +2655,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:432 lxc/auth.go:1994
+#: lxc/auth.go:430 lxc/auth.go:1992
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2717,7 +2714,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:969
+#: lxc/auth.go:967
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2749,16 +2746,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:829
+#: lxc/auth.go:827
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1716
+#: lxc/auth.go:1714
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1766
+#: lxc/auth.go:1764
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2887,7 +2884,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1441 lxc/auth.go:1442
+#: lxc/auth.go:1439 lxc/auth.go:1440
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3191,15 +3188,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:337 lxc/auth.go:338
+#: lxc/auth.go:335 lxc/auth.go:336
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:917 lxc/auth.go:918
+#: lxc/auth.go:915 lxc/auth.go:916
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1900
+#: lxc/auth.go:1897 lxc/auth.go:1898
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3354,7 +3351,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1463 lxc/auth.go:1464
+#: lxc/auth.go:1461 lxc/auth.go:1462
 msgid "List permissions"
 msgstr ""
 
@@ -3522,7 +3519,7 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:823
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
@@ -3556,19 +3553,19 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1291 lxc/auth.go:1292
+#: lxc/auth.go:1289 lxc/auth.go:1290
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:736 lxc/auth.go:737
+#: lxc/auth.go:734 lxc/auth.go:735
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2059 lxc/auth.go:2060
+#: lxc/auth.go:2057 lxc/auth.go:2058
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3659,7 +3656,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:498 lxc/auth.go:499
+#: lxc/auth.go:496 lxc/auth.go:497
 msgid "Manage permissions"
 msgstr ""
 
@@ -3808,21 +3805,21 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
-#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
-#: lxc/auth.go:1339 lxc/auth.go:1397
+#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
+#: lxc/auth.go:1337 lxc/auth.go:1395
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
+#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2107 lxc/auth.go:2160
+#: lxc/auth.go:2105 lxc/auth.go:2158
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4043,7 +4040,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
@@ -4447,7 +4444,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4806,7 +4803,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1372 lxc/auth.go:1373
+#: lxc/auth.go:1370 lxc/auth.go:1371
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4842,7 +4839,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2135 lxc/auth.go:2136
+#: lxc/auth.go:2133 lxc/auth.go:2134
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4854,7 +4851,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:580 lxc/auth.go:581
+#: lxc/auth.go:578 lxc/auth.go:579
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4899,11 +4896,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:397 lxc/auth.go:398
+#: lxc/auth.go:395 lxc/auth.go:396
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1959 lxc/auth.go:1960
+#: lxc/auth.go:1957 lxc/auth.go:1958
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5424,7 +5421,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2008 lxc/auth.go:2009
+#: lxc/auth.go:2006 lxc/auth.go:2007
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5452,11 +5449,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:446 lxc/auth.go:447
+#: lxc/auth.go:444 lxc/auth.go:445
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:985
+#: lxc/auth.go:983
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5561,7 +5558,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1048
+#: lxc/auth.go:1046
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5799,12 +5796,12 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:876
+#: lxc/auth.go:874
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:902
+#: lxc/auth.go:900
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
@@ -5813,7 +5810,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1747 lxc/warning.go:216
@@ -6485,11 +6482,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:984
+#: lxc/auth.go:982
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1047
+#: lxc/auth.go:1045
 msgid "View the current identity"
 msgstr ""
 
@@ -6560,7 +6557,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6593,7 +6590,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1462
+#: lxc/auth.go:1460
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6654,17 +6651,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:772
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:983 lxc/auth.go:1235
+#: lxc/auth.go:981 lxc/auth.go:1233
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6672,13 +6669,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
-#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
+#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:520 lxc/auth.go:578
+#: lxc/auth.go:518 lxc/auth.go:576
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6688,19 +6685,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:395
+#: lxc/auth.go:393
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
+#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2081
+#: lxc/auth.go:2079
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1957
+#: lxc/auth.go:1955
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7248,14 +7245,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1111
+#: lxc/auth.go:1109
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1783
+#: lxc/auth.go:1781
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-19 16:04-0700\n"
+"POT-Creation-Date: 2025-01-07 15:23+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -133,34 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:219
-msgid ""
-"### This is a YAML representation of the group.\n"
-"### Any line starting with a '# will be ignored.\n"
-"###\n"
-"### A group has the following format:\n"
-"### name: my-first-group\n"
-"### description: My first group.\n"
-"### permissions:\n"
-"### - entity_type: project\n"
-"###   url: /1.0/projects/default\n"
-"###   entitlement: can_view\n"
-"### identities:\n"
-"### - authentication_method: oidc\n"
-"###   type: OIDC client\n"
-"###   identifier: jane.doe@example.com\n"
-"###   name: Jane Doe\n"
-"###   metadata:\n"
-"###     subject: auth0|123456789\n"
-"### identity_provider_groups:\n"
-"### - sales\n"
-"### - operations\n"
-"###\n"
-"### Note that all group information is shown but only the description and "
-"permissions can be modified"
-msgstr ""
-
-#: lxc/auth.go:1121
+#: lxc/auth.go:1119
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +154,31 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1793
+#: lxc/auth.go:219
+msgid ""
+"### This is a YAML representation of the group.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### NOTE: All group information is shown but only the description and "
+"permissions can be modified.\n"
+"### \n"
+"### name: my-first-group\n"
+"### description: My first group.\n"
+"### permissions:\n"
+"### - entity_type: project\n"
+"###   url: /1.0/projects/default\n"
+"###   entitlement: can_view\n"
+"### identities:\n"
+"###   oidc:\n"
+"###   - jane.doe@example.com\n"
+"###   tls:\n"
+"###   - eaa46a1b73827350e0543949fb161410c50e950d4cb9802fc58dbfbd5700e508\n"
+"### identity_provider_groups:\n"
+"### - sales\n"
+"### - operations\n"
+msgstr ""
+
+#: lxc/auth.go:1791
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -560,7 +557,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:966
+#: lxc/auth.go:964
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -598,11 +595,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1312 lxc/auth.go:1313
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2082 lxc/auth.go:2083
+#: lxc/auth.go:2080 lxc/auth.go:2081
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -671,7 +668,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:521 lxc/auth.go:522
+#: lxc/auth.go:519 lxc/auth.go:520
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -1347,12 +1344,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:306 lxc/auth.go:1868
+#: lxc/auth.go:304 lxc/auth.go:1866
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1207
+#: lxc/auth.go:1205
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1381,7 +1378,7 @@ msgstr ""
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:776
+#: lxc/auth.go:774
 msgid "Create a TLS identity"
 msgstr ""
 
@@ -1401,7 +1398,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:775
+#: lxc/auth.go:773
 msgid "Create an identity"
 msgstr ""
 
@@ -1421,7 +1418,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1679 lxc/auth.go:1680
+#: lxc/auth.go:1677 lxc/auth.go:1678
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1529,7 +1526,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1572,7 +1569,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1237 lxc/auth.go:1238
+#: lxc/auth.go:1235 lxc/auth.go:1236
 msgid "Delete an identity"
 msgstr ""
 
@@ -1584,7 +1581,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1729 lxc/auth.go:1730
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1663,14 +1660,14 @@ msgstr ""
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
 #: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
-#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
-#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
-#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
-#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
-#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
-#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
-#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
+#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
+#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
+#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
+#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
+#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
+#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -1939,7 +1936,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1108 lxc/auth.go:1109
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1955,7 +1952,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1780 lxc/auth.go:1781
+#: lxc/auth.go:1778 lxc/auth.go:1779
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2441,7 +2438,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
@@ -2499,7 +2496,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:970 lxc/auth.go:1944
+#: lxc/auth.go:968 lxc/auth.go:1942
 msgid "GROUPS"
 msgstr ""
 
@@ -2658,7 +2655,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:432 lxc/auth.go:1994
+#: lxc/auth.go:430 lxc/auth.go:1992
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2717,7 +2714,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:969
+#: lxc/auth.go:967
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2749,16 +2746,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:829
+#: lxc/auth.go:827
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1716
+#: lxc/auth.go:1714
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1766
+#: lxc/auth.go:1764
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2887,7 +2884,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1441 lxc/auth.go:1442
+#: lxc/auth.go:1439 lxc/auth.go:1440
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3191,15 +3188,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:337 lxc/auth.go:338
+#: lxc/auth.go:335 lxc/auth.go:336
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:917 lxc/auth.go:918
+#: lxc/auth.go:915 lxc/auth.go:916
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1900
+#: lxc/auth.go:1897 lxc/auth.go:1898
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3354,7 +3351,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1463 lxc/auth.go:1464
+#: lxc/auth.go:1461 lxc/auth.go:1462
 msgid "List permissions"
 msgstr ""
 
@@ -3522,7 +3519,7 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:823
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
@@ -3556,19 +3553,19 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1291 lxc/auth.go:1292
+#: lxc/auth.go:1289 lxc/auth.go:1290
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:736 lxc/auth.go:737
+#: lxc/auth.go:734 lxc/auth.go:735
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2059 lxc/auth.go:2060
+#: lxc/auth.go:2057 lxc/auth.go:2058
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3659,7 +3656,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:498 lxc/auth.go:499
+#: lxc/auth.go:496 lxc/auth.go:497
 msgid "Manage permissions"
 msgstr ""
 
@@ -3808,21 +3805,21 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
-#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
-#: lxc/auth.go:1339 lxc/auth.go:1397
+#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
+#: lxc/auth.go:1337 lxc/auth.go:1395
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
+#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2107 lxc/auth.go:2160
+#: lxc/auth.go:2105 lxc/auth.go:2158
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4043,7 +4040,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
@@ -4447,7 +4444,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4806,7 +4803,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1372 lxc/auth.go:1373
+#: lxc/auth.go:1370 lxc/auth.go:1371
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4842,7 +4839,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2135 lxc/auth.go:2136
+#: lxc/auth.go:2133 lxc/auth.go:2134
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4854,7 +4851,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:580 lxc/auth.go:581
+#: lxc/auth.go:578 lxc/auth.go:579
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4899,11 +4896,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:397 lxc/auth.go:398
+#: lxc/auth.go:395 lxc/auth.go:396
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1959 lxc/auth.go:1960
+#: lxc/auth.go:1957 lxc/auth.go:1958
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5424,7 +5421,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2008 lxc/auth.go:2009
+#: lxc/auth.go:2006 lxc/auth.go:2007
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5452,11 +5449,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:446 lxc/auth.go:447
+#: lxc/auth.go:444 lxc/auth.go:445
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:985
+#: lxc/auth.go:983
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5561,7 +5558,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1048
+#: lxc/auth.go:1046
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5799,12 +5796,12 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:876
+#: lxc/auth.go:874
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:902
+#: lxc/auth.go:900
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
@@ -5813,7 +5810,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1747 lxc/warning.go:216
@@ -6485,11 +6482,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:984
+#: lxc/auth.go:982
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1047
+#: lxc/auth.go:1045
 msgid "View the current identity"
 msgstr ""
 
@@ -6560,7 +6557,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6593,7 +6590,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1462
+#: lxc/auth.go:1460
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6654,17 +6651,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:772
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:983 lxc/auth.go:1235
+#: lxc/auth.go:981 lxc/auth.go:1233
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6672,13 +6669,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
-#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
+#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:520 lxc/auth.go:578
+#: lxc/auth.go:518 lxc/auth.go:576
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6688,19 +6685,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:395
+#: lxc/auth.go:393
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
+#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2081
+#: lxc/auth.go:2079
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1957
+#: lxc/auth.go:1955
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7248,14 +7245,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1111
+#: lxc/auth.go:1109
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1783
+#: lxc/auth.go:1781
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/th.po
+++ b/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-19 16:04-0700\n"
+"POT-Creation-Date: 2025-01-07 15:23+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -130,34 +130,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:219
-msgid ""
-"### This is a YAML representation of the group.\n"
-"### Any line starting with a '# will be ignored.\n"
-"###\n"
-"### A group has the following format:\n"
-"### name: my-first-group\n"
-"### description: My first group.\n"
-"### permissions:\n"
-"### - entity_type: project\n"
-"###   url: /1.0/projects/default\n"
-"###   entitlement: can_view\n"
-"### identities:\n"
-"### - authentication_method: oidc\n"
-"###   type: OIDC client\n"
-"###   identifier: jane.doe@example.com\n"
-"###   name: Jane Doe\n"
-"###   metadata:\n"
-"###     subject: auth0|123456789\n"
-"### identity_provider_groups:\n"
-"### - sales\n"
-"### - operations\n"
-"###\n"
-"### Note that all group information is shown but only the description and "
-"permissions can be modified"
-msgstr ""
-
-#: lxc/auth.go:1121
+#: lxc/auth.go:1119
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -178,7 +151,31 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1793
+#: lxc/auth.go:219
+msgid ""
+"### This is a YAML representation of the group.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### NOTE: All group information is shown but only the description and "
+"permissions can be modified.\n"
+"### \n"
+"### name: my-first-group\n"
+"### description: My first group.\n"
+"### permissions:\n"
+"### - entity_type: project\n"
+"###   url: /1.0/projects/default\n"
+"###   entitlement: can_view\n"
+"### identities:\n"
+"###   oidc:\n"
+"###   - jane.doe@example.com\n"
+"###   tls:\n"
+"###   - eaa46a1b73827350e0543949fb161410c50e950d4cb9802fc58dbfbd5700e508\n"
+"### identity_provider_groups:\n"
+"### - sales\n"
+"### - operations\n"
+msgstr ""
+
+#: lxc/auth.go:1791
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -557,7 +554,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:966
+#: lxc/auth.go:964
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -595,11 +592,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1312 lxc/auth.go:1313
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2082 lxc/auth.go:2083
+#: lxc/auth.go:2080 lxc/auth.go:2081
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -668,7 +665,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:521 lxc/auth.go:522
+#: lxc/auth.go:519 lxc/auth.go:520
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -1344,12 +1341,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:306 lxc/auth.go:1868
+#: lxc/auth.go:304 lxc/auth.go:1866
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1207
+#: lxc/auth.go:1205
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1378,7 +1375,7 @@ msgstr ""
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:776
+#: lxc/auth.go:774
 msgid "Create a TLS identity"
 msgstr ""
 
@@ -1398,7 +1395,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:775
+#: lxc/auth.go:773
 msgid "Create an identity"
 msgstr ""
 
@@ -1418,7 +1415,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1679 lxc/auth.go:1680
+#: lxc/auth.go:1677 lxc/auth.go:1678
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1526,7 +1523,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1569,7 +1566,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1237 lxc/auth.go:1238
+#: lxc/auth.go:1235 lxc/auth.go:1236
 msgid "Delete an identity"
 msgstr ""
 
@@ -1581,7 +1578,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1729 lxc/auth.go:1730
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1660,14 +1657,14 @@ msgstr ""
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
 #: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
-#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
-#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
-#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
-#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
-#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
-#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
-#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
+#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
+#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
+#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
+#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
+#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
+#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -1936,7 +1933,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1108 lxc/auth.go:1109
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1952,7 +1949,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1780 lxc/auth.go:1781
+#: lxc/auth.go:1778 lxc/auth.go:1779
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2438,7 +2435,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
@@ -2496,7 +2493,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:970 lxc/auth.go:1944
+#: lxc/auth.go:968 lxc/auth.go:1942
 msgid "GROUPS"
 msgstr ""
 
@@ -2655,7 +2652,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:432 lxc/auth.go:1994
+#: lxc/auth.go:430 lxc/auth.go:1992
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2714,7 +2711,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:969
+#: lxc/auth.go:967
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2746,16 +2743,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:829
+#: lxc/auth.go:827
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1716
+#: lxc/auth.go:1714
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1766
+#: lxc/auth.go:1764
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2884,7 +2881,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1441 lxc/auth.go:1442
+#: lxc/auth.go:1439 lxc/auth.go:1440
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3188,15 +3185,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:337 lxc/auth.go:338
+#: lxc/auth.go:335 lxc/auth.go:336
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:917 lxc/auth.go:918
+#: lxc/auth.go:915 lxc/auth.go:916
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1900
+#: lxc/auth.go:1897 lxc/auth.go:1898
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3351,7 +3348,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1463 lxc/auth.go:1464
+#: lxc/auth.go:1461 lxc/auth.go:1462
 msgid "List permissions"
 msgstr ""
 
@@ -3519,7 +3516,7 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:823
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
@@ -3553,19 +3550,19 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1291 lxc/auth.go:1292
+#: lxc/auth.go:1289 lxc/auth.go:1290
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:736 lxc/auth.go:737
+#: lxc/auth.go:734 lxc/auth.go:735
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2059 lxc/auth.go:2060
+#: lxc/auth.go:2057 lxc/auth.go:2058
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3656,7 +3653,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:498 lxc/auth.go:499
+#: lxc/auth.go:496 lxc/auth.go:497
 msgid "Manage permissions"
 msgstr ""
 
@@ -3805,21 +3802,21 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
-#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
-#: lxc/auth.go:1339 lxc/auth.go:1397
+#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
+#: lxc/auth.go:1337 lxc/auth.go:1395
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
+#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2107 lxc/auth.go:2160
+#: lxc/auth.go:2105 lxc/auth.go:2158
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4040,7 +4037,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
@@ -4444,7 +4441,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4803,7 +4800,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1372 lxc/auth.go:1373
+#: lxc/auth.go:1370 lxc/auth.go:1371
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4839,7 +4836,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2135 lxc/auth.go:2136
+#: lxc/auth.go:2133 lxc/auth.go:2134
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4851,7 +4848,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:580 lxc/auth.go:581
+#: lxc/auth.go:578 lxc/auth.go:579
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4896,11 +4893,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:397 lxc/auth.go:398
+#: lxc/auth.go:395 lxc/auth.go:396
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1959 lxc/auth.go:1960
+#: lxc/auth.go:1957 lxc/auth.go:1958
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5421,7 +5418,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2008 lxc/auth.go:2009
+#: lxc/auth.go:2006 lxc/auth.go:2007
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5449,11 +5446,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:446 lxc/auth.go:447
+#: lxc/auth.go:444 lxc/auth.go:445
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:985
+#: lxc/auth.go:983
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5558,7 +5555,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1048
+#: lxc/auth.go:1046
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5796,12 +5793,12 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:876
+#: lxc/auth.go:874
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:902
+#: lxc/auth.go:900
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
@@ -5810,7 +5807,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1747 lxc/warning.go:216
@@ -6482,11 +6479,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:984
+#: lxc/auth.go:982
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1047
+#: lxc/auth.go:1045
 msgid "View the current identity"
 msgstr ""
 
@@ -6557,7 +6554,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6590,7 +6587,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1462
+#: lxc/auth.go:1460
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6651,17 +6648,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:772
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:983 lxc/auth.go:1235
+#: lxc/auth.go:981 lxc/auth.go:1233
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6669,13 +6666,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
-#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
+#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:520 lxc/auth.go:578
+#: lxc/auth.go:518 lxc/auth.go:576
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6685,19 +6682,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:395
+#: lxc/auth.go:393
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
+#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2081
+#: lxc/auth.go:2079
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1957
+#: lxc/auth.go:1955
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7245,14 +7242,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1111
+#: lxc/auth.go:1109
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1783
+#: lxc/auth.go:1781
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-19 16:04-0700\n"
+"POT-Creation-Date: 2025-01-07 15:23+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -133,34 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:219
-msgid ""
-"### This is a YAML representation of the group.\n"
-"### Any line starting with a '# will be ignored.\n"
-"###\n"
-"### A group has the following format:\n"
-"### name: my-first-group\n"
-"### description: My first group.\n"
-"### permissions:\n"
-"### - entity_type: project\n"
-"###   url: /1.0/projects/default\n"
-"###   entitlement: can_view\n"
-"### identities:\n"
-"### - authentication_method: oidc\n"
-"###   type: OIDC client\n"
-"###   identifier: jane.doe@example.com\n"
-"###   name: Jane Doe\n"
-"###   metadata:\n"
-"###     subject: auth0|123456789\n"
-"### identity_provider_groups:\n"
-"### - sales\n"
-"### - operations\n"
-"###\n"
-"### Note that all group information is shown but only the description and "
-"permissions can be modified"
-msgstr ""
-
-#: lxc/auth.go:1121
+#: lxc/auth.go:1119
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +154,31 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1793
+#: lxc/auth.go:219
+msgid ""
+"### This is a YAML representation of the group.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### NOTE: All group information is shown but only the description and "
+"permissions can be modified.\n"
+"### \n"
+"### name: my-first-group\n"
+"### description: My first group.\n"
+"### permissions:\n"
+"### - entity_type: project\n"
+"###   url: /1.0/projects/default\n"
+"###   entitlement: can_view\n"
+"### identities:\n"
+"###   oidc:\n"
+"###   - jane.doe@example.com\n"
+"###   tls:\n"
+"###   - eaa46a1b73827350e0543949fb161410c50e950d4cb9802fc58dbfbd5700e508\n"
+"### identity_provider_groups:\n"
+"### - sales\n"
+"### - operations\n"
+msgstr ""
+
+#: lxc/auth.go:1791
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -560,7 +557,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:966
+#: lxc/auth.go:964
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -598,11 +595,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1312 lxc/auth.go:1313
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2082 lxc/auth.go:2083
+#: lxc/auth.go:2080 lxc/auth.go:2081
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -671,7 +668,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:521 lxc/auth.go:522
+#: lxc/auth.go:519 lxc/auth.go:520
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -1347,12 +1344,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:306 lxc/auth.go:1868
+#: lxc/auth.go:304 lxc/auth.go:1866
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1207
+#: lxc/auth.go:1205
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1381,7 +1378,7 @@ msgstr ""
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:776
+#: lxc/auth.go:774
 msgid "Create a TLS identity"
 msgstr ""
 
@@ -1401,7 +1398,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:775
+#: lxc/auth.go:773
 msgid "Create an identity"
 msgstr ""
 
@@ -1421,7 +1418,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1679 lxc/auth.go:1680
+#: lxc/auth.go:1677 lxc/auth.go:1678
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1529,7 +1526,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1572,7 +1569,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1237 lxc/auth.go:1238
+#: lxc/auth.go:1235 lxc/auth.go:1236
 msgid "Delete an identity"
 msgstr ""
 
@@ -1584,7 +1581,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1729 lxc/auth.go:1730
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1663,14 +1660,14 @@ msgstr ""
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
 #: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
-#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
-#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
-#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
-#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
-#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
-#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
-#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
+#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
+#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
+#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
+#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
+#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
+#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -1939,7 +1936,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1108 lxc/auth.go:1109
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1955,7 +1952,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1780 lxc/auth.go:1781
+#: lxc/auth.go:1778 lxc/auth.go:1779
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2441,7 +2438,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
@@ -2499,7 +2496,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:970 lxc/auth.go:1944
+#: lxc/auth.go:968 lxc/auth.go:1942
 msgid "GROUPS"
 msgstr ""
 
@@ -2658,7 +2655,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:432 lxc/auth.go:1994
+#: lxc/auth.go:430 lxc/auth.go:1992
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2717,7 +2714,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:969
+#: lxc/auth.go:967
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2749,16 +2746,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:829
+#: lxc/auth.go:827
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1716
+#: lxc/auth.go:1714
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1766
+#: lxc/auth.go:1764
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2887,7 +2884,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1441 lxc/auth.go:1442
+#: lxc/auth.go:1439 lxc/auth.go:1440
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3191,15 +3188,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:337 lxc/auth.go:338
+#: lxc/auth.go:335 lxc/auth.go:336
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:917 lxc/auth.go:918
+#: lxc/auth.go:915 lxc/auth.go:916
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1900
+#: lxc/auth.go:1897 lxc/auth.go:1898
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3354,7 +3351,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1463 lxc/auth.go:1464
+#: lxc/auth.go:1461 lxc/auth.go:1462
 msgid "List permissions"
 msgstr ""
 
@@ -3522,7 +3519,7 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:823
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
@@ -3556,19 +3553,19 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1291 lxc/auth.go:1292
+#: lxc/auth.go:1289 lxc/auth.go:1290
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:736 lxc/auth.go:737
+#: lxc/auth.go:734 lxc/auth.go:735
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2059 lxc/auth.go:2060
+#: lxc/auth.go:2057 lxc/auth.go:2058
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3659,7 +3656,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:498 lxc/auth.go:499
+#: lxc/auth.go:496 lxc/auth.go:497
 msgid "Manage permissions"
 msgstr ""
 
@@ -3808,21 +3805,21 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
-#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
-#: lxc/auth.go:1339 lxc/auth.go:1397
+#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
+#: lxc/auth.go:1337 lxc/auth.go:1395
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
+#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2107 lxc/auth.go:2160
+#: lxc/auth.go:2105 lxc/auth.go:2158
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4043,7 +4040,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
@@ -4447,7 +4444,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4806,7 +4803,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1372 lxc/auth.go:1373
+#: lxc/auth.go:1370 lxc/auth.go:1371
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4842,7 +4839,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2135 lxc/auth.go:2136
+#: lxc/auth.go:2133 lxc/auth.go:2134
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4854,7 +4851,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:580 lxc/auth.go:581
+#: lxc/auth.go:578 lxc/auth.go:579
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4899,11 +4896,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:397 lxc/auth.go:398
+#: lxc/auth.go:395 lxc/auth.go:396
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1959 lxc/auth.go:1960
+#: lxc/auth.go:1957 lxc/auth.go:1958
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5424,7 +5421,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2008 lxc/auth.go:2009
+#: lxc/auth.go:2006 lxc/auth.go:2007
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5452,11 +5449,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:446 lxc/auth.go:447
+#: lxc/auth.go:444 lxc/auth.go:445
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:985
+#: lxc/auth.go:983
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5561,7 +5558,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1048
+#: lxc/auth.go:1046
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5799,12 +5796,12 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:876
+#: lxc/auth.go:874
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:902
+#: lxc/auth.go:900
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
@@ -5813,7 +5810,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1747 lxc/warning.go:216
@@ -6485,11 +6482,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:984
+#: lxc/auth.go:982
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1047
+#: lxc/auth.go:1045
 msgid "View the current identity"
 msgstr ""
 
@@ -6560,7 +6557,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6593,7 +6590,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1462
+#: lxc/auth.go:1460
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6654,17 +6651,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:772
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:983 lxc/auth.go:1235
+#: lxc/auth.go:981 lxc/auth.go:1233
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6672,13 +6669,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
-#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
+#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:520 lxc/auth.go:578
+#: lxc/auth.go:518 lxc/auth.go:576
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6688,19 +6685,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:395
+#: lxc/auth.go:393
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
+#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2081
+#: lxc/auth.go:2079
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1957
+#: lxc/auth.go:1955
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7248,14 +7245,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1111
+#: lxc/auth.go:1109
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1783
+#: lxc/auth.go:1781
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-19 16:04-0700\n"
+"POT-Creation-Date: 2025-01-07 15:23+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -133,34 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:219
-msgid ""
-"### This is a YAML representation of the group.\n"
-"### Any line starting with a '# will be ignored.\n"
-"###\n"
-"### A group has the following format:\n"
-"### name: my-first-group\n"
-"### description: My first group.\n"
-"### permissions:\n"
-"### - entity_type: project\n"
-"###   url: /1.0/projects/default\n"
-"###   entitlement: can_view\n"
-"### identities:\n"
-"### - authentication_method: oidc\n"
-"###   type: OIDC client\n"
-"###   identifier: jane.doe@example.com\n"
-"###   name: Jane Doe\n"
-"###   metadata:\n"
-"###     subject: auth0|123456789\n"
-"### identity_provider_groups:\n"
-"### - sales\n"
-"### - operations\n"
-"###\n"
-"### Note that all group information is shown but only the description and "
-"permissions can be modified"
-msgstr ""
-
-#: lxc/auth.go:1121
+#: lxc/auth.go:1119
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +154,31 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1793
+#: lxc/auth.go:219
+msgid ""
+"### This is a YAML representation of the group.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### NOTE: All group information is shown but only the description and "
+"permissions can be modified.\n"
+"### \n"
+"### name: my-first-group\n"
+"### description: My first group.\n"
+"### permissions:\n"
+"### - entity_type: project\n"
+"###   url: /1.0/projects/default\n"
+"###   entitlement: can_view\n"
+"### identities:\n"
+"###   oidc:\n"
+"###   - jane.doe@example.com\n"
+"###   tls:\n"
+"###   - eaa46a1b73827350e0543949fb161410c50e950d4cb9802fc58dbfbd5700e508\n"
+"### identity_provider_groups:\n"
+"### - sales\n"
+"### - operations\n"
+msgstr ""
+
+#: lxc/auth.go:1791
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -560,7 +557,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:966
+#: lxc/auth.go:964
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -598,11 +595,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1312 lxc/auth.go:1313
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2082 lxc/auth.go:2083
+#: lxc/auth.go:2080 lxc/auth.go:2081
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -671,7 +668,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:521 lxc/auth.go:522
+#: lxc/auth.go:519 lxc/auth.go:520
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -1347,12 +1344,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:306 lxc/auth.go:1868
+#: lxc/auth.go:304 lxc/auth.go:1866
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1207
+#: lxc/auth.go:1205
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1381,7 +1378,7 @@ msgstr ""
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:776
+#: lxc/auth.go:774
 msgid "Create a TLS identity"
 msgstr ""
 
@@ -1401,7 +1398,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:775
+#: lxc/auth.go:773
 msgid "Create an identity"
 msgstr ""
 
@@ -1421,7 +1418,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1679 lxc/auth.go:1680
+#: lxc/auth.go:1677 lxc/auth.go:1678
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1529,7 +1526,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1572,7 +1569,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1237 lxc/auth.go:1238
+#: lxc/auth.go:1235 lxc/auth.go:1236
 msgid "Delete an identity"
 msgstr ""
 
@@ -1584,7 +1581,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1729 lxc/auth.go:1730
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1663,14 +1660,14 @@ msgstr ""
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
 #: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
-#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
-#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
-#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
-#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
-#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
-#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
-#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
+#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
+#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
+#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
+#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
+#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
+#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -1939,7 +1936,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1108 lxc/auth.go:1109
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1955,7 +1952,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1780 lxc/auth.go:1781
+#: lxc/auth.go:1778 lxc/auth.go:1779
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2441,7 +2438,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
@@ -2499,7 +2496,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:970 lxc/auth.go:1944
+#: lxc/auth.go:968 lxc/auth.go:1942
 msgid "GROUPS"
 msgstr ""
 
@@ -2658,7 +2655,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:432 lxc/auth.go:1994
+#: lxc/auth.go:430 lxc/auth.go:1992
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2717,7 +2714,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:969
+#: lxc/auth.go:967
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2749,16 +2746,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:829
+#: lxc/auth.go:827
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1716
+#: lxc/auth.go:1714
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1766
+#: lxc/auth.go:1764
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2887,7 +2884,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1441 lxc/auth.go:1442
+#: lxc/auth.go:1439 lxc/auth.go:1440
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3191,15 +3188,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:337 lxc/auth.go:338
+#: lxc/auth.go:335 lxc/auth.go:336
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:917 lxc/auth.go:918
+#: lxc/auth.go:915 lxc/auth.go:916
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1900
+#: lxc/auth.go:1897 lxc/auth.go:1898
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3354,7 +3351,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1463 lxc/auth.go:1464
+#: lxc/auth.go:1461 lxc/auth.go:1462
 msgid "List permissions"
 msgstr ""
 
@@ -3522,7 +3519,7 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:823
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
@@ -3556,19 +3553,19 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1291 lxc/auth.go:1292
+#: lxc/auth.go:1289 lxc/auth.go:1290
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:736 lxc/auth.go:737
+#: lxc/auth.go:734 lxc/auth.go:735
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2059 lxc/auth.go:2060
+#: lxc/auth.go:2057 lxc/auth.go:2058
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3659,7 +3656,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:498 lxc/auth.go:499
+#: lxc/auth.go:496 lxc/auth.go:497
 msgid "Manage permissions"
 msgstr ""
 
@@ -3808,21 +3805,21 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
-#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
-#: lxc/auth.go:1339 lxc/auth.go:1397
+#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
+#: lxc/auth.go:1337 lxc/auth.go:1395
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
+#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2107 lxc/auth.go:2160
+#: lxc/auth.go:2105 lxc/auth.go:2158
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4043,7 +4040,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
@@ -4447,7 +4444,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4806,7 +4803,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1372 lxc/auth.go:1373
+#: lxc/auth.go:1370 lxc/auth.go:1371
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4842,7 +4839,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2135 lxc/auth.go:2136
+#: lxc/auth.go:2133 lxc/auth.go:2134
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4854,7 +4851,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:580 lxc/auth.go:581
+#: lxc/auth.go:578 lxc/auth.go:579
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4899,11 +4896,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:397 lxc/auth.go:398
+#: lxc/auth.go:395 lxc/auth.go:396
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1959 lxc/auth.go:1960
+#: lxc/auth.go:1957 lxc/auth.go:1958
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5424,7 +5421,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2008 lxc/auth.go:2009
+#: lxc/auth.go:2006 lxc/auth.go:2007
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5452,11 +5449,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:446 lxc/auth.go:447
+#: lxc/auth.go:444 lxc/auth.go:445
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:985
+#: lxc/auth.go:983
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5561,7 +5558,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1048
+#: lxc/auth.go:1046
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5799,12 +5796,12 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:876
+#: lxc/auth.go:874
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:902
+#: lxc/auth.go:900
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
@@ -5813,7 +5810,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1747 lxc/warning.go:216
@@ -6485,11 +6482,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:984
+#: lxc/auth.go:982
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1047
+#: lxc/auth.go:1045
 msgid "View the current identity"
 msgstr ""
 
@@ -6560,7 +6557,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6593,7 +6590,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1462
+#: lxc/auth.go:1460
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6654,17 +6651,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:772
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:983 lxc/auth.go:1235
+#: lxc/auth.go:981 lxc/auth.go:1233
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6672,13 +6669,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
-#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
+#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:520 lxc/auth.go:578
+#: lxc/auth.go:518 lxc/auth.go:576
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6688,19 +6685,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:395
+#: lxc/auth.go:393
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
+#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2081
+#: lxc/auth.go:2079
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1957
+#: lxc/auth.go:1955
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7248,14 +7245,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1111
+#: lxc/auth.go:1109
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1783
+#: lxc/auth.go:1781
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-19 16:04-0700\n"
+"POT-Creation-Date: 2025-01-07 15:23+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -133,34 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:219
-msgid ""
-"### This is a YAML representation of the group.\n"
-"### Any line starting with a '# will be ignored.\n"
-"###\n"
-"### A group has the following format:\n"
-"### name: my-first-group\n"
-"### description: My first group.\n"
-"### permissions:\n"
-"### - entity_type: project\n"
-"###   url: /1.0/projects/default\n"
-"###   entitlement: can_view\n"
-"### identities:\n"
-"### - authentication_method: oidc\n"
-"###   type: OIDC client\n"
-"###   identifier: jane.doe@example.com\n"
-"###   name: Jane Doe\n"
-"###   metadata:\n"
-"###     subject: auth0|123456789\n"
-"### identity_provider_groups:\n"
-"### - sales\n"
-"### - operations\n"
-"###\n"
-"### Note that all group information is shown but only the description and "
-"permissions can be modified"
-msgstr ""
-
-#: lxc/auth.go:1121
+#: lxc/auth.go:1119
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +154,31 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1793
+#: lxc/auth.go:219
+msgid ""
+"### This is a YAML representation of the group.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### NOTE: All group information is shown but only the description and "
+"permissions can be modified.\n"
+"### \n"
+"### name: my-first-group\n"
+"### description: My first group.\n"
+"### permissions:\n"
+"### - entity_type: project\n"
+"###   url: /1.0/projects/default\n"
+"###   entitlement: can_view\n"
+"### identities:\n"
+"###   oidc:\n"
+"###   - jane.doe@example.com\n"
+"###   tls:\n"
+"###   - eaa46a1b73827350e0543949fb161410c50e950d4cb9802fc58dbfbd5700e508\n"
+"### identity_provider_groups:\n"
+"### - sales\n"
+"### - operations\n"
+msgstr ""
+
+#: lxc/auth.go:1791
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -560,7 +557,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:966
+#: lxc/auth.go:964
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -598,11 +595,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1312 lxc/auth.go:1313
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2082 lxc/auth.go:2083
+#: lxc/auth.go:2080 lxc/auth.go:2081
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -671,7 +668,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:521 lxc/auth.go:522
+#: lxc/auth.go:519 lxc/auth.go:520
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -1347,12 +1344,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:306 lxc/auth.go:1868
+#: lxc/auth.go:304 lxc/auth.go:1866
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1207
+#: lxc/auth.go:1205
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1381,7 +1378,7 @@ msgstr ""
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:776
+#: lxc/auth.go:774
 msgid "Create a TLS identity"
 msgstr ""
 
@@ -1401,7 +1398,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:775
+#: lxc/auth.go:773
 msgid "Create an identity"
 msgstr ""
 
@@ -1421,7 +1418,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1679 lxc/auth.go:1680
+#: lxc/auth.go:1677 lxc/auth.go:1678
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1529,7 +1526,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1572,7 +1569,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1237 lxc/auth.go:1238
+#: lxc/auth.go:1235 lxc/auth.go:1236
 msgid "Delete an identity"
 msgstr ""
 
@@ -1584,7 +1581,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1729 lxc/auth.go:1730
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1663,14 +1660,14 @@ msgstr ""
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
 #: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
-#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
-#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
-#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
-#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
-#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
-#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
-#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
+#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
+#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
+#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
+#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
+#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
+#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -1939,7 +1936,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1108 lxc/auth.go:1109
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1955,7 +1952,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1780 lxc/auth.go:1781
+#: lxc/auth.go:1778 lxc/auth.go:1779
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2441,7 +2438,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
@@ -2499,7 +2496,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:970 lxc/auth.go:1944
+#: lxc/auth.go:968 lxc/auth.go:1942
 msgid "GROUPS"
 msgstr ""
 
@@ -2658,7 +2655,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:432 lxc/auth.go:1994
+#: lxc/auth.go:430 lxc/auth.go:1992
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2717,7 +2714,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:969
+#: lxc/auth.go:967
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2749,16 +2746,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:829
+#: lxc/auth.go:827
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1716
+#: lxc/auth.go:1714
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1766
+#: lxc/auth.go:1764
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2887,7 +2884,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1441 lxc/auth.go:1442
+#: lxc/auth.go:1439 lxc/auth.go:1440
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3191,15 +3188,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:337 lxc/auth.go:338
+#: lxc/auth.go:335 lxc/auth.go:336
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:917 lxc/auth.go:918
+#: lxc/auth.go:915 lxc/auth.go:916
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1900
+#: lxc/auth.go:1897 lxc/auth.go:1898
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3354,7 +3351,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1463 lxc/auth.go:1464
+#: lxc/auth.go:1461 lxc/auth.go:1462
 msgid "List permissions"
 msgstr ""
 
@@ -3522,7 +3519,7 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:823
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
@@ -3556,19 +3553,19 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1291 lxc/auth.go:1292
+#: lxc/auth.go:1289 lxc/auth.go:1290
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:736 lxc/auth.go:737
+#: lxc/auth.go:734 lxc/auth.go:735
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2059 lxc/auth.go:2060
+#: lxc/auth.go:2057 lxc/auth.go:2058
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3659,7 +3656,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:498 lxc/auth.go:499
+#: lxc/auth.go:496 lxc/auth.go:497
 msgid "Manage permissions"
 msgstr ""
 
@@ -3808,21 +3805,21 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
-#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
-#: lxc/auth.go:1339 lxc/auth.go:1397
+#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
+#: lxc/auth.go:1337 lxc/auth.go:1395
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
+#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2107 lxc/auth.go:2160
+#: lxc/auth.go:2105 lxc/auth.go:2158
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4043,7 +4040,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
@@ -4447,7 +4444,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4806,7 +4803,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1372 lxc/auth.go:1373
+#: lxc/auth.go:1370 lxc/auth.go:1371
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4842,7 +4839,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2135 lxc/auth.go:2136
+#: lxc/auth.go:2133 lxc/auth.go:2134
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4854,7 +4851,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:580 lxc/auth.go:581
+#: lxc/auth.go:578 lxc/auth.go:579
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4899,11 +4896,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:397 lxc/auth.go:398
+#: lxc/auth.go:395 lxc/auth.go:396
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1959 lxc/auth.go:1960
+#: lxc/auth.go:1957 lxc/auth.go:1958
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5424,7 +5421,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2008 lxc/auth.go:2009
+#: lxc/auth.go:2006 lxc/auth.go:2007
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5452,11 +5449,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:446 lxc/auth.go:447
+#: lxc/auth.go:444 lxc/auth.go:445
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:985
+#: lxc/auth.go:983
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5561,7 +5558,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1048
+#: lxc/auth.go:1046
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5799,12 +5796,12 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:876
+#: lxc/auth.go:874
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:902
+#: lxc/auth.go:900
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
@@ -5813,7 +5810,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1747 lxc/warning.go:216
@@ -6485,11 +6482,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:984
+#: lxc/auth.go:982
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1047
+#: lxc/auth.go:1045
 msgid "View the current identity"
 msgstr ""
 
@@ -6560,7 +6557,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6593,7 +6590,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1462
+#: lxc/auth.go:1460
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6654,17 +6651,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:772
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:983 lxc/auth.go:1235
+#: lxc/auth.go:981 lxc/auth.go:1233
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6672,13 +6669,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
-#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
+#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:520 lxc/auth.go:578
+#: lxc/auth.go:518 lxc/auth.go:576
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6688,19 +6685,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:395
+#: lxc/auth.go:393
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
+#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2081
+#: lxc/auth.go:2079
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1957
+#: lxc/auth.go:1955
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7248,14 +7245,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1111
+#: lxc/auth.go:1109
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1783
+#: lxc/auth.go:1781
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-19 16:04-0700\n"
+"POT-Creation-Date: 2025-01-07 15:23+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -134,34 +134,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:219
-msgid ""
-"### This is a YAML representation of the group.\n"
-"### Any line starting with a '# will be ignored.\n"
-"###\n"
-"### A group has the following format:\n"
-"### name: my-first-group\n"
-"### description: My first group.\n"
-"### permissions:\n"
-"### - entity_type: project\n"
-"###   url: /1.0/projects/default\n"
-"###   entitlement: can_view\n"
-"### identities:\n"
-"### - authentication_method: oidc\n"
-"###   type: OIDC client\n"
-"###   identifier: jane.doe@example.com\n"
-"###   name: Jane Doe\n"
-"###   metadata:\n"
-"###     subject: auth0|123456789\n"
-"### identity_provider_groups:\n"
-"### - sales\n"
-"### - operations\n"
-"###\n"
-"### Note that all group information is shown but only the description and "
-"permissions can be modified"
-msgstr ""
-
-#: lxc/auth.go:1121
+#: lxc/auth.go:1119
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -182,7 +155,31 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1793
+#: lxc/auth.go:219
+msgid ""
+"### This is a YAML representation of the group.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### NOTE: All group information is shown but only the description and "
+"permissions can be modified.\n"
+"### \n"
+"### name: my-first-group\n"
+"### description: My first group.\n"
+"### permissions:\n"
+"### - entity_type: project\n"
+"###   url: /1.0/projects/default\n"
+"###   entitlement: can_view\n"
+"### identities:\n"
+"###   oidc:\n"
+"###   - jane.doe@example.com\n"
+"###   tls:\n"
+"###   - eaa46a1b73827350e0543949fb161410c50e950d4cb9802fc58dbfbd5700e508\n"
+"### identity_provider_groups:\n"
+"### - sales\n"
+"### - operations\n"
+msgstr ""
+
+#: lxc/auth.go:1791
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -561,7 +558,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:966
+#: lxc/auth.go:964
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -599,11 +596,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1312 lxc/auth.go:1313
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2082 lxc/auth.go:2083
+#: lxc/auth.go:2080 lxc/auth.go:2081
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -672,7 +669,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:521 lxc/auth.go:522
+#: lxc/auth.go:519 lxc/auth.go:520
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -1348,12 +1345,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:306 lxc/auth.go:1868
+#: lxc/auth.go:304 lxc/auth.go:1866
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1207
+#: lxc/auth.go:1205
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1382,7 +1379,7 @@ msgstr ""
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:776
+#: lxc/auth.go:774
 msgid "Create a TLS identity"
 msgstr ""
 
@@ -1402,7 +1399,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:775
+#: lxc/auth.go:773
 msgid "Create an identity"
 msgstr ""
 
@@ -1422,7 +1419,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1679 lxc/auth.go:1680
+#: lxc/auth.go:1677 lxc/auth.go:1678
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1530,7 +1527,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1573,7 +1570,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1237 lxc/auth.go:1238
+#: lxc/auth.go:1235 lxc/auth.go:1236
 msgid "Delete an identity"
 msgstr ""
 
@@ -1585,7 +1582,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1729 lxc/auth.go:1730
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1664,14 +1661,14 @@ msgstr ""
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
 #: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
-#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
-#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
-#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
-#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
-#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
-#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
-#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
+#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
+#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
+#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
+#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
+#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
+#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -1940,7 +1937,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1108 lxc/auth.go:1109
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1956,7 +1953,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1780 lxc/auth.go:1781
+#: lxc/auth.go:1778 lxc/auth.go:1779
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2442,7 +2439,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
@@ -2500,7 +2497,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:970 lxc/auth.go:1944
+#: lxc/auth.go:968 lxc/auth.go:1942
 msgid "GROUPS"
 msgstr ""
 
@@ -2659,7 +2656,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:432 lxc/auth.go:1994
+#: lxc/auth.go:430 lxc/auth.go:1992
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2718,7 +2715,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:969
+#: lxc/auth.go:967
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2750,16 +2747,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:829
+#: lxc/auth.go:827
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1716
+#: lxc/auth.go:1714
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1766
+#: lxc/auth.go:1764
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2888,7 +2885,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1441 lxc/auth.go:1442
+#: lxc/auth.go:1439 lxc/auth.go:1440
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3192,15 +3189,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:337 lxc/auth.go:338
+#: lxc/auth.go:335 lxc/auth.go:336
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:917 lxc/auth.go:918
+#: lxc/auth.go:915 lxc/auth.go:916
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1900
+#: lxc/auth.go:1897 lxc/auth.go:1898
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3355,7 +3352,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1463 lxc/auth.go:1464
+#: lxc/auth.go:1461 lxc/auth.go:1462
 msgid "List permissions"
 msgstr ""
 
@@ -3523,7 +3520,7 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:823
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
@@ -3557,19 +3554,19 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1291 lxc/auth.go:1292
+#: lxc/auth.go:1289 lxc/auth.go:1290
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:736 lxc/auth.go:737
+#: lxc/auth.go:734 lxc/auth.go:735
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2059 lxc/auth.go:2060
+#: lxc/auth.go:2057 lxc/auth.go:2058
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3660,7 +3657,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:498 lxc/auth.go:499
+#: lxc/auth.go:496 lxc/auth.go:497
 msgid "Manage permissions"
 msgstr ""
 
@@ -3809,21 +3806,21 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
-#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
-#: lxc/auth.go:1339 lxc/auth.go:1397
+#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
+#: lxc/auth.go:1337 lxc/auth.go:1395
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
+#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2107 lxc/auth.go:2160
+#: lxc/auth.go:2105 lxc/auth.go:2158
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4044,7 +4041,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
@@ -4448,7 +4445,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4807,7 +4804,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1372 lxc/auth.go:1373
+#: lxc/auth.go:1370 lxc/auth.go:1371
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4843,7 +4840,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2135 lxc/auth.go:2136
+#: lxc/auth.go:2133 lxc/auth.go:2134
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4855,7 +4852,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:580 lxc/auth.go:581
+#: lxc/auth.go:578 lxc/auth.go:579
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4900,11 +4897,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:397 lxc/auth.go:398
+#: lxc/auth.go:395 lxc/auth.go:396
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1959 lxc/auth.go:1960
+#: lxc/auth.go:1957 lxc/auth.go:1958
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5425,7 +5422,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2008 lxc/auth.go:2009
+#: lxc/auth.go:2006 lxc/auth.go:2007
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5453,11 +5450,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:446 lxc/auth.go:447
+#: lxc/auth.go:444 lxc/auth.go:445
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:985
+#: lxc/auth.go:983
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5562,7 +5559,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1048
+#: lxc/auth.go:1046
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5800,12 +5797,12 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:876
+#: lxc/auth.go:874
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:902
+#: lxc/auth.go:900
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
@@ -5814,7 +5811,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1747 lxc/warning.go:216
@@ -6486,11 +6483,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:984
+#: lxc/auth.go:982
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1047
+#: lxc/auth.go:1045
 msgid "View the current identity"
 msgstr ""
 
@@ -6561,7 +6558,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6594,7 +6591,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1462
+#: lxc/auth.go:1460
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6655,17 +6652,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:772
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:983 lxc/auth.go:1235
+#: lxc/auth.go:981 lxc/auth.go:1233
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6673,13 +6670,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
-#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
+#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:520 lxc/auth.go:578
+#: lxc/auth.go:518 lxc/auth.go:576
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6689,19 +6686,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:395
+#: lxc/auth.go:393
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
+#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2081
+#: lxc/auth.go:2079
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1957
+#: lxc/auth.go:1955
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7249,14 +7246,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1111
+#: lxc/auth.go:1109
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1783
+#: lxc/auth.go:1781
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-19 16:04-0700\n"
+"POT-Creation-Date: 2025-01-07 15:23+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -207,34 +207,7 @@ msgstr ""
 "###\n"
 "### Note that the name is shown but cannot be changed"
 
-#: lxc/auth.go:219
-msgid ""
-"### This is a YAML representation of the group.\n"
-"### Any line starting with a '# will be ignored.\n"
-"###\n"
-"### A group has the following format:\n"
-"### name: my-first-group\n"
-"### description: My first group.\n"
-"### permissions:\n"
-"### - entity_type: project\n"
-"###   url: /1.0/projects/default\n"
-"###   entitlement: can_view\n"
-"### identities:\n"
-"### - authentication_method: oidc\n"
-"###   type: OIDC client\n"
-"###   identifier: jane.doe@example.com\n"
-"###   name: Jane Doe\n"
-"###   metadata:\n"
-"###     subject: auth0|123456789\n"
-"### identity_provider_groups:\n"
-"### - sales\n"
-"### - operations\n"
-"###\n"
-"### Note that all group information is shown but only the description and "
-"permissions can be modified"
-msgstr ""
-
-#: lxc/auth.go:1121
+#: lxc/auth.go:1119
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -255,7 +228,31 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1793
+#: lxc/auth.go:219
+msgid ""
+"### This is a YAML representation of the group.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### NOTE: All group information is shown but only the description and "
+"permissions can be modified.\n"
+"### \n"
+"### name: my-first-group\n"
+"### description: My first group.\n"
+"### permissions:\n"
+"### - entity_type: project\n"
+"###   url: /1.0/projects/default\n"
+"###   entitlement: can_view\n"
+"### identities:\n"
+"###   oidc:\n"
+"###   - jane.doe@example.com\n"
+"###   tls:\n"
+"###   - eaa46a1b73827350e0543949fb161410c50e950d4cb9802fc58dbfbd5700e508\n"
+"### identity_provider_groups:\n"
+"### - sales\n"
+"### - operations\n"
+msgstr ""
+
+#: lxc/auth.go:1791
 #, fuzzy
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
@@ -721,7 +718,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:966
+#: lxc/auth.go:964
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -759,11 +756,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1312 lxc/auth.go:1313
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2082 lxc/auth.go:2083
+#: lxc/auth.go:2080 lxc/auth.go:2081
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -832,7 +829,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:521 lxc/auth.go:522
+#: lxc/auth.go:519 lxc/auth.go:520
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -1508,12 +1505,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:306 lxc/auth.go:1868
+#: lxc/auth.go:304 lxc/auth.go:1866
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1207
+#: lxc/auth.go:1205
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1542,7 +1539,7 @@ msgstr ""
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:776
+#: lxc/auth.go:774
 msgid "Create a TLS identity"
 msgstr ""
 
@@ -1562,7 +1559,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:775
+#: lxc/auth.go:773
 msgid "Create an identity"
 msgstr ""
 
@@ -1582,7 +1579,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1679 lxc/auth.go:1680
+#: lxc/auth.go:1677 lxc/auth.go:1678
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1690,7 +1687,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1733,7 +1730,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1237 lxc/auth.go:1238
+#: lxc/auth.go:1235 lxc/auth.go:1236
 msgid "Delete an identity"
 msgstr ""
 
@@ -1745,7 +1742,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1729 lxc/auth.go:1730
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1824,14 +1821,14 @@ msgstr ""
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
 #: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
-#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
-#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
-#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
-#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
-#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
-#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
-#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
+#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
+#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
+#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
+#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
+#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
+#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -2100,7 +2097,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1108 lxc/auth.go:1109
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -2116,7 +2113,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1780 lxc/auth.go:1781
+#: lxc/auth.go:1778 lxc/auth.go:1779
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2602,7 +2599,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
@@ -2660,7 +2657,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:970 lxc/auth.go:1944
+#: lxc/auth.go:968 lxc/auth.go:1942
 msgid "GROUPS"
 msgstr ""
 
@@ -2819,7 +2816,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:432 lxc/auth.go:1994
+#: lxc/auth.go:430 lxc/auth.go:1992
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2878,7 +2875,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:969
+#: lxc/auth.go:967
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2910,16 +2907,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:829
+#: lxc/auth.go:827
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1716
+#: lxc/auth.go:1714
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1766
+#: lxc/auth.go:1764
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -3048,7 +3045,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1441 lxc/auth.go:1442
+#: lxc/auth.go:1439 lxc/auth.go:1440
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3352,15 +3349,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:337 lxc/auth.go:338
+#: lxc/auth.go:335 lxc/auth.go:336
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:917 lxc/auth.go:918
+#: lxc/auth.go:915 lxc/auth.go:916
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1900
+#: lxc/auth.go:1897 lxc/auth.go:1898
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3515,7 +3512,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1463 lxc/auth.go:1464
+#: lxc/auth.go:1461 lxc/auth.go:1462
 msgid "List permissions"
 msgstr ""
 
@@ -3683,7 +3680,7 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:823
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
@@ -3717,19 +3714,19 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1291 lxc/auth.go:1292
+#: lxc/auth.go:1289 lxc/auth.go:1290
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:736 lxc/auth.go:737
+#: lxc/auth.go:734 lxc/auth.go:735
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2059 lxc/auth.go:2060
+#: lxc/auth.go:2057 lxc/auth.go:2058
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3820,7 +3817,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:498 lxc/auth.go:499
+#: lxc/auth.go:496 lxc/auth.go:497
 msgid "Manage permissions"
 msgstr ""
 
@@ -3969,21 +3966,21 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
-#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
-#: lxc/auth.go:1339 lxc/auth.go:1397
+#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
+#: lxc/auth.go:1337 lxc/auth.go:1395
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
+#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2107 lxc/auth.go:2160
+#: lxc/auth.go:2105 lxc/auth.go:2158
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4204,7 +4201,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
@@ -4608,7 +4605,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4967,7 +4964,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1372 lxc/auth.go:1373
+#: lxc/auth.go:1370 lxc/auth.go:1371
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -5003,7 +5000,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2135 lxc/auth.go:2136
+#: lxc/auth.go:2133 lxc/auth.go:2134
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -5015,7 +5012,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:580 lxc/auth.go:581
+#: lxc/auth.go:578 lxc/auth.go:579
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -5060,11 +5057,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:397 lxc/auth.go:398
+#: lxc/auth.go:395 lxc/auth.go:396
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1959 lxc/auth.go:1960
+#: lxc/auth.go:1957 lxc/auth.go:1958
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5585,7 +5582,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2008 lxc/auth.go:2009
+#: lxc/auth.go:2006 lxc/auth.go:2007
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5613,11 +5610,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:446 lxc/auth.go:447
+#: lxc/auth.go:444 lxc/auth.go:445
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:985
+#: lxc/auth.go:983
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5722,7 +5719,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1048
+#: lxc/auth.go:1046
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5960,12 +5957,12 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:876
+#: lxc/auth.go:874
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:902
+#: lxc/auth.go:900
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
@@ -5974,7 +5971,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1747 lxc/warning.go:216
@@ -6646,11 +6643,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:984
+#: lxc/auth.go:982
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1047
+#: lxc/auth.go:1045
 msgid "View the current identity"
 msgstr ""
 
@@ -6721,7 +6718,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6754,7 +6751,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1462
+#: lxc/auth.go:1460
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6815,17 +6812,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:772
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:983 lxc/auth.go:1235
+#: lxc/auth.go:981 lxc/auth.go:1233
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6833,13 +6830,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
-#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
+#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:520 lxc/auth.go:578
+#: lxc/auth.go:518 lxc/auth.go:576
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6849,19 +6846,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:395
+#: lxc/auth.go:393
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
+#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2081
+#: lxc/auth.go:2079
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1957
+#: lxc/auth.go:1955
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7409,14 +7406,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1111
+#: lxc/auth.go:1109
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1783
+#: lxc/auth.go:1781
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2024-12-19 16:04-0700\n"
+"POT-Creation-Date: 2025-01-07 15:23+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -133,34 +133,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/auth.go:219
-msgid ""
-"### This is a YAML representation of the group.\n"
-"### Any line starting with a '# will be ignored.\n"
-"###\n"
-"### A group has the following format:\n"
-"### name: my-first-group\n"
-"### description: My first group.\n"
-"### permissions:\n"
-"### - entity_type: project\n"
-"###   url: /1.0/projects/default\n"
-"###   entitlement: can_view\n"
-"### identities:\n"
-"### - authentication_method: oidc\n"
-"###   type: OIDC client\n"
-"###   identifier: jane.doe@example.com\n"
-"###   name: Jane Doe\n"
-"###   metadata:\n"
-"###     subject: auth0|123456789\n"
-"### identity_provider_groups:\n"
-"### - sales\n"
-"### - operations\n"
-"###\n"
-"### Note that all group information is shown but only the description and "
-"permissions can be modified"
-msgstr ""
-
-#: lxc/auth.go:1121
+#: lxc/auth.go:1119
 msgid ""
 "### This is a YAML representation of the group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -181,7 +154,31 @@ msgid ""
 "groups can be modified"
 msgstr ""
 
-#: lxc/auth.go:1793
+#: lxc/auth.go:219
+msgid ""
+"### This is a YAML representation of the group.\n"
+"### Any line starting with a '# will be ignored.\n"
+"###\n"
+"### NOTE: All group information is shown but only the description and "
+"permissions can be modified.\n"
+"### \n"
+"### name: my-first-group\n"
+"### description: My first group.\n"
+"### permissions:\n"
+"### - entity_type: project\n"
+"###   url: /1.0/projects/default\n"
+"###   entitlement: can_view\n"
+"### identities:\n"
+"###   oidc:\n"
+"###   - jane.doe@example.com\n"
+"###   tls:\n"
+"###   - eaa46a1b73827350e0543949fb161410c50e950d4cb9802fc58dbfbd5700e508\n"
+"### identity_provider_groups:\n"
+"### - sales\n"
+"### - operations\n"
+msgstr ""
+
+#: lxc/auth.go:1791
 msgid ""
 "### This is a YAML representation of the identity provider group.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -560,7 +557,7 @@ msgstr ""
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/auth.go:966
+#: lxc/auth.go:964
 msgid "AUTHENTICATION METHOD"
 msgstr ""
 
@@ -598,11 +595,11 @@ msgstr ""
 msgid "Add a cluster member to a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1314 lxc/auth.go:1315
+#: lxc/auth.go:1312 lxc/auth.go:1313
 msgid "Add a group to an identity"
 msgstr ""
 
-#: lxc/auth.go:2082 lxc/auth.go:2083
+#: lxc/auth.go:2080 lxc/auth.go:2081
 msgid "Add a group to an identity provider group"
 msgstr ""
 
@@ -671,7 +668,7 @@ msgid ""
 "restricted to one or more projects.\n"
 msgstr ""
 
-#: lxc/auth.go:521 lxc/auth.go:522
+#: lxc/auth.go:519 lxc/auth.go:520
 msgid "Add permissions to groups"
 msgstr ""
 
@@ -1347,12 +1344,12 @@ msgstr ""
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/auth.go:306 lxc/auth.go:1868
+#: lxc/auth.go:304 lxc/auth.go:1866
 #, c-format
 msgid "Could not parse group: %s"
 msgstr ""
 
-#: lxc/auth.go:1207
+#: lxc/auth.go:1205
 #, c-format
 msgid "Could not parse identity: %s"
 msgstr ""
@@ -1381,7 +1378,7 @@ msgstr ""
 msgid "Couldn't find a matching entry"
 msgstr ""
 
-#: lxc/auth.go:776
+#: lxc/auth.go:774
 msgid "Create a TLS identity"
 msgstr ""
 
@@ -1401,7 +1398,7 @@ msgstr ""
 msgid "Create an empty instance"
 msgstr ""
 
-#: lxc/auth.go:775
+#: lxc/auth.go:773
 msgid "Create an identity"
 msgstr ""
 
@@ -1421,7 +1418,7 @@ msgstr ""
 msgid "Create groups"
 msgstr ""
 
-#: lxc/auth.go:1679 lxc/auth.go:1680
+#: lxc/auth.go:1677 lxc/auth.go:1678
 msgid "Create identity provider groups"
 msgstr ""
 
@@ -1529,7 +1526,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/auth.go:382 lxc/cluster.go:197 lxc/cluster_group.go:504
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
 #: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1095
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
@@ -1572,7 +1569,7 @@ msgstr ""
 msgid "Delete all warnings"
 msgstr ""
 
-#: lxc/auth.go:1237 lxc/auth.go:1238
+#: lxc/auth.go:1235 lxc/auth.go:1236
 msgid "Delete an identity"
 msgstr ""
 
@@ -1584,7 +1581,7 @@ msgstr ""
 msgid "Delete groups"
 msgstr ""
 
-#: lxc/auth.go:1731 lxc/auth.go:1732
+#: lxc/auth.go:1729 lxc/auth.go:1730
 msgid "Delete identity provider groups"
 msgstr ""
 
@@ -1663,14 +1660,14 @@ msgstr ""
 #: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111
 #: lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159
 #: lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104
-#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:338 lxc/auth.go:398
-#: lxc/auth.go:447 lxc/auth.go:499 lxc/auth.go:522 lxc/auth.go:581
-#: lxc/auth.go:737 lxc/auth.go:776 lxc/auth.go:918 lxc/auth.go:985
-#: lxc/auth.go:1048 lxc/auth.go:1109 lxc/auth.go:1238 lxc/auth.go:1292
-#: lxc/auth.go:1315 lxc/auth.go:1373 lxc/auth.go:1442 lxc/auth.go:1464
-#: lxc/auth.go:1642 lxc/auth.go:1680 lxc/auth.go:1732 lxc/auth.go:1781
-#: lxc/auth.go:1900 lxc/auth.go:1960 lxc/auth.go:2009 lxc/auth.go:2060
-#: lxc/auth.go:2083 lxc/auth.go:2136 lxc/cluster.go:30 lxc/cluster.go:123
+#: lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396
+#: lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579
+#: lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983
+#: lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290
+#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462
+#: lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779
+#: lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058
+#: lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123
 #: lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404
 #: lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677
 #: lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088
@@ -1939,7 +1936,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1108 lxc/auth.go:1109
+#: lxc/auth.go:1106 lxc/auth.go:1107
 msgid "Edit an identity as YAML"
 msgstr ""
 
@@ -1955,7 +1952,7 @@ msgstr ""
 msgid "Edit groups as YAML"
 msgstr ""
 
-#: lxc/auth.go:1780 lxc/auth.go:1781
+#: lxc/auth.go:1778 lxc/auth.go:1779
 msgid "Edit identity provider groups as YAML"
 msgstr ""
 
@@ -2441,7 +2438,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:112 lxc/auth.go:342 lxc/auth.go:922 lxc/auth.go:1904
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
 #: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1010
@@ -2499,7 +2496,7 @@ msgstr ""
 msgid "GPUs:"
 msgstr ""
 
-#: lxc/auth.go:970 lxc/auth.go:1944
+#: lxc/auth.go:968 lxc/auth.go:1942
 msgid "GROUPS"
 msgstr ""
 
@@ -2658,7 +2655,7 @@ msgstr ""
 msgid "Group %s deleted"
 msgstr ""
 
-#: lxc/auth.go:432 lxc/auth.go:1994
+#: lxc/auth.go:430 lxc/auth.go:1992
 #, c-format
 msgid "Group %s renamed to %s"
 msgstr ""
@@ -2717,7 +2714,7 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/auth.go:969
+#: lxc/auth.go:967
 msgid "IDENTIFIER"
 msgstr ""
 
@@ -2749,16 +2746,16 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/auth.go:829
+#: lxc/auth.go:827
 msgid "Identity creation only supported for TLS identities"
 msgstr ""
 
-#: lxc/auth.go:1716
+#: lxc/auth.go:1714
 #, c-format
 msgid "Identity provider group %s created"
 msgstr ""
 
-#: lxc/auth.go:1766
+#: lxc/auth.go:1764
 #, c-format
 msgid "Identity provider group %s deleted"
 msgstr ""
@@ -2887,7 +2884,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/auth.go:1441 lxc/auth.go:1442
+#: lxc/auth.go:1439 lxc/auth.go:1440
 msgid "Inspect permissions"
 msgstr ""
 
@@ -3191,15 +3188,15 @@ msgstr ""
 msgid "List background operations"
 msgstr ""
 
-#: lxc/auth.go:337 lxc/auth.go:338
+#: lxc/auth.go:335 lxc/auth.go:336
 msgid "List groups"
 msgstr ""
 
-#: lxc/auth.go:917 lxc/auth.go:918
+#: lxc/auth.go:915 lxc/auth.go:916
 msgid "List identities"
 msgstr ""
 
-#: lxc/auth.go:1899 lxc/auth.go:1900
+#: lxc/auth.go:1897 lxc/auth.go:1898
 msgid "List identity provider groups"
 msgstr ""
 
@@ -3354,7 +3351,7 @@ msgstr ""
 msgid "List operations from all projects"
 msgstr ""
 
-#: lxc/auth.go:1463 lxc/auth.go:1464
+#: lxc/auth.go:1461 lxc/auth.go:1462
 msgid "List permissions"
 msgstr ""
 
@@ -3522,7 +3519,7 @@ msgstr ""
 msgid "Make the image public (accessible to unauthenticated clients as well)"
 msgstr ""
 
-#: lxc/auth.go:825
+#: lxc/auth.go:823
 msgid ""
 "Malformed argument, expected `[<remote>:]<authentication_method>/<name>`, "
 "got "
@@ -3556,19 +3553,19 @@ msgstr ""
 msgid "Manage files in instances"
 msgstr ""
 
-#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1641 lxc/auth.go:1642
+#: lxc/auth.go:64 lxc/auth.go:65 lxc/auth.go:1639 lxc/auth.go:1640
 msgid "Manage groups"
 msgstr ""
 
-#: lxc/auth.go:1291 lxc/auth.go:1292
+#: lxc/auth.go:1289 lxc/auth.go:1290
 msgid "Manage groups for the identity"
 msgstr ""
 
-#: lxc/auth.go:736 lxc/auth.go:737
+#: lxc/auth.go:734 lxc/auth.go:735
 msgid "Manage identities"
 msgstr ""
 
-#: lxc/auth.go:2059 lxc/auth.go:2060
+#: lxc/auth.go:2057 lxc/auth.go:2058
 msgid "Manage identity provider group mappings"
 msgstr ""
 
@@ -3659,7 +3656,7 @@ msgstr ""
 msgid "Manage network zones"
 msgstr ""
 
-#: lxc/auth.go:498 lxc/auth.go:499
+#: lxc/auth.go:496 lxc/auth.go:497
 msgid "Manage permissions"
 msgstr ""
 
@@ -3808,21 +3805,21 @@ msgstr ""
 msgid "Missing cluster member name"
 msgstr ""
 
-#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:260 lxc/auth.go:422
-#: lxc/auth.go:471 lxc/auth.go:546 lxc/auth.go:605 lxc/auth.go:2033
+#: lxc/auth.go:128 lxc/auth.go:182 lxc/auth.go:258 lxc/auth.go:420
+#: lxc/auth.go:469 lxc/auth.go:544 lxc/auth.go:603 lxc/auth.go:2031
 msgid "Missing group name"
 msgstr ""
 
-#: lxc/auth.go:820 lxc/auth.go:1015 lxc/auth.go:1156 lxc/auth.go:1273
-#: lxc/auth.go:1339 lxc/auth.go:1397
+#: lxc/auth.go:818 lxc/auth.go:1013 lxc/auth.go:1154 lxc/auth.go:1271
+#: lxc/auth.go:1337 lxc/auth.go:1395
 msgid "Missing identity argument"
 msgstr ""
 
-#: lxc/auth.go:1703 lxc/auth.go:1756 lxc/auth.go:1822 lxc/auth.go:1984
+#: lxc/auth.go:1701 lxc/auth.go:1754 lxc/auth.go:1820 lxc/auth.go:1982
 msgid "Missing identity provider group name"
 msgstr ""
 
-#: lxc/auth.go:2107 lxc/auth.go:2160
+#: lxc/auth.go:2105 lxc/auth.go:2158
 msgid "Missing identity provider group name argument"
 msgstr ""
 
@@ -4043,7 +4040,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/auth.go:381 lxc/auth.go:968 lxc/auth.go:1943 lxc/cluster.go:192
+#: lxc/auth.go:379 lxc/auth.go:966 lxc/auth.go:1941 lxc/cluster.go:192
 #: lxc/cluster.go:1070 lxc/cluster_group.go:503 lxc/config_trust.go:409
 #: lxc/config_trust.go:514 lxc/list.go:573 lxc/network.go:1090
 #: lxc/network_acl.go:156 lxc/network_peer.go:148 lxc/network_zone.go:147
@@ -4447,7 +4444,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/auth.go:307 lxc/auth.go:1208 lxc/auth.go:1869 lxc/cluster.go:861
+#: lxc/auth.go:305 lxc/auth.go:1206 lxc/auth.go:1867 lxc/cluster.go:861
 #: lxc/cluster_group.go:398 lxc/config.go:282 lxc/config.go:357
 #: lxc/config.go:1342 lxc/config_metadata.go:157 lxc/config_template.go:239
 #: lxc/config_trust.go:315 lxc/image.go:492 lxc/network.go:760
@@ -4806,7 +4803,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/auth.go:1372 lxc/auth.go:1373
+#: lxc/auth.go:1370 lxc/auth.go:1371
 msgid "Remove a group from an identity"
 msgstr ""
 
@@ -4842,7 +4839,7 @@ msgstr ""
 msgid "Remove entries from a network zone record"
 msgstr ""
 
-#: lxc/auth.go:2135 lxc/auth.go:2136
+#: lxc/auth.go:2133 lxc/auth.go:2134
 msgid "Remove identities from groups"
 msgstr ""
 
@@ -4854,7 +4851,7 @@ msgstr ""
 msgid "Remove member from group"
 msgstr ""
 
-#: lxc/auth.go:580 lxc/auth.go:581
+#: lxc/auth.go:578 lxc/auth.go:579
 msgid "Remove permissions from groups"
 msgstr ""
 
@@ -4899,11 +4896,11 @@ msgstr ""
 msgid "Rename aliases"
 msgstr ""
 
-#: lxc/auth.go:397 lxc/auth.go:398
+#: lxc/auth.go:395 lxc/auth.go:396
 msgid "Rename groups"
 msgstr ""
 
-#: lxc/auth.go:1959 lxc/auth.go:1960
+#: lxc/auth.go:1957 lxc/auth.go:1958
 msgid "Rename identity provider groups"
 msgstr ""
 
@@ -5424,7 +5421,7 @@ msgstr ""
 msgid "Show all information messages"
 msgstr ""
 
-#: lxc/auth.go:2008 lxc/auth.go:2009
+#: lxc/auth.go:2006 lxc/auth.go:2007
 msgid "Show an identity provider group"
 msgstr ""
 
@@ -5452,11 +5449,11 @@ msgstr ""
 msgid "Show full device configuration"
 msgstr ""
 
-#: lxc/auth.go:446 lxc/auth.go:447
+#: lxc/auth.go:444 lxc/auth.go:445
 msgid "Show group configurations"
 msgstr ""
 
-#: lxc/auth.go:985
+#: lxc/auth.go:983
 msgid ""
 "Show identity configurations\n"
 "\n"
@@ -5561,7 +5558,7 @@ msgstr ""
 msgid "Show storage volume state information"
 msgstr ""
 
-#: lxc/auth.go:1048
+#: lxc/auth.go:1046
 msgid ""
 "Show the current identity\n"
 "\n"
@@ -5799,12 +5796,12 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/auth.go:876
+#: lxc/auth.go:874
 #, c-format
 msgid "TLS identity %q (%s) pending identity token:"
 msgstr ""
 
-#: lxc/auth.go:902
+#: lxc/auth.go:900
 #, c-format
 msgid "TLS identity %q created with fingerprint %q"
 msgstr ""
@@ -5813,7 +5810,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:967 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1091
 #: lxc/network.go:1173 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1747 lxc/warning.go:216
@@ -6485,11 +6482,11 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/auth.go:984
+#: lxc/auth.go:982
 msgid "View an identity"
 msgstr ""
 
-#: lxc/auth.go:1047
+#: lxc/auth.go:1045
 msgid "View the current identity"
 msgstr ""
 
@@ -6560,7 +6557,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/auth.go:335 lxc/auth.go:915 lxc/auth.go:1046 lxc/auth.go:1897
+#: lxc/auth.go:333 lxc/auth.go:913 lxc/auth.go:1044 lxc/auth.go:1895
 #: lxc/cluster.go:120 lxc/cluster.go:976 lxc/cluster_group.go:437
 #: lxc/config_trust.go:347 lxc/config_trust.go:430 lxc/monitor.go:32
 #: lxc/network.go:1003 lxc/network_acl.go:92 lxc/network_zone.go:83
@@ -6593,7 +6590,7 @@ msgstr ""
 msgid "[<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/auth.go:1462
+#: lxc/auth.go:1460
 msgid "[<remote>:] [project=<project_name>] [entity_type=<entity_type>]"
 msgstr ""
 
@@ -6654,17 +6651,17 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:774
+#: lxc/auth.go:772
 msgid ""
 "[<remote>:]<authentication_method>/<name> [<path to PEM encoded "
 "certificate>] [[--group <group_name>]]"
 msgstr ""
 
-#: lxc/auth.go:983 lxc/auth.go:1235
+#: lxc/auth.go:981 lxc/auth.go:1233
 msgid "[<remote>:]<authentication_method>/<name_or_identifier>"
 msgstr ""
 
-#: lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:2134
+#: lxc/auth.go:1311 lxc/auth.go:1369 lxc/auth.go:2132
 msgid "[<remote>:]<authentication_method>/<name_or_identifier> <group>"
 msgstr ""
 
@@ -6672,13 +6669,13 @@ msgstr ""
 msgid "[<remote>:]<fingerprint>"
 msgstr ""
 
-#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:445
-#: lxc/auth.go:1107 lxc/auth.go:1678 lxc/cluster_group.go:168
+#: lxc/auth.go:102 lxc/auth.go:155 lxc/auth.go:205 lxc/auth.go:443
+#: lxc/auth.go:1105 lxc/auth.go:1676 lxc/cluster_group.go:168
 #: lxc/cluster_group.go:253 lxc/cluster_group.go:314 lxc/cluster_group.go:661
 msgid "[<remote>:]<group>"
 msgstr ""
 
-#: lxc/auth.go:520 lxc/auth.go:578
+#: lxc/auth.go:518 lxc/auth.go:576
 msgid ""
 "[<remote>:]<group> <entity_type> [<entity_name>] <entitlement> "
 "[<key>=<value>...]"
@@ -6688,19 +6685,19 @@ msgstr ""
 msgid "[<remote>:]<group> <new-name>"
 msgstr ""
 
-#: lxc/auth.go:395
+#: lxc/auth.go:393
 msgid "[<remote>:]<group> <new_name>"
 msgstr ""
 
-#: lxc/auth.go:1729 lxc/auth.go:1779 lxc/auth.go:2007
+#: lxc/auth.go:1727 lxc/auth.go:1777 lxc/auth.go:2005
 msgid "[<remote>:]<identity_provider_group>"
 msgstr ""
 
-#: lxc/auth.go:2081
+#: lxc/auth.go:2079
 msgid "[<remote>:]<identity_provider_group> <group>"
 msgstr ""
 
-#: lxc/auth.go:1957
+#: lxc/auth.go:1955
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
@@ -7248,14 +7245,14 @@ msgid ""
 "   Update a group using the content of group.yaml"
 msgstr ""
 
-#: lxc/auth.go:1111
+#: lxc/auth.go:1109
 msgid ""
 "lxc auth identity edit <authentication_method>/<name_or_identifier> < "
 "identity.yaml\n"
 "   Update an identity using the content of identity.yaml"
 msgstr ""
 
-#: lxc/auth.go:1783
+#: lxc/auth.go:1781
 msgid ""
 "lxc auth identity-provider-group edit <identity_provider_group> < identity-"
 "provider-group.yaml\n"


### PR DESCRIPTION
I noticed that the help text does contain a note about the fields not being editable, so I just moved it to the top to make it more prominent. This is the same behaviour as for many `lxc edit` commands so I don't think we should change it otherwise.

Closes #14751 