### PR TITLE
Network: Prevent removal of OVN uplink volatile keys when associated network IP is populated

### DIFF
--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -3960,7 +3960,7 @@ func (n *ovn) InstanceDevicePortStart(opts *OVNInstanceNICSetupOpts, securityACL
 		}
 	}
 
-	var routes []openvswitch.OVNRouterRoute
+	routes := make([]openvswitch.OVNRouterRoute, 0, len(internalRoutes)+len(externalRoutes))
 
 	// In l3only mode we add the instance port's IPs as static routes to the router.
 	if shared.IsTrue(n.config["ipv4.l3only"]) && dnsIPv4 != nil {
@@ -4312,7 +4312,7 @@ func (n *ovn) InstanceDevicePortRemove(instanceUUID string, deviceName string, d
 		return err
 	}
 
-	var removeRoutes []net.IPNet
+	removeRoutes := make([]net.IPNet, 0, len(dnsIPs)+len(internalRoutes)+len(externalRoutes))
 	var removeNATIPs []net.IP
 
 	if len(dnsIPs) > 0 {

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -3246,7 +3246,7 @@ func (n *ovn) Update(newNetwork api.NetworkPut, targetNode string, clientType re
 		delete(newNetwork.Config, ovnVolatileUplinkIPv6)
 	}
 
-	// Apply changes to all nodes and databse.
+	// Apply changes to all nodes and database.
 	err = n.common.update(newNetwork, targetNode, clientType)
 	if err != nil {
 		return err

--- a/test/suites/network_ovn.sh
+++ b/test/suites/network_ovn.sh
@@ -189,6 +189,10 @@ test_network_ovn() {
   address_set_ipv6_name="${port_group_name}_routes_ip6"
   [ "$(ovn-nbctl get address_set "${address_set_ipv6_name}" addresses | jq -er '.[0]')" = "fd42:bd85:5f89:5293::/64" ]
 
+  # Check that uplink volatile address keys cannot be removed when associated network address is set.
+  ! lxc network unset "${ovn_network}" volatile.network.ipv4.address || false
+  ! lxc network unset "${ovn_network}" volatile.network.ipv6.address || false
+
   # Launch an instance on the OVN network and assert configuration changes.
   ensure_import_testimage
   lxc launch testimage c1 --network "${ovn_network}"


### PR DESCRIPTION
Fixes https://github.com/canonical/lxd/issues/14531

The original problem was that the LXD UI was removing the `volatile.network.ipvx.address` keys, and these were being partially regenerated on the member that received the update request, but not on the other cluster members, leading to inconsistent BGP next hop addresses.

But really we shouldn't be allowing the `volatile.network.ipvx.address` keys to be removed when the associated `ipvn.address` keys are populated in the network.