### PR TITLE
devlxd: Avoid superfluous call to `WriteHeader`

### DIFF
--- a/lxd/devlxd.go
+++ b/lxd/devlxd.go
@@ -119,14 +119,7 @@ func devlxdImageExportHandler(d *Daemon, c instance.Instance, w http.ResponseWri
 		return response.DevLxdErrorResponse(api.StatusErrorf(http.StatusForbidden, "not authorized"), c.Type() == instancetype.VM)
 	}
 
-	resp := imageExport(d, r)
-
-	err := resp.Render(w, r)
-	if err != nil {
-		return response.DevLxdErrorResponse(api.StatusErrorf(http.StatusInternalServerError, "internal server error"), c.Type() == instancetype.VM)
-	}
-
-	return response.DevLxdResponse(http.StatusOK, "", "raw", c.Type() == instancetype.VM)
+	return imageExport(d, r)
 }
 
 var devlxdMetadataGet = devLxdHandler{

--- a/lxd/response/response.go
+++ b/lxd/response/response.go
@@ -52,9 +52,7 @@ type devLxdResponse struct {
 }
 
 // Render renders a response for requests against the /dev/lxd socket.
-func (r *devLxdResponse) Render(w http.ResponseWriter, req *http.Request) error {
-	var err error
-
+func (r *devLxdResponse) Render(w http.ResponseWriter, req *http.Request) (err error) {
 	if r.code != http.StatusOK {
 		http.Error(w, fmt.Sprintf("%s", r.content), r.code)
 	} else if r.contentType == "json" {
@@ -72,11 +70,7 @@ func (r *devLxdResponse) Render(w http.ResponseWriter, req *http.Request) error 
 		_, err = fmt.Fprint(w, r.content.(string))
 	}
 
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 func (r *devLxdResponse) String() string {


### PR DESCRIPTION
The returned response will be rendered using the same `ResponseWriter` object, resulting on a redundant call to `WriteHeader` on the second Render call.

Closes https://github.com/canonical/lxd/issues/14641