### PR TITLE
doc: update ref to cloud-init docs

### DIFF
--- a/doc/cloud-init.md
+++ b/doc/cloud-init.md
@@ -47,7 +47,7 @@ However, there might be exceptions to that rule.
 
 The following configuration options are supported:
 
-* `cloud-init.vendor-data` or `user.vendor-data` (see {ref}`cloud-init:vendordata`)
+* `cloud-init.vendor-data` or `user.vendor-data` (see {ref}`cloud-init:vendor-data`)
 * `cloud-init.user-data` or `user.user-data` (see {ref}`cloud-init:user_data_formats`)
 * `cloud-init.network-config` or `user.network-config` (see {ref}`cloud-init:network_config`)
 


### PR DESCRIPTION
Recent update in cloud-init docs https://github.com/canonical/cloud-init/pull/5909 included changing an anchor #vendordata to #vendor-data in one of their pages, which caused `WARNING: undefined label: 'cloud-init:vendordata' [ref.ref]` error when building our docs. This PR simply updates that reference to `cloud-init:vendor-data`. 