### PR TITLE
doc: Add file command as requirement for lxd-migrate

### DIFF
--- a/doc/howto/import_machines_to_instances.md
+++ b/doc/howto/import_machines_to_instances.md
@@ -86,8 +86,8 @@ Complete the following steps to migrate an existing machine to a LXD instance:
 1. Download the `bin.linux.lxd-migrate` tool ([`bin.linux.lxd-migrate.aarch64`](https://github.com/canonical/lxd/releases/latest/download/bin.linux.lxd-migrate.aarch64) or [`bin.linux.lxd-migrate.x86_64`](https://github.com/canonical/lxd/releases/latest/download/bin.linux.lxd-migrate.x86_64)) from the **Assets** section of the latest [LXD release](https://github.com/canonical/lxd/releases).
 1. Place the tool on the machine that you want to use to create the instance.
    Make it executable (usually by running `chmod u+x bin.linux.lxd-migrate`).
-1. Make sure that the machine has `rsync` installed.
-   If it is missing, install it (for example, with `sudo apt install rsync`).
+1. Make sure that the machine has `rsync` and `file` installed.
+   If they are missing, install them (for example, with `sudo apt install rsync file`).
 1. Run the tool:
 
        sudo ./bin.linux.lxd-migrate


### PR DESCRIPTION
Add missing command `file` requirement for `lxd-migrate` in the docs.