### PR TITLE
github: add `actions/reclaim-memory`

### DIFF
--- a/.github/actions/reclaim-memory/action.yml
+++ b/.github/actions/reclaim-memory/action.yml
@@ -1,0 +1,33 @@
+name: Reclaim memory
+description: Turn off unneeded services to free up memory
+
+runs:
+  using: composite
+  steps:
+    - name: Reclaim memory
+      shell: bash
+      run: |
+        set -eux
+
+        free -mt
+
+        # turn off .timer, .socket and .service that are not relevant on a CI runner
+        sudo systemctl stop dpkg-db-backup.timer e2scrub_all.timer fstrim.timer logrotate.timer man-db.timer motd-news.timer update-notifier-download.timer update-notifier-motd.timer || true
+        sudo systemctl stop iscsid.socket multipathd.socket || true
+        sudo systemctl stop cron.service irqbalance.service multipathd.service networkd-dispatcher.service || true
+
+        # CI runners are ephemeral, don't bother with cleaning up
+        sudo systemctl stop systemd-tmpfiles-clean.timer || true
+        sudo systemctl stop phpsessionclean.timer || true
+
+        # the mono service doesn't cleanly stop so use pkill
+        sudo systemctl stop mono-xsp4.service || true
+        sudo pkill -x mono || true
+
+        # php8.1 (Jammy), php8.3 (Noble)
+        sudo systemctl stop php8.1-fpm.service php8.3-fpm.service || true
+
+        # the podman `systemctl --user` service doesn't cleanly stop so use pkill
+        sudo pkill podman -u runner || true
+
+        free -mt

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -230,6 +230,9 @@ jobs:
       - name: Tune disk performance
         uses: ./.github/actions/tune-disk-performance
 
+      - name: Reclaim some memory
+        uses: ./.github/actions/reclaim-memory
+
       - name: Reclaim disk space
         uses: ./.github/actions/reclaim-disk-space
 
@@ -316,6 +319,9 @@ jobs:
 
       - name: Tune disk performance
         uses: ./.github/actions/tune-disk-performance
+
+      - name: Reclaim some memory
+        uses: ./.github/actions/reclaim-memory
 
       - name: Reclaim disk space
         uses: ./.github/actions/reclaim-disk-space


### PR DESCRIPTION
Reclaims between 80 and 120MiB of memory from `ubuntu-22.04` runners.