### PR TITLE
lxd-agent: If the target path of a mount is relative, make it absolute.

### DIFF
--- a/lxd-agent/events.go
+++ b/lxd-agent/events.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -151,6 +152,12 @@ func eventsProcess(event api.Event) {
 	}
 
 	l := logger.AddContext(logger.Ctx{"type": "virtiofs", "source": mntSource, "path": e.Config["path"]})
+	// If the path is not absolute, the mount will be created at `/run/lxd_agent/<path>`
+	// (since the mount command executed below originates from the `lxd-agent` binary that is in the `/run/lxd_agent` directory).
+	// This is not ideal and not consistent with the way mounts are handled with containers. We then make the path absolute.
+	if !filepath.IsAbs(e.Config["path"]) {
+		e.Config["path"] = filepath.Join("/", e.Config["path"])
+	}
 
 	_ = os.MkdirAll(e.Config["path"], 0755)
 


### PR DESCRIPTION
closes #13406

If the path is not absolute, the mount will be created at `/run/lxd_agent/<path>`, since the mount command executed below originates from the `lxd-agent` binary that is in the `/run/lxd_agent` directory. This is not ideal and not consistent with the way mounts are handled with containers. We then make the path absolute.