### PR TITLE
Auth: Make OIDC scopes configurable

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2552,3 +2552,8 @@ This adds support for listing network zones across all projects using the `all-p
 Adds support for instance root volumes to be attached to other instances as disk
 devices. Introduces the `<type>/<volume>` syntax for the `source` property of
 disk devices.
+
+## `oidc_scopes`
+
+This optional API extension enables setting an {config:option}`server-oidc:oidc.scopes` configuration key, which can be used to overwrite the default scopes that are requested during the OIDC flow.
+If not set, the flow will request `oidc offline_access email profile` as scopes and if defined the `oidc_groups_claim` as an additional scope.

--- a/doc/metadata.txt
+++ b/doc/metadata.txt
@@ -4829,6 +4829,15 @@ for automatic access control.
 
 ```
 
+```{config:option} oidc.scopes server-oidc
+:scope: "global"
+:shortdesc: "Scopes requested during OIDC flows"
+:type: "string"
+Overwrite the default scopes that are requested during OIDC flows.
+If not set, the flow will request oidc, offline_access, email,
+profile, and if defined the oidc_groups_claim as scopes.
+```
+
 <!-- config group server-oidc end -->
 <!-- config group storage-btrfs-bucket-conf start -->
 ```{config:option} size storage-btrfs-bucket-conf

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -230,7 +230,7 @@ func api10Get(d *Daemon, r *http.Request) response.Response {
 	// Get the authentication methods.
 	authMethods := []string{api.AuthenticationMethodTLS}
 
-	oidcIssuer, oidcClientID, _, _ := s.GlobalConfig.OIDCServer()
+	oidcIssuer, oidcClientID, _, _, _ := s.GlobalConfig.OIDCServer()
 	if oidcIssuer != "" && oidcClientID != "" {
 		authMethods = append(authMethods, api.AuthenticationMethodOIDC)
 	}
@@ -1016,7 +1016,7 @@ func doAPI10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 	}
 
 	if oidcChanged {
-		oidcIssuer, oidcClientID, oidcAudience, oidcGroupsClaim := clusterConfig.OIDCServer()
+		oidcIssuer, oidcClientID, oidcAudience, oidcGroupsClaim, oidcScopes := clusterConfig.OIDCServer()
 
 		if oidcIssuer == "" || oidcClientID == "" {
 			d.oidcVerifier = nil

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -868,7 +868,7 @@ func doAPI10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 			acmeCAURLChanged = true
 		case "acme.domain":
 			acmeDomainChanged = true
-		case "oidc.issuer", "oidc.client.id", "oidc.audience", "oidc.groups.claim":
+		case "oidc.issuer", "oidc.client.id", "oidc.audience", "oidc.groups.claim", "oidc.scopes":
 			oidcChanged = true
 		}
 	}
@@ -1027,7 +1027,7 @@ func doAPI10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 				return util.HTTPClient("", d.proxy)
 			}
 
-			d.oidcVerifier, err = oidc.NewVerifier(oidcIssuer, oidcClientID, oidcAudience, s.ServerCert, d.identityCache, httpClientFunc, &oidc.Opts{GroupsClaim: oidcGroupsClaim})
+			d.oidcVerifier, err = oidc.NewVerifier(oidcIssuer, oidcClientID, oidcAudience, oidcScopes, s.ServerCert, d.identityCache, httpClientFunc, &oidc.Opts{GroupsClaim: oidcGroupsClaim})
 			if err != nil {
 				return fmt.Errorf("Failed creating verifier: %w", err)
 			}

--- a/lxd/auth/oidc/oidc.go
+++ b/lxd/auth/oidc/oidc.go
@@ -429,6 +429,10 @@ func (o *Verifier) setRelyingParty(ctx context.Context, host string) error {
 		oidcScopes = append(oidcScopes, o.groupsClaim)
 	}
 
+	if o.scopes != "" {
+		oidcScopes = strings.Split(o.scopes, " ")
+	}
+
 	relyingParty, err := rp.NewRelyingPartyOIDC(ctx, o.issuer, o.clientID, "", fmt.Sprintf("https://%s/oidc/callback", host), oidcScopes, options...)
 	if err != nil {
 		return fmt.Errorf("Failed to get OIDC relying party: %w", err)

--- a/lxd/auth/oidc/oidc.go
+++ b/lxd/auth/oidc/oidc.go
@@ -331,6 +331,7 @@ func (o *Verifier) WriteHeaders(w http.ResponseWriter) error {
 	w.Header().Set("X-LXD-OIDC-clientid", o.clientID)
 	w.Header().Set("X-LXD-OIDC-audience", o.audience)
 	w.Header().Set("X-LXD-OIDC-groups-claim", o.groupsClaim)
+	w.Header().Set("X-LXD-OIDC-scopes", o.scopes)
 
 	return nil
 }

--- a/lxd/auth/oidc/oidc.go
+++ b/lxd/auth/oidc/oidc.go
@@ -51,6 +51,7 @@ type Verifier struct {
 	issuer         string
 	audience       string
 	groupsClaim    string
+	scopes         string
 	clusterCert    func() *shared.CertInfo
 	httpClientFunc func() (*http.Client, error)
 
@@ -617,7 +618,7 @@ type Opts struct {
 }
 
 // NewVerifier returns a Verifier.
-func NewVerifier(issuer string, clientID string, audience string, clusterCert func() *shared.CertInfo, identityCache *identity.Cache, httpClientFunc func() (*http.Client, error), options *Opts) (*Verifier, error) {
+func NewVerifier(issuer string, clientID string, audience string, scopes string, clusterCert func() *shared.CertInfo, identityCache *identity.Cache, httpClientFunc func() (*http.Client, error), options *Opts) (*Verifier, error) {
 	opts := &Opts{}
 
 	if options != nil && options.GroupsClaim != "" {
@@ -628,6 +629,7 @@ func NewVerifier(issuer string, clientID string, audience string, clusterCert fu
 		issuer:               issuer,
 		clientID:             clientID,
 		audience:             audience,
+		scopes:               scopes,
 		identityCache:        identityCache,
 		groupsClaim:          opts.GroupsClaim,
 		clusterCert:          clusterCert,

--- a/lxd/cluster/config/config.go
+++ b/lxd/cluster/config/config.go
@@ -223,8 +223,8 @@ func (c *Config) RemoteTokenExpiry() string {
 }
 
 // OIDCServer returns all the OpenID Connect settings needed to connect to a server.
-func (c *Config) OIDCServer() (issuer string, clientID string, audience string, groupsClaim string) {
-	return c.m.GetString("oidc.issuer"), c.m.GetString("oidc.client.id"), c.m.GetString("oidc.audience"), c.m.GetString("oidc.groups.claim")
+func (c *Config) OIDCServer() (issuer string, clientID string, audience string, groupsClaim string, scopes string) {
+	return c.m.GetString("oidc.issuer"), c.m.GetString("oidc.client.id"), c.m.GetString("oidc.audience"), c.m.GetString("oidc.groups.claim"), c.m.GetString("oidc.scopes")
 }
 
 // ClusterHealingThreshold returns the configured healing threshold, i.e. the
@@ -689,6 +689,16 @@ var ConfigSchema = config.Schema{
 	//  scope: global
 	//  shortdesc: A claim used for mapping identity provider groups to LXD groups.
 	"oidc.groups.claim": {},
+
+	// lxdmeta:generate(entities=server; group=oidc; key=oidc.scopes)
+	// Overwrite the default scopes that are requested during OIDC flows.
+	// If not set, the flow will request oidc, offline_access, email,
+	// profile, and if defined the oidc_groups_claim as scopes.
+	// ---
+	//  type: string
+	//  scope: global
+	//  shortdesc: Scopes requested during OIDC flows
+	"oidc.scopes": {},
 	// OVN networking global keys.
 
 	// lxdmeta:generate(entities=server; group=miscellaneous; key=network.ovn.integration_bridge)

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1570,7 +1570,7 @@ func (d *Daemon) init() error {
 	maasAPIURL, maasAPIKey = d.globalConfig.MAASController()
 	d.gateway.HeartbeatOfflineThreshold = d.globalConfig.OfflineThreshold()
 	lokiURL, lokiUsername, lokiPassword, lokiCACert, lokiInstance, lokiLoglevel, lokiLabels, lokiTypes := d.globalConfig.LokiServer()
-	oidcIssuer, oidcClientID, oidcAudience, oidcGroupsClaim := d.globalConfig.OIDCServer()
+	oidcIssuer, oidcClientID, oidcAudience, oidcGroupsClaim, oidcScopes := d.globalConfig.OIDCServer()
 	syslogSocketEnabled := d.localConfig.SyslogSocket()
 	instancePlacementScriptlet := d.globalConfig.InstancesPlacementScriptlet()
 
@@ -1598,7 +1598,7 @@ func (d *Daemon) init() error {
 			return util.HTTPClient("", d.proxy)
 		}
 
-		d.oidcVerifier, err = oidc.NewVerifier(oidcIssuer, oidcClientID, oidcAudience, d.serverCert, d.identityCache, httpClientFunc, &oidc.Opts{GroupsClaim: oidcGroupsClaim})
+		d.oidcVerifier, err = oidc.NewVerifier(oidcIssuer, oidcClientID, oidcAudience, oidcScopes, d.serverCert, d.identityCache, httpClientFunc, &oidc.Opts{GroupsClaim: oidcGroupsClaim})
 		if err != nil {
 			return err
 		}

--- a/lxd/metadata/configuration.json
+++ b/lxd/metadata/configuration.json
@@ -5446,6 +5446,14 @@
 							"shortdesc": "OpenID Connect Discovery URL for the provider",
 							"type": "string"
 						}
+					},
+					{
+						"oidc.scopes": {
+							"longdesc": "Overwrite the default scopes that are requested during OIDC flows.\nIf not set, the flow will request oidc, offline_access, email,\nprofile, and if defined the oidc_groups_claim as scopes.",
+							"scope": "global",
+							"shortdesc": "Scopes requested during OIDC flows",
+							"type": "string"
+						}
 					}
 				]
 			}

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -431,6 +431,7 @@ var APIExtensions = []string{
 	"network_get_target",
 	"network_zones_all_projects",
 	"instance_root_volume_attachment",
+	"oidc_scopes",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
This PR adds a new server configuration key `oidc.scopes`. When set, the value of this config key is used to determine which scopes to request during OIDC flows.

The current behavior is hardcoded to request the `openid offline_access profile email`. The `offline_access` scope is marked as optional in the OpenID Connect specification and is not supported by all auth providers. For example, [GitLab as an OpenID Connect identity provider](https://docs.gitlab.com/ee/integration/openid_connect_provider.html) rejects requests with the `offline_access` scope, even though it supports refresh tokens. The proposed `oidc.scopes` option could be used in this case, to only request `openid profile email` scopes, so that LXD can be used with GitLab as an identity provider.

Additionally, #14141 shows how the `oidc.groups.claim` configuration option is added as an additional scope which breaks various identity providers. This pull request also provides a backwards-compatible fix for this issue. As long as `oidc.scopes` is not configured, the current behavior is unchanged and the default scopes are used with the value of `oidc.groups.claim` as an additional scope. When `oidc.scopes` is set, it overwrites all scopes, so that the scopes can be configured to work with existing identity providers.