### PR TITLE
devlxd: Unmask Render errors

### DIFF
--- a/lxd/api.go
+++ b/lxd/api.go
@@ -243,7 +243,15 @@ func hoistReqVM(f func(*Daemon, instance.Instance, http.ResponseWriter, *http.Re
 		}
 
 		resp := f(d, inst, w, r)
-		_ = resp.Render(w, r)
+		if resp != nil {
+			err = resp.Render(w, r)
+			if err != nil {
+				writeErr := response.DevLxdErrorResponse(err, true).Render(w, r)
+				if writeErr != nil {
+					logger.Warn("Failed writing error for HTTP response", logger.Ctx{"url": r.URL, "err": err, "writeErr": writeErr})
+				}
+			}
+		}
 	}
 }
 

--- a/lxd/devlxd.go
+++ b/lxd/devlxd.go
@@ -344,7 +344,15 @@ func hoistReq(f func(*Daemon, instance.Instance, http.ResponseWriter, *http.Requ
 		}
 
 		resp := f(d, c, w, r)
-		_ = resp.Render(w, r)
+		if resp != nil {
+			err = resp.Render(w, r)
+			if err != nil {
+				writeErr := response.DevLxdErrorResponse(err, false).Render(w, r)
+				if writeErr != nil {
+					logger.Warn("Failed writing error for HTTP response", logger.Ctx{"url": r.URL, "err": err, "writeErr": writeErr})
+				}
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
This implements a better handling of errors during Render on devlxd handlers, following the same pattern seen on https://github.com/hamistao/lxd/blob/unmask_write_errors/lxd/daemon.go#L846
When rendering a response (send it to the client) fails, instead of masking the error we try to send a response using `DevLxdErrorResponse` to the client communicating the error, since this determines the response type used for communicating erros on the devlxd API. If that also fails, an error is logged on the server.