### PR TITLE
lxd/network/acl: Use the `journalctl` wrapper script introduced in the LXD snap

### DIFF
--- a/lxd/network/acl/acl_ovn.go
+++ b/lxd/network/acl/acl_ovn.go
@@ -1163,9 +1163,8 @@ func ovnParseLogEntry(logline string, syslogTimestamp string, prefix string) str
 func ovnParseLogEntriesFromJournald(ctx context.Context, systemdUnitName string, filter string) ([]string, error) {
 	var logEntries []string
 	cmd := []string{
-		"/usr/bin/journalctl",
+		"journalctl",
 		"--unit", systemdUnitName,
-		"--directory", shared.HostPath("/var/log/journal"),
 		"--no-pager",
 		"--boot", "0",
 		"--case-sensitive",


### PR DESCRIPTION
Requires https://github.com/canonical/lxd-pkg-snap/pull/688

This way, we rely on the `journalctl` host binary and not on the one shipped within the snap (which the version might differ whether LXD uses core22 or core24 as a base snap) We can also remove the `--directory ..` flag as the wrapper script which executes the host journalctl targets by default the host journal directory.