### PR TITLE
lxd/storage: Fix scope of `volume.size` for storage pools

### DIFF
--- a/doc/metadata.txt
+++ b/doc/metadata.txt
@@ -4911,7 +4911,7 @@ Enabling this option allows attaching the volume to multiple isolated instances.
 ```{config:option} size storage-btrfs-volume-conf
 :condition: "appropriate driver"
 :defaultdesc: "same as `volume.size`"
-:scope: "local"
+:scope: "global"
 :shortdesc: "Size/quota of the storage volume"
 :type: "string"
 
@@ -5103,7 +5103,7 @@ Enabling this option allows attaching the volume to multiple isolated instances.
 ```{config:option} size storage-ceph-volume-conf
 :condition: "appropriate driver"
 :defaultdesc: "same as `volume.size`"
-:scope: "local"
+:scope: "global"
 :shortdesc: "Size/quota of the storage volume"
 :type: "string"
 
@@ -5268,7 +5268,7 @@ Enabling this option allows attaching the volume to multiple isolated instances.
 ```{config:option} size storage-cephfs-volume-conf
 :condition: "appropriate driver"
 :defaultdesc: "same as `volume.size`"
-:scope: "local"
+:scope: "global"
 :shortdesc: "Size/quota of the storage volume"
 :type: "string"
 
@@ -5434,7 +5434,7 @@ Enabling this option allows attaching the volume to multiple isolated instances.
 ```{config:option} size storage-dir-volume-conf
 :condition: "appropriate driver"
 :defaultdesc: "same as `volume.size`"
-:scope: "local"
+:scope: "global"
 :shortdesc: "Size/quota of the storage volume"
 :type: "string"
 
@@ -5652,7 +5652,7 @@ Enabling this option allows attaching the volume to multiple isolated instances.
 ```{config:option} size storage-lvm-volume-conf
 :condition: "appropriate driver"
 :defaultdesc: "same as `volume.size`"
-:scope: "local"
+:scope: "global"
 :shortdesc: "Size/quota of the storage volume"
 :type: "string"
 
@@ -6033,7 +6033,7 @@ Enabling this option allows attaching the volume to multiple isolated instances.
 ```{config:option} size storage-zfs-volume-conf
 :condition: "appropriate driver"
 :defaultdesc: "same as `volume.size`"
-:scope: "local"
+:scope: "global"
 :shortdesc: "Size/quota of the storage volume"
 :type: "string"
 

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -5541,7 +5541,7 @@
 							"condition": "appropriate driver",
 							"defaultdesc": "same as `volume.size`",
 							"longdesc": "",
-							"scope": "local",
+							"scope": "global",
 							"shortdesc": "Size/quota of the storage volume",
 							"type": "string"
 						}
@@ -5746,7 +5746,7 @@
 							"condition": "appropriate driver",
 							"defaultdesc": "same as `volume.size`",
 							"longdesc": "",
-							"scope": "local",
+							"scope": "global",
 							"shortdesc": "Size/quota of the storage volume",
 							"type": "string"
 						}
@@ -5919,7 +5919,7 @@
 							"condition": "appropriate driver",
 							"defaultdesc": "same as `volume.size`",
 							"longdesc": "",
-							"scope": "local",
+							"scope": "global",
 							"shortdesc": "Size/quota of the storage volume",
 							"type": "string"
 						}
@@ -6102,7 +6102,7 @@
 							"condition": "appropriate driver",
 							"defaultdesc": "same as `volume.size`",
 							"longdesc": "",
-							"scope": "local",
+							"scope": "global",
 							"shortdesc": "Size/quota of the storage volume",
 							"type": "string"
 						}
@@ -6332,7 +6332,7 @@
 							"condition": "appropriate driver",
 							"defaultdesc": "same as `volume.size`",
 							"longdesc": "",
-							"scope": "local",
+							"scope": "global",
 							"shortdesc": "Size/quota of the storage volume",
 							"type": "string"
 						}
@@ -6729,7 +6729,7 @@
 							"condition": "appropriate driver",
 							"defaultdesc": "same as `volume.size`",
 							"longdesc": "",
-							"scope": "local",
+							"scope": "global",
 							"shortdesc": "Size/quota of the storage volume",
 							"type": "string"
 						}

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -515,7 +515,7 @@ func poolAndVolumeCommonRules(vol *drivers.Volume) map[string]func(string) error
 		//  condition: appropriate driver
 		//  defaultdesc: same as `volume.size`
 		//  shortdesc: Size/quota of the storage volume
-		//  scope: local
+		//  scope: global
 
 		// lxdmeta:generate(entities=storage-cephobject; group=bucket-conf; key=size)
 		//


### PR DESCRIPTION
The scope for `volume.size` should be global since `volume.size` on a storage pool is not node specific.