### PR TITLE
Storage: Revert "lxd/storage/drivers/generic/vfs: Truncate/Discard ahead of sparse write"

### DIFF
--- a/lxd/storage/drivers/generic_vfs.go
+++ b/lxd/storage/drivers/generic_vfs.go
@@ -2,10 +2,8 @@ package drivers
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -338,15 +336,6 @@ func genericVFSCreateVolumeFromMigration(d Driver, initVolume func(vol Volume) (
 		var wrapper *ioprogress.ProgressTracker
 		if volTargetArgs.TrackProgress {
 			wrapper = migration.ProgressTracker(op, "block_progress", volName)
-		}
-
-		// Reset the volume.
-		// The sparse writer will skip any zero blocks, so need to discard (block) or
-		// truncate (file) prior to unpacking the data or we risk having leftover data from
-		// a previous snapshot interfere with the new state.
-		err := block.ClearBlock(path, 0)
-		if err != nil && !errors.Is(err, fs.ErrNotExist) {
-			return fmt.Errorf("Failed clearing block volume %q: %w", path, err)
 		}
 
 		to, err := os.OpenFile(path, os.O_WRONLY|os.O_TRUNC, 0)
@@ -799,15 +788,6 @@ func genericVFSBackupUnpack(d Driver, sysOS *sys.OS, vol VolumeCopy, snapshots [
 
 			unpack := func(size int64) error {
 				var allowUnsafeResize bool
-
-				// Reset the volume.
-				// The sparse writer will skip any zero blocks, so need to discard (block) or
-				// truncate (file) prior to unpacking the data or we risk having leftover data from
-				// a previous snapshot interfere with the new state.
-				err = block.ClearBlock(targetPath, 0)
-				if err != nil && !errors.Is(err, fs.ErrNotExist) {
-					return fmt.Errorf("Failed clearing block volume %q: %w", targetPath, err)
-				}
 
 				// Open block file (use O_CREATE to support drivers that use image files).
 				to, err := os.OpenFile(targetPath, os.O_WRONLY|os.O_TRUNC|os.O_CREATE, 0644)


### PR DESCRIPTION
This reverts commit ab910ac2cfbe2c91d6b5bcfe303dfe350b79ebe9 from https://github.com/canonical/lxd/pull/14761.

It is causing failures with our LVM CI tests due to the additional time it takes to do a slow `blkdiscard --zeroout` run when resetting the volume after an initial snapshot is transferred.

As the other commit in this PR deals with resetting the newly created volume, no old data from previously deleted volumes will be present, and this commit is just designed to ensure that "holes" of zeroes in the incoming data stream don't corrupt the volume when using the sparse writer.

As we've not landed the sparse writer yet, all of the bytes from the incoming data stream are written to the volume and thus there is no issue.

So we can hold off from landing this commit until we land the sparse writer.