### PR TITLE
CLI: `lxc image alias` completions (from Incus)

### DIFF
--- a/lxc/completion.go
+++ b/lxc/completion.go
@@ -223,6 +223,29 @@ func (g *cmdGlobal) cmpImages(toComplete string) ([]string, cobra.ShellCompDirec
 	return results, cmpDirectives
 }
 
+// cmpImageFingerprintsFromRemote provides shell completion for image fingerprints.
+// It takes a partial input string and a remote and returns image fingerprints for that remote along with a shell completion directive.
+func (g *cmdGlobal) cmpImageFingerprintsFromRemote(toComplete string, remote string) ([]string, cobra.ShellCompDirective) {
+	if remote == "" {
+		remote = g.conf.DefaultRemote
+	}
+
+	remoteServer, _ := g.conf.GetImageServer(remote)
+
+	images, _ := remoteServer.GetImages()
+
+	results := make([]string, 0, len(images))
+	for _, image := range images {
+		if !strings.HasPrefix(image.Fingerprint, toComplete) {
+			continue
+		}
+
+		results = append(results, image.Fingerprint)
+	}
+
+	return results, cobra.ShellCompDirectiveNoFileComp
+}
+
 // cmpInstanceKeys provides shell completion for all instance configuration keys.
 // It takes an instance name to determine instance type and returns a list of all instance configuration keys along with a shell completion directive.
 func (g *cmdGlobal) cmpInstanceKeys(instanceName string) ([]string, cobra.ShellCompDirective) {

--- a/lxc/image_alias.go
+++ b/lxc/image_alias.go
@@ -62,6 +62,23 @@ func (c *cmdImageAliasCreate) command() *cobra.Command {
 
 	cmd.RunE = c.run
 
+	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) > 1 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		if len(args) == 0 {
+			return c.global.cmpRemotes(toComplete, true)
+		}
+
+		remote, _, found := strings.Cut(args[0], ":")
+		if !found {
+			remote = ""
+		}
+
+		return c.global.cmpImageFingerprintsFromRemote(toComplete, remote)
+	}
+
 	return cmd
 }
 

--- a/lxc/image_alias.go
+++ b/lxc/image_alias.go
@@ -126,6 +126,14 @@ func (c *cmdImageAliasDelete) command() *cobra.Command {
 
 	cmd.RunE = c.run
 
+	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) > 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		return c.global.cmpImages(toComplete)
+	}
+
 	return cmd
 }
 
@@ -174,6 +182,14 @@ Filters may be part of the image hash or part of the image alias name.
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G("Format (csv|json|table|yaml|compact)")+"``")
 
 	cmd.RunE = c.run
+
+	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) > 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		return c.global.cmpRemotes(toComplete, true)
+	}
 
 	return cmd
 }
@@ -273,6 +289,14 @@ func (c *cmdImageAliasRename) command() *cobra.Command {
 		`Rename aliases`))
 
 	cmd.RunE = c.run
+
+	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) > 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		return c.global.cmpImages(toComplete)
+	}
 
 	return cmd
 }


### PR DESCRIPTION
This PR adds completions for `lxc image alias`.

Summary of changes:
- Adds a function `cmpImageFingerprintsFromRemote` which provides shell completion for image fingerprints.
- Adds completions for `lxc image alias create|list|delete|rename`.