### PR TITLE
Storage: Standardize `volume.size` usage across drivers

### DIFF
--- a/lxd/storage/drivers/volume_test.go
+++ b/lxd/storage/drivers/volume_test.go
@@ -35,10 +35,10 @@ func Test_Volume_ConfigSizeFromSource(t *testing.T) {
 		{
 			// Check the volume's pool volume.size is used when volume size not specified and empty
 			// image source volume used.
-			vol:    Volume{driver: &nonBlockBackedDriver, volType: VolumeTypeContainer, poolConfig: map[string]string{"volume.size": "2GiB"}},
+			vol:    Volume{driver: &blockBackedDriver, volType: VolumeTypeContainer, poolConfig: map[string]string{"volume.size": "2GiB"}},
 			srcVol: Volume{volType: VolumeTypeImage},
 			err:    nil,
-			size:   "2GiB",
+			size:   "",
 		},
 		{
 			// Check the volume's default block disk size is used when volume is a block type and


### PR DESCRIPTION
On non-block based drivers, filesystem volumes can be unbounded, having access to the entire storage quota of its pool. When creating such volumes on `btrfs` and `dir`, the pool's `volume.size` config is ignored unbounded volumes are created. But on `zfs` those volumes are bounded by whatever is defined on `volume.size`, which is inconsistent behavior. To reproduce this, one can run the following on the specified drivers and compare their behaviors:
```
lxc launch ubuntu:n c -s poolName
lxc storage volume create poolName vol
lxc storage volume attach poolName vol c /mnt/foo
lxc exec c -- df -h
```