### PR TITLE
Storage: Align Ceph block device name encoding

### DIFF
--- a/lxd/device/device_utils_disk.go
+++ b/lxd/device/device_utils_disk.go
@@ -31,7 +31,7 @@ const RBDFormatPrefix = "rbd"
 const RBDFormatSeparator = " "
 
 // DiskParseRBDFormat parses an rbd formatted string, and returns the pool name, volume name, and list of options.
-func DiskParseRBDFormat(rbd string) (poolName string, volumeName string, options []string, err error) {
+func DiskParseRBDFormat(rbd string) (cephPoolName string, rbdImageName string, options []string, err error) {
 	if !strings.HasPrefix(rbd, fmt.Sprintf("%s%s", RBDFormatPrefix, RBDFormatSeparator)) {
 		return "", "", nil, fmt.Errorf("Invalid rbd format, missing prefix")
 	}
@@ -52,17 +52,17 @@ func DiskParseRBDFormat(rbd string) (poolName string, volumeName string, options
 }
 
 // DiskGetRBDFormat returns a rbd formatted string with the given values.
-func DiskGetRBDFormat(clusterName string, userName string, poolName string, volumeName string) string {
+func DiskGetRBDFormat(clusterName string, userName string, cephPoolName string, rbdImageName string) string {
 	// Configuration values containing :, @, or = can be escaped with a leading \ character.
 	// According to https://docs.ceph.com/docs/hammer/rbd/qemu-rbd/#usage
 	optEscaper := strings.NewReplacer(":", `\:`, "@", `\@`, "=", `\=`)
 	opts := []string{
 		fmt.Sprintf("id=%s", optEscaper.Replace(userName)),
-		fmt.Sprintf("pool=%s", optEscaper.Replace(poolName)),
+		fmt.Sprintf("pool=%s", optEscaper.Replace(cephPoolName)),
 		fmt.Sprintf("conf=/etc/ceph/%s.conf", optEscaper.Replace(clusterName)),
 	}
 
-	return fmt.Sprintf("%s%s%s/%s%s%s", RBDFormatPrefix, RBDFormatSeparator, optEscaper.Replace(poolName), optEscaper.Replace(volumeName), RBDFormatSeparator, strings.Join(opts, ":"))
+	return fmt.Sprintf("%s%s%s/%s%s%s", RBDFormatPrefix, RBDFormatSeparator, optEscaper.Replace(cephPoolName), optEscaper.Replace(rbdImageName), RBDFormatSeparator, strings.Join(opts, ":"))
 }
 
 // BlockFsDetect detects the type of block device.


### PR DESCRIPTION
Different calls of `DiskGetRBDFormat` and `DiskParseRBDFormat` are currently using both senses of "volume":
- A Ceph block device (RBD Image)
- A LXD storage volume

Because a disk device can specify an RBD image with source `ceph:<pool_name>/<volume_name>"`, these functions should use the first meaning: the name passed should be the name of a RADOS block device (RBD image), not a LXD storage volume.

These functions should (in future) be replaced with a more comprehensive abstraction for what `MountInfo.DevPath` is currently doing. This serialization doesn't seem to be written anywhere, it's just deserialized when it gets to the instance driver.

This fixes the failures from https://github.com/canonical/lxd-ci/pull/366; the QEMU driver was inferring a virtual-machine `VolumeType` only when `TargetPath == "/"`