### PR TITLE
LXC: Fix `lxc image list --all-projects`

### DIFF
--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -50,8 +50,6 @@ type ImageServer interface {
 	GetImages() (images []api.Image, err error)
 	GetImageFingerprints() (fingerprints []string, err error)
 	GetImagesWithFilter(filters []string) (images []api.Image, err error)
-	GetImagesAllProjects() (images []api.Image, err error)
-	GetImagesAllProjectsWithFilter(filters []string) (images []api.Image, err error)
 
 	GetImage(fingerprint string) (image *api.Image, ETag string, err error)
 	GetImageFile(fingerprint string, req ImageFileRequest) (resp *ImageFileResponse, err error)
@@ -245,6 +243,8 @@ type InstanceServer interface {
 	UpdateImageAlias(name string, alias api.ImageAliasesEntryPut, ETag string) (err error)
 	RenameImageAlias(name string, alias api.ImageAliasesEntryPost) (err error)
 	DeleteImageAlias(name string) (err error)
+	GetImagesAllProjects() (images []api.Image, err error)
+	GetImagesAllProjectsWithFilter(filters []string) (images []api.Image, err error)
 
 	// Network functions ("network" API extension)
 	GetNetworkNames() (names []string, err error)

--- a/client/simplestreams_images.go
+++ b/client/simplestreams_images.go
@@ -23,11 +23,6 @@ func (r *ProtocolSimpleStreams) GetImages() ([]api.Image, error) {
 	return r.ssClient.ListImages()
 }
 
-// GetImagesAllProjects returns a list of available images as Image structs.
-func (r *ProtocolSimpleStreams) GetImagesAllProjects() ([]api.Image, error) {
-	return r.GetImages()
-}
-
 // GetImageFingerprints returns a list of available image fingerprints.
 func (r *ProtocolSimpleStreams) GetImageFingerprints() ([]string, error) {
 	// Get all the images from simplestreams
@@ -48,11 +43,6 @@ func (r *ProtocolSimpleStreams) GetImageFingerprints() ([]string, error) {
 // GetImagesWithFilter returns a filtered list of available images as Image structs.
 func (r *ProtocolSimpleStreams) GetImagesWithFilter(filters []string) ([]api.Image, error) {
 	return nil, fmt.Errorf("GetImagesWithFilter is not supported by the simplestreams protocol")
-}
-
-// GetImagesAllProjectsWithFilter returns an error indicating compatibility with the simplestreams protocol.
-func (r *ProtocolSimpleStreams) GetImagesAllProjectsWithFilter(filters []string) ([]api.Image, error) {
-	return nil, fmt.Errorf("GetImagesAllProjectsWithFilter is not supported by the simplestreams protocol")
 }
 
 // GetImage returns an Image struct for the provided fingerprint.

--- a/lxc/image.go
+++ b/lxc/image.go
@@ -1353,11 +1353,6 @@ func (c *cmdImageList) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	d, err := c.global.conf.GetInstanceServer(remoteName)
-	if err != nil {
-		return err
-	}
-
 	// Process the filters
 	filters := []string{}
 	if name != "" {
@@ -1378,9 +1373,14 @@ func (c *cmdImageList) run(cmd *cobra.Command, args []string) error {
 
 	var allImages []api.Image
 	if c.flagAllProjects {
-		allImages, err = d.GetImagesAllProjectsWithFilter(serverFilters)
+		instanceServer, ok := remoteServer.(lxd.InstanceServer)
+		if !ok {
+			return fmt.Errorf("--all-projects flag is not supported for this server")
+		}
+
+		allImages, err = instanceServer.GetImagesAllProjectsWithFilter(serverFilters)
 		if err != nil {
-			allImages, err = d.GetImagesAllProjects()
+			allImages, err = instanceServer.GetImagesAllProjects()
 			if err != nil {
 				return err
 			}

--- a/lxc/image.go
+++ b/lxc/image.go
@@ -1353,6 +1353,11 @@ func (c *cmdImageList) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	d, err := c.global.conf.GetInstanceServer(remoteName)
+	if err != nil {
+		return err
+	}
+
 	// Process the filters
 	filters := []string{}
 	if name != "" {
@@ -1373,9 +1378,9 @@ func (c *cmdImageList) run(cmd *cobra.Command, args []string) error {
 
 	var allImages []api.Image
 	if c.flagAllProjects {
-		allImages, err = remoteServer.GetImagesAllProjectsWithFilter(serverFilters)
+		allImages, err = d.GetImagesAllProjectsWithFilter(serverFilters)
 		if err != nil {
-			allImages, err = remoteServer.GetImagesAllProjects()
+			allImages, err = d.GetImagesAllProjects()
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
https://github.com/canonical/lxd/pull/14563 attempted to fix https://github.com/canonical/lxd/issues/14561 by adding `GetImagesAllProjects` and `GetImagesAllProjectsWithFilter` functions to `client/simplestreams_images.go`, and moving their method signatures to the `ImageServer` interface. Instead, we should only expand the `InstanceServer` interface and correctly use the client functions when `--all-projects` is set.