### PR TITLE
CLI: Add flag completions for `--project`, `--profile` and `--mode`

### DIFF
--- a/lxc/init.go
+++ b/lxc/init.go
@@ -75,6 +75,10 @@ lxc init ubuntu:24.04 v1 --vm -c limits.cpu=2 -c limits.memory=8GiB -d root,size
 		return c.global.cmpImages(toComplete)
 	}
 
+	_ = cmd.RegisterFlagCompletionFunc("profile", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return c.global.cmpProfiles(toComplete, true)
+	})
+
 	return cmd
 }
 

--- a/lxc/main.go
+++ b/lxc/main.go
@@ -99,6 +99,15 @@ For help with any of those, simply call them with --help.`))
 	app.PersistentFlags().BoolVarP(&globalCmd.flagQuiet, "quiet", "q", false, i18n.G("Don't show progress information"))
 	app.PersistentFlags().BoolVar(&globalCmd.flagSubCmds, "sub-commands", false, i18n.G("Use with help or --help to view sub-commands"))
 
+	_ = app.RegisterFlagCompletionFunc("project", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		projects, directives := globalCmd.cmpProjects(toComplete)
+		if projects != nil {
+			return projects, directives
+		}
+
+		return nil, cobra.ShellCompDirectiveError
+	})
+
 	// Wrappers
 	app.PersistentPreRunE = globalCmd.PreRun
 	app.PersistentPostRunE = globalCmd.PostRun

--- a/lxc/move.go
+++ b/lxc/move.go
@@ -70,7 +70,8 @@ lxc move <instance>/<old snapshot name> <instance>/<new snapshot name>
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if len(args) == 0 {
-			return c.global.cmpInstances(toComplete)
+			instances, directives := c.global.cmpInstances(toComplete)
+			return instances, directives | cobra.ShellCompDirectiveNoSpace
 		}
 
 		if len(args) == 1 {

--- a/lxc/move.go
+++ b/lxc/move.go
@@ -80,6 +80,10 @@ lxc move <instance>/<old snapshot name> <instance>/<new snapshot name>
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 
+	_ = cmd.RegisterFlagCompletionFunc("mode", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return []string{"pull", "push", "relay"}, cobra.ShellCompDirectiveNoFileComp
+	})
+
 	return cmd
 }
 


### PR DESCRIPTION
Closes https://github.com/canonical/lxd/issues/14691.

This PR adds flag completions for the following flags and commands:
- `--project` for all commands;
- `--profile` for `lxc init|launch`; and
- `--mode` for `lxc move`.