### PR TITLE
Storage: Fix copying storage volumes between cluster nodes when target and project parameters are set

### DIFF
--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -1128,7 +1128,7 @@ func clusterCopyCustomVolumeInternal(s *state.State, r *http.Request, sourceAddr
 		Pool:       req.Source.Pool,
 		Migration:  true,
 		VolumeOnly: req.Source.VolumeOnly,
-		Project:    req.Source.Project,
+		Project:    projectName,
 		Source: api.StorageVolumeSource{
 			Location: req.Source.Location,
 		},
@@ -1430,7 +1430,7 @@ func storagePoolVolumePost(d *Daemon, r *http.Request) response.Response {
 			return response.BadRequest(fmt.Errorf("Target project does not have features.storage.volumes enabled"))
 		}
 
-		if effectiveProjectName == targetProjectName {
+		if targetProjectName != api.ProjectDefaultName && effectiveProjectName == targetProjectName {
 			return response.BadRequest(fmt.Errorf("Project and target project are the same"))
 		}
 

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -659,6 +659,9 @@ test_clustering_storage() {
     LXD_DIR="${LXD_ONE_DIR}" lxc storage volume create pool1 vol1 --target=node1
     LXD_DIR="${LXD_ONE_DIR}" lxc storage volume copy pool1/vol1 pool1/vol1 --target=node1 --destination-target=node2
     LXD_DIR="${LXD_ONE_DIR}" lxc storage volume copy pool1/vol1 pool1/vol1 --target=node1 --destination-target=node2 --refresh
+    LXD_DIR="${LXD_ONE_DIR}" lxc project create foo
+    LXD_DIR="${LXD_ONE_DIR}" lxc storage volume copy pool1/vol1 pool1/vol1 --target=node1 --destination-target=node2 --target-project foo
+    LXD_DIR="${LXD_ONE_DIR}" lxc project delete foo
 
     # Check renaming storage volume works.
     LXD_DIR="${LXD_ONE_DIR}" lxc storage volume create pool1 vol2 --target=node1


### PR DESCRIPTION
Fixes https://github.com/canonical/lxd/issues/14155.

Summary of changes:
- Includes the request project name in the `clusterCopyCustomVolumeInternal` function when building the `storageVolumePost` request. This is required to ensure the request project name is not always default when copying storage volumes with a target project set.
- Fixes storage volume migration error handling by checking if effective project and target project are the same only when the target project is not `default`.
- Adds a test for copying storage volumes across cluster members when both a target and target project are set.