### PR TITLE
Revert images_all_projects feature (stable-5.21)

### DIFF
--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -243,7 +243,6 @@ type InstanceServer interface {
 	UpdateImageAlias(name string, alias api.ImageAliasesEntryPut, ETag string) (err error)
 	RenameImageAlias(name string, alias api.ImageAliasesEntryPost) (err error)
 	DeleteImageAlias(name string) (err error)
-	GetImagesAllProjects() (images []api.Image, err error)
 
 	// Network functions ("network" API extension)
 	GetNetworkNames() (names []string, err error)

--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -244,7 +244,6 @@ type InstanceServer interface {
 	RenameImageAlias(name string, alias api.ImageAliasesEntryPost) (err error)
 	DeleteImageAlias(name string) (err error)
 	GetImagesAllProjects() (images []api.Image, err error)
-	GetImagesAllProjectsWithFilter(filters []string) (images []api.Image, err error)
 
 	// Network functions ("network" API extension)
 	GetNetworkNames() (names []string, err error)

--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -50,8 +50,6 @@ type ImageServer interface {
 	GetImages() (images []api.Image, err error)
 	GetImageFingerprints() (fingerprints []string, err error)
 	GetImagesWithFilter(filters []string) (images []api.Image, err error)
-	GetImagesAllProjects() (images []api.Image, err error)
-	GetImagesAllProjectsWithFilter(filters []string) (images []api.Image, err error)
 
 	GetImage(fingerprint string) (image *api.Image, ETag string, err error)
 	GetImageFile(fingerprint string, req ImageFileRequest) (resp *ImageFileResponse, err error)
@@ -245,6 +243,8 @@ type InstanceServer interface {
 	UpdateImageAlias(name string, alias api.ImageAliasesEntryPut, ETag string) (err error)
 	RenameImageAlias(name string, alias api.ImageAliasesEntryPost) (err error)
 	DeleteImageAlias(name string) (err error)
+	GetImagesAllProjects() (images []api.Image, err error)
+	GetImagesAllProjectsWithFilter(filters []string) (images []api.Image, err error)
 
 	// Network functions ("network" API extension)
 	GetNetworkNames() (names []string, err error)

--- a/client/lxd_images.go
+++ b/client/lxd_images.go
@@ -51,29 +51,6 @@ func (r *ProtocolLXD) GetImagesAllProjects() ([]api.Image, error) {
 	return images, nil
 }
 
-// GetImagesAllProjectsWithFilter returns a filtered list of images across all projects as Image structs.
-func (r *ProtocolLXD) GetImagesAllProjectsWithFilter(filters []string) ([]api.Image, error) {
-	err := r.CheckExtension("api_filtering")
-	if err != nil {
-		return nil, err
-	}
-
-	images := []api.Image{}
-
-	err = r.CheckExtension("images_all_projects")
-	if err != nil {
-		return nil, err
-	}
-
-	u := api.NewURL().Path("images").WithQuery("recursion", "1").WithQuery("all-projects", "true").WithQuery("filter", parseFilters(filters))
-	_, err = r.queryStruct("GET", u.String(), nil, "", &images)
-	if err != nil {
-		return nil, err
-	}
-
-	return images, nil
-}
-
 // GetImagesWithFilter returns a filtered list of available images as Image structs.
 func (r *ProtocolLXD) GetImagesWithFilter(filters []string) ([]api.Image, error) {
 	err := r.CheckExtension("api_filtering")

--- a/client/lxd_images.go
+++ b/client/lxd_images.go
@@ -33,24 +33,6 @@ func (r *ProtocolLXD) GetImages() ([]api.Image, error) {
 	return images, nil
 }
 
-// GetImagesAllProjects returns a list of images across all projects as Image structs.
-func (r *ProtocolLXD) GetImagesAllProjects() ([]api.Image, error) {
-	images := []api.Image{}
-
-	err := r.CheckExtension("images_all_projects")
-	if err != nil {
-		return nil, err
-	}
-
-	u := api.NewURL().Path("images").WithQuery("recursion", "1").WithQuery("all-projects", "true")
-	_, err = r.queryStruct("GET", u.String(), nil, "", &images)
-	if err != nil {
-		return nil, err
-	}
-
-	return images, nil
-}
-
 // GetImagesWithFilter returns a filtered list of available images as Image structs.
 func (r *ProtocolLXD) GetImagesWithFilter(filters []string) ([]api.Image, error) {
 	err := r.CheckExtension("api_filtering")

--- a/client/simplestreams_images.go
+++ b/client/simplestreams_images.go
@@ -23,11 +23,6 @@ func (r *ProtocolSimpleStreams) GetImages() ([]api.Image, error) {
 	return r.ssClient.ListImages()
 }
 
-// GetImagesAllProjects returns a list of available images as Image structs.
-func (r *ProtocolSimpleStreams) GetImagesAllProjects() ([]api.Image, error) {
-	return r.GetImages()
-}
-
 // GetImageFingerprints returns a list of available image fingerprints.
 func (r *ProtocolSimpleStreams) GetImageFingerprints() ([]string, error) {
 	// Get all the images from simplestreams
@@ -48,11 +43,6 @@ func (r *ProtocolSimpleStreams) GetImageFingerprints() ([]string, error) {
 // GetImagesWithFilter returns a filtered list of available images as Image structs.
 func (r *ProtocolSimpleStreams) GetImagesWithFilter(filters []string) ([]api.Image, error) {
 	return nil, fmt.Errorf("GetImagesWithFilter is not supported by the simplestreams protocol")
-}
-
-// GetImagesAllProjectsWithFilter returns an error indicating compatibility with the simplestreams protocol.
-func (r *ProtocolSimpleStreams) GetImagesAllProjectsWithFilter(filters []string) ([]api.Image, error) {
-	return nil, fmt.Errorf("GetImagesAllProjectsWithFilter is not supported by the simplestreams protocol")
 }
 
 // GetImage returns an Image struct for the provided fingerprint.

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2519,7 +2519,3 @@ Adds a new {config:option}`instance-resource-limits:limits.cpu.pin_strategy` con
 ## `gpu_cdi`
 
 Adds support for using the Container Device Interface (CDI) specification to configure GPU passthrough in LXD containers. The `id` field of GPU devices now accepts CDI identifiers (for example, `{VENDOR_DOMAIN_NAME}/gpu=gpu{INDEX}`) for containers, in addition to DRM card IDs. This enables GPU passthrough for devices that don't use PCI addressing (like NVIDIA Tegra iGPUs) and provides a more flexible way to identify and configure GPU devices.
-
-## `images_all_projects`
-
-This adds support for listing images across all projects using the `all-projects` parameter in `GET /1.0/images` requests.

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -987,11 +987,6 @@ definitions:
                     type: string
                 type: array
                 x-go-name: Profiles
-            project:
-                description: Project name
-                example: project1
-                type: string
-                x-go-name: Project
             properties:
                 additionalProperties:
                     type: string
@@ -9024,10 +9019,6 @@ paths:
                   in: query
                   name: filter
                   type: string
-                - description: Retrieve images from all projects
-                  in: query
-                  name: all-projects
-                  type: boolean
             produces:
                 - application/json
             responses:
@@ -9779,10 +9770,6 @@ paths:
                   in: query
                   name: filter
                   type: string
-                - description: Retrieve images from all projects
-                  in: query
-                  name: all-projects
-                  type: boolean
             produces:
                 - application/json
             responses:
@@ -9871,10 +9858,6 @@ paths:
                   in: query
                   name: filter
                   type: string
-                - description: Retrieve images from all projects
-                  in: query
-                  name: all-projects
-                  type: boolean
             produces:
                 - application/json
             responses:
@@ -9923,11 +9906,6 @@ paths:
                   in: query
                   name: filter
                   type: string
-                - description: Retrieve images from all projects
-                  example: default
-                  in: query
-                  name: all-projects
-                  type: boolean
             produces:
                 - application/json
             responses:

--- a/lxc/image.go
+++ b/lxc/image.go
@@ -1078,9 +1078,8 @@ type cmdImageList struct {
 	global *cmdGlobal
 	image  *cmdImage
 
-	flagFormat      string
-	flagColumns     string
-	flagAllProjects bool
+	flagFormat  string
+	flagColumns string
 }
 
 func (c *cmdImageList) command() *cobra.Command {
@@ -1108,15 +1107,13 @@ Column shorthand chars:
     F - Fingerprint (long)
     p - Whether image is public
     d - Description
-    e - Project
     a - Architecture
     s - Size
     u - Upload date
     t - Type`))
 
-	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", defaultImagesColumns, i18n.G("Columns")+"``")
+	cmd.Flags().StringVarP(&c.flagColumns, "columns", "c", "lfpdatsu", i18n.G("Columns")+"``")
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", "table", i18n.G("Format (csv|json|table|yaml|compact)")+"``")
-	cmd.Flags().BoolVar(&c.flagAllProjects, "all-projects", false, i18n.G("Display images from all projects"))
 	cmd.RunE = c.run
 
 	cmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
@@ -1130,32 +1127,23 @@ Column shorthand chars:
 	return cmd
 }
 
-const defaultImagesColumns = "lfpdatsu"
-const defaultImagesColumnsAllProjects = "elfpdatsu"
-
 func (c *cmdImageList) parseColumns() ([]imageColumn, error) {
 	columnsShorthandMap := map[rune]imageColumn{
-		'a': {i18n.G("ARCHITECTURE"), c.architectureColumnData},
-		'd': {i18n.G("DESCRIPTION"), c.descriptionColumnData},
-		'e': {i18n.G("PROJECT"), c.projectColumnData},
-		'f': {i18n.G("FINGERPRINT"), c.fingerprintColumnData},
-		'F': {i18n.G("FINGERPRINT"), c.fingerprintFullColumnData},
 		'l': {i18n.G("ALIAS"), c.aliasColumnData},
 		'L': {i18n.G("ALIASES"), c.aliasesColumnData},
+		'f': {i18n.G("FINGERPRINT"), c.fingerprintColumnData},
+		'F': {i18n.G("FINGERPRINT"), c.fingerprintFullColumnData},
 		'p': {i18n.G("PUBLIC"), c.publicColumnData},
+		'd': {i18n.G("DESCRIPTION"), c.descriptionColumnData},
+		'a': {i18n.G("ARCHITECTURE"), c.architectureColumnData},
 		's': {i18n.G("SIZE"), c.sizeColumnData},
-		't': {i18n.G("TYPE"), c.typeColumnData},
 		'u': {i18n.G("UPLOAD DATE"), c.uploadDateColumnData},
-	}
-
-	// Add project column if --all-projects flag specified and custom columns are not specified.
-	if c.flagAllProjects && c.flagColumns == defaultImagesColumns {
-		c.flagColumns = defaultImagesColumnsAllProjects
+		't': {i18n.G("TYPE"), c.typeColumnData},
 	}
 
 	columnList := strings.Split(c.flagColumns, ",")
-	columns := []imageColumn{}
 
+	columns := []imageColumn{}
 	for _, columnEntry := range columnList {
 		if columnEntry == "" {
 			return nil, fmt.Errorf(i18n.G("Empty column entry (redundant, leading or trailing command) in '%s'"), c.flagColumns)
@@ -1211,10 +1199,6 @@ func (c *cmdImageList) publicColumnData(image api.Image) string {
 
 func (c *cmdImageList) descriptionColumnData(image api.Image) string {
 	return c.findDescription(image.Properties)
-}
-
-func (c *cmdImageList) projectColumnData(image api.Image) string {
-	return image.Project
 }
 
 func (c *cmdImageList) architectureColumnData(image api.Image) string {
@@ -1353,11 +1337,6 @@ func (c *cmdImageList) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	d, err := c.global.conf.GetInstanceServer(remoteName)
-	if err != nil {
-		return err
-	}
-
 	// Process the filters
 	filters := []string{}
 	if name != "" {
@@ -1376,27 +1355,15 @@ func (c *cmdImageList) run(cmd *cobra.Command, args []string) error {
 
 	serverFilters, clientFilters := getServerSupportedFilters(filters, api.Image{})
 
-	var allImages, images []api.Image //nolint:prealloc
-	if c.flagAllProjects {
-		allImages, err = d.GetImagesAllProjectsWithFilter(serverFilters)
+	var images []api.Image //nolint:prealloc
+	allImages, err := remoteServer.GetImagesWithFilter(serverFilters)
+	if err != nil {
+		allImages, err = remoteServer.GetImages()
 		if err != nil {
-			allImages, err = d.GetImagesAllProjects()
-			if err != nil {
-				return err
-			}
-
-			clientFilters = filters
+			return err
 		}
-	} else {
-		allImages, err = remoteServer.GetImagesWithFilter(serverFilters)
-		if err != nil {
-			allImages, err = remoteServer.GetImages()
-			if err != nil {
-				return err
-			}
 
-			clientFilters = filters
-		}
+		clientFilters = filters
 	}
 
 	for _, image := range allImages {

--- a/lxc/image.go
+++ b/lxc/image.go
@@ -1353,6 +1353,11 @@ func (c *cmdImageList) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	d, err := c.global.conf.GetInstanceServer(remoteName)
+	if err != nil {
+		return err
+	}
+
 	// Process the filters
 	filters := []string{}
 	if name != "" {
@@ -1373,9 +1378,9 @@ func (c *cmdImageList) run(cmd *cobra.Command, args []string) error {
 
 	var allImages, images []api.Image //nolint:prealloc
 	if c.flagAllProjects {
-		allImages, err = remoteServer.GetImagesAllProjectsWithFilter(serverFilters)
+		allImages, err = d.GetImagesAllProjectsWithFilter(serverFilters)
 		if err != nil {
-			allImages, err = remoteServer.GetImagesAllProjects()
+			allImages, err = d.GetImagesAllProjects()
 			if err != nil {
 				return err
 			}

--- a/lxd/db/images.go
+++ b/lxd/db/images.go
@@ -401,7 +401,6 @@ func (c *ClusterTx) GetImageByFingerprintPrefix(ctx context.Context, fingerprint
 	image.Cached = object.Cached
 	image.Public = object.Public
 	image.AutoUpdate = object.AutoUpdate
-	image.Project = object.Project
 
 	err = c.imageFill(
 		ctx, object.ID, &image,

--- a/lxd/db/images.go
+++ b/lxd/db/images.go
@@ -528,7 +528,6 @@ SELECT nodes.address FROM nodes
 WHERE images.fingerprint = ?
 `
 	var localAddress string // Address of this node
-	var addresses []string  // Addresses of online nodes with the image
 
 	offlineThreshold, err := c.GetNodeOfflineThreshold(ctx)
 	if err != nil {
@@ -545,6 +544,7 @@ WHERE images.fingerprint = ?
 		return "", err
 	}
 
+	addresses := make([]string, 0, len(allAddresses)-1) // Addresses of online nodes with the image
 	for _, address := range allAddresses {
 		node, err := c.GetNodeByAddress(ctx, address)
 		if err != nil {
@@ -1111,8 +1111,6 @@ SELECT DISTINCT nodes.address FROM nodes WHERE nodes.address NOT IN (
 }
 
 func (c *ClusterTx) getNodesByImageFingerprint(ctx context.Context, stmt string, fingerprint string, autoUpdate *bool) ([]string, error) {
-	var addresses []string // Addresses of online nodes with the image
-
 	offlineThreshold, err := c.GetNodeOfflineThreshold(ctx)
 	if err != nil {
 		return nil, err
@@ -1130,6 +1128,7 @@ func (c *ClusterTx) getNodesByImageFingerprint(ctx context.Context, stmt string,
 		return nil, err
 	}
 
+	addresses := make([]string, 0, len(allAddresses)) // Addresses of online nodes with the image
 	for _, address := range allAddresses {
 		node, err := c.GetNodeByAddress(ctx, address)
 		if err != nil {

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -1452,53 +1451,30 @@ func getImageMetadata(fname string) (*api.ImageMetadata, string, error) {
 	return &result, imageType, nil
 }
 
-func doImagesGet(ctx context.Context, tx *db.ClusterTx, recursion bool, projectName string, public bool, clauses *filter.ClauseSet, hasPermission auth.PermissionChecker, allProjects bool) (any, error) {
+func doImagesGet(ctx context.Context, tx *db.ClusterTx, recursion bool, projectName string, public bool, clauses *filter.ClauseSet, hasPermission auth.PermissionChecker) (any, error) {
 	mustLoadObjects := recursion || (clauses != nil && len(clauses.Clauses) > 0)
 
-	imagesProjectsMap := map[string][]string{}
-	if allProjects {
-		var err error
-
-		imagesProjectsMap, err = tx.GetImages(ctx)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		fingerprints, err := tx.GetImagesFingerprints(ctx, projectName, public)
-		if err != nil {
-			return nil, err
-		}
-
-		for _, fingerprint := range fingerprints {
-			imagesProjectsMap[fingerprint] = []string{projectName}
-		}
+	fingerprints, err := tx.GetImagesFingerprints(ctx, projectName, public)
+	if err != nil {
+		return err, err
 	}
 
 	var resultString []string
 	var resultMap []*api.Image
 
 	if recursion {
-		resultMap = make([]*api.Image, 0, len(imagesProjectsMap))
+		resultMap = make([]*api.Image, 0, len(fingerprints))
 	} else {
-		resultString = make([]string, 0, len(imagesProjectsMap))
+		resultString = make([]string, 0, len(fingerprints))
 	}
 
-	for fingerprint, projects := range imagesProjectsMap {
-		hasAccess := false
-
-		image, err := doImageGet(ctx, tx, projects[0], fingerprint, public)
+	for _, fingerprint := range fingerprints {
+		image, err := doImageGet(ctx, tx, projectName, fingerprint, public)
 		if err != nil {
 			continue
 		}
 
-		for _, project := range projects {
-			if image.Public || hasPermission(entity.ImageURL(project, fingerprint)) {
-				hasAccess = true
-				break
-			}
-		}
-
-		if !hasAccess {
+		if !image.Public && !hasPermission(entity.ImageURL(projectName, fingerprint)) {
 			continue
 		}
 
@@ -1551,10 +1527,6 @@ func doImagesGet(ctx context.Context, tx *db.ClusterTx, recursion bool, projectN
 //      description: Collection filter
 //      type: string
 //      example: default
-//    - in: query
-//      name: all-projects
-//      description: Retrieve images from all projects
-//      type: boolean
 //  responses:
 //    "200":
 //      description: API endpoints
@@ -1609,10 +1581,6 @@ func doImagesGet(ctx context.Context, tx *db.ClusterTx, recursion bool, projectN
 //      description: Collection filter
 //      type: string
 //      example: default
-//    - in: query
-//      name: all-projects
-//      description: Retrieve images from all projects
-//      type: boolean
 //  responses:
 //    "200":
 //      description: API endpoints
@@ -1662,10 +1630,6 @@ func doImagesGet(ctx context.Context, tx *db.ClusterTx, recursion bool, projectN
 //      description: Collection filter
 //      type: string
 //      example: default
-//    - in: query
-//      name: all-projects
-//      description: Retrieve images from all projects
-//      type: boolean
 //  responses:
 //    "200":
 //      description: API endpoints
@@ -1720,11 +1684,6 @@ func doImagesGet(ctx context.Context, tx *db.ClusterTx, recursion bool, projectN
 //	    description: Collection filter
 //	    type: string
 //	    example: default
-//	  - in: query
-//	    name: all-projects
-//	    description: Retrieve images from all projects
-//	    type: boolean
-//	    example: default
 //	responses:
 //	  "200":
 //	    description: API endpoints
@@ -1755,13 +1714,7 @@ func doImagesGet(ctx context.Context, tx *db.ClusterTx, recursion bool, projectN
 //	    $ref: "#/responses/InternalServerError"
 func imagesGet(d *Daemon, r *http.Request) response.Response {
 	projectName := request.ProjectParam(r)
-	allProjects := shared.IsTrue(r.FormValue("all-projects"))
 	filterStr := r.FormValue("filter")
-
-	// ProjectParam returns default if not set
-	if allProjects && projectName != api.ProjectDefaultName {
-		return response.BadRequest(fmt.Errorf("Cannot specify a project when requesting all projects"))
-	}
 
 	s := d.State()
 	var effectiveProjectName string
@@ -1776,14 +1729,8 @@ func imagesGet(d *Daemon, r *http.Request) response.Response {
 
 	request.SetCtxValue(r, request.CtxEffectiveProjectName, effectiveProjectName)
 
-	// If the caller is not trusted, we only want to list public images in the default project.
-	trusted := auth.IsTrusted(r.Context())
-	publicOnly := !trusted
-
-	// Untrusted callers can't request images from all projects or projects other than default.
-	if !trusted && (allProjects || projectName != api.ProjectDefaultName) {
-		return response.Forbidden(errors.New("Untrusted callers may only access public images in the default project"))
-	}
+	// If the caller is not trusted, we only want to list public images.
+	publicOnly := !auth.IsTrusted(r.Context())
 
 	// Get a permission checker. If the caller is not authenticated, the permission checker will deny all.
 	// However, the permission checker is only called when an image is private. Both trusted and untrusted clients will
@@ -1800,7 +1747,7 @@ func imagesGet(d *Daemon, r *http.Request) response.Response {
 
 	var result any
 	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
-		result, err = doImagesGet(ctx, tx, util.IsRecursionRequest(r), projectName, publicOnly, clauses, canViewImage, allProjects)
+		result, err = doImagesGet(ctx, tx, util.IsRecursionRequest(r), projectName, publicOnly, clauses, canViewImage)
 		if err != nil {
 			return err
 		}

--- a/po/ar.po
+++ b/po/ar.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-14 16:50+0000\n"
+"POT-Creation-Date: 2025-01-22 08:25+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -417,7 +417,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1168
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -538,11 +538,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1133
 msgid "ALIASES"
 msgstr ""
 
@@ -1166,7 +1166,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1596
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1596
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1524,7 +1524,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1691,8 +1691,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
+#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1878,10 +1878,6 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
-msgid "Display images from all projects"
-msgstr ""
-
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -2025,7 +2021,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1773
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1773
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2199,7 +2195,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2434,7 +2430,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2509,7 +2505,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1573 lxc/image.go:1574
 msgid "Get image properties"
 msgstr ""
 
@@ -2787,7 +2783,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1489
 msgid "Image already up to date."
 msgstr ""
 
@@ -2803,11 +2799,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1444
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1670
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2817,7 +2813,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1487
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3204,11 +3200,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1090
 msgid ""
 "List images\n"
 "\n"
@@ -3229,7 +3225,6 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
-"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4369,8 +4364,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1763
-#: lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1763 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4378,7 +4372,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:854
+#: lxc/image.go:1136 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
@@ -4558,7 +4552,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1621
 msgid "Property not found"
 msgstr ""
 
@@ -4688,7 +4682,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4725,7 +4719,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1416 lxc/image.go:1417
 msgid "Refresh images"
 msgstr ""
 
@@ -4734,7 +4728,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1453
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5030,7 +5024,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1139
 msgid "SIZE"
 msgstr ""
 
@@ -5153,7 +5147,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1637 lxc/image.go:1638
 msgid "Set image properties"
 msgstr ""
 
@@ -5458,7 +5452,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1507 lxc/image.go:1508
 msgid "Show image properties"
 msgstr ""
 
@@ -5802,7 +5796,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1737 lxc/warning.go:216
@@ -6162,7 +6156,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1140
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6208,7 +6202,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1779
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1779
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6250,7 +6244,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1700 lxc/image.go:1701
 msgid "Unset image properties"
 msgstr ""
 
@@ -6574,7 +6568,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1087 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6693,15 +6687,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1572 lxc/image.go:1699
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1636
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6721,7 +6715,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1415
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7679,7 +7673,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
 msgid "no"
 msgstr ""
 
@@ -7725,6 +7719,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1194
 msgid "yes"
 msgstr ""

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-14 16:50+0000\n"
+"POT-Creation-Date: 2025-01-22 08:25+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1168
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -541,11 +541,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1133
 msgid "ALIASES"
 msgstr ""
 
@@ -1169,7 +1169,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1596
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1596
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1527,7 +1527,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1694,8 +1694,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
+#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1881,10 +1881,6 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
-msgid "Display images from all projects"
-msgstr ""
-
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -2028,7 +2024,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1773
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1773
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2202,7 +2198,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2437,7 +2433,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2512,7 +2508,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1573 lxc/image.go:1574
 msgid "Get image properties"
 msgstr ""
 
@@ -2790,7 +2786,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1489
 msgid "Image already up to date."
 msgstr ""
 
@@ -2806,11 +2802,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1444
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1670
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2820,7 +2816,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1487
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3207,11 +3203,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1090
 msgid ""
 "List images\n"
 "\n"
@@ -3232,7 +3228,6 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
-"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4372,8 +4367,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1763
-#: lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1763 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4381,7 +4375,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:854
+#: lxc/image.go:1136 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
@@ -4561,7 +4555,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1621
 msgid "Property not found"
 msgstr ""
 
@@ -4691,7 +4685,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4728,7 +4722,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1416 lxc/image.go:1417
 msgid "Refresh images"
 msgstr ""
 
@@ -4737,7 +4731,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1453
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5033,7 +5027,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1139
 msgid "SIZE"
 msgstr ""
 
@@ -5156,7 +5150,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1637 lxc/image.go:1638
 msgid "Set image properties"
 msgstr ""
 
@@ -5461,7 +5455,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1507 lxc/image.go:1508
 msgid "Show image properties"
 msgstr ""
 
@@ -5805,7 +5799,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1737 lxc/warning.go:216
@@ -6165,7 +6159,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1140
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6211,7 +6205,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1779
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1779
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6253,7 +6247,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1700 lxc/image.go:1701
 msgid "Unset image properties"
 msgstr ""
 
@@ -6577,7 +6571,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1087 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6696,15 +6690,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1572 lxc/image.go:1699
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1636
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6724,7 +6718,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1415
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7682,7 +7676,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
 msgid "no"
 msgstr ""
 
@@ -7728,6 +7722,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1194
 msgid "yes"
 msgstr ""

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-14 16:50+0000\n"
+"POT-Creation-Date: 2025-01-22 08:25+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1168
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -541,11 +541,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1133
 msgid "ALIASES"
 msgstr ""
 
@@ -1169,7 +1169,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1596
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1596
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1527,7 +1527,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1694,8 +1694,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
+#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1881,10 +1881,6 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
-msgid "Display images from all projects"
-msgstr ""
-
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -2028,7 +2024,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1773
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1773
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2202,7 +2198,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2437,7 +2433,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2512,7 +2508,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1573 lxc/image.go:1574
 msgid "Get image properties"
 msgstr ""
 
@@ -2790,7 +2786,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1489
 msgid "Image already up to date."
 msgstr ""
 
@@ -2806,11 +2802,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1444
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1670
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2820,7 +2816,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1487
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3207,11 +3203,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1090
 msgid ""
 "List images\n"
 "\n"
@@ -3232,7 +3228,6 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
-"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4372,8 +4367,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1763
-#: lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1763 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4381,7 +4375,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:854
+#: lxc/image.go:1136 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
@@ -4561,7 +4555,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1621
 msgid "Property not found"
 msgstr ""
 
@@ -4691,7 +4685,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4728,7 +4722,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1416 lxc/image.go:1417
 msgid "Refresh images"
 msgstr ""
 
@@ -4737,7 +4731,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1453
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5033,7 +5027,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1139
 msgid "SIZE"
 msgstr ""
 
@@ -5156,7 +5150,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1637 lxc/image.go:1638
 msgid "Set image properties"
 msgstr ""
 
@@ -5461,7 +5455,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1507 lxc/image.go:1508
 msgid "Show image properties"
 msgstr ""
 
@@ -5805,7 +5799,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1737 lxc/warning.go:216
@@ -6165,7 +6159,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1140
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6211,7 +6205,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1779
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1779
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6253,7 +6247,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1700 lxc/image.go:1701
 msgid "Unset image properties"
 msgstr ""
 
@@ -6577,7 +6571,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1087 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6696,15 +6690,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1572 lxc/image.go:1699
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1636
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6724,7 +6718,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1415
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7682,7 +7676,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
 msgid "no"
 msgstr ""
 
@@ -7728,6 +7722,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1194
 msgid "yes"
 msgstr ""

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-14 16:50+0000\n"
+"POT-Creation-Date: 2025-01-22 08:25+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1168
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -541,11 +541,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1133
 msgid "ALIASES"
 msgstr ""
 
@@ -1169,7 +1169,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1596
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1596
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1527,7 +1527,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1694,8 +1694,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
+#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1881,10 +1881,6 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
-msgid "Display images from all projects"
-msgstr ""
-
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -2028,7 +2024,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1773
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1773
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2202,7 +2198,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2437,7 +2433,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2512,7 +2508,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1573 lxc/image.go:1574
 msgid "Get image properties"
 msgstr ""
 
@@ -2790,7 +2786,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1489
 msgid "Image already up to date."
 msgstr ""
 
@@ -2806,11 +2802,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1444
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1670
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2820,7 +2816,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1487
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3207,11 +3203,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1090
 msgid ""
 "List images\n"
 "\n"
@@ -3232,7 +3228,6 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
-"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4372,8 +4367,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1763
-#: lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1763 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4381,7 +4375,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:854
+#: lxc/image.go:1136 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
@@ -4561,7 +4555,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1621
 msgid "Property not found"
 msgstr ""
 
@@ -4691,7 +4685,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4728,7 +4722,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1416 lxc/image.go:1417
 msgid "Refresh images"
 msgstr ""
 
@@ -4737,7 +4731,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1453
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5033,7 +5027,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1139
 msgid "SIZE"
 msgstr ""
 
@@ -5156,7 +5150,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1637 lxc/image.go:1638
 msgid "Set image properties"
 msgstr ""
 
@@ -5461,7 +5455,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1507 lxc/image.go:1508
 msgid "Show image properties"
 msgstr ""
 
@@ -5805,7 +5799,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1737 lxc/warning.go:216
@@ -6165,7 +6159,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1140
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6211,7 +6205,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1779
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1779
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6253,7 +6247,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1700 lxc/image.go:1701
 msgid "Unset image properties"
 msgstr ""
 
@@ -6577,7 +6571,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1087 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6696,15 +6690,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1572 lxc/image.go:1699
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1636
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6724,7 +6718,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1415
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7682,7 +7676,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
 msgid "no"
 msgstr ""
 
@@ -7728,6 +7722,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1194
 msgid "yes"
 msgstr ""

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-14 16:50+0000\n"
+"POT-Creation-Date: 2025-01-22 08:25+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1168
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -541,11 +541,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1133
 msgid "ALIASES"
 msgstr ""
 
@@ -1169,7 +1169,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1596
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1596
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1527,7 +1527,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1694,8 +1694,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
+#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1881,10 +1881,6 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
-msgid "Display images from all projects"
-msgstr ""
-
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -2028,7 +2024,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1773
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1773
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2202,7 +2198,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2437,7 +2433,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2512,7 +2508,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1573 lxc/image.go:1574
 msgid "Get image properties"
 msgstr ""
 
@@ -2790,7 +2786,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1489
 msgid "Image already up to date."
 msgstr ""
 
@@ -2806,11 +2802,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1444
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1670
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2820,7 +2816,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1487
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3207,11 +3203,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1090
 msgid ""
 "List images\n"
 "\n"
@@ -3232,7 +3228,6 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
-"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4372,8 +4367,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1763
-#: lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1763 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4381,7 +4375,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:854
+#: lxc/image.go:1136 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
@@ -4561,7 +4555,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1621
 msgid "Property not found"
 msgstr ""
 
@@ -4691,7 +4685,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4728,7 +4722,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1416 lxc/image.go:1417
 msgid "Refresh images"
 msgstr ""
 
@@ -4737,7 +4731,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1453
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5033,7 +5027,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1139
 msgid "SIZE"
 msgstr ""
 
@@ -5156,7 +5150,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1637 lxc/image.go:1638
 msgid "Set image properties"
 msgstr ""
 
@@ -5461,7 +5455,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1507 lxc/image.go:1508
 msgid "Show image properties"
 msgstr ""
 
@@ -5805,7 +5799,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1737 lxc/warning.go:216
@@ -6165,7 +6159,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1140
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6211,7 +6205,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1779
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1779
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6253,7 +6247,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1700 lxc/image.go:1701
 msgid "Unset image properties"
 msgstr ""
 
@@ -6577,7 +6571,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1087 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6696,15 +6690,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1572 lxc/image.go:1699
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1636
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6724,7 +6718,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1415
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7682,7 +7676,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
 msgid "no"
 msgstr ""
 
@@ -7728,6 +7722,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1194
 msgid "yes"
 msgstr ""

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-14 16:50+0000\n"
+"POT-Creation-Date: 2025-01-22 08:25+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -669,7 +669,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr "%d (ID: %d, Online: %v, NUMA-Knoten: %v)"
 
-#: lxc/image.go:1180
+#: lxc/image.go:1168
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (%d mehr)"
@@ -805,11 +805,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: lxc/image.go:1144
+#: lxc/image.go:1133
 msgid "ALIASES"
 msgstr "ALIASES"
 
@@ -1471,7 +1471,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1596
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1596
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr "Spalten"
@@ -1861,7 +1861,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -2039,8 +2039,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
+#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -2239,11 +2239,6 @@ msgstr " Prozessorauslastung:"
 msgid "Disks:"
 msgstr " Prozessorauslastung:"
 
-#: lxc/image.go:1119
-#, fuzzy
-msgid "Display images from all projects"
-msgstr "Herunterfahren des Containers erzwingen."
-
 #: lxc/list.go:135
 #, fuzzy
 msgid "Display instances from all projects"
@@ -2405,7 +2400,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1773
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1773
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2593,7 +2588,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr "FINGERABDRUCK"
@@ -2832,7 +2827,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2909,7 +2904,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1573 lxc/image.go:1574
 msgid "Get image properties"
 msgstr ""
 
@@ -3210,7 +3205,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/image.go:1522
+#: lxc/image.go:1489
 msgid "Image already up to date."
 msgstr ""
 
@@ -3226,11 +3221,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1444
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1670
 #, fuzzy, c-format
 msgid "Image identifier missing: %s"
 msgstr "Abbild mit Fingerabdruck %s importiert\n"
@@ -3240,7 +3235,7 @@ msgstr "Abbild mit Fingerabdruck %s importiert\n"
 msgid "Image imported with fingerprint: %s"
 msgstr "Abbild mit Fingerabdruck %s importiert\n"
 
-#: lxc/image.go:1520
+#: lxc/image.go:1487
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3648,11 +3643,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1090
 msgid ""
 "List images\n"
 "\n"
@@ -3673,7 +3668,6 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
-"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4912,8 +4906,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1763
-#: lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1763 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4921,7 +4914,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:854
+#: lxc/image.go:1136 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
@@ -5111,7 +5104,7 @@ msgstr ""
 msgid "Properties:"
 msgstr "Eigenschaften:\n"
 
-#: lxc/image.go:1654
+#: lxc/image.go:1621
 msgid "Property not found"
 msgstr ""
 
@@ -5244,7 +5237,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5284,7 +5277,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1416 lxc/image.go:1417
 msgid "Refresh images"
 msgstr ""
 
@@ -5293,7 +5286,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/image.go:1486
+#: lxc/image.go:1453
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5619,7 +5612,7 @@ msgstr "Fehlerhafte Profil URL %s"
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1139
 msgid "SIZE"
 msgstr ""
 
@@ -5747,7 +5740,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1637 lxc/image.go:1638
 msgid "Set image properties"
 msgstr ""
 
@@ -6078,7 +6071,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1507 lxc/image.go:1508
 msgid "Show image properties"
 msgstr ""
 
@@ -6450,7 +6443,7 @@ msgstr "Abbild mit Fingerabdruck %s importiert\n"
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1737 lxc/warning.go:216
@@ -6823,7 +6816,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1140
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6870,7 +6863,7 @@ msgstr "Unbekannter Befehl %s für Abbild"
 msgid "Unknown channel type for client %q: %s"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1779
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1779
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6916,7 +6909,7 @@ msgstr "nicht alle Profile der Quelle sind am Ziel vorhanden."
 msgid "Unset device configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1700 lxc/image.go:1701
 msgid "Unset image properties"
 msgstr ""
 
@@ -7307,7 +7300,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1087 lxc/list.go:46
 #, fuzzy
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
@@ -7528,7 +7521,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr ""
@@ -7537,7 +7530,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1572 lxc/image.go:1699
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr ""
@@ -7546,7 +7539,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/image.go:1669
+#: lxc/image.go:1636
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
@@ -7586,7 +7579,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1415
 #, fuzzy
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
@@ -9012,7 +9005,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
 msgid "no"
 msgstr ""
 
@@ -9058,9 +9051,13 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1194
 msgid "yes"
 msgstr ""
+
+#, fuzzy
+#~ msgid "Display images from all projects"
+#~ msgstr "Herunterfahren des Containers erzwingen."
 
 #~ msgid "Action (defaults to GET)"
 #~ msgstr "Aktion (Standard: GET)"

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-14 16:50+0000\n"
+"POT-Creation-Date: 2025-01-22 08:25+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1168
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -541,11 +541,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1133
 msgid "ALIASES"
 msgstr ""
 
@@ -1173,7 +1173,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1596
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1596
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1534,7 +1534,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1706,8 +1706,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
+#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1897,10 +1897,6 @@ msgstr "  Χρήση CPU:"
 msgid "Disks:"
 msgstr "  Χρήση CPU:"
 
-#: lxc/image.go:1119
-msgid "Display images from all projects"
-msgstr ""
-
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -2050,7 +2046,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1773
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1773
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2224,7 +2220,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2459,7 +2455,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2534,7 +2530,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1573 lxc/image.go:1574
 msgid "Get image properties"
 msgstr ""
 
@@ -2825,7 +2821,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1489
 msgid "Image already up to date."
 msgstr ""
 
@@ -2841,11 +2837,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1444
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1670
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2855,7 +2851,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1487
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3244,11 +3240,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1090
 msgid ""
 "List images\n"
 "\n"
@@ -3269,7 +3265,6 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
-"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4436,8 +4431,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1763
-#: lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1763 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4445,7 +4439,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:854
+#: lxc/image.go:1136 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
@@ -4626,7 +4620,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1621
 msgid "Property not found"
 msgstr ""
 
@@ -4756,7 +4750,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4793,7 +4787,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1416 lxc/image.go:1417
 msgid "Refresh images"
 msgstr ""
 
@@ -4802,7 +4796,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1453
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5104,7 +5098,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1139
 msgid "SIZE"
 msgstr ""
 
@@ -5228,7 +5222,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1637 lxc/image.go:1638
 msgid "Set image properties"
 msgstr ""
 
@@ -5547,7 +5541,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1507 lxc/image.go:1508
 msgid "Show image properties"
 msgstr ""
 
@@ -5900,7 +5894,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1737 lxc/warning.go:216
@@ -6261,7 +6255,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1140
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6307,7 +6301,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1779
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1779
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6350,7 +6344,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1700 lxc/image.go:1701
 msgid "Unset image properties"
 msgstr ""
 
@@ -6690,7 +6684,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1087 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6809,15 +6803,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1572 lxc/image.go:1699
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1636
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6837,7 +6831,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1415
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7795,7 +7789,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
 msgid "no"
 msgstr ""
 
@@ -7841,7 +7835,7 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1194
 msgid "yes"
 msgstr ""
 

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-14 16:50+0000\n"
+"POT-Creation-Date: 2025-01-22 08:25+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1168
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -541,11 +541,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1133
 msgid "ALIASES"
 msgstr ""
 
@@ -1169,7 +1169,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1596
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1596
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1527,7 +1527,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1694,8 +1694,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
+#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1881,10 +1881,6 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
-msgid "Display images from all projects"
-msgstr ""
-
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -2028,7 +2024,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1773
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1773
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2202,7 +2198,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2437,7 +2433,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2512,7 +2508,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1573 lxc/image.go:1574
 msgid "Get image properties"
 msgstr ""
 
@@ -2790,7 +2786,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1489
 msgid "Image already up to date."
 msgstr ""
 
@@ -2806,11 +2802,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1444
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1670
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2820,7 +2816,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1487
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3207,11 +3203,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1090
 msgid ""
 "List images\n"
 "\n"
@@ -3232,7 +3228,6 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
-"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4372,8 +4367,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1763
-#: lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1763 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4381,7 +4375,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:854
+#: lxc/image.go:1136 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
@@ -4561,7 +4555,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1621
 msgid "Property not found"
 msgstr ""
 
@@ -4691,7 +4685,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4728,7 +4722,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1416 lxc/image.go:1417
 msgid "Refresh images"
 msgstr ""
 
@@ -4737,7 +4731,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1453
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5033,7 +5027,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1139
 msgid "SIZE"
 msgstr ""
 
@@ -5156,7 +5150,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1637 lxc/image.go:1638
 msgid "Set image properties"
 msgstr ""
 
@@ -5461,7 +5455,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1507 lxc/image.go:1508
 msgid "Show image properties"
 msgstr ""
 
@@ -5805,7 +5799,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1737 lxc/warning.go:216
@@ -6165,7 +6159,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1140
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6211,7 +6205,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1779
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1779
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6253,7 +6247,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1700 lxc/image.go:1701
 msgid "Unset image properties"
 msgstr ""
 
@@ -6577,7 +6571,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1087 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6696,15 +6690,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1572 lxc/image.go:1699
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1636
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6724,7 +6718,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1415
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7682,7 +7676,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
 msgid "no"
 msgstr ""
 
@@ -7728,6 +7722,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1194
 msgid "yes"
 msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-14 16:50+0000\n"
+"POT-Creation-Date: 2025-01-22 08:25+0000\n"
 "PO-Revision-Date: 2023-06-16 20:55+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -657,7 +657,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1168
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (%d más)"
@@ -784,11 +784,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: lxc/image.go:1144
+#: lxc/image.go:1133
 msgid "ALIASES"
 msgstr "ALIASES"
 
@@ -1425,7 +1425,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1596
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1596
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr "Columnas"
@@ -1797,7 +1797,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1970,8 +1970,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
+#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -2159,11 +2159,6 @@ msgstr "Disco:"
 msgid "Disks:"
 msgstr "Discos:"
 
-#: lxc/image.go:1119
-#, fuzzy
-msgid "Display images from all projects"
-msgstr "No se puede proveer el nombre del container a la lista"
-
 #: lxc/list.go:135
 #, fuzzy
 msgid "Display instances from all projects"
@@ -2315,7 +2310,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1773
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1773
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2493,7 +2488,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr "HUELLA DIGITAL"
@@ -2729,7 +2724,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2805,7 +2800,7 @@ msgstr "Aliases:"
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1573 lxc/image.go:1574
 msgid "Get image properties"
 msgstr ""
 
@@ -3099,7 +3094,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1489
 msgid "Image already up to date."
 msgstr ""
 
@@ -3115,11 +3110,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1444
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1670
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -3129,7 +3124,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1487
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3531,11 +3526,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1090
 msgid ""
 "List images\n"
 "\n"
@@ -3556,7 +3551,6 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
-"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4737,8 +4731,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1763
-#: lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1763 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4746,7 +4739,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:854
+#: lxc/image.go:1136 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
@@ -4931,7 +4924,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1621
 msgid "Property not found"
 msgstr ""
 
@@ -5061,7 +5054,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5100,7 +5093,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1416 lxc/image.go:1417
 msgid "Refresh images"
 msgstr ""
 
@@ -5109,7 +5102,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:1486
+#: lxc/image.go:1453
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr "Refrescando la imagen: %s"
@@ -5418,7 +5411,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1139
 msgid "SIZE"
 msgstr ""
 
@@ -5543,7 +5536,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1637 lxc/image.go:1638
 msgid "Set image properties"
 msgstr ""
 
@@ -5862,7 +5855,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1507 lxc/image.go:1508
 msgid "Show image properties"
 msgstr ""
 
@@ -6217,7 +6210,7 @@ msgstr "Contenedor publicado con huella digital: %s"
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1737 lxc/warning.go:216
@@ -6583,7 +6576,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1140
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6629,7 +6622,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1779
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1779
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6673,7 +6666,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1700 lxc/image.go:1701
 msgid "Unset image properties"
 msgstr ""
 
@@ -7021,7 +7014,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:] [<cert>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1087 lxc/list.go:46
 #, fuzzy
 msgid "[<remote>:] [<filter>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7164,17 +7157,17 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1572 lxc/image.go:1699
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:1669
+#: lxc/image.go:1636
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7199,7 +7192,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<image> [<target>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1415
 #, fuzzy
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -8264,7 +8257,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
 msgid "no"
 msgstr ""
 
@@ -8310,9 +8303,13 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1194
 msgid "yes"
 msgstr ""
+
+#, fuzzy
+#~ msgid "Display images from all projects"
+#~ msgstr "No se puede proveer el nombre del container a la lista"
 
 #~ msgid "Action (defaults to GET)"
 #~ msgstr "Accion (predeterminados a GET)"

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-14 16:50+0000\n"
+"POT-Creation-Date: 2025-01-22 08:25+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1168
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -541,11 +541,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1133
 msgid "ALIASES"
 msgstr ""
 
@@ -1169,7 +1169,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1596
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1596
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1527,7 +1527,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1694,8 +1694,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
+#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1881,10 +1881,6 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
-msgid "Display images from all projects"
-msgstr ""
-
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -2028,7 +2024,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1773
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1773
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2202,7 +2198,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2437,7 +2433,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2512,7 +2508,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1573 lxc/image.go:1574
 msgid "Get image properties"
 msgstr ""
 
@@ -2790,7 +2786,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1489
 msgid "Image already up to date."
 msgstr ""
 
@@ -2806,11 +2802,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1444
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1670
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2820,7 +2816,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1487
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3207,11 +3203,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1090
 msgid ""
 "List images\n"
 "\n"
@@ -3232,7 +3228,6 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
-"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4372,8 +4367,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1763
-#: lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1763 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4381,7 +4375,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:854
+#: lxc/image.go:1136 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
@@ -4561,7 +4555,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1621
 msgid "Property not found"
 msgstr ""
 
@@ -4691,7 +4685,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4728,7 +4722,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1416 lxc/image.go:1417
 msgid "Refresh images"
 msgstr ""
 
@@ -4737,7 +4731,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1453
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5033,7 +5027,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1139
 msgid "SIZE"
 msgstr ""
 
@@ -5156,7 +5150,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1637 lxc/image.go:1638
 msgid "Set image properties"
 msgstr ""
 
@@ -5461,7 +5455,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1507 lxc/image.go:1508
 msgid "Show image properties"
 msgstr ""
 
@@ -5805,7 +5799,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1737 lxc/warning.go:216
@@ -6165,7 +6159,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1140
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6211,7 +6205,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1779
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1779
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6253,7 +6247,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1700 lxc/image.go:1701
 msgid "Unset image properties"
 msgstr ""
 
@@ -6577,7 +6571,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1087 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6696,15 +6690,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1572 lxc/image.go:1699
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1636
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6724,7 +6718,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1415
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7682,7 +7676,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
 msgid "no"
 msgstr ""
 
@@ -7728,6 +7722,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1194
 msgid "yes"
 msgstr ""

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-14 16:50+0000\n"
+"POT-Creation-Date: 2025-01-22 08:25+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1168
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -541,11 +541,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1133
 msgid "ALIASES"
 msgstr ""
 
@@ -1169,7 +1169,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1596
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1596
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1527,7 +1527,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1694,8 +1694,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
+#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1881,10 +1881,6 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
-msgid "Display images from all projects"
-msgstr ""
-
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -2028,7 +2024,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1773
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1773
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2202,7 +2198,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2437,7 +2433,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2512,7 +2508,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1573 lxc/image.go:1574
 msgid "Get image properties"
 msgstr ""
 
@@ -2790,7 +2786,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1489
 msgid "Image already up to date."
 msgstr ""
 
@@ -2806,11 +2802,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1444
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1670
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2820,7 +2816,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1487
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3207,11 +3203,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1090
 msgid ""
 "List images\n"
 "\n"
@@ -3232,7 +3228,6 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
-"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4372,8 +4367,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1763
-#: lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1763 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4381,7 +4375,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:854
+#: lxc/image.go:1136 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
@@ -4561,7 +4555,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1621
 msgid "Property not found"
 msgstr ""
 
@@ -4691,7 +4685,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4728,7 +4722,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1416 lxc/image.go:1417
 msgid "Refresh images"
 msgstr ""
 
@@ -4737,7 +4731,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1453
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5033,7 +5027,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1139
 msgid "SIZE"
 msgstr ""
 
@@ -5156,7 +5150,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1637 lxc/image.go:1638
 msgid "Set image properties"
 msgstr ""
 
@@ -5461,7 +5455,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1507 lxc/image.go:1508
 msgid "Show image properties"
 msgstr ""
 
@@ -5805,7 +5799,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1737 lxc/warning.go:216
@@ -6165,7 +6159,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1140
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6211,7 +6205,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1779
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1779
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6253,7 +6247,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1700 lxc/image.go:1701
 msgid "Unset image properties"
 msgstr ""
 
@@ -6577,7 +6571,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1087 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6696,15 +6690,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1572 lxc/image.go:1699
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1636
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6724,7 +6718,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1415
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7682,7 +7676,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
 msgid "no"
 msgstr ""
 
@@ -7728,6 +7722,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1194
 msgid "yes"
 msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-14 16:50+0000\n"
+"POT-Creation-Date: 2025-01-22 08:25+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -666,7 +666,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr "%d (id: %d, online: %v, NUMA node: %v)"
 
-#: lxc/image.go:1180
+#: lxc/image.go:1168
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (%d de plus)"
@@ -801,11 +801,11 @@ msgstr "<cible>"
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: lxc/image.go:1144
+#: lxc/image.go:1133
 #, fuzzy
 msgid "ALIASES"
 msgstr "ALIAS"
@@ -1465,7 +1465,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1596
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1596
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr "Colonnes"
@@ -1880,7 +1880,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -2064,8 +2064,8 @@ msgstr "Récupération de l'image : %s"
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
+#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -2258,11 +2258,6 @@ msgstr "  Disque utilisé :"
 msgid "Disks:"
 msgstr "  Disque utilisé :"
 
-#: lxc/image.go:1119
-#, fuzzy
-msgid "Display images from all projects"
-msgstr "Forcer le conteneur à s'arrêter"
-
 #: lxc/list.go:135
 #, fuzzy
 msgid "Display instances from all projects"
@@ -2426,7 +2421,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1773
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1773
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2625,7 +2620,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr "NOM"
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr "EMPREINTE"
@@ -2866,7 +2861,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2942,7 +2937,7 @@ msgstr "Création du conteneur"
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1573 lxc/image.go:1574
 msgid "Get image properties"
 msgstr ""
 
@@ -3250,7 +3245,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/image.go:1522
+#: lxc/image.go:1489
 msgid "Image already up to date."
 msgstr ""
 
@@ -3267,11 +3262,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr "Image copiée avec succès !"
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1444
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1670
 #, fuzzy, c-format
 msgid "Image identifier missing: %s"
 msgstr "Image importée avec l'empreinte : %s"
@@ -3281,7 +3276,7 @@ msgstr "Image importée avec l'empreinte : %s"
 msgid "Image imported with fingerprint: %s"
 msgstr "Image importée avec l'empreinte : %s"
 
-#: lxc/image.go:1520
+#: lxc/image.go:1487
 #, fuzzy
 msgid "Image refreshed successfully!"
 msgstr "Image copiée avec succès !"
@@ -3690,11 +3685,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1090
 msgid ""
 "List images\n"
 "\n"
@@ -3715,7 +3710,6 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
-"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -5013,8 +5007,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr "PROFILS"
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1763
-#: lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1763 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -5022,7 +5015,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr "PROTOCOLE"
 
-#: lxc/image.go:1145 lxc/remote.go:854
+#: lxc/image.go:1136 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
@@ -5213,7 +5206,7 @@ msgstr ""
 msgid "Properties:"
 msgstr "Propriétés :"
 
-#: lxc/image.go:1654
+#: lxc/image.go:1621
 msgid "Property not found"
 msgstr ""
 
@@ -5346,7 +5339,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5388,7 +5381,7 @@ msgstr "Pousser ou récupérer des fichiers récursivement"
 msgid "Refresh and update the existing storage volume copies"
 msgstr "Copie de l'image : %s"
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1416 lxc/image.go:1417
 #, fuzzy
 msgid "Refresh images"
 msgstr "Récupération de l'image : %s"
@@ -5398,7 +5391,7 @@ msgstr "Récupération de l'image : %s"
 msgid "Refreshing instance: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/image.go:1486
+#: lxc/image.go:1453
 #, fuzzy, c-format
 msgid "Refreshing the image: %s"
 msgstr "Récupération de l'image : %s"
@@ -5742,7 +5735,7 @@ msgstr "Rendre l'image publique"
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1139
 msgid "SIZE"
 msgstr "TAILLE"
 
@@ -5873,7 +5866,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1637 lxc/image.go:1638
 msgid "Set image properties"
 msgstr ""
 
@@ -6206,7 +6199,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1507 lxc/image.go:1508
 msgid "Show image properties"
 msgstr ""
 
@@ -6587,7 +6580,7 @@ msgstr "Image importée avec l'empreinte : %s"
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1737 lxc/warning.go:216
@@ -6966,7 +6959,7 @@ msgstr "Type : éphémère"
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1140
 msgid "UPLOAD DATE"
 msgstr "DATE DE PUBLICATION"
 
@@ -7013,7 +7006,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1779
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1779
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -7059,7 +7052,7 @@ msgstr "tous les profils de la source n'existent pas sur la cible"
 msgid "Unset device configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1700 lxc/image.go:1701
 msgid "Unset image properties"
 msgstr ""
 
@@ -7454,7 +7447,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1087 lxc/list.go:46
 #, fuzzy
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
@@ -7690,7 +7683,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr ""
@@ -7702,7 +7695,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1572 lxc/image.go:1699
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr ""
@@ -7714,7 +7707,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/image.go:1669
+#: lxc/image.go:1636
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
@@ -7754,7 +7747,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1415
 #, fuzzy
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
@@ -9293,7 +9286,7 @@ msgstr "non"
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
 msgid "no"
 msgstr "non"
 
@@ -9339,9 +9332,13 @@ msgid "y"
 msgstr "o"
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1194
 msgid "yes"
 msgstr "oui"
+
+#, fuzzy
+#~ msgid "Display images from all projects"
+#~ msgstr "Forcer le conteneur à s'arrêter"
 
 #~ msgid "Action (defaults to GET)"
 #~ msgstr "Action (GET par défaut)"

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-14 16:50+0000\n"
+"POT-Creation-Date: 2025-01-22 08:25+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -421,7 +421,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1168
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -542,11 +542,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1133
 msgid "ALIASES"
 msgstr ""
 
@@ -1170,7 +1170,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1596
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1596
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1528,7 +1528,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1695,8 +1695,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
+#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1882,10 +1882,6 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
-msgid "Display images from all projects"
-msgstr ""
-
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -2029,7 +2025,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1773
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1773
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2203,7 +2199,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2438,7 +2434,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2513,7 +2509,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1573 lxc/image.go:1574
 msgid "Get image properties"
 msgstr ""
 
@@ -2791,7 +2787,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1489
 msgid "Image already up to date."
 msgstr ""
 
@@ -2807,11 +2803,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1444
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1670
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2821,7 +2817,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1487
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3208,11 +3204,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1090
 msgid ""
 "List images\n"
 "\n"
@@ -3233,7 +3229,6 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
-"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4373,8 +4368,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1763
-#: lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1763 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4382,7 +4376,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:854
+#: lxc/image.go:1136 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
@@ -4562,7 +4556,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1621
 msgid "Property not found"
 msgstr ""
 
@@ -4692,7 +4686,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4729,7 +4723,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1416 lxc/image.go:1417
 msgid "Refresh images"
 msgstr ""
 
@@ -4738,7 +4732,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1453
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5034,7 +5028,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1139
 msgid "SIZE"
 msgstr ""
 
@@ -5157,7 +5151,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1637 lxc/image.go:1638
 msgid "Set image properties"
 msgstr ""
 
@@ -5462,7 +5456,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1507 lxc/image.go:1508
 msgid "Show image properties"
 msgstr ""
 
@@ -5806,7 +5800,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1737 lxc/warning.go:216
@@ -6166,7 +6160,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1140
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6212,7 +6206,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1779
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1779
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6254,7 +6248,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1700 lxc/image.go:1701
 msgid "Unset image properties"
 msgstr ""
 
@@ -6578,7 +6572,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1087 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6697,15 +6691,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1572 lxc/image.go:1699
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1636
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6725,7 +6719,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1415
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7683,7 +7677,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
 msgid "no"
 msgstr ""
 
@@ -7729,6 +7723,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1194
 msgid "yes"
 msgstr ""

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-14 16:50+0000\n"
+"POT-Creation-Date: 2025-01-22 08:25+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1168
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -541,11 +541,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1133
 msgid "ALIASES"
 msgstr ""
 
@@ -1169,7 +1169,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1596
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1596
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1527,7 +1527,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1694,8 +1694,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
+#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1881,10 +1881,6 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
-msgid "Display images from all projects"
-msgstr ""
-
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -2028,7 +2024,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1773
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1773
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2202,7 +2198,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2437,7 +2433,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2512,7 +2508,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1573 lxc/image.go:1574
 msgid "Get image properties"
 msgstr ""
 
@@ -2790,7 +2786,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1489
 msgid "Image already up to date."
 msgstr ""
 
@@ -2806,11 +2802,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1444
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1670
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2820,7 +2816,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1487
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3207,11 +3203,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1090
 msgid ""
 "List images\n"
 "\n"
@@ -3232,7 +3228,6 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
-"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4372,8 +4367,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1763
-#: lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1763 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4381,7 +4375,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:854
+#: lxc/image.go:1136 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
@@ -4561,7 +4555,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1621
 msgid "Property not found"
 msgstr ""
 
@@ -4691,7 +4685,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4728,7 +4722,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1416 lxc/image.go:1417
 msgid "Refresh images"
 msgstr ""
 
@@ -4737,7 +4731,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1453
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5033,7 +5027,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1139
 msgid "SIZE"
 msgstr ""
 
@@ -5156,7 +5150,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1637 lxc/image.go:1638
 msgid "Set image properties"
 msgstr ""
 
@@ -5461,7 +5455,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1507 lxc/image.go:1508
 msgid "Show image properties"
 msgstr ""
 
@@ -5805,7 +5799,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1737 lxc/warning.go:216
@@ -6165,7 +6159,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1140
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6211,7 +6205,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1779
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1779
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6253,7 +6247,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1700 lxc/image.go:1701
 msgid "Unset image properties"
 msgstr ""
 
@@ -6577,7 +6571,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1087 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6696,15 +6690,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1572 lxc/image.go:1699
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1636
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6724,7 +6718,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1415
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7682,7 +7676,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
 msgid "no"
 msgstr ""
 
@@ -7728,6 +7722,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1194
 msgid "yes"
 msgstr ""

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-14 16:50+0000\n"
+"POT-Creation-Date: 2025-01-22 08:25+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1168
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -541,11 +541,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1133
 msgid "ALIASES"
 msgstr ""
 
@@ -1169,7 +1169,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1596
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1596
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1527,7 +1527,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1694,8 +1694,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
+#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1881,10 +1881,6 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
-msgid "Display images from all projects"
-msgstr ""
-
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -2028,7 +2024,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1773
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1773
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2202,7 +2198,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2437,7 +2433,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2512,7 +2508,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1573 lxc/image.go:1574
 msgid "Get image properties"
 msgstr ""
 
@@ -2790,7 +2786,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1489
 msgid "Image already up to date."
 msgstr ""
 
@@ -2806,11 +2802,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1444
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1670
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2820,7 +2816,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1487
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3207,11 +3203,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1090
 msgid ""
 "List images\n"
 "\n"
@@ -3232,7 +3228,6 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
-"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4372,8 +4367,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1763
-#: lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1763 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4381,7 +4375,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:854
+#: lxc/image.go:1136 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
@@ -4561,7 +4555,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1621
 msgid "Property not found"
 msgstr ""
 
@@ -4691,7 +4685,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4728,7 +4722,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1416 lxc/image.go:1417
 msgid "Refresh images"
 msgstr ""
 
@@ -4737,7 +4731,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1453
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5033,7 +5027,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1139
 msgid "SIZE"
 msgstr ""
 
@@ -5156,7 +5150,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1637 lxc/image.go:1638
 msgid "Set image properties"
 msgstr ""
 
@@ -5461,7 +5455,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1507 lxc/image.go:1508
 msgid "Show image properties"
 msgstr ""
 
@@ -5805,7 +5799,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1737 lxc/warning.go:216
@@ -6165,7 +6159,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1140
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6211,7 +6205,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1779
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1779
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6253,7 +6247,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1700 lxc/image.go:1701
 msgid "Unset image properties"
 msgstr ""
 
@@ -6577,7 +6571,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1087 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6696,15 +6690,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1572 lxc/image.go:1699
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1636
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6724,7 +6718,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1415
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7682,7 +7676,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
 msgid "no"
 msgstr ""
 
@@ -7728,6 +7722,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1194
 msgid "yes"
 msgstr ""

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-14 16:50+0000\n"
+"POT-Creation-Date: 2025-01-22 08:25+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -662,7 +662,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1168
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (altri %d)"
@@ -786,11 +786,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: lxc/image.go:1144
+#: lxc/image.go:1133
 msgid "ALIASES"
 msgstr "ALIAS"
 
@@ -1423,7 +1423,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1596
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1596
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr "Colonne"
@@ -1794,7 +1794,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1966,8 +1966,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
+#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -2157,11 +2157,6 @@ msgstr "Utilizzo disco:"
 msgid "Disks:"
 msgstr "Utilizzo disco:"
 
-#: lxc/image.go:1119
-#, fuzzy
-msgid "Display images from all projects"
-msgstr "Creazione del container in corso"
-
 #: lxc/list.go:135
 #, fuzzy
 msgid "Display instances from all projects"
@@ -2313,7 +2308,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1773
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1773
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2490,7 +2485,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2727,7 +2722,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2803,7 +2798,7 @@ msgstr "Creazione del container in corso"
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1573 lxc/image.go:1574
 msgid "Get image properties"
 msgstr ""
 
@@ -3093,7 +3088,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:1522
+#: lxc/image.go:1489
 msgid "Image already up to date."
 msgstr ""
 
@@ -3109,11 +3104,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1444
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1670
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -3123,7 +3118,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1487
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3525,11 +3520,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1090
 msgid ""
 "List images\n"
 "\n"
@@ -3550,7 +3545,6 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
-"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4738,8 +4732,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1763
-#: lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1763 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4747,7 +4740,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:854
+#: lxc/image.go:1136 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
@@ -4931,7 +4924,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1621
 msgid "Property not found"
 msgstr ""
 
@@ -5062,7 +5055,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5101,7 +5094,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1416 lxc/image.go:1417
 msgid "Refresh images"
 msgstr ""
 
@@ -5110,7 +5103,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:1486
+#: lxc/image.go:1453
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5420,7 +5413,7 @@ msgstr "Creazione del container in corso"
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1139
 msgid "SIZE"
 msgstr ""
 
@@ -5545,7 +5538,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1637 lxc/image.go:1638
 msgid "Set image properties"
 msgstr ""
 
@@ -5860,7 +5853,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1507 lxc/image.go:1508
 msgid "Show image properties"
 msgstr ""
 
@@ -6218,7 +6211,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1737 lxc/warning.go:216
@@ -6583,7 +6576,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1140
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6630,7 +6623,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1779
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1779
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6675,7 +6668,7 @@ msgstr "non tutti i profili dell'origine esistono nella destinazione"
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1700 lxc/image.go:1701
 msgid "Unset image properties"
 msgstr ""
 
@@ -7021,7 +7014,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:] [<cert>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1087 lxc/list.go:46
 #, fuzzy
 msgid "[<remote>:] [<filter>...]"
 msgstr "Creazione del container in corso"
@@ -7164,17 +7157,17 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1572 lxc/image.go:1699
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:1669
+#: lxc/image.go:1636
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr "Creazione del container in corso"
@@ -7199,7 +7192,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<image> [<target>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1415
 #, fuzzy
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "Creazione del container in corso"
@@ -8265,7 +8258,7 @@ msgstr "no"
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
 msgid "no"
 msgstr "no"
 
@@ -8311,9 +8304,13 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1194
 msgid "yes"
 msgstr "si"
+
+#, fuzzy
+#~ msgid "Display images from all projects"
+#~ msgstr "Creazione del container in corso"
 
 #~ msgid "Action (defaults to GET)"
 #~ msgstr "Azione (default a GET)"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-14 16:50+0000\n"
+"POT-Creation-Date: 2025-01-22 08:25+0000\n"
 "PO-Revision-Date: 2023-03-10 15:14+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -654,7 +654,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr "%d (id: %d, オンライン: %v, NUMA ノード: %v)"
 
-#: lxc/image.go:1180
+#: lxc/image.go:1168
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (他%d個)"
@@ -777,11 +777,11 @@ msgstr "<target>"
 msgid "ADDRESS"
 msgstr "IP ADDRESS"
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: lxc/image.go:1144
+#: lxc/image.go:1133
 msgid "ALIASES"
 msgstr "ALIASES"
 
@@ -1439,7 +1439,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr "クラスタリングが有効になりました"
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1596
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1596
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr "カラムレイアウト"
@@ -1825,7 +1825,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr "DEFAULT TARGET ADDRESS"
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1995,8 +1995,8 @@ msgstr "警告を削除します"
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
+#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -2188,11 +2188,6 @@ msgstr "ディスク:"
 msgid "Disks:"
 msgstr "ディスク:"
 
-#: lxc/image.go:1119
-#, fuzzy
-msgid "Display images from all projects"
-msgstr "すべてのプロジェクトのインスタンスを表示します"
-
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr "すべてのプロジェクトのインスタンスを表示します"
@@ -2342,7 +2337,7 @@ msgstr "ストレージボリュームの設定をYAMLで編集します"
 msgid "Edit trust configurations as YAML"
 msgstr "信頼済みクライアント設定をYAMLで編集します"
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1773
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1773
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2543,7 +2538,7 @@ msgstr "FAILURE DOMAIN"
 msgid "FILENAME"
 msgstr "FILENAME"
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr "FINGERPRINT"
@@ -2794,7 +2789,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2870,7 +2865,7 @@ msgstr "インスタンスからファイルをマウントします"
 msgid "Get a summary of resource allocations"
 msgstr "リソース割当の状況を表示します"
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1573 lxc/image.go:1574
 msgid "Get image properties"
 msgstr "イメージのプロパティを取得します"
 
@@ -3163,7 +3158,7 @@ msgstr "コピー中にファイルが更新された場合のエラーを無視
 msgid "Ignore the instance state"
 msgstr "インスタンスの状態を無視します"
 
-#: lxc/image.go:1522
+#: lxc/image.go:1489
 msgid "Image already up to date."
 msgstr "イメージは更新済みです。"
 
@@ -3179,11 +3174,11 @@ msgstr "イメージの失効日（フォーマット: rfc3339）"
 msgid "Image exported successfully!"
 msgstr "イメージのエクスポートが成功しました!"
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1444
 msgid "Image identifier missing"
 msgstr "イメージ名を指定してください"
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1670
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr "イメージ名を指定してください: %s"
@@ -3193,7 +3188,7 @@ msgstr "イメージ名を指定してください: %s"
 msgid "Image imported with fingerprint: %s"
 msgstr "イメージは以下のフィンガープリントでインポートされました: %s"
 
-#: lxc/image.go:1520
+#: lxc/image.go:1487
 msgid "Image refreshed successfully!"
 msgstr "イメージの更新が成功しました!"
 
@@ -3606,11 +3601,11 @@ msgstr ""
 "指定するフィルタはイメージのハッシュ値の一部でもイメージのエイリアスの一部で"
 "も構いません。\n"
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 msgid "List images"
 msgstr "イメージを一覧表示します"
 
-#: lxc/image.go:1091
+#: lxc/image.go:1090
 #, fuzzy
 msgid ""
 "List images\n"
@@ -3632,7 +3627,6 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
-"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4960,8 +4954,7 @@ msgstr "PROCESSES"
 msgid "PROFILES"
 msgstr "PROFILES"
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1763
-#: lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1763 lxc/warning.go:213
 msgid "PROJECT"
 msgstr "PROJECT"
 
@@ -4969,7 +4962,7 @@ msgstr "PROJECT"
 msgid "PROTOCOL"
 msgstr "PROTOCOL"
 
-#: lxc/image.go:1145 lxc/remote.go:854
+#: lxc/image.go:1136 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
@@ -5152,7 +5145,7 @@ msgstr "リモートで使用するプロジェクト"
 msgid "Properties:"
 msgstr "プロパティ:"
 
-#: lxc/image.go:1654
+#: lxc/image.go:1621
 msgid "Property not found"
 msgstr "プロパティが見つかりません"
 
@@ -5288,7 +5281,7 @@ msgstr "ファイル %s をコンテナ %s 内にコピーします: %%s"
 msgid "Query path must start with /"
 msgstr "query のパスは / で始める必要があります"
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
 msgid "Query virtual machine images"
 msgstr "仮想マシンイメージを対象にします"
 
@@ -5327,7 +5320,7 @@ msgstr "再帰的にファイルを転送します"
 msgid "Refresh and update the existing storage volume copies"
 msgstr "既存のストレージボリュームのコピーの再読込と更新"
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1416 lxc/image.go:1417
 msgid "Refresh images"
 msgstr "イメージを更新します"
 
@@ -5336,7 +5329,7 @@ msgstr "イメージを更新します"
 msgid "Refreshing instance: %s"
 msgstr "インスタンスの更新中: %s"
 
-#: lxc/image.go:1486
+#: lxc/image.go:1453
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr "イメージの更新中: %s"
@@ -5647,7 +5640,7 @@ msgstr "すべてのインスタンスに対してコマンドを実行します
 msgid "SEVERITY"
 msgstr "SEVERITY"
 
-#: lxc/image.go:1146
+#: lxc/image.go:1139
 msgid "SIZE"
 msgstr "SIZE"
 
@@ -5780,7 +5773,7 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1637 lxc/image.go:1638
 msgid "Set image properties"
 msgstr "イメージのプロパティを設定します"
 
@@ -6148,7 +6141,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1507 lxc/image.go:1508
 msgid "Show image properties"
 msgstr "イメージのプロパティを表示します"
 
@@ -6494,7 +6487,7 @@ msgstr "イメージは以下のフィンガープリントでインポートさ
 msgid "TOKEN"
 msgstr "TOKEN"
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1737 lxc/warning.go:216
@@ -6886,7 +6879,7 @@ msgstr "タイプ: %s (ephemeral)"
 msgid "UNLIMITED"
 msgstr "UNLIMITED"
 
-#: lxc/image.go:1148
+#: lxc/image.go:1140
 msgid "UPLOAD DATE"
 msgstr "UPLOAD DATE"
 
@@ -6932,7 +6925,7 @@ msgstr "未知の証明書タイプ %q"
 msgid "Unknown channel type for client %q: %s"
 msgstr "クライアント %q の未知のチャンネルタイプ: %s"
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1779
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1779
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6975,7 +6968,7 @@ msgstr "移動先のインスタンスのすべてのプロファイルを削除
 msgid "Unset device configuration keys"
 msgstr "デバイスの設定を削除します"
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1700 lxc/image.go:1701
 msgid "Unset image properties"
 msgstr "イメージのプロパティを削除します"
 
@@ -7320,7 +7313,7 @@ msgstr "[<remote>:] <name>"
 msgid "[<remote>:] [<cert>]"
 msgstr "[<remote>:] [<cert>]"
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1087 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr "[<remote>:] [<filter>...]"
 
@@ -7444,15 +7437,15 @@ msgstr "[<remote>:]<member> <group>"
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr "[<remote>:]<group> <new-name>"
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
 msgid "[<remote>:]<image>"
 msgstr "[<remote>:]<image>"
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1572 lxc/image.go:1699
 msgid "[<remote>:]<image> <key>"
 msgstr "[<remote>:]<image> <key>"
 
-#: lxc/image.go:1669
+#: lxc/image.go:1636
 msgid "[<remote>:]<image> <key> <value>"
 msgstr "[<remote>:]<image> <key> <value>"
 
@@ -7473,7 +7466,7 @@ msgstr "[<remote>:]<image> [<remote>:][<name>]"
 msgid "[<remote>:]<image> [<target>]"
 msgstr "[<remote>:]<image> [<target>]"
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1415
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "[<remote>:]<image> [[<remote>:]<image>...]"
 
@@ -8670,7 +8663,7 @@ msgstr "n"
 msgid "name"
 msgstr "名前"
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
 msgid "no"
 msgstr "no"
 
@@ -8718,9 +8711,13 @@ msgid "y"
 msgstr "y"
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1194
 msgid "yes"
 msgstr "yes"
+
+#, fuzzy
+#~ msgid "Display images from all projects"
+#~ msgstr "すべてのプロジェクトのインスタンスを表示します"
 
 #~ msgid "Action (defaults to GET)"
 #~ msgstr "使用するHTTPのメソッド (デフォルト: GET)"

--- a/po/ka.po
+++ b/po/ka.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-14 16:50+0000\n"
+"POT-Creation-Date: 2025-01-22 08:25+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -417,7 +417,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1168
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -538,11 +538,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1133
 msgid "ALIASES"
 msgstr ""
 
@@ -1166,7 +1166,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1596
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1596
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1524,7 +1524,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1691,8 +1691,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
+#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1878,10 +1878,6 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
-msgid "Display images from all projects"
-msgstr ""
-
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -2025,7 +2021,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1773
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1773
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2199,7 +2195,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2434,7 +2430,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2509,7 +2505,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1573 lxc/image.go:1574
 msgid "Get image properties"
 msgstr ""
 
@@ -2787,7 +2783,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1489
 msgid "Image already up to date."
 msgstr ""
 
@@ -2803,11 +2799,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1444
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1670
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2817,7 +2813,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1487
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3204,11 +3200,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1090
 msgid ""
 "List images\n"
 "\n"
@@ -3229,7 +3225,6 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
-"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4369,8 +4364,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1763
-#: lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1763 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4378,7 +4372,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:854
+#: lxc/image.go:1136 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
@@ -4558,7 +4552,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1621
 msgid "Property not found"
 msgstr ""
 
@@ -4688,7 +4682,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4725,7 +4719,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1416 lxc/image.go:1417
 msgid "Refresh images"
 msgstr ""
 
@@ -4734,7 +4728,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1453
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5030,7 +5024,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1139
 msgid "SIZE"
 msgstr ""
 
@@ -5153,7 +5147,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1637 lxc/image.go:1638
 msgid "Set image properties"
 msgstr ""
 
@@ -5458,7 +5452,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1507 lxc/image.go:1508
 msgid "Show image properties"
 msgstr ""
 
@@ -5802,7 +5796,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1737 lxc/warning.go:216
@@ -6162,7 +6156,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1140
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6208,7 +6202,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1779
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1779
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6250,7 +6244,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1700 lxc/image.go:1701
 msgid "Unset image properties"
 msgstr ""
 
@@ -6574,7 +6568,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1087 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6693,15 +6687,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1572 lxc/image.go:1699
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1636
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6721,7 +6715,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1415
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7679,7 +7673,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
 msgid "no"
 msgstr ""
 
@@ -7725,6 +7719,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1194
 msgid "yes"
 msgstr ""

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-14 16:50+0000\n"
+"POT-Creation-Date: 2025-01-22 08:25+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1168
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -541,11 +541,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1133
 msgid "ALIASES"
 msgstr ""
 
@@ -1169,7 +1169,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1596
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1596
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1527,7 +1527,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1694,8 +1694,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
+#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1881,10 +1881,6 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
-msgid "Display images from all projects"
-msgstr ""
-
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -2028,7 +2024,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1773
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1773
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2202,7 +2198,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2437,7 +2433,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2512,7 +2508,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1573 lxc/image.go:1574
 msgid "Get image properties"
 msgstr ""
 
@@ -2790,7 +2786,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1489
 msgid "Image already up to date."
 msgstr ""
 
@@ -2806,11 +2802,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1444
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1670
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2820,7 +2816,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1487
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3207,11 +3203,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1090
 msgid ""
 "List images\n"
 "\n"
@@ -3232,7 +3228,6 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
-"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4372,8 +4367,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1763
-#: lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1763 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4381,7 +4375,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:854
+#: lxc/image.go:1136 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
@@ -4561,7 +4555,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1621
 msgid "Property not found"
 msgstr ""
 
@@ -4691,7 +4685,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4728,7 +4722,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1416 lxc/image.go:1417
 msgid "Refresh images"
 msgstr ""
 
@@ -4737,7 +4731,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1453
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5033,7 +5027,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1139
 msgid "SIZE"
 msgstr ""
 
@@ -5156,7 +5150,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1637 lxc/image.go:1638
 msgid "Set image properties"
 msgstr ""
 
@@ -5461,7 +5455,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1507 lxc/image.go:1508
 msgid "Show image properties"
 msgstr ""
 
@@ -5805,7 +5799,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1737 lxc/warning.go:216
@@ -6165,7 +6159,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1140
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6211,7 +6205,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1779
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1779
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6253,7 +6247,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1700 lxc/image.go:1701
 msgid "Unset image properties"
 msgstr ""
 
@@ -6577,7 +6571,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1087 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6696,15 +6690,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1572 lxc/image.go:1699
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1636
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6724,7 +6718,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1415
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7682,7 +7676,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
 msgid "no"
 msgstr ""
 
@@ -7728,6 +7722,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1194
 msgid "yes"
 msgstr ""

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-        "POT-Creation-Date: 2025-01-14 16:50+0000\n"
+        "POT-Creation-Date: 2025-01-22 08:25+0000\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -388,7 +388,7 @@ msgstr  ""
 msgid   "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr  ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1168
 #, c-format
 msgid   "%s (%d more)"
 msgstr  ""
@@ -507,11 +507,11 @@ msgstr  ""
 msgid   "ADDRESS"
 msgstr  ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
 msgid   "ALIAS"
 msgstr  ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1133
 msgid   "ALIASES"
 msgstr  ""
 
@@ -1097,7 +1097,7 @@ msgstr  ""
 msgid   "Clustering enabled"
 msgstr  ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1596 lxc/warning.go:93
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1596 lxc/warning.go:93
 msgid   "Columns"
 msgstr  ""
 
@@ -1436,7 +1436,7 @@ msgstr  ""
 msgid   "DEFAULT TARGET ADDRESS"
 msgstr  ""
 
-#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504 lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086 lxc/network_acl.go:157 lxc/network_forward.go:157 lxc/network_load_balancer.go:160 lxc/network_peer.go:149 lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173 lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723 lxc/storage_bucket.go:513 lxc/storage_bucket.go:833 lxc/storage_volume.go:1739
+#: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504 lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086 lxc/network_acl.go:157 lxc/network_forward.go:157 lxc/network_load_balancer.go:160 lxc/network_peer.go:149 lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173 lxc/profile.go:756 lxc/project.go:574 lxc/storage.go:723 lxc/storage_bucket.go:513 lxc/storage_bucket.go:833 lxc/storage_volume.go:1739
 msgid   "DESCRIPTION"
 msgstr  ""
 
@@ -1560,7 +1560,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104 lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396 lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579 lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983 lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290 lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462 lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779 lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058 lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088 lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330 lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170 lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542 lxc/config.go:775 lxc/config.go:907 lxc/config.go:959 lxc/config.go:999 lxc/config.go:1054 lxc/config.go:1145 lxc/config.go:1176 lxc/config.go:1230 lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409 lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634 lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28 lxc/config_metadata.go:56 lxc/config_metadata.go:189 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:119 lxc/config_template.go:173 lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689 lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607 lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106 lxc/network.go:1185 lxc/network.go:1245 lxc/network.go:1341 lxc/network.go:1413 lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53 lxc/network_forward.go:33 lxc/network_forward.go:90 lxc/network_forward.go:179 lxc/network_forward.go:256 lxc/network_forward.go:404 lxc/network_forward.go:489 lxc/network_forward.go:599 lxc/network_forward.go:646 lxc/network_forward.go:800 lxc/network_forward.go:874 lxc/network_forward.go:889 lxc/network_forward.go:970 lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121 lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:165 lxc/network_zone.go:228 lxc/network_zone.go:301 lxc/network_zone.go:396 lxc/network_zone.go:484 lxc/network_zone.go:527 lxc/network_zone.go:654 lxc/network_zone.go:710 lxc/network_zone.go:767 lxc/network_zone.go:845 lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083 lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349 lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483 lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:750 lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019 lxc/remote.go:1067 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250 lxc/storage_bucket.go:383 lxc/storage_bucket.go:459 lxc/storage_bucket.go:536 lxc/storage_bucket.go:630 lxc/storage_bucket.go:699 lxc/storage_bucket.go:733 lxc/storage_bucket.go:774 lxc/storage_bucket.go:853 lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158 lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:284 lxc/storage_volume.go:391 lxc/storage_volume.go:612 lxc/storage_volume.go:721 lxc/storage_volume.go:808 lxc/storage_volume.go:906 lxc/storage_volume.go:1003 lxc/storage_volume.go:1224 lxc/storage_volume.go:1355 lxc/storage_volume.go:1514 lxc/storage_volume.go:1598 lxc/storage_volume.go:1851 lxc/storage_volume.go:1950 lxc/storage_volume.go:2077 lxc/storage_volume.go:2235 lxc/storage_volume.go:2356 lxc/storage_volume.go:2418 lxc/storage_volume.go:2554 lxc/storage_volume.go:2637 lxc/storage_volume.go:2803 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/action.go:33 lxc/action.go:58 lxc/action.go:84 lxc/action.go:111 lxc/alias.go:23 lxc/alias.go:60 lxc/alias.go:110 lxc/alias.go:159 lxc/alias.go:214 lxc/auth.go:36 lxc/auth.go:65 lxc/auth.go:104 lxc/auth.go:158 lxc/auth.go:207 lxc/auth.go:336 lxc/auth.go:396 lxc/auth.go:445 lxc/auth.go:497 lxc/auth.go:520 lxc/auth.go:579 lxc/auth.go:735 lxc/auth.go:774 lxc/auth.go:916 lxc/auth.go:983 lxc/auth.go:1046 lxc/auth.go:1107 lxc/auth.go:1236 lxc/auth.go:1290 lxc/auth.go:1313 lxc/auth.go:1371 lxc/auth.go:1440 lxc/auth.go:1462 lxc/auth.go:1640 lxc/auth.go:1678 lxc/auth.go:1730 lxc/auth.go:1779 lxc/auth.go:1898 lxc/auth.go:1958 lxc/auth.go:2007 lxc/auth.go:2058 lxc/auth.go:2081 lxc/auth.go:2134 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:215 lxc/cluster.go:272 lxc/cluster.go:331 lxc/cluster.go:404 lxc/cluster.go:484 lxc/cluster.go:528 lxc/cluster.go:586 lxc/cluster.go:677 lxc/cluster.go:771 lxc/cluster.go:894 lxc/cluster.go:978 lxc/cluster.go:1088 lxc/cluster.go:1176 lxc/cluster.go:1300 lxc/cluster.go:1330 lxc/cluster_group.go:31 lxc/cluster_group.go:85 lxc/cluster_group.go:170 lxc/cluster_group.go:256 lxc/cluster_group.go:316 lxc/cluster_group.go:440 lxc/cluster_group.go:522 lxc/cluster_group.go:607 lxc/cluster_group.go:663 lxc/cluster_group.go:725 lxc/cluster_role.go:24 lxc/cluster_role.go:51 lxc/cluster_role.go:115 lxc/config.go:33 lxc/config.go:100 lxc/config.go:393 lxc/config.go:542 lxc/config.go:775 lxc/config.go:907 lxc/config.go:959 lxc/config.go:999 lxc/config.go:1054 lxc/config.go:1145 lxc/config.go:1176 lxc/config.go:1230 lxc/config_device.go:25 lxc/config_device.go:79 lxc/config_device.go:229 lxc/config_device.go:326 lxc/config_device.go:409 lxc/config_device.go:511 lxc/config_device.go:627 lxc/config_device.go:634 lxc/config_device.go:767 lxc/config_device.go:852 lxc/config_metadata.go:28 lxc/config_metadata.go:56 lxc/config_metadata.go:189 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:119 lxc/config_template.go:173 lxc/config_template.go:273 lxc/config_template.go:341 lxc/config_trust.go:34 lxc/config_trust.go:87 lxc/config_trust.go:236 lxc/config_trust.go:350 lxc/config_trust.go:432 lxc/config_trust.go:534 lxc/config_trust.go:580 lxc/config_trust.go:651 lxc/console.go:40 lxc/copy.go:42 lxc/delete.go:32 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:88 lxc/file.go:135 lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689 lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337 lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948 lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574 lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24 lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152 lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44 lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22 lxc/monitor.go:34 lxc/move.go:38 lxc/network.go:33 lxc/network.go:136 lxc/network.go:233 lxc/network.go:318 lxc/network.go:405 lxc/network.go:463 lxc/network.go:560 lxc/network.go:657 lxc/network.go:793 lxc/network.go:874 lxc/network.go:1005 lxc/network.go:1106 lxc/network.go:1185 lxc/network.go:1245 lxc/network.go:1341 lxc/network.go:1413 lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:174 lxc/network_acl.go:235 lxc/network_acl.go:291 lxc/network_acl.go:364 lxc/network_acl.go:461 lxc/network_acl.go:549 lxc/network_acl.go:592 lxc/network_acl.go:731 lxc/network_acl.go:788 lxc/network_acl.go:845 lxc/network_acl.go:860 lxc/network_acl.go:997 lxc/network_allocations.go:53 lxc/network_forward.go:33 lxc/network_forward.go:90 lxc/network_forward.go:179 lxc/network_forward.go:256 lxc/network_forward.go:404 lxc/network_forward.go:489 lxc/network_forward.go:599 lxc/network_forward.go:646 lxc/network_forward.go:800 lxc/network_forward.go:874 lxc/network_forward.go:889 lxc/network_forward.go:970 lxc/network_load_balancer.go:33 lxc/network_load_balancer.go:94 lxc/network_load_balancer.go:181 lxc/network_load_balancer.go:258 lxc/network_load_balancer.go:408 lxc/network_load_balancer.go:476 lxc/network_load_balancer.go:586 lxc/network_load_balancer.go:616 lxc/network_load_balancer.go:771 lxc/network_load_balancer.go:844 lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:935 lxc/network_load_balancer.go:1033 lxc/network_load_balancer.go:1048 lxc/network_load_balancer.go:1121 lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:167 lxc/network_peer.go:236 lxc/network_peer.go:360 lxc/network_peer.go:445 lxc/network_peer.go:547 lxc/network_peer.go:594 lxc/network_peer.go:731 lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:165 lxc/network_zone.go:228 lxc/network_zone.go:301 lxc/network_zone.go:396 lxc/network_zone.go:484 lxc/network_zone.go:527 lxc/network_zone.go:654 lxc/network_zone.go:710 lxc/network_zone.go:767 lxc/network_zone.go:845 lxc/network_zone.go:909 lxc/network_zone.go:985 lxc/network_zone.go:1083 lxc/network_zone.go:1172 lxc/network_zone.go:1219 lxc/network_zone.go:1349 lxc/network_zone.go:1410 lxc/network_zone.go:1425 lxc/network_zone.go:1483 lxc/operation.go:25 lxc/operation.go:57 lxc/operation.go:107 lxc/operation.go:194 lxc/profile.go:30 lxc/profile.go:105 lxc/profile.go:180 lxc/profile.go:271 lxc/profile.go:353 lxc/profile.go:435 lxc/profile.go:493 lxc/profile.go:629 lxc/profile.go:703 lxc/profile.go:772 lxc/profile.go:860 lxc/profile.go:920 lxc/profile.go:1009 lxc/profile.go:1073 lxc/project.go:31 lxc/project.go:95 lxc/project.go:191 lxc/project.go:262 lxc/project.go:398 lxc/project.go:472 lxc/project.go:592 lxc/project.go:657 lxc/project.go:745 lxc/project.go:789 lxc/project.go:850 lxc/project.go:917 lxc/publish.go:34 lxc/query.go:34 lxc/rebuild.go:28 lxc/remote.go:35 lxc/remote.go:91 lxc/remote.go:750 lxc/remote.go:788 lxc/remote.go:874 lxc/remote.go:955 lxc/remote.go:1019 lxc/remote.go:1067 lxc/rename.go:22 lxc/restore.go:24 lxc/snapshot.go:32 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:203 lxc/storage.go:261 lxc/storage.go:393 lxc/storage.go:475 lxc/storage.go:655 lxc/storage.go:742 lxc/storage.go:846 lxc/storage.go:940 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:189 lxc/storage_bucket.go:250 lxc/storage_bucket.go:383 lxc/storage_bucket.go:459 lxc/storage_bucket.go:536 lxc/storage_bucket.go:630 lxc/storage_bucket.go:699 lxc/storage_bucket.go:733 lxc/storage_bucket.go:774 lxc/storage_bucket.go:853 lxc/storage_bucket.go:959 lxc/storage_bucket.go:1023 lxc/storage_bucket.go:1158 lxc/storage_volume.go:58 lxc/storage_volume.go:169 lxc/storage_volume.go:284 lxc/storage_volume.go:391 lxc/storage_volume.go:612 lxc/storage_volume.go:721 lxc/storage_volume.go:808 lxc/storage_volume.go:906 lxc/storage_volume.go:1003 lxc/storage_volume.go:1224 lxc/storage_volume.go:1355 lxc/storage_volume.go:1514 lxc/storage_volume.go:1598 lxc/storage_volume.go:1851 lxc/storage_volume.go:1950 lxc/storage_volume.go:2077 lxc/storage_volume.go:2235 lxc/storage_volume.go:2356 lxc/storage_volume.go:2418 lxc/storage_volume.go:2554 lxc/storage_volume.go:2637 lxc/storage_volume.go:2803 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid   "Description"
 msgstr  ""
 
@@ -1669,10 +1669,6 @@ msgstr  ""
 
 #: lxc/info.go:433
 msgid   "Disks:"
-msgstr  ""
-
-#: lxc/image.go:1119
-msgid   "Display images from all projects"
 msgstr  ""
 
 #: lxc/list.go:135
@@ -1816,7 +1812,7 @@ msgstr  ""
 msgid   "Edit trust configurations as YAML"
 msgstr  ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1773 lxc/warning.go:236
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1773 lxc/warning.go:236
 #, c-format
 msgid   "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr  ""
@@ -1971,7 +1967,7 @@ msgstr  ""
 msgid   "FILENAME"
 msgstr  ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142 lxc/image_alias.go:235
+#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135 lxc/image_alias.go:235
 msgid   "FINGERPRINT"
 msgstr  ""
 
@@ -2196,7 +2192,7 @@ msgid   "Forcefully removing a server from the cluster should only be done as a 
         "Are you really sure you want to force removing %s? (yes/no): "
 msgstr  ""
 
-#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902 lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442 lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434 lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009 lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59 lxc/network_forward.go:93 lxc/network_load_balancer.go:97 lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770 lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474 lxc/project.go:919 lxc/remote.go:792 lxc/storage.go:657 lxc/storage_bucket.go:460 lxc/storage_bucket.go:775 lxc/storage_volume.go:1615 lxc/warning.go:94
+#: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902 lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442 lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434 lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009 lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59 lxc/network_forward.go:93 lxc/network_load_balancer.go:97 lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770 lxc/operation.go:109 lxc/profile.go:707 lxc/project.go:474 lxc/project.go:919 lxc/remote.go:792 lxc/storage.go:657 lxc/storage_bucket.go:460 lxc/storage_bucket.go:775 lxc/storage_volume.go:1615 lxc/warning.go:94
 msgid   "Format (csv|json|table|yaml|compact)"
 msgstr  ""
 
@@ -2264,7 +2260,7 @@ msgstr  ""
 msgid   "Get a summary of resource allocations"
 msgstr  ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1573 lxc/image.go:1574
 msgid   "Get image properties"
 msgstr  ""
 
@@ -2540,7 +2536,7 @@ msgstr  ""
 msgid   "Ignore the instance state"
 msgstr  ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1489
 msgid   "Image already up to date."
 msgstr  ""
 
@@ -2556,11 +2552,11 @@ msgstr  ""
 msgid   "Image exported successfully!"
 msgstr  ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1444
 msgid   "Image identifier missing"
 msgstr  ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1670
 #, c-format
 msgid   "Image identifier missing: %s"
 msgstr  ""
@@ -2570,7 +2566,7 @@ msgstr  ""
 msgid   "Image imported with fingerprint: %s"
 msgstr  ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1487
 msgid   "Image refreshed successfully!"
 msgstr  ""
 
@@ -2948,11 +2944,11 @@ msgid   "List image aliases\n"
         "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr  ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 msgid   "List images"
 msgstr  ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1090
 msgid   "List images\n"
         "\n"
         "Filters may be of the <key>=<value> form for property based filtering,\n"
@@ -2972,7 +2968,6 @@ msgid   "List images\n"
         "    F - Fingerprint (long)\n"
         "    p - Whether image is public\n"
         "    d - Description\n"
-        "    e - Project\n"
         "    a - Architecture\n"
         "    s - Size\n"
         "    u - Upload date\n"
@@ -4015,7 +4010,7 @@ msgstr  ""
 msgid   "PROFILES"
 msgstr  ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1763 lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1763 lxc/warning.go:213
 msgid   "PROJECT"
 msgstr  ""
 
@@ -4023,7 +4018,7 @@ msgstr  ""
 msgid   "PROTOCOL"
 msgstr  ""
 
-#: lxc/image.go:1145 lxc/remote.go:854
+#: lxc/image.go:1136 lxc/remote.go:854
 msgid   "PUBLIC"
 msgstr  ""
 
@@ -4194,7 +4189,7 @@ msgstr  ""
 msgid   "Properties:"
 msgstr  ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1621
 msgid   "Property not found"
 msgstr  ""
 
@@ -4308,7 +4303,7 @@ msgstr  ""
 msgid   "Query path must start with /"
 msgstr  ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
 msgid   "Query virtual machine images"
 msgstr  ""
 
@@ -4345,7 +4340,7 @@ msgstr  ""
 msgid   "Refresh and update the existing storage volume copies"
 msgstr  ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1416 lxc/image.go:1417
 msgid   "Refresh images"
 msgstr  ""
 
@@ -4354,7 +4349,7 @@ msgstr  ""
 msgid   "Refreshing instance: %s"
 msgstr  ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1453
 #, c-format
 msgid   "Refreshing the image: %s"
 msgstr  ""
@@ -4646,7 +4641,7 @@ msgstr  ""
 msgid   "SEVERITY"
 msgstr  ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1139
 msgid   "SIZE"
 msgstr  ""
 
@@ -4764,7 +4759,7 @@ msgid   "Set device configuration keys\n"
         "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr  ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1637 lxc/image.go:1638
 msgid   "Set image properties"
 msgstr  ""
 
@@ -5041,7 +5036,7 @@ msgid   "Show identity configurations\n"
         "method. Use the identifier instead if this occurs.\n"
 msgstr  ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1507 lxc/image.go:1508
 msgid   "Show image properties"
 msgstr  ""
 
@@ -5383,7 +5378,7 @@ msgstr  ""
 msgid   "TOKEN"
 msgstr  ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147 lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082 lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172 lxc/storage_volume.go:1737 lxc/warning.go:216
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1141 lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082 lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172 lxc/storage_volume.go:1737 lxc/warning.go:216
 msgid   "TYPE"
 msgstr  ""
 
@@ -5724,7 +5719,7 @@ msgstr  ""
 msgid   "UNLIMITED"
 msgstr  ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1140
 msgid   "UPLOAD DATE"
 msgstr  ""
 
@@ -5768,7 +5763,7 @@ msgstr  ""
 msgid   "Unknown channel type for client %q: %s"
 msgstr  ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1779 lxc/warning.go:242
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1779 lxc/warning.go:242
 #, c-format
 msgid   "Unknown column shorthand char '%c' in '%s'"
 msgstr  ""
@@ -5809,7 +5804,7 @@ msgstr  ""
 msgid   "Unset device configuration keys"
 msgstr  ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1700 lxc/image.go:1701
 msgid   "Unset image properties"
 msgstr  ""
 
@@ -6118,7 +6113,7 @@ msgstr  ""
 msgid   "[<remote>:] [<cert>]"
 msgstr  ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1087 lxc/list.go:46
 msgid   "[<remote>:] [<filter>...]"
 msgstr  ""
 
@@ -6230,15 +6225,15 @@ msgstr  ""
 msgid   "[<remote>:]<identity_provider_group> <new_name>"
 msgstr  ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
 msgid   "[<remote>:]<image>"
 msgstr  ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1572 lxc/image.go:1699
 msgid   "[<remote>:]<image> <key>"
 msgstr  ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1636
 msgid   "[<remote>:]<image> <key> <value>"
 msgstr  ""
 
@@ -6258,7 +6253,7 @@ msgstr  ""
 msgid   "[<remote>:]<image> [<target>]"
 msgstr  ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1415
 msgid   "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr  ""
 
@@ -7107,7 +7102,7 @@ msgstr  ""
 msgid   "name"
 msgstr  ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
 msgid   "no"
 msgstr  ""
 
@@ -7152,7 +7147,7 @@ msgstr  ""
 msgid   "y"
 msgstr  ""
 
-#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001 lxc/image.go:1206
+#: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001 lxc/image.go:1194
 msgid   "yes"
 msgstr  ""
 

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-14 16:50+0000\n"
+"POT-Creation-Date: 2025-01-22 08:25+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1168
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -541,11 +541,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1133
 msgid "ALIASES"
 msgstr ""
 
@@ -1169,7 +1169,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1596
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1596
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1527,7 +1527,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1694,8 +1694,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
+#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1881,10 +1881,6 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
-msgid "Display images from all projects"
-msgstr ""
-
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -2028,7 +2024,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1773
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1773
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2202,7 +2198,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2437,7 +2433,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2512,7 +2508,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1573 lxc/image.go:1574
 msgid "Get image properties"
 msgstr ""
 
@@ -2790,7 +2786,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1489
 msgid "Image already up to date."
 msgstr ""
 
@@ -2806,11 +2802,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1444
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1670
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2820,7 +2816,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1487
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3207,11 +3203,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1090
 msgid ""
 "List images\n"
 "\n"
@@ -3232,7 +3228,6 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
-"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4372,8 +4367,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1763
-#: lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1763 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4381,7 +4375,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:854
+#: lxc/image.go:1136 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
@@ -4561,7 +4555,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1621
 msgid "Property not found"
 msgstr ""
 
@@ -4691,7 +4685,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4728,7 +4722,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1416 lxc/image.go:1417
 msgid "Refresh images"
 msgstr ""
 
@@ -4737,7 +4731,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1453
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5033,7 +5027,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1139
 msgid "SIZE"
 msgstr ""
 
@@ -5156,7 +5150,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1637 lxc/image.go:1638
 msgid "Set image properties"
 msgstr ""
 
@@ -5461,7 +5455,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1507 lxc/image.go:1508
 msgid "Show image properties"
 msgstr ""
 
@@ -5805,7 +5799,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1737 lxc/warning.go:216
@@ -6165,7 +6159,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1140
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6211,7 +6205,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1779
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1779
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6253,7 +6247,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1700 lxc/image.go:1701
 msgid "Unset image properties"
 msgstr ""
 
@@ -6577,7 +6571,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1087 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6696,15 +6690,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1572 lxc/image.go:1699
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1636
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6724,7 +6718,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1415
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7682,7 +7676,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
 msgid "no"
 msgstr ""
 
@@ -7728,6 +7722,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1194
 msgid "yes"
 msgstr ""

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-14 16:50+0000\n"
+"POT-Creation-Date: 2025-01-22 08:25+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1168
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -541,11 +541,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1133
 msgid "ALIASES"
 msgstr ""
 
@@ -1169,7 +1169,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1596
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1596
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1527,7 +1527,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1694,8 +1694,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
+#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1881,10 +1881,6 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
-msgid "Display images from all projects"
-msgstr ""
-
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -2028,7 +2024,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1773
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1773
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2202,7 +2198,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2437,7 +2433,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2512,7 +2508,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1573 lxc/image.go:1574
 msgid "Get image properties"
 msgstr ""
 
@@ -2790,7 +2786,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1489
 msgid "Image already up to date."
 msgstr ""
 
@@ -2806,11 +2802,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1444
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1670
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2820,7 +2816,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1487
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3207,11 +3203,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1090
 msgid ""
 "List images\n"
 "\n"
@@ -3232,7 +3228,6 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
-"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4372,8 +4367,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1763
-#: lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1763 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4381,7 +4375,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:854
+#: lxc/image.go:1136 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
@@ -4561,7 +4555,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1621
 msgid "Property not found"
 msgstr ""
 
@@ -4691,7 +4685,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4728,7 +4722,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1416 lxc/image.go:1417
 msgid "Refresh images"
 msgstr ""
 
@@ -4737,7 +4731,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1453
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5033,7 +5027,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1139
 msgid "SIZE"
 msgstr ""
 
@@ -5156,7 +5150,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1637 lxc/image.go:1638
 msgid "Set image properties"
 msgstr ""
 
@@ -5461,7 +5455,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1507 lxc/image.go:1508
 msgid "Show image properties"
 msgstr ""
 
@@ -5805,7 +5799,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1737 lxc/warning.go:216
@@ -6165,7 +6159,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1140
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6211,7 +6205,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1779
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1779
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6253,7 +6247,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1700 lxc/image.go:1701
 msgid "Unset image properties"
 msgstr ""
 
@@ -6577,7 +6571,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1087 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6696,15 +6690,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1572 lxc/image.go:1699
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1636
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6724,7 +6718,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1415
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7682,7 +7676,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
 msgid "no"
 msgstr ""
 
@@ -7728,6 +7722,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1194
 msgid "yes"
 msgstr ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-14 16:50+0000\n"
+"POT-Creation-Date: 2025-01-22 08:25+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -644,7 +644,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1168
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (en nog %d)"
@@ -765,11 +765,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: lxc/image.go:1144
+#: lxc/image.go:1133
 msgid "ALIASES"
 msgstr ""
 
@@ -1393,7 +1393,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1596
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1596
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1751,7 +1751,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1918,8 +1918,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
+#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -2105,10 +2105,6 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
-msgid "Display images from all projects"
-msgstr ""
-
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -2252,7 +2248,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1773
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1773
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2426,7 +2422,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2661,7 +2657,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2736,7 +2732,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1573 lxc/image.go:1574
 msgid "Get image properties"
 msgstr ""
 
@@ -3014,7 +3010,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1489
 msgid "Image already up to date."
 msgstr ""
 
@@ -3030,11 +3026,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1444
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1670
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -3044,7 +3040,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1487
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3431,11 +3427,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1090
 msgid ""
 "List images\n"
 "\n"
@@ -3456,7 +3452,6 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
-"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4596,8 +4591,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1763
-#: lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1763 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4605,7 +4599,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:854
+#: lxc/image.go:1136 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
@@ -4785,7 +4779,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1621
 msgid "Property not found"
 msgstr ""
 
@@ -4915,7 +4909,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4952,7 +4946,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1416 lxc/image.go:1417
 msgid "Refresh images"
 msgstr ""
 
@@ -4961,7 +4955,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1453
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5257,7 +5251,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1139
 msgid "SIZE"
 msgstr ""
 
@@ -5380,7 +5374,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1637 lxc/image.go:1638
 msgid "Set image properties"
 msgstr ""
 
@@ -5685,7 +5679,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1507 lxc/image.go:1508
 msgid "Show image properties"
 msgstr ""
 
@@ -6029,7 +6023,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1737 lxc/warning.go:216
@@ -6389,7 +6383,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1140
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6435,7 +6429,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1779
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1779
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6477,7 +6471,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1700 lxc/image.go:1701
 msgid "Unset image properties"
 msgstr ""
 
@@ -6801,7 +6795,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1087 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6920,15 +6914,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1572 lxc/image.go:1699
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1636
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6948,7 +6942,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1415
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7906,7 +7900,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
 msgid "no"
 msgstr ""
 
@@ -7952,7 +7946,7 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1194
 msgid "yes"
 msgstr ""
 

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-14 16:50+0000\n"
+"POT-Creation-Date: 2025-01-22 08:25+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1168
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -541,11 +541,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1133
 msgid "ALIASES"
 msgstr ""
 
@@ -1169,7 +1169,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1596
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1596
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1527,7 +1527,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1694,8 +1694,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
+#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1881,10 +1881,6 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
-msgid "Display images from all projects"
-msgstr ""
-
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -2028,7 +2024,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1773
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1773
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2202,7 +2198,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2437,7 +2433,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2512,7 +2508,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1573 lxc/image.go:1574
 msgid "Get image properties"
 msgstr ""
 
@@ -2790,7 +2786,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1489
 msgid "Image already up to date."
 msgstr ""
 
@@ -2806,11 +2802,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1444
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1670
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2820,7 +2816,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1487
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3207,11 +3203,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1090
 msgid ""
 "List images\n"
 "\n"
@@ -3232,7 +3228,6 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
-"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4372,8 +4367,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1763
-#: lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1763 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4381,7 +4375,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:854
+#: lxc/image.go:1136 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
@@ -4561,7 +4555,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1621
 msgid "Property not found"
 msgstr ""
 
@@ -4691,7 +4685,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4728,7 +4722,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1416 lxc/image.go:1417
 msgid "Refresh images"
 msgstr ""
 
@@ -4737,7 +4731,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1453
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5033,7 +5027,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1139
 msgid "SIZE"
 msgstr ""
 
@@ -5156,7 +5150,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1637 lxc/image.go:1638
 msgid "Set image properties"
 msgstr ""
 
@@ -5461,7 +5455,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1507 lxc/image.go:1508
 msgid "Show image properties"
 msgstr ""
 
@@ -5805,7 +5799,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1737 lxc/warning.go:216
@@ -6165,7 +6159,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1140
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6211,7 +6205,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1779
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1779
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6253,7 +6247,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1700 lxc/image.go:1701
 msgid "Unset image properties"
 msgstr ""
 
@@ -6577,7 +6571,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1087 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6696,15 +6690,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1572 lxc/image.go:1699
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1636
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6724,7 +6718,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1415
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7682,7 +7676,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
 msgid "no"
 msgstr ""
 
@@ -7728,6 +7722,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1194
 msgid "yes"
 msgstr ""

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-14 16:50+0000\n"
+"POT-Creation-Date: 2025-01-22 08:25+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -682,7 +682,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1168
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -803,11 +803,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1133
 msgid "ALIASES"
 msgstr ""
 
@@ -1431,7 +1431,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1596
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1596
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1789,7 +1789,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1956,8 +1956,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
+#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -2143,10 +2143,6 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
-msgid "Display images from all projects"
-msgstr ""
-
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -2290,7 +2286,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1773
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1773
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2464,7 +2460,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2699,7 +2695,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2774,7 +2770,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1573 lxc/image.go:1574
 msgid "Get image properties"
 msgstr ""
 
@@ -3052,7 +3048,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1489
 msgid "Image already up to date."
 msgstr ""
 
@@ -3068,11 +3064,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1444
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1670
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -3082,7 +3078,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1487
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3469,11 +3465,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1090
 msgid ""
 "List images\n"
 "\n"
@@ -3494,7 +3490,6 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
-"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4634,8 +4629,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1763
-#: lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1763 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4643,7 +4637,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:854
+#: lxc/image.go:1136 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
@@ -4823,7 +4817,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1621
 msgid "Property not found"
 msgstr ""
 
@@ -4953,7 +4947,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4990,7 +4984,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1416 lxc/image.go:1417
 msgid "Refresh images"
 msgstr ""
 
@@ -4999,7 +4993,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1453
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5295,7 +5289,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1139
 msgid "SIZE"
 msgstr ""
 
@@ -5418,7 +5412,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1637 lxc/image.go:1638
 msgid "Set image properties"
 msgstr ""
 
@@ -5723,7 +5717,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1507 lxc/image.go:1508
 msgid "Show image properties"
 msgstr ""
 
@@ -6067,7 +6061,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1737 lxc/warning.go:216
@@ -6427,7 +6421,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1140
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6473,7 +6467,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1779
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1779
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6515,7 +6509,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1700 lxc/image.go:1701
 msgid "Unset image properties"
 msgstr ""
 
@@ -6839,7 +6833,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1087 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6958,15 +6952,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1572 lxc/image.go:1699
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1636
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6986,7 +6980,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1415
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7944,7 +7938,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
 msgid "no"
 msgstr ""
 
@@ -7990,7 +7984,7 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1194
 msgid "yes"
 msgstr ""
 

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-14 16:50+0000\n"
+"POT-Creation-Date: 2025-01-22 08:25+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -417,7 +417,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1168
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -538,11 +538,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1133
 msgid "ALIASES"
 msgstr ""
 
@@ -1166,7 +1166,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1596
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1596
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1524,7 +1524,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1691,8 +1691,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
+#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1878,10 +1878,6 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
-msgid "Display images from all projects"
-msgstr ""
-
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -2025,7 +2021,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1773
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1773
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2199,7 +2195,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2434,7 +2430,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2509,7 +2505,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1573 lxc/image.go:1574
 msgid "Get image properties"
 msgstr ""
 
@@ -2787,7 +2783,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1489
 msgid "Image already up to date."
 msgstr ""
 
@@ -2803,11 +2799,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1444
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1670
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2817,7 +2813,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1487
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3204,11 +3200,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1090
 msgid ""
 "List images\n"
 "\n"
@@ -3229,7 +3225,6 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
-"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4369,8 +4364,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1763
-#: lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1763 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4378,7 +4372,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:854
+#: lxc/image.go:1136 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
@@ -4558,7 +4552,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1621
 msgid "Property not found"
 msgstr ""
 
@@ -4688,7 +4682,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4725,7 +4719,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1416 lxc/image.go:1417
 msgid "Refresh images"
 msgstr ""
 
@@ -4734,7 +4728,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1453
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5030,7 +5024,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1139
 msgid "SIZE"
 msgstr ""
 
@@ -5153,7 +5147,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1637 lxc/image.go:1638
 msgid "Set image properties"
 msgstr ""
 
@@ -5458,7 +5452,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1507 lxc/image.go:1508
 msgid "Show image properties"
 msgstr ""
 
@@ -5802,7 +5796,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1737 lxc/warning.go:216
@@ -6162,7 +6156,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1140
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6208,7 +6202,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1779
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1779
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6250,7 +6244,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1700 lxc/image.go:1701
 msgid "Unset image properties"
 msgstr ""
 
@@ -6574,7 +6568,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1087 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6693,15 +6687,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1572 lxc/image.go:1699
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1636
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6721,7 +6715,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1415
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7679,7 +7673,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
 msgid "no"
 msgstr ""
 
@@ -7725,6 +7719,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1194
 msgid "yes"
 msgstr ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-14 16:50+0000\n"
+"POT-Creation-Date: 2025-01-22 08:25+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -668,7 +668,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr "%d (id: %d, online: %v, NUMA nó: %v)"
 
-#: lxc/image.go:1180
+#: lxc/image.go:1168
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (%d mais)"
@@ -800,11 +800,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: lxc/image.go:1144
+#: lxc/image.go:1133
 msgid "ALIASES"
 msgstr "ALIASES"
 
@@ -1449,7 +1449,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr "Clustering ativado"
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1596
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1596
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr "Colunas"
@@ -1838,7 +1838,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -2019,8 +2019,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
+#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -2212,11 +2212,6 @@ msgstr "Uso de disco:"
 msgid "Disks:"
 msgstr "Uso de disco:"
 
-#: lxc/image.go:1119
-#, fuzzy
-msgid "Display images from all projects"
-msgstr "Criar projetos"
-
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -2379,7 +2374,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1773
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1773
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2554,7 +2549,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2790,7 +2785,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2866,7 +2861,7 @@ msgstr "Adicionar perfis aos containers"
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1573 lxc/image.go:1574
 #, fuzzy
 msgid "Get image properties"
 msgstr "Editar propriedades da imagem"
@@ -3164,7 +3159,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr "Ignorar o estado do container"
 
-#: lxc/image.go:1522
+#: lxc/image.go:1489
 msgid "Image already up to date."
 msgstr ""
 
@@ -3180,11 +3175,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr "Imagem exportada com sucesso!"
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1444
 msgid "Image identifier missing"
 msgstr "Falta o identificador da imagem"
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1670
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr "Falta o identificador da imagem: %s"
@@ -3194,7 +3189,7 @@ msgstr "Falta o identificador da imagem: %s"
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1487
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3590,11 +3585,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1090
 msgid ""
 "List images\n"
 "\n"
@@ -3615,7 +3610,6 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
-"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4803,8 +4797,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1763
-#: lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1763 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4812,7 +4805,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:854
+#: lxc/image.go:1136 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
@@ -4998,7 +4991,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1621
 msgid "Property not found"
 msgstr ""
 
@@ -5129,7 +5122,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5168,7 +5161,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1416 lxc/image.go:1417
 msgid "Refresh images"
 msgstr ""
 
@@ -5177,7 +5170,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/image.go:1486
+#: lxc/image.go:1453
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5499,7 +5492,7 @@ msgstr "Criar projetos"
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1139
 msgid "SIZE"
 msgstr ""
 
@@ -5625,7 +5618,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1637 lxc/image.go:1638
 #, fuzzy
 msgid "Set image properties"
 msgstr "Editar propriedades da imagem"
@@ -5951,7 +5944,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1507 lxc/image.go:1508
 msgid "Show image properties"
 msgstr ""
 
@@ -6314,7 +6307,7 @@ msgstr "Certificado fingerprint: %s"
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1737 lxc/warning.go:216
@@ -6682,7 +6675,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1140
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6729,7 +6722,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1779
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1779
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6775,7 +6768,7 @@ msgstr "Não pode fornecer um nome para a imagem de destino"
 msgid "Unset device configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1700 lxc/image.go:1701
 #, fuzzy
 msgid "Unset image properties"
 msgstr "Editar propriedades da imagem"
@@ -7125,7 +7118,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr "Criar perfis"
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1087 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -7262,16 +7255,16 @@ msgstr "Editar templates de arquivo do container"
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr "Criar perfis"
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1572 lxc/image.go:1699
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/image.go:1669
+#: lxc/image.go:1636
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr "Editar templates de arquivo do container"
@@ -7293,7 +7286,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1415
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -8302,7 +8295,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
 msgid "no"
 msgstr ""
 
@@ -8348,9 +8341,13 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1194
 msgid "yes"
 msgstr "sim"
+
+#, fuzzy
+#~ msgid "Display images from all projects"
+#~ msgstr "Criar projetos"
 
 #~ msgid "Action (defaults to GET)"
 #~ msgstr "Ação (padrão para o GET)"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-14 16:50+0000\n"
+"POT-Creation-Date: 2025-01-22 08:25+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -677,7 +677,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1168
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -803,11 +803,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr "ПСЕВДОНИМ"
 
-#: lxc/image.go:1144
+#: lxc/image.go:1133
 #, fuzzy
 msgid "ALIASES"
 msgstr "ПСЕВДОНИМ"
@@ -1449,7 +1449,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1596
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1596
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr "Столбцы"
@@ -1830,7 +1830,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -2007,8 +2007,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
+#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -2199,11 +2199,6 @@ msgstr " Использование диска:"
 msgid "Disks:"
 msgstr " Использование диска:"
 
-#: lxc/image.go:1119
-#, fuzzy
-msgid "Display images from all projects"
-msgstr "Копирование образа: %s"
-
 #: lxc/list.go:135
 #, fuzzy
 msgid "Display instances from all projects"
@@ -2357,7 +2352,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1773
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1773
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2540,7 +2535,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2776,7 +2771,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2852,7 +2847,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1573 lxc/image.go:1574
 msgid "Get image properties"
 msgstr ""
 
@@ -3147,7 +3142,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/image.go:1522
+#: lxc/image.go:1489
 msgid "Image already up to date."
 msgstr ""
 
@@ -3163,11 +3158,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1444
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1670
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -3177,7 +3172,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1487
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3581,11 +3576,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1090
 msgid ""
 "List images\n"
 "\n"
@@ -3606,7 +3601,6 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
-"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4810,8 +4804,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1763
-#: lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1763 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4819,7 +4812,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:854
+#: lxc/image.go:1136 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
@@ -5000,7 +4993,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1621
 msgid "Property not found"
 msgstr ""
 
@@ -5130,7 +5123,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -5170,7 +5163,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr "Копирование образа: %s"
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1416 lxc/image.go:1417
 #, fuzzy
 msgid "Refresh images"
 msgstr "Копирование образа: %s"
@@ -5180,7 +5173,7 @@ msgstr "Копирование образа: %s"
 msgid "Refreshing instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/image.go:1486
+#: lxc/image.go:1453
 #, fuzzy, c-format
 msgid "Refreshing the image: %s"
 msgstr "Копирование образа: %s"
@@ -5495,7 +5488,7 @@ msgstr "Доступные команды:"
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1139
 msgid "SIZE"
 msgstr ""
 
@@ -5620,7 +5613,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1637 lxc/image.go:1638
 msgid "Set image properties"
 msgstr ""
 
@@ -5942,7 +5935,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1507 lxc/image.go:1508
 msgid "Show image properties"
 msgstr ""
 
@@ -6306,7 +6299,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1737 lxc/warning.go:216
@@ -6668,7 +6661,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1140
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6714,7 +6707,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1779
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1779
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6758,7 +6751,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1700 lxc/image.go:1701
 msgid "Unset image properties"
 msgstr ""
 
@@ -7130,7 +7123,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1087 lxc/list.go:46
 #, fuzzy
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
@@ -7345,7 +7338,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
 #, fuzzy
 msgid "[<remote>:]<image>"
 msgstr ""
@@ -7353,7 +7346,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1572 lxc/image.go:1699
 #, fuzzy
 msgid "[<remote>:]<image> <key>"
 msgstr ""
@@ -7361,7 +7354,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:1669
+#: lxc/image.go:1636
 #, fuzzy
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
@@ -7401,7 +7394,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1415
 #, fuzzy
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
@@ -8791,7 +8784,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
 msgid "no"
 msgstr ""
 
@@ -8837,9 +8830,13 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1194
 msgid "yes"
 msgstr "да"
+
+#, fuzzy
+#~ msgid "Display images from all projects"
+#~ msgstr "Копирование образа: %s"
 
 #, fuzzy
 #~ msgid "[<remote>:]<cluster member>"

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-14 16:50+0000\n"
+"POT-Creation-Date: 2025-01-22 08:25+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1168
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -541,11 +541,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1133
 msgid "ALIASES"
 msgstr ""
 
@@ -1169,7 +1169,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1596
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1596
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1527,7 +1527,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1694,8 +1694,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
+#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1881,10 +1881,6 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
-msgid "Display images from all projects"
-msgstr ""
-
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -2028,7 +2024,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1773
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1773
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2202,7 +2198,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2437,7 +2433,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2512,7 +2508,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1573 lxc/image.go:1574
 msgid "Get image properties"
 msgstr ""
 
@@ -2790,7 +2786,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1489
 msgid "Image already up to date."
 msgstr ""
 
@@ -2806,11 +2802,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1444
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1670
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2820,7 +2816,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1487
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3207,11 +3203,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1090
 msgid ""
 "List images\n"
 "\n"
@@ -3232,7 +3228,6 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
-"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4372,8 +4367,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1763
-#: lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1763 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4381,7 +4375,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:854
+#: lxc/image.go:1136 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
@@ -4561,7 +4555,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1621
 msgid "Property not found"
 msgstr ""
 
@@ -4691,7 +4685,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4728,7 +4722,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1416 lxc/image.go:1417
 msgid "Refresh images"
 msgstr ""
 
@@ -4737,7 +4731,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1453
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5033,7 +5027,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1139
 msgid "SIZE"
 msgstr ""
 
@@ -5156,7 +5150,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1637 lxc/image.go:1638
 msgid "Set image properties"
 msgstr ""
 
@@ -5461,7 +5455,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1507 lxc/image.go:1508
 msgid "Show image properties"
 msgstr ""
 
@@ -5805,7 +5799,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1737 lxc/warning.go:216
@@ -6165,7 +6159,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1140
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6211,7 +6205,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1779
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1779
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6253,7 +6247,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1700 lxc/image.go:1701
 msgid "Unset image properties"
 msgstr ""
 
@@ -6577,7 +6571,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1087 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6696,15 +6690,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1572 lxc/image.go:1699
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1636
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6724,7 +6718,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1415
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7682,7 +7676,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
 msgid "no"
 msgstr ""
 
@@ -7728,6 +7722,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1194
 msgid "yes"
 msgstr ""

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-14 16:50+0000\n"
+"POT-Creation-Date: 2025-01-22 08:25+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -421,7 +421,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1168
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -542,11 +542,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1133
 msgid "ALIASES"
 msgstr ""
 
@@ -1170,7 +1170,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1596
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1596
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1528,7 +1528,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1695,8 +1695,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
+#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1882,10 +1882,6 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
-msgid "Display images from all projects"
-msgstr ""
-
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -2029,7 +2025,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1773
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1773
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2203,7 +2199,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2438,7 +2434,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2513,7 +2509,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1573 lxc/image.go:1574
 msgid "Get image properties"
 msgstr ""
 
@@ -2791,7 +2787,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1489
 msgid "Image already up to date."
 msgstr ""
 
@@ -2807,11 +2803,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1444
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1670
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2821,7 +2817,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1487
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3208,11 +3204,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1090
 msgid ""
 "List images\n"
 "\n"
@@ -3233,7 +3229,6 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
-"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4373,8 +4368,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1763
-#: lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1763 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4382,7 +4376,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:854
+#: lxc/image.go:1136 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
@@ -4562,7 +4556,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1621
 msgid "Property not found"
 msgstr ""
 
@@ -4692,7 +4686,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4729,7 +4723,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1416 lxc/image.go:1417
 msgid "Refresh images"
 msgstr ""
 
@@ -4738,7 +4732,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1453
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5034,7 +5028,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1139
 msgid "SIZE"
 msgstr ""
 
@@ -5157,7 +5151,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1637 lxc/image.go:1638
 msgid "Set image properties"
 msgstr ""
 
@@ -5462,7 +5456,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1507 lxc/image.go:1508
 msgid "Show image properties"
 msgstr ""
 
@@ -5806,7 +5800,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1737 lxc/warning.go:216
@@ -6166,7 +6160,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1140
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6212,7 +6206,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1779
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1779
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6254,7 +6248,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1700 lxc/image.go:1701
 msgid "Unset image properties"
 msgstr ""
 
@@ -6578,7 +6572,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1087 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6697,15 +6691,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1572 lxc/image.go:1699
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1636
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6725,7 +6719,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1415
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7683,7 +7677,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
 msgid "no"
 msgstr ""
 
@@ -7729,6 +7723,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1194
 msgid "yes"
 msgstr ""

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-14 16:50+0000\n"
+"POT-Creation-Date: 2025-01-22 08:25+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -421,7 +421,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1168
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -542,11 +542,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1133
 msgid "ALIASES"
 msgstr ""
 
@@ -1170,7 +1170,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1596
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1596
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1528,7 +1528,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1695,8 +1695,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
+#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1882,10 +1882,6 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
-msgid "Display images from all projects"
-msgstr ""
-
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -2029,7 +2025,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1773
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1773
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2203,7 +2199,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2438,7 +2434,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2513,7 +2509,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1573 lxc/image.go:1574
 msgid "Get image properties"
 msgstr ""
 
@@ -2791,7 +2787,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1489
 msgid "Image already up to date."
 msgstr ""
 
@@ -2807,11 +2803,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1444
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1670
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2821,7 +2817,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1487
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3208,11 +3204,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1090
 msgid ""
 "List images\n"
 "\n"
@@ -3233,7 +3229,6 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
-"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4373,8 +4368,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1763
-#: lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1763 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4382,7 +4376,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:854
+#: lxc/image.go:1136 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
@@ -4562,7 +4556,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1621
 msgid "Property not found"
 msgstr ""
 
@@ -4692,7 +4686,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4729,7 +4723,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1416 lxc/image.go:1417
 msgid "Refresh images"
 msgstr ""
 
@@ -4738,7 +4732,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1453
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5034,7 +5028,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1139
 msgid "SIZE"
 msgstr ""
 
@@ -5157,7 +5151,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1637 lxc/image.go:1638
 msgid "Set image properties"
 msgstr ""
 
@@ -5462,7 +5456,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1507 lxc/image.go:1508
 msgid "Show image properties"
 msgstr ""
 
@@ -5806,7 +5800,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1737 lxc/warning.go:216
@@ -6166,7 +6160,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1140
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6212,7 +6206,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1779
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1779
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6254,7 +6248,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1700 lxc/image.go:1701
 msgid "Unset image properties"
 msgstr ""
 
@@ -6578,7 +6572,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1087 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6697,15 +6691,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1572 lxc/image.go:1699
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1636
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6725,7 +6719,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1415
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7683,7 +7677,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
 msgid "no"
 msgstr ""
 
@@ -7729,6 +7723,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1194
 msgid "yes"
 msgstr ""

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-14 16:50+0000\n"
+"POT-Creation-Date: 2025-01-22 08:25+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1168
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -541,11 +541,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1133
 msgid "ALIASES"
 msgstr ""
 
@@ -1169,7 +1169,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1596
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1596
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1527,7 +1527,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1694,8 +1694,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
+#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1881,10 +1881,6 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
-msgid "Display images from all projects"
-msgstr ""
-
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -2028,7 +2024,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1773
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1773
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2202,7 +2198,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2437,7 +2433,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2512,7 +2508,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1573 lxc/image.go:1574
 msgid "Get image properties"
 msgstr ""
 
@@ -2790,7 +2786,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1489
 msgid "Image already up to date."
 msgstr ""
 
@@ -2806,11 +2802,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1444
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1670
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2820,7 +2816,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1487
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3207,11 +3203,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1090
 msgid ""
 "List images\n"
 "\n"
@@ -3232,7 +3228,6 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
-"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4372,8 +4367,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1763
-#: lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1763 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4381,7 +4375,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:854
+#: lxc/image.go:1136 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
@@ -4561,7 +4555,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1621
 msgid "Property not found"
 msgstr ""
 
@@ -4691,7 +4685,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4728,7 +4722,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1416 lxc/image.go:1417
 msgid "Refresh images"
 msgstr ""
 
@@ -4737,7 +4731,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1453
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5033,7 +5027,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1139
 msgid "SIZE"
 msgstr ""
 
@@ -5156,7 +5150,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1637 lxc/image.go:1638
 msgid "Set image properties"
 msgstr ""
 
@@ -5461,7 +5455,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1507 lxc/image.go:1508
 msgid "Show image properties"
 msgstr ""
 
@@ -5805,7 +5799,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1737 lxc/warning.go:216
@@ -6165,7 +6159,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1140
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6211,7 +6205,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1779
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1779
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6253,7 +6247,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1700 lxc/image.go:1701
 msgid "Unset image properties"
 msgstr ""
 
@@ -6577,7 +6571,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1087 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6696,15 +6690,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1572 lxc/image.go:1699
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1636
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6724,7 +6718,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1415
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7682,7 +7676,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
 msgid "no"
 msgstr ""
 
@@ -7728,6 +7722,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1194
 msgid "yes"
 msgstr ""

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-14 16:50+0000\n"
+"POT-Creation-Date: 2025-01-22 08:25+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1168
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -541,11 +541,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1133
 msgid "ALIASES"
 msgstr ""
 
@@ -1169,7 +1169,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1596
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1596
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1527,7 +1527,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1694,8 +1694,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
+#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1881,10 +1881,6 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
-msgid "Display images from all projects"
-msgstr ""
-
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -2028,7 +2024,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1773
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1773
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2202,7 +2198,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2437,7 +2433,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2512,7 +2508,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1573 lxc/image.go:1574
 msgid "Get image properties"
 msgstr ""
 
@@ -2790,7 +2786,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1489
 msgid "Image already up to date."
 msgstr ""
 
@@ -2806,11 +2802,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1444
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1670
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2820,7 +2816,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1487
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3207,11 +3203,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1090
 msgid ""
 "List images\n"
 "\n"
@@ -3232,7 +3228,6 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
-"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4372,8 +4367,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1763
-#: lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1763 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4381,7 +4375,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:854
+#: lxc/image.go:1136 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
@@ -4561,7 +4555,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1621
 msgid "Property not found"
 msgstr ""
 
@@ -4691,7 +4685,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4728,7 +4722,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1416 lxc/image.go:1417
 msgid "Refresh images"
 msgstr ""
 
@@ -4737,7 +4731,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1453
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5033,7 +5027,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1139
 msgid "SIZE"
 msgstr ""
 
@@ -5156,7 +5150,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1637 lxc/image.go:1638
 msgid "Set image properties"
 msgstr ""
 
@@ -5461,7 +5455,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1507 lxc/image.go:1508
 msgid "Show image properties"
 msgstr ""
 
@@ -5805,7 +5799,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1737 lxc/warning.go:216
@@ -6165,7 +6159,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1140
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6211,7 +6205,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1779
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1779
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6253,7 +6247,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1700 lxc/image.go:1701
 msgid "Unset image properties"
 msgstr ""
 
@@ -6577,7 +6571,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1087 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6696,15 +6690,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1572 lxc/image.go:1699
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1636
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6724,7 +6718,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1415
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7682,7 +7676,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
 msgid "no"
 msgstr ""
 
@@ -7728,6 +7722,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1194
 msgid "yes"
 msgstr ""

--- a/po/th.po
+++ b/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-14 16:50+0000\n"
+"POT-Creation-Date: 2025-01-22 08:25+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -417,7 +417,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1168
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -538,11 +538,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1133
 msgid "ALIASES"
 msgstr ""
 
@@ -1166,7 +1166,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1596
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1596
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1524,7 +1524,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1691,8 +1691,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
+#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1878,10 +1878,6 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
-msgid "Display images from all projects"
-msgstr ""
-
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -2025,7 +2021,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1773
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1773
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2199,7 +2195,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2434,7 +2430,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2509,7 +2505,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1573 lxc/image.go:1574
 msgid "Get image properties"
 msgstr ""
 
@@ -2787,7 +2783,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1489
 msgid "Image already up to date."
 msgstr ""
 
@@ -2803,11 +2799,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1444
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1670
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2817,7 +2813,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1487
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3204,11 +3200,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1090
 msgid ""
 "List images\n"
 "\n"
@@ -3229,7 +3225,6 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
-"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4369,8 +4364,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1763
-#: lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1763 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4378,7 +4372,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:854
+#: lxc/image.go:1136 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
@@ -4558,7 +4552,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1621
 msgid "Property not found"
 msgstr ""
 
@@ -4688,7 +4682,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4725,7 +4719,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1416 lxc/image.go:1417
 msgid "Refresh images"
 msgstr ""
 
@@ -4734,7 +4728,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1453
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5030,7 +5024,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1139
 msgid "SIZE"
 msgstr ""
 
@@ -5153,7 +5147,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1637 lxc/image.go:1638
 msgid "Set image properties"
 msgstr ""
 
@@ -5458,7 +5452,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1507 lxc/image.go:1508
 msgid "Show image properties"
 msgstr ""
 
@@ -5802,7 +5796,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1737 lxc/warning.go:216
@@ -6162,7 +6156,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1140
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6208,7 +6202,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1779
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1779
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6250,7 +6244,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1700 lxc/image.go:1701
 msgid "Unset image properties"
 msgstr ""
 
@@ -6574,7 +6568,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1087 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6693,15 +6687,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1572 lxc/image.go:1699
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1636
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6721,7 +6715,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1415
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7679,7 +7673,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
 msgid "no"
 msgstr ""
 
@@ -7725,6 +7719,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1194
 msgid "yes"
 msgstr ""

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-14 16:50+0000\n"
+"POT-Creation-Date: 2025-01-22 08:25+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1168
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -541,11 +541,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1133
 msgid "ALIASES"
 msgstr ""
 
@@ -1169,7 +1169,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1596
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1596
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1527,7 +1527,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1694,8 +1694,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
+#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1881,10 +1881,6 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
-msgid "Display images from all projects"
-msgstr ""
-
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -2028,7 +2024,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1773
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1773
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2202,7 +2198,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2437,7 +2433,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2512,7 +2508,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1573 lxc/image.go:1574
 msgid "Get image properties"
 msgstr ""
 
@@ -2790,7 +2786,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1489
 msgid "Image already up to date."
 msgstr ""
 
@@ -2806,11 +2802,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1444
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1670
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2820,7 +2816,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1487
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3207,11 +3203,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1090
 msgid ""
 "List images\n"
 "\n"
@@ -3232,7 +3228,6 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
-"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4372,8 +4367,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1763
-#: lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1763 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4381,7 +4375,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:854
+#: lxc/image.go:1136 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
@@ -4561,7 +4555,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1621
 msgid "Property not found"
 msgstr ""
 
@@ -4691,7 +4685,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4728,7 +4722,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1416 lxc/image.go:1417
 msgid "Refresh images"
 msgstr ""
 
@@ -4737,7 +4731,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1453
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5033,7 +5027,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1139
 msgid "SIZE"
 msgstr ""
 
@@ -5156,7 +5150,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1637 lxc/image.go:1638
 msgid "Set image properties"
 msgstr ""
 
@@ -5461,7 +5455,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1507 lxc/image.go:1508
 msgid "Show image properties"
 msgstr ""
 
@@ -5805,7 +5799,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1737 lxc/warning.go:216
@@ -6165,7 +6159,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1140
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6211,7 +6205,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1779
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1779
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6253,7 +6247,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1700 lxc/image.go:1701
 msgid "Unset image properties"
 msgstr ""
 
@@ -6577,7 +6571,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1087 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6696,15 +6690,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1572 lxc/image.go:1699
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1636
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6724,7 +6718,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1415
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7682,7 +7676,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
 msgid "no"
 msgstr ""
 
@@ -7728,6 +7722,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1194
 msgid "yes"
 msgstr ""

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-14 16:50+0000\n"
+"POT-Creation-Date: 2025-01-22 08:25+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1168
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -541,11 +541,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1133
 msgid "ALIASES"
 msgstr ""
 
@@ -1169,7 +1169,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1596
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1596
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1527,7 +1527,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1694,8 +1694,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
+#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1881,10 +1881,6 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
-msgid "Display images from all projects"
-msgstr ""
-
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -2028,7 +2024,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1773
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1773
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2202,7 +2198,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2437,7 +2433,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2512,7 +2508,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1573 lxc/image.go:1574
 msgid "Get image properties"
 msgstr ""
 
@@ -2790,7 +2786,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1489
 msgid "Image already up to date."
 msgstr ""
 
@@ -2806,11 +2802,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1444
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1670
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2820,7 +2816,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1487
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3207,11 +3203,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1090
 msgid ""
 "List images\n"
 "\n"
@@ -3232,7 +3228,6 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
-"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4372,8 +4367,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1763
-#: lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1763 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4381,7 +4375,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:854
+#: lxc/image.go:1136 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
@@ -4561,7 +4555,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1621
 msgid "Property not found"
 msgstr ""
 
@@ -4691,7 +4685,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4728,7 +4722,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1416 lxc/image.go:1417
 msgid "Refresh images"
 msgstr ""
 
@@ -4737,7 +4731,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1453
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5033,7 +5027,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1139
 msgid "SIZE"
 msgstr ""
 
@@ -5156,7 +5150,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1637 lxc/image.go:1638
 msgid "Set image properties"
 msgstr ""
 
@@ -5461,7 +5455,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1507 lxc/image.go:1508
 msgid "Show image properties"
 msgstr ""
 
@@ -5805,7 +5799,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1737 lxc/warning.go:216
@@ -6165,7 +6159,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1140
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6211,7 +6205,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1779
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1779
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6253,7 +6247,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1700 lxc/image.go:1701
 msgid "Unset image properties"
 msgstr ""
 
@@ -6577,7 +6571,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1087 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6696,15 +6690,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1572 lxc/image.go:1699
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1636
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6724,7 +6718,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1415
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7682,7 +7676,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
 msgid "no"
 msgstr ""
 
@@ -7728,6 +7722,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1194
 msgid "yes"
 msgstr ""

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-14 16:50+0000\n"
+"POT-Creation-Date: 2025-01-22 08:25+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1168
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -541,11 +541,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1133
 msgid "ALIASES"
 msgstr ""
 
@@ -1169,7 +1169,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1596
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1596
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1527,7 +1527,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1694,8 +1694,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
+#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1881,10 +1881,6 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
-msgid "Display images from all projects"
-msgstr ""
-
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -2028,7 +2024,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1773
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1773
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2202,7 +2198,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2437,7 +2433,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2512,7 +2508,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1573 lxc/image.go:1574
 msgid "Get image properties"
 msgstr ""
 
@@ -2790,7 +2786,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1489
 msgid "Image already up to date."
 msgstr ""
 
@@ -2806,11 +2802,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1444
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1670
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2820,7 +2816,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1487
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3207,11 +3203,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1090
 msgid ""
 "List images\n"
 "\n"
@@ -3232,7 +3228,6 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
-"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4372,8 +4367,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1763
-#: lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1763 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4381,7 +4375,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:854
+#: lxc/image.go:1136 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
@@ -4561,7 +4555,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1621
 msgid "Property not found"
 msgstr ""
 
@@ -4691,7 +4685,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4728,7 +4722,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1416 lxc/image.go:1417
 msgid "Refresh images"
 msgstr ""
 
@@ -4737,7 +4731,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1453
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5033,7 +5027,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1139
 msgid "SIZE"
 msgstr ""
 
@@ -5156,7 +5150,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1637 lxc/image.go:1638
 msgid "Set image properties"
 msgstr ""
 
@@ -5461,7 +5455,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1507 lxc/image.go:1508
 msgid "Show image properties"
 msgstr ""
 
@@ -5805,7 +5799,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1737 lxc/warning.go:216
@@ -6165,7 +6159,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1140
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6211,7 +6205,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1779
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1779
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6253,7 +6247,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1700 lxc/image.go:1701
 msgid "Unset image properties"
 msgstr ""
 
@@ -6577,7 +6571,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1087 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6696,15 +6690,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1572 lxc/image.go:1699
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1636
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6724,7 +6718,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1415
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7682,7 +7676,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
 msgid "no"
 msgstr ""
 
@@ -7728,6 +7722,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1194
 msgid "yes"
 msgstr ""

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-14 16:50+0000\n"
+"POT-Creation-Date: 2025-01-22 08:25+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -421,7 +421,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1168
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -542,11 +542,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1133
 msgid "ALIASES"
 msgstr ""
 
@@ -1170,7 +1170,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1596
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1596
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1528,7 +1528,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1695,8 +1695,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
+#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1882,10 +1882,6 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
-msgid "Display images from all projects"
-msgstr ""
-
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -2029,7 +2025,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1773
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1773
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2203,7 +2199,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2438,7 +2434,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2513,7 +2509,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1573 lxc/image.go:1574
 msgid "Get image properties"
 msgstr ""
 
@@ -2791,7 +2787,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1489
 msgid "Image already up to date."
 msgstr ""
 
@@ -2807,11 +2803,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1444
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1670
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2821,7 +2817,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1487
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3208,11 +3204,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1090
 msgid ""
 "List images\n"
 "\n"
@@ -3233,7 +3229,6 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
-"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4373,8 +4368,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1763
-#: lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1763 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4382,7 +4376,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:854
+#: lxc/image.go:1136 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
@@ -4562,7 +4556,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1621
 msgid "Property not found"
 msgstr ""
 
@@ -4692,7 +4686,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4729,7 +4723,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1416 lxc/image.go:1417
 msgid "Refresh images"
 msgstr ""
 
@@ -4738,7 +4732,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1453
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5034,7 +5028,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1139
 msgid "SIZE"
 msgstr ""
 
@@ -5157,7 +5151,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1637 lxc/image.go:1638
 msgid "Set image properties"
 msgstr ""
 
@@ -5462,7 +5456,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1507 lxc/image.go:1508
 msgid "Show image properties"
 msgstr ""
 
@@ -5806,7 +5800,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1737 lxc/warning.go:216
@@ -6166,7 +6160,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1140
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6212,7 +6206,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1779
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1779
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6254,7 +6248,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1700 lxc/image.go:1701
 msgid "Unset image properties"
 msgstr ""
 
@@ -6578,7 +6572,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1087 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6697,15 +6691,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1572 lxc/image.go:1699
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1636
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6725,7 +6719,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1415
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7683,7 +7677,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
 msgid "no"
 msgstr ""
 
@@ -7729,6 +7723,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1194
 msgid "yes"
 msgstr ""

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-14 16:50+0000\n"
+"POT-Creation-Date: 2025-01-22 08:25+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -581,7 +581,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1168
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -702,11 +702,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1133
 msgid "ALIASES"
 msgstr ""
 
@@ -1330,7 +1330,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1596
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1596
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1688,7 +1688,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1855,8 +1855,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
+#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -2042,10 +2042,6 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
-msgid "Display images from all projects"
-msgstr ""
-
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -2189,7 +2185,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1773
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1773
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2363,7 +2359,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2598,7 +2594,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2673,7 +2669,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1573 lxc/image.go:1574
 msgid "Get image properties"
 msgstr ""
 
@@ -2951,7 +2947,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1489
 msgid "Image already up to date."
 msgstr ""
 
@@ -2967,11 +2963,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1444
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1670
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2981,7 +2977,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1487
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3368,11 +3364,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1090
 msgid ""
 "List images\n"
 "\n"
@@ -3393,7 +3389,6 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
-"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4533,8 +4528,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1763
-#: lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1763 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4542,7 +4536,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:854
+#: lxc/image.go:1136 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
@@ -4722,7 +4716,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1621
 msgid "Property not found"
 msgstr ""
 
@@ -4852,7 +4846,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4889,7 +4883,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1416 lxc/image.go:1417
 msgid "Refresh images"
 msgstr ""
 
@@ -4898,7 +4892,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1453
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5194,7 +5188,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1139
 msgid "SIZE"
 msgstr ""
 
@@ -5317,7 +5311,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1637 lxc/image.go:1638
 msgid "Set image properties"
 msgstr ""
 
@@ -5622,7 +5616,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1507 lxc/image.go:1508
 msgid "Show image properties"
 msgstr ""
 
@@ -5966,7 +5960,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1737 lxc/warning.go:216
@@ -6326,7 +6320,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1140
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6372,7 +6366,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1779
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1779
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6414,7 +6408,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1700 lxc/image.go:1701
 msgid "Unset image properties"
 msgstr ""
 
@@ -6738,7 +6732,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1087 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6857,15 +6851,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1572 lxc/image.go:1699
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1636
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6885,7 +6879,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1415
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7843,7 +7837,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
 msgid "no"
 msgstr ""
 
@@ -7889,7 +7883,7 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1194
 msgid "yes"
 msgstr ""
 

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxd@lists.canonical.com\n"
-"POT-Creation-Date: 2025-01-14 16:50+0000\n"
+"POT-Creation-Date: 2025-01-22 08:25+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -420,7 +420,7 @@ msgstr ""
 msgid "%d (id: %d, online: %v, NUMA node: %v)"
 msgstr ""
 
-#: lxc/image.go:1180
+#: lxc/image.go:1168
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -541,11 +541,11 @@ msgstr ""
 msgid "ADDRESS"
 msgstr ""
 
-#: lxc/alias.go:139 lxc/image.go:1143 lxc/image_alias.go:234
+#: lxc/alias.go:139 lxc/image.go:1132 lxc/image_alias.go:234
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:1144
+#: lxc/image.go:1133
 msgid "ALIASES"
 msgstr ""
 
@@ -1169,7 +1169,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1117 lxc/list.go:132 lxc/storage_volume.go:1596
+#: lxc/image.go:1115 lxc/list.go:132 lxc/storage_volume.go:1596
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1527,7 +1527,7 @@ msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
 #: lxc/auth.go:380 lxc/cluster.go:197 lxc/cluster_group.go:504
-#: lxc/image.go:1139 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
+#: lxc/image.go:1137 lxc/image_alias.go:237 lxc/list.go:565 lxc/network.go:1086
 #: lxc/network_acl.go:157 lxc/network_forward.go:157
 #: lxc/network_load_balancer.go:160 lxc/network_peer.go:149
 #: lxc/network_zone.go:148 lxc/network_zone.go:828 lxc/operation.go:173
@@ -1694,8 +1694,8 @@ msgstr ""
 #: lxc/file.go:321 lxc/file.go:378 lxc/file.go:456 lxc/file.go:689
 #: lxc/file.go:1208 lxc/image.go:38 lxc/image.go:159 lxc/image.go:337
 #: lxc/image.go:396 lxc/image.go:525 lxc/image.go:697 lxc/image.go:948
-#: lxc/image.go:1091 lxc/image.go:1450 lxc/image.go:1541 lxc/image.go:1607
-#: lxc/image.go:1671 lxc/image.go:1734 lxc/image_alias.go:24
+#: lxc/image.go:1090 lxc/image.go:1417 lxc/image.go:1508 lxc/image.go:1574
+#: lxc/image.go:1638 lxc/image.go:1701 lxc/image_alias.go:24
 #: lxc/image_alias.go:60 lxc/image_alias.go:107 lxc/image_alias.go:152
 #: lxc/image_alias.go:255 lxc/import.go:29 lxc/info.go:33 lxc/init.go:44
 #: lxc/launch.go:24 lxc/list.go:49 lxc/main.go:83 lxc/manpage.go:22
@@ -1881,10 +1881,6 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/image.go:1119
-msgid "Display images from all projects"
-msgstr ""
-
 #: lxc/list.go:135
 msgid "Display instances from all projects"
 msgstr ""
@@ -2028,7 +2024,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1161 lxc/list.go:622 lxc/storage_volume.go:1773
+#: lxc/image.go:1149 lxc/list.go:622 lxc/storage_volume.go:1773
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2202,7 +2198,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:411 lxc/image.go:1141 lxc/image.go:1142
+#: lxc/config_trust.go:411 lxc/image.go:1134 lxc/image.go:1135
 #: lxc/image_alias.go:235
 msgid "FINGERPRINT"
 msgstr ""
@@ -2437,7 +2433,7 @@ msgstr ""
 #: lxc/alias.go:112 lxc/auth.go:340 lxc/auth.go:920 lxc/auth.go:1902
 #: lxc/cluster.go:125 lxc/cluster.go:979 lxc/cluster_group.go:442
 #: lxc/config_template.go:275 lxc/config_trust.go:352 lxc/config_trust.go:434
-#: lxc/image.go:1118 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
+#: lxc/image.go:1116 lxc/image_alias.go:157 lxc/list.go:133 lxc/network.go:1009
 #: lxc/network.go:1108 lxc/network_acl.go:98 lxc/network_allocations.go:59
 #: lxc/network_forward.go:93 lxc/network_load_balancer.go:97
 #: lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:770
@@ -2512,7 +2508,7 @@ msgstr ""
 msgid "Get a summary of resource allocations"
 msgstr ""
 
-#: lxc/image.go:1606 lxc/image.go:1607
+#: lxc/image.go:1573 lxc/image.go:1574
 msgid "Get image properties"
 msgstr ""
 
@@ -2790,7 +2786,7 @@ msgstr ""
 msgid "Ignore the instance state"
 msgstr ""
 
-#: lxc/image.go:1522
+#: lxc/image.go:1489
 msgid "Image already up to date."
 msgstr ""
 
@@ -2806,11 +2802,11 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:364 lxc/image.go:1477
+#: lxc/image.go:364 lxc/image.go:1444
 msgid "Image identifier missing"
 msgstr ""
 
-#: lxc/image.go:444 lxc/image.go:1703
+#: lxc/image.go:444 lxc/image.go:1670
 #, c-format
 msgid "Image identifier missing: %s"
 msgstr ""
@@ -2820,7 +2816,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1520
+#: lxc/image.go:1487
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -3207,11 +3203,11 @@ msgid ""
 "Filters may be part of the image hash or part of the image alias name.\n"
 msgstr ""
 
-#: lxc/image.go:1090
+#: lxc/image.go:1089
 msgid "List images"
 msgstr ""
 
-#: lxc/image.go:1091
+#: lxc/image.go:1090
 msgid ""
 "List images\n"
 "\n"
@@ -3232,7 +3228,6 @@ msgid ""
 "    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
-"    e - Project\n"
 "    a - Architecture\n"
 "    s - Size\n"
 "    u - Upload date\n"
@@ -4372,8 +4367,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/image.go:1140 lxc/list.go:567 lxc/storage_volume.go:1763
-#: lxc/warning.go:213
+#: lxc/list.go:567 lxc/storage_volume.go:1763 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4381,7 +4375,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:1145 lxc/remote.go:854
+#: lxc/image.go:1136 lxc/remote.go:854
 msgid "PUBLIC"
 msgstr ""
 
@@ -4561,7 +4555,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/image.go:1654
+#: lxc/image.go:1621
 msgid "Property not found"
 msgstr ""
 
@@ -4691,7 +4685,7 @@ msgstr ""
 msgid "Query path must start with /"
 msgstr ""
 
-#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1544
+#: lxc/image.go:530 lxc/image.go:951 lxc/image.go:1511
 msgid "Query virtual machine images"
 msgstr ""
 
@@ -4728,7 +4722,7 @@ msgstr ""
 msgid "Refresh and update the existing storage volume copies"
 msgstr ""
 
-#: lxc/image.go:1449 lxc/image.go:1450
+#: lxc/image.go:1416 lxc/image.go:1417
 msgid "Refresh images"
 msgstr ""
 
@@ -4737,7 +4731,7 @@ msgstr ""
 msgid "Refreshing instance: %s"
 msgstr ""
 
-#: lxc/image.go:1486
+#: lxc/image.go:1453
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -5033,7 +5027,7 @@ msgstr ""
 msgid "SEVERITY"
 msgstr ""
 
-#: lxc/image.go:1146
+#: lxc/image.go:1139
 msgid "SIZE"
 msgstr ""
 
@@ -5156,7 +5150,7 @@ msgid ""
 "    lxc profile device set [<remote>:]<profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/image.go:1670 lxc/image.go:1671
+#: lxc/image.go:1637 lxc/image.go:1638
 msgid "Set image properties"
 msgstr ""
 
@@ -5461,7 +5455,7 @@ msgid ""
 "method. Use the identifier instead if this occurs.\n"
 msgstr ""
 
-#: lxc/image.go:1540 lxc/image.go:1541
+#: lxc/image.go:1507 lxc/image.go:1508
 msgid "Show image properties"
 msgstr ""
 
@@ -5805,7 +5799,7 @@ msgstr ""
 msgid "TOKEN"
 msgstr ""
 
-#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1147
+#: lxc/auth.go:965 lxc/config_trust.go:408 lxc/image.go:1141
 #: lxc/image_alias.go:236 lxc/list.go:579 lxc/network.go:1082
 #: lxc/network.go:1164 lxc/network_allocations.go:27 lxc/operation.go:172
 #: lxc/storage_volume.go:1737 lxc/warning.go:216
@@ -6165,7 +6159,7 @@ msgstr ""
 msgid "UNLIMITED"
 msgstr ""
 
-#: lxc/image.go:1148
+#: lxc/image.go:1140
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -6211,7 +6205,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1167 lxc/list.go:631 lxc/storage_volume.go:1779
+#: lxc/image.go:1155 lxc/list.go:631 lxc/storage_volume.go:1779
 #: lxc/warning.go:242
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6253,7 +6247,7 @@ msgstr ""
 msgid "Unset device configuration keys"
 msgstr ""
 
-#: lxc/image.go:1733 lxc/image.go:1734
+#: lxc/image.go:1700 lxc/image.go:1701
 msgid "Unset image properties"
 msgstr ""
 
@@ -6577,7 +6571,7 @@ msgstr ""
 msgid "[<remote>:] [<cert>]"
 msgstr ""
 
-#: lxc/image.go:1088 lxc/list.go:46
+#: lxc/image.go:1087 lxc/list.go:46
 msgid "[<remote>:] [<filter>...]"
 msgstr ""
 
@@ -6696,15 +6690,15 @@ msgstr ""
 msgid "[<remote>:]<identity_provider_group> <new_name>"
 msgstr ""
 
-#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1539
+#: lxc/image.go:394 lxc/image.go:946 lxc/image.go:1506
 msgid "[<remote>:]<image>"
 msgstr ""
 
-#: lxc/image.go:1605 lxc/image.go:1732
+#: lxc/image.go:1572 lxc/image.go:1699
 msgid "[<remote>:]<image> <key>"
 msgstr ""
 
-#: lxc/image.go:1669
+#: lxc/image.go:1636
 msgid "[<remote>:]<image> <key> <value>"
 msgstr ""
 
@@ -6724,7 +6718,7 @@ msgstr ""
 msgid "[<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/image.go:334 lxc/image.go:1448
+#: lxc/image.go:334 lxc/image.go:1415
 msgid "[<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -7682,7 +7676,7 @@ msgstr ""
 msgid "name"
 msgstr ""
 
-#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1209
+#: lxc/image.go:994 lxc/image.go:999 lxc/image.go:1197
 msgid "no"
 msgstr ""
 
@@ -7728,6 +7722,6 @@ msgid "y"
 msgstr ""
 
 #: lxc/cluster.go:624 lxc/delete.go:52 lxc/image.go:996 lxc/image.go:1001
-#: lxc/image.go:1206
+#: lxc/image.go:1194
 msgid "yes"
 msgstr ""

--- a/shared/api/image.go
+++ b/shared/api/image.go
@@ -201,12 +201,6 @@ type Image struct {
 	//
 	// API extension: image_profiles
 	Profiles []string `json:"profiles" yaml:"profiles"`
-
-	// Project name
-	// Example: project1
-	//
-	// API extension: images_all_projects
-	Project string `json:"project" yaml:"project"`
 }
 
 // Writable converts a full Image struct into a ImagePut struct (filters read-only fields).

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -423,7 +423,6 @@ var APIExtensions = []string{
 	"state_logical_cpus",
 	"vm_limits_cpu_pin_strategy",
 	"gpu_cdi",
-	"images_all_projects",
 }
 
 // APIExtensionsCount returns the number of available API extensions.

--- a/test/suites/auth.sh
+++ b/test/suites/auth.sh
@@ -665,7 +665,6 @@ user_is_not_project_operator() {
 
   # Image list will still work but none will be shown because none are public.
   [ "$(lxc_remote image list "${remote}:" -f csv | wc -l)" = 0 ]
-  [ "$(lxc_remote image list "${remote}:" -f csv --all-projects | wc -l)" = 0 ]
 
   # Image edit will fail. Note that this fails with "not found" because we fail to resolve the alias (image is not public
   # so it is not returned from the DB).
@@ -742,14 +741,11 @@ auth_project_features() {
 
   # We can always list images, but there are no public images in the default project now, so the list should be empty.
   [ "$(lxc_remote image list "${remote}:" --project default --format csv)" = "" ]
-  # The list should also be empty when the --all-projects flag is set to true.
-  [ "$(lxc_remote image list "${remote}:" --all-projects --format csv)" = "" ]
   ! lxc_remote image show "${remote}:testimage" --project default || false
 
   # Set the image to public and ensure we can view it.
   lxc image show testimage --project default | sed -e "s/public: false/public: true/" | lxc image edit testimage --project default
-  [ "$(lxc_remote image list "${remote}:" --project default --format csv | wc -l)" = 1 ] # --project flag set to default.
-  [ "$(lxc_remote image list "${remote}:" --all-projects --format csv | wc -l)" = 1 ] # --all-projects flag set to true.
+  [ "$(lxc_remote image list "${remote}:" --project default --format csv | wc -l)" = 1 ]
   lxc_remote image show "${remote}:testimage" --project default
 
   # Check we can export the public image:


### PR DESCRIPTION
As this wasn't in LXD 6.2 we should not include it in the LTS backport until its been released in LXD 6.3. The feature itself is still in flux too.